### PR TITLE
Fix missing "replace_manager_ip.sh" script

### DIFF
--- a/debs/wazuh-agent/debian/changelog
+++ b/debs/wazuh-agent/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-agent (2.1.0-2) stable; urgency=low
+
+  * Add missing "replace_manager_ip.sh" script.
+
+ -- Dan Fuhry <dan@fuhry.com>  Thu, 21 Sept 2017 16:17:59 +0000
+
 wazuh-agent (2.1.0-1) stable; urgency=low
 
   * https://github.com/wazuh/wazuh/blob/master/CHANGELOG.md#v210---2017-08-14.

--- a/debs/wazuh-agent/debian/changelog
+++ b/debs/wazuh-agent/debian/changelog
@@ -1,8 +1,15 @@
+wazuh-agent (2.1.1-2) stable; urgency=low
+
+  * New upstream release.
+  * Fix lock in agent on HP-UX
+
+ -- Dan Fuhry <dan@fuhry.com>  Fri, 22 Sep 2017 16:41:19 +0000
+
 wazuh-agent (2.1.0-2) stable; urgency=low
 
   * Add missing "replace_manager_ip.sh" script.
 
- -- Dan Fuhry <dan@fuhry.com>  Thu, 21 Sept 2017 16:17:59 +0000
+ -- Dan Fuhry <dan@fuhry.com>  Thu, 21 Sep 2017 16:17:59 +0000
 
 wazuh-agent (2.1.0-1) stable; urgency=low
 

--- a/debs/wazuh-agent/debian/patches/SourceToDeb
+++ b/debs/wazuh-agent/debian/patches/SourceToDeb
@@ -42,7 +42,7 @@
  	${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs
  	${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/ossec
  	${INSTALL} -m 0660 -o ${OSSEC_USER} -g ${OSSEC_GROUP} /dev/null ${PREFIX}/logs/ossec.log
-@@ -412,14 +418,36 @@
+@@ -412,14 +418,37 @@
  	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/oscap/content
  
  	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/oscap.py ${PREFIX}/wodles/oscap
@@ -71,6 +71,7 @@
 +	install -m 0640 init/inst-functions.sh ${PREFIX}/tmp/src/init
 +	install -m 0640 init/template-select.sh ${PREFIX}/tmp/src/init
 +	install -m 0640 init/shared.sh ${PREFIX}/tmp/src/init
++	install -m 0750 init/replace_manager_ip.sh ${PREFIX}/tmp/src/init
 +	install -m 0640 LOCATION ${PREFIX}/tmp/src
 +	install -m 0640 VERSION ${PREFIX}/tmp/src
 +	install -m 0640 REVISION ${PREFIX}/tmp/src
@@ -82,7 +83,7 @@
  ifneq (,$(wildcard /etc/TIMEZONE))
  	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} /etc/TIMEZONE ${PREFIX}/etc/
  endif
-@@ -443,7 +471,7 @@
+@@ -443,7 +472,7 @@
  ifneq (,$(wildcard ../etc/ossec.mc))
  	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../etc/ossec.mc ${PREFIX}/etc/ossec.conf
  else
@@ -91,7 +92,7 @@
  endif
  endif
  
-@@ -1377,8 +1405,9 @@
+@@ -1377,8 +1406,9 @@
  	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
  	cd ${EXTERNAL_LUA} && ${MAKE} clean
  

--- a/debs/wazuh-agent/debian/patches/SourceToDeb
+++ b/debs/wazuh-agent/debian/patches/SourceToDeb
@@ -1,5 +1,5 @@
---- wazuh-agent-2.1.0.orig/src/Makefile
-+++ wazuh-agent-2.1.0/src/Makefile
+--- wazuh-agent-2.1.1.orig/src/Makefile
++++ wazuh-agent-2.1.1/src/Makefile
 @@ -2,6 +2,9 @@
  
  uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
@@ -19,7 +19,7 @@
  PG_CONFIG?=pg_config
  MY_CONFIG?=mysql_config
  PRELUDE_CONFIG?=libprelude-config
-@@ -36,7 +39,7 @@
+@@ -37,7 +40,7 @@
  CLEANFULL?=no
  
  DEFINES=-DMAX_AGENTS=${MAXAGENTS} -DOSSECHIDS
@@ -28,7 +28,7 @@
  DEFINES+=-DUSER=\"${OSSEC_USER}\"
  DEFINES+=-DREMUSER=\"${OSSEC_USER_REM}\"
  DEFINES+=-DGROUPGLOBAL=\"${OSSEC_GROUP}\"
-@@ -377,9 +380,12 @@
+@@ -389,9 +392,12 @@
  install-server: install-server-generic
  
  install-common: build
@@ -42,27 +42,30 @@
  	${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs
  	${INSTALL} -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/logs/ossec
  	${INSTALL} -m 0660 -o ${OSSEC_USER} -g ${OSSEC_GROUP} /dev/null ${PREFIX}/logs/ossec.log
-@@ -412,14 +418,37 @@
+@@ -424,8 +430,19 @@
  	${INSTALL} -d -m 0750 -o root -g ${OSSEC_GROUP} ${PREFIX}/wodles/oscap/content
  
  	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/oscap.py ${PREFIX}/wodles/oscap
 -	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/template_*.xsl ${PREFIX}/wodles/oscap
 -	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/* ${PREFIX}/wodles/oscap/content
--
++
 +	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/template_oval.xsl ${PREFIX}/wodles/oscap
 +	${INSTALL} -m 0750 -o root -g ${OSSEC_GROUP} ../wodles/oscap/template_xccdf.xsl ${PREFIX}/wodles/oscap
 +ifeq (${OS},Debian)
 +	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/ssg-debian-8-ds.xml ${PREFIX}/wodles/oscap/content
 +	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/cve-debian-oval.xml ${PREFIX}/wodles/oscap/content
 +endif
++
 +ifeq (${OS},Ubuntu)
 +ifeq (${VER},16.04)
 +	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../wodles/oscap/content/ssg-ubuntu-1604-ds.xml ${PREFIX}/wodles/oscap/content
 +endif
 +endif
- 	${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/etc
- 	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} /etc/localtime ${PREFIX}/etc
  
+ 	${INSTALL} -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/etc
+ ifneq (,$(wildcard /etc/localtime))
+@@ -433,6 +450,21 @@
+ endif
  	${INSTALL} -d -m 1750 -o root -g ${OSSEC_GROUP} ${PREFIX}/tmp
  
 +	install -d -m 1750 -o root -g ${OSSEC_GROUP} ${PREFIX}/tmp/src/init
@@ -83,7 +86,7 @@
  ifneq (,$(wildcard /etc/TIMEZONE))
  	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} /etc/TIMEZONE ${PREFIX}/etc/
  endif
-@@ -443,7 +472,7 @@
+@@ -456,7 +488,7 @@
  ifneq (,$(wildcard ../etc/ossec.mc))
  	${INSTALL} -m 0640 -o root -g ${OSSEC_GROUP} ../etc/ossec.mc ${PREFIX}/etc/ossec.conf
  else
@@ -92,7 +95,7 @@
  endif
  endif
  
-@@ -1377,8 +1406,9 @@
+@@ -1391,8 +1423,9 @@
  	rm -f ${EXTERNAL_ZLIB}/Makefile ${EXTERNAL_ZLIB}/zconf.h
  	cd ${EXTERNAL_LUA} && ${MAKE} clean
  


### PR DESCRIPTION
The wazuh-agent package currently fails to upgrade from ossec-hids-agent
(and possibly others) because the "replace_manager_ip.sh" script is
missing from the /var/ossec/tmp/src/init directory. The Debian postinst
script attempts to call it but it's not there, so the postinst script
exits with an error status.