### PR TITLE
20180625 jhowe Fix postinstall/config for package upgrades

### DIFF
--- a/debs/wazuh-agent/debian/postinst
+++ b/debs/wazuh-agent/debian/postinst
@@ -106,7 +106,7 @@ case "$1" in
     fi
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
-        rm -rr ${WAZUH_TMP_DIR}
+        rm -rf ${WAZUH_TMP_DIR}
     fi
 
     if [ -d /usr/share/wazuh-agent ]; then


### PR DESCRIPTION
Related to Issue #16 Ubuntu deb package broken with nonexec /tmp

## Description

There is an malformed option for rm in the debian package for wazuh-agent. This causes unattended-updates to fail, as well as installing from apt-get || dselect leaves package in unconfigured state.

## References

**Related issue**:      16
**Related PR**:          None
**Branch**:                 None
**Documentation**:   None

# Unit tests

Do a fresh install of wazuh-agent 3.3.0 ( stretch Debian 9 )
Run dselect and update to wazuh-agent 3.3.1
dselect run fails on post-install configure process

Work around

exit dselect
rm -rf /tmp/wazuh-agent
rerun dselect and run install/configure


- [ ] Test...

