### PR TITLE
Fix purge option for wazuh-manager and wazuh-agent packages

### DIFF
--- a/debs/SPECS/3.6.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.6.0/wazuh-agent/debian/postrm
@@ -7,6 +7,8 @@ WAZUH_TMP_DIR="/tmp/wazuh-agent"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    action="$1"
+    
 	if getent passwd | grep -q "^ossec" ; then
 		deluser ossec > /dev/null 2>&1
 	fi
@@ -27,7 +29,7 @@ case "$1" in
 
 	update-rc.d -f wazuh-agent remove
 
-    if [ -d /run/systemd/system ]; then
+    if [ -d /run/systemd/system ] && [ "$action" != "purge" ]; then
         systemctl disable wazuh-agent > /dev/null 2>&1
         systemctl daemon-reload
         systemctl reset-failed

--- a/debs/SPECS/3.6.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.6.0/wazuh-manager/debian/postrm
@@ -7,7 +7,7 @@ WAZUH_TMP_DIR="/tmp/wazuh-manager"
 
 case "$1" in
     purge|remove|failed-upgrade|abort-install|abort-upgrade|disappear)
-
+    action="$1"
 
     # Fix for forcing the stop of the api
     if ps aux | grep ${DIR}/api/app.js | grep -v grep; then
@@ -41,7 +41,7 @@ case "$1" in
 
 	update-rc.d -f wazuh-manager remove
 
-    if [ -d /run/systemd/system ]; then
+    if [ -d /run/systemd/system ] && [ "$action" != "purge" ]; then
         systemctl disable wazuh-manager > /dev/null 2>&1
         systemctl daemon-reload
         systemctl reset-failed


### PR DESCRIPTION
Hi team,

this PR solves #40. The `remove` option works fine but when you execute `apt-get purge wazuh-*****` in a Debian based OS with `systemd`, the purge option will fail.

This problem was caused by these lines: https://github.com/wazuh/wazuh-packages/blob/dfb98f72ddf32eae18f1ee879d6f2f191b674ffe/debs/SPECS/3.6.0/wazuh-manager/debian/postrm#L44-L48

Now it works fine.

Regards,
Braulio.