### PR TITLE
3.6.1 Debian specs: Prevent ossec.conf and client.keys overwrites.

### DIFF
--- a/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
@@ -12,8 +12,7 @@ case "$1" in
     DIR="/var/ossec"
     USER="ossec"
     GROUP="ossec"
-    OLD_TMP_DIR="/tmp/wazuh-agent"
-    WAZUH_TMP_DIR="${DIR}/tmp/wazuh-agent"
+    WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
     SCRIPTS_DIR="/usr/share/wazuh-agent/scripts/tmp"
 
     OSMYSHELL="/sbin/nologin"

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
@@ -109,6 +109,12 @@ case "$1" in
         fi
         update-rc.d wazuh-agent defaults > /dev/null 2>&1
     fi
+
+    # Delete tmp directory
+    if [ -d ${WAZUH_TMP_DIR} ]; then
+        rm -rf ${WAZUH_TMP_DIR}
+    fi
+
     if cat ${DIR}/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
       service wazuh-agent restart || :
     fi
@@ -117,10 +123,6 @@ case "$1" in
     fi
     if cat ${DIR}/etc/ossec.conf | grep -o -P '(?<=<address>)(?!MANAGER_IP).*(?=</address>)' > /dev/null 2>&1; then
       service wazuh-agent restart || :
-    fi
-    # Delete tmp directory
-    if [ -d ${WAZUH_TMP_DIR} ]; then
-        rm -rf ${WAZUH_TMP_DIR}
     fi
 
     if [ -d /usr/share/wazuh-agent ]; then

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/postinst
@@ -12,7 +12,8 @@ case "$1" in
     DIR="/var/ossec"
     USER="ossec"
     GROUP="ossec"
-    WAZUH_TMP_DIR="/tmp/wazuh-agent"
+    OLD_TMP_DIR="/tmp/wazuh-agent"
+    WAZUH_TMP_DIR="${DIR}/tmp/wazuh-agent"
     SCRIPTS_DIR="/usr/share/wazuh-agent/scripts/tmp"
 
     OSMYSHELL="/sbin/nologin"

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/postrm
@@ -3,7 +3,6 @@
 # Wazuh, Inc 2016
 
 set -e
-WAZUH_TMP_DIR="/tmp/wazuh-agent"
 
 case "$1" in
     purge|remove|failed-upgrade|abort-install|abort-upgrade|disappear)
@@ -21,10 +20,6 @@ case "$1" in
 
     if [ -f /etc/ossec-init.conf ]; then
         rm -f /etc/ossec-init.conf
-    fi
-
-    if [ -d ${WAZUH_TMP_DIR} ]; then
-        rm -rf ${WAZUH_TMP_DIR}
     fi
 
 	update-rc.d -f wazuh-agent remove

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/postrm
@@ -6,7 +6,7 @@ set -e
 WAZUH_TMP_DIR="/tmp/wazuh-agent"
 
 case "$1" in
-    purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    purge|remove|failed-upgrade|abort-install|abort-upgrade|disappear)
     action="$1"
     
 	if getent passwd | grep -q "^ossec" ; then

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/preinst
@@ -5,8 +5,7 @@ set -e
 
 # configuration variables
 DIR="/var/ossec"
-OLD_WAZUH_TMP_DIR="/tmp/wazuh-agent"
-WAZUH_TMP_DIR="${DIR}/tmp/wazuh-agent"
+WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then

--- a/debs/SPECS/3.6.1/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.6.1/wazuh-agent/debian/preinst
@@ -4,8 +4,9 @@
 set -e
 
 # configuration variables
-WAZUH_TMP_DIR="/tmp/wazuh-agent"
 DIR="/var/ossec"
+OLD_WAZUH_TMP_DIR="/tmp/wazuh-agent"
+WAZUH_TMP_DIR="${DIR}/tmp/wazuh-agent"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then


### PR DESCRIPTION
Now the Debian packages are using a new temporal folder to backup configuration files when upgrading, it just doing it just a security measure to prevent overwrites.