### PR TITLE
RPM specs 3.7.0. Rename default-firewall-drop.sh to firewall-drop.sh.

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -122,6 +122,9 @@ install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh
 install -m 0640 etc/wpk_root.pem ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc
 install -m 0640 etc/internal_options* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc
 install -m 0640 etc/local_internal_options.conf ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc
+pushd src
+./init/fw-check.sh execute
+popd
 install -m 0755 active-response/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin
 install -m 0750 active-response/*.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin
 install -m 0755 active-response/firewalls/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -103,6 +103,9 @@ cp -rp  etc/templates/config/rhel/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp
 
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 install -m 0750 active-response/firewalls/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin
+pushd src
+./init/fw-check.sh execute
+popd
 install -m 0750 active-response/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin
 install -m 0750 active-response/*.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/active-response/bin
 install -m 0550 src/agentlessd/scripts/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/agentless


### PR DESCRIPTION
Problem: The script firewall-drop.sh is not present in the RPM installation package.
Fix: Copy and rename default-firewall-drop.sh to firewall-drop.sh in the SPECS for manager and agent.
