### PR TITLE
Improve RPM specs for Wazuh v3.7.0

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -319,60 +319,42 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,root)
 %doc BUGS CONFIG CONTRIBUTORS INSTALL LICENSE README.md CHANGELOG
+%{_initrddir}/*
 %attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/backup
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/aws
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/oscap
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/oscap/content
-%attr(700,root,ossec) %dir %{_localstatedir}/ossec/.ssh
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/active-response
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/active-response/bin
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/shared
-%attr(750,root,root) %dir %{_localstatedir}/ossec/lib
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/logs
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec
+%attr(750,root,ossec) %{_localstatedir}/ossec/agentless
+%dir %attr(700,root,ossec) %{_localstatedir}/ossec/.ssh
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/active-response
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/active-response/bin
+%attr(750,root,ossec) %{_localstatedir}/ossec/active-response/bin/*
+%dir %attr(750,root,root) %{_localstatedir}/ossec/bin
+%attr(750,root,root) %{_localstatedir}/ossec/bin/*
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/backup
+%dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/etc
+%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
+%attr(640,root,ossec) %{_localstatedir}/ossec/etc/internal_options*
+%attr(640,root,ossec) %{_localstatedir}/ossec/etc/localtime
+%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
+%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
+%{_localstatedir}/ossec/etc/ossec-init.conf
+%attr(640,root,ossec) %{_localstatedir}/ossec/etc/wpk_root.pem
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/etc/shared
+%attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/ossec/etc/shared/*
+%dir %attr(750,root,root) %{_localstatedir}/ossec/lib
+%attr(750,root,root) %{_localstatedir}/ossec/lib/*
+%dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/logs
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/active-responses.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/ossec
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/queue
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/agents
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/queue/ossec
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/diff
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/queue/alerts
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/rids
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/syscheck
-%attr(750,root,root) %dir %{_localstatedir}/ossec/bin
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/etc
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/var
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/incoming
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/run
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/selinux
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/wodles
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/upgrade
-%attr(750,root,ossec) %{_localstatedir}/ossec/active-response/bin/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/agentless
-%attr(750,root,root) %{_localstatedir}/ossec/bin/*
-%{_initrddir}/*
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/internal_options*
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/wpk_root.pem
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/ossec.conf
-%attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/ossec/etc/shared/*
-%{_localstatedir}/ossec/etc/ossec-init.conf
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/localtime
-%attr(750,root,root) %{_localstatedir}/ossec/lib/*
-%attr(1750,root,ossec) %dir %{_localstatedir}/ossec/tmp
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws/*
-%attr(640,root,ossec) %{_localstatedir}/ossec/var/selinux/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.py
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
-%attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
-
-#Template files
+%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/logs/ossec
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/queue
+%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/agents
+%dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/ossec
+%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/diff
+%dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/alerts
+%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/rids
+%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/syscheck
+%dir %attr(1750,root,ossec) %{_localstatedir}/ossec/tmp
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
@@ -380,6 +362,21 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/var
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/incoming
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/run
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/selinux
+%attr(640,root,ossec) %{_localstatedir}/ossec/var/selinux/*
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/upgrade
+%dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/wodles
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws
+%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws/*
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap
+%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.py
+%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
+%dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
+%attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 
 %changelog

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -195,15 +195,9 @@ if [ -d /run/systemd/system ]; then
   systemctl enable wazuh-agent > /dev/null 2>&1
 fi
 
-chmod 640 %{_sysconfdir}/ossec-init.conf
-chown root:ossec %{_sysconfdir}/ossec-init.conf
-
 rm -rf %{_localstatedir}/ossec/tmp/etc
 rm -rf %{_localstatedir}/ossec/tmp/src
 rm -f %{_localstatedir}/ossec/tmp/add_localfiles.sh
-ln -sf %{_sysconfdir}/ossec-init.conf %{_localstatedir}/ossec/etc/ossec-init.conf
-
-chown root:ossec %{_localstatedir}/ossec/etc/shared/*
 
 if [ $1 = 2 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.bck ]; then

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -346,8 +346,8 @@ rm -fr %{buildroot}
 %attr(750,root,root) %{_localstatedir}/ossec/lib/*
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/logs
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/active-responses.log
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
+%attr(660,root,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
+%attr(660,root,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/logs/ossec
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/queue
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/agents

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -140,7 +140,7 @@ fi
 if [ -f /etc/init.d/ossec ]; then
   rm /etc/init.d/ossec
 fi
-
+# Execute this if only when installing the package
 if [ $1 = 1 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.conf ]; then
     echo "====================================================================================="
@@ -150,11 +150,13 @@ if [ $1 = 1 ]; then
     mv %{_localstatedir}/ossec/etc/ossec.conf %{_localstatedir}/ossec/etc/ossec.conf.rpmorig
   fi
 fi
+# Execute this if only when upgrading the package
 if [ $1 = 2 ]; then
     cp -rp %{_localstatedir}/ossec/etc/ossec.conf %{_localstatedir}/ossec/etc/ossec.bck
 fi
-%post
 
+%post
+# If the package is being installed 
 if [ $1 = 1 ]; then
   if [ -f /etc/os-release ]; then
     sles=$(grep "\"sles" /etc/os-release)
@@ -182,17 +184,17 @@ if [ $1 = 1 ]; then
   /sbin/chkconfig --add wazuh-agent
   /sbin/chkconfig wazuh-agent on
 
+  if [ -d /run/systemd/system ]; then
+    install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-agent.service /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl stop wazuh-agent
+    systemctl enable wazuh-agent > /dev/null 2>&1
+  fi
+
 fi
 
 if [ ! -d /run/systemd/system ]; then
   update-rc.d wazuh-agent defaults > /dev/null 2>&1
-fi
-
-if [ -d /run/systemd/system ]; then
-  install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-agent.service /etc/systemd/system/
-  systemctl daemon-reload
-  systemctl stop wazuh-agent
-  systemctl enable wazuh-agent > /dev/null 2>&1
 fi
 
 rm -rf %{_localstatedir}/ossec/tmp/etc

--- a/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
@@ -73,7 +73,6 @@ fi
 
 if [ $1 = 1 ]; then
   %{_localstatedir}/ossec/api/scripts/install_daemon.sh
-  echo "Don’t forget to secure the API configuration by running the script %{_localstatedir}/ossec/api/scripts/configure_api.sh"
 fi
 
 API_PATH="${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api"

--- a/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
@@ -15,7 +15,7 @@ Requires(preun):  /sbin/chkconfig /sbin/service
 Requires(postun): /sbin/service
 
 Requires: nodejs >= 4.6
-Requires: wazuh-manager >= 3.6.1
+Requires: wazuh-manager >= 3.7.0
 BuildRequires: nodejs >= 4.6
 ExclusiveOS: linux
 
@@ -26,37 +26,28 @@ from your own application or with a simple web browser or tools like cURL
 %prep
 %setup -q
 
+# Install nodejs dependencies
 npm install --production
+# Create the ossec user 
+groupadd ossec
+useradd ossec -g ossec
 
 %install
 # Clean BUILDROOT
 rm -fr %{buildroot}
 
+# Create the directories needed to install the wazuh-api
+mkdir -p %{_localstatedir}/ossec/{framework,logs}
+echo 'DIRECTORY="%{_localstatedir}/ossec"' > /etc/ossec-init.conf
+# Install the wazuh-api
+./install_api.sh
+# Remove the framework directory
+rmdir %{_localstatedir}/ossec/framework
+
+# Add the files for the package
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
-#Folders
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/{configuration,controllers,examples,helpers,models,scripts}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/configuration/{auth,ssl}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/node_modules
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/logs/api
-#Files
-install -m 0400 package.json ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api
-install -m 0500 app.js ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api
-install -m 0500 configuration/config.js ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/configuration
-install -m 0500 configuration/preloaded_vars.conf ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/configuration
-install -m 0660 configuration/auth/user  ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/configuration/auth
-install -m 0500 controllers/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/controllers
-install -m 0500 examples/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/examples
-install -m 0500 helpers/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/helpers
-install -m 0500 models/*  ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/models
-install -m 0500 scripts/bump_version.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/scripts
-install -m 0500 scripts/configure_api.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/scripts
-install -m 0500 scripts/install_daemon.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/scripts
-install -m 0400 scripts/wazuh-api ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/scripts
-install -m 0400 scripts/wazuh-api.service  ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/scripts
-
-cp -r node_modules/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/api/node_modules/
-
+cp -pr %{_localstatedir}/ossec/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/
 cp CHANGELOG.md CHANGELOG
 
 exit 0
@@ -92,16 +83,6 @@ if [ -d ${API_PATH_BACKUP} ]; then
   cp -rfnp ${API_PATH_BACKUP}/configuration ${API_PATH_BACKUP_BACKUP}/configuration
   rm -rf ${API_PATH_BACKUP}
 fi
-
-touch %{_localstatedir}/ossec/logs/api.log
-chmod 660 %{_localstatedir}/ossec/logs/api.log
-chown root:ossec %{_localstatedir}/ossec/logs/api.log
-chmod 740 %{_localstatedir}/ossec/api/configuration/config.js
-chown root:ossec %{_localstatedir}/ossec/api/configuration/config.js
-
-ln -sf %{_localstatedir}/ossec/api/node_modules/htpasswd/bin/htpasswd %{_localstatedir}/ossec/api/configuration/auth/htpasswd
-
-sed -i "s:config.ossec_path =.*:config.ossec_path = \"%{_localstatedir}/ossec\";:g" "%{_localstatedir}/ossec/api/configuration/config.js"
 
 #veriy python version
 if python -V >/dev/null 2>&1; then
@@ -143,31 +124,35 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,root)
 %doc CHANGELOG
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api
-%attr(750,root,ossec) %config(noreplace) %dir %{_localstatedir}/ossec/api/configuration
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api/controllers
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api/examples
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api/helpers
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api/models
-%attr(750,root,root) %dir %{_localstatedir}/ossec/api/scripts
-%attr(750,root,root) %config(noreplace) %dir %{_localstatedir}/ossec/api/configuration/auth
-%attr(750,root,root) %config(noreplace) %dir %{_localstatedir}/ossec/api/configuration/ssl
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/api/node_modules
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/api
-
-%attr(640,root,ossec) %{_localstatedir}/ossec/api/package.json
-%attr(750,root,ossec) %{_localstatedir}/ossec/api/app.js
-%attr(740,root,ossec) %config(noreplace) %{_localstatedir}/ossec/api/configuration/config.js
-%attr(750,root,root) %{_localstatedir}/ossec/api/configuration/preloaded_vars.conf
-%attr(660,root,root) %config(noreplace) %{_localstatedir}/ossec/api/configuration/auth/user
-%attr(750,root,ossec) %{_localstatedir}/ossec/api/controllers/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/api/examples/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/api/helpers/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/api/models/*
-%attr(750,root,root) %{_localstatedir}/ossec/api/scripts/*.sh
-%attr(640,root,root) %{_localstatedir}/ossec/api/scripts/wazuh-api
-%attr(640,root,root) %{_localstatedir}/ossec/api/scripts/wazuh-api.service
-%attr(750,ossec,ossec) %{_localstatedir}/ossec/api/node_modules/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api
+%attr(750, root, ossec) %{_localstatedir}/ossec/api/app.js
+%attr(640, root, ossec) %{_localstatedir}/ossec/api/package.json
+%attr(644, root, root) %{_localstatedir}/ossec/api/package-lock.json
+%dir %attr(750, root, ossec) %config(noreplace) %{_localstatedir}/ossec/api/configuration
+%attr(740, root, ossec) %config(noreplace) %{_localstatedir}/ossec/api/configuration/config.js
+%attr(750, root, root) %{_localstatedir}/ossec/api/configuration/preloaded_vars.conf
+%dir %attr(750, root, root) %config(noreplace) %{_localstatedir}/ossec/api/configuration/auth
+%{_localstatedir}/ossec/api/configuration/auth/htpasswd
+%attr(660, root, root) %config(noreplace) %{_localstatedir}/ossec/api/configuration/auth/user
+%dir %attr(750, root, root) %config(noreplace) %{_localstatedir}/ossec/api/configuration/ssl
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/controllers
+%attr(750, root, ossec) %{_localstatedir}/ossec/api/controllers/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/examples
+%attr(750, root, ossec) %{_localstatedir}/ossec/api/examples/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/helpers
+%attr(750, root, ossec) %{_localstatedir}/ossec/api/helpers/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/models
+%attr(750, root, ossec) %{_localstatedir}/ossec/api/models/*
+%dir %attr(750, root, root) %{_localstatedir}/ossec/api/scripts
+%attr(750, root, root) %{_localstatedir}/ossec/api/scripts/*.sh
+%attr(640, root, root) %{_localstatedir}/ossec/api/scripts/wazuh-api
+%attr(640, root, root) %{_localstatedir}/ossec/api/scripts/wazuh-api.service
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/node_modules
+%attr(750, ossec, ossec) %{_localstatedir}/ossec/api/node_modules/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/api/node_modules/.bin
+%{_localstatedir}/ossec/api/node_modules/.bin/*
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/api
+%attr(660, ossec, ossec) %ghost %{_localstatedir}/ossec/logs/api.log
 
 %changelog
 * Fri Sep 7 2018 support <info@wazuh.com> - 3.7.0

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -458,8 +458,8 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/cluster_control
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/wazuh-clusterd
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc
-%attr(640, root, ossec)  %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
-%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
+%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
+%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
 %attr(640, root, ossec)  %{_localstatedir}/ossec/etc/internal_options*
 %attr(640, root, ossec)  %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
 %{_localstatedir}/ossec/etc/ossec-init.conf

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -181,6 +181,7 @@ rm -f %{_localstatedir}/ossec/queue/db/.template.db
 if [ -f /etc/init.d/ossec ]; then
   rm /etc/init.d/ossec
 fi
+# Execute this if only when installing the package
 if [ $1 = 1 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.conf ]; then
     echo "====================================================================================="
@@ -190,6 +191,7 @@ if [ $1 = 1 ]; then
     mv %{_localstatedir}/ossec/etc/ossec.conf %{_localstatedir}/ossec/etc/ossec.conf.rpmorig
   fi
 fi
+# Execute this if only when upgrading the package
 if [ $1 = 2 ]; then
     cp -rp %{_localstatedir}/ossec/etc/ossec.conf %{_localstatedir}/ossec/etc/ossec.bck
     cp -rp %{_localstatedir}/ossec/etc/shared %{_localstatedir}/ossec/backup/
@@ -202,6 +204,7 @@ if [ $1 = 2 ]; then
 fi
 %post
 
+# If the package is being installed 
 if [ $1 = 1 ]; then
   # Generating osse.conf file
   . %{_localstatedir}/ossec/tmp/src/init/dist-detect.sh
@@ -276,6 +279,14 @@ if [ $1 = 1 ]; then
    /sbin/chkconfig --add wazuh-manager
    /sbin/chkconfig wazuh-manager on
 
+  # If systemd is installed, add the wazuh-manager.service file to systemd files directory
+  if [ -d /run/systemd/system ]; then
+    install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-manager.service /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl stop wazuh-manager
+    systemctl enable wazuh-manager > /dev/null 2>&1
+  fi
+  
 fi
 
 if [ -f "%{_localstatedir}/ossec/etc/shared/agent.conf" ]; then
@@ -309,14 +320,6 @@ fi
 # Agent info change between 2.1.1 and 3.0.0
 chmod 0660 %{_localstatedir}/ossec/queue/agent-info/* 2>/dev/null || true
 chown ossecr:ossec %{_localstatedir}/ossec/queue/agent-info/* 2>/dev/null || true
-
-# If systemd is installed, add the wazuh-manager.service file to systemd files directory
-if [ -d /run/systemd/system ]; then
-  install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-manager.service /etc/systemd/system/
-  systemctl daemon-reload
-  systemctl stop wazuh-manager
-  systemctl enable wazuh-manager > /dev/null 2>&1
-fi
 
 # The check for SELinux is not executed in the legacy OS.
 add_selinux="yes"
@@ -527,10 +530,19 @@ rm -fr %{buildroot}
 %dir %attr(1750, root, ossec) %{_localstatedir}/ossec/tmp
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/var
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -128,6 +128,8 @@ cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/systemd
 
+rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc/sslmanager*
+
 exit 0
 %pre
 
@@ -460,10 +462,9 @@ rm -fr %{buildroot}
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
-%attr(640, root, ossec)  %{_localstatedir}/ossec/etc/internal_options*
-%attr(640, root, ossec)  %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
+%attr(640, root, ossec) %{_localstatedir}/ossec/etc/internal_options*
+%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
 %{_localstatedir}/ossec/etc/ossec-init.conf
-%attr(640, root, root) %config(noreplace) %{_localstatedir}/ossec/etc/sslmanager*
 %attr(640, root, ossec) %{_localstatedir}/ossec/etc/localtime
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/decoders
 %attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/decoders/local_decoder.xml

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -177,11 +177,6 @@ rm -f %{_localstatedir}/ossec/var/db/agents/* || true
 rm -f %{_localstatedir}/ossec/queue/db/*.db*
 rm -f %{_localstatedir}/ossec/queue/db/.template.db
 
-# Backup /etc/shared/default/agent.conf file
-if [ -f %{_localstatedir}/ossec/etc/shared/default/agent.conf ]; then
-  cp -p %{_localstatedir}/ossec/etc/shared/default/agent.conf %{_localstatedir}/ossec/tmp/agent.conf
-fi
-
 # Delete old service
 if [ -f /etc/init.d/ossec ]; then
   rm /etc/init.d/ossec
@@ -281,14 +276,6 @@ if [ $1 = 1 ]; then
    /sbin/chkconfig --add wazuh-manager
    /sbin/chkconfig wazuh-manager on
 
-fi
-
-# Restore the agent.conf
-if [ -f %{_localstatedir}/ossec/tmp/agent.conf ]; then
-  cp -rp %{_localstatedir}/ossec/tmp/agent.conf %{_localstatedir}/ossec/etc/shared/default/agent.conf
-  rm %{_localstatedir}/ossec/tmp/agent.conf
-  chown ossec:ossec %{_localstatedir}/ossec/etc/shared/default/agent.conf
-  chmod 660 %{_localstatedir}/ossec/etc/shared/default/agent.conf
 fi
 
 if [ -f "%{_localstatedir}/ossec/etc/shared/agent.conf" ]; then

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -426,10 +426,6 @@ fi
 
 # If the package is been uninstalled
 if [ $1 == 0 ];then
-  # Remove the ossec user if it exists
-  if id -u ossec > /dev/null 2>&1; then
-    userdel ossec
-  fi
   # Remove the ossecr user if it exists
   if id -u ossecr > /dev/null 2>&1; then
     userdel ossecr
@@ -437,6 +433,10 @@ if [ $1 == 0 ];then
   # Remove the ossecm user if it exists
   if id -u ossecm > /dev/null 2>&1; then
     userdel ossecm
+  fi
+  # Remove the ossec user if it exists
+  if id -u ossec > /dev/null 2>&1; then
+    userdel ossec
   fi
   # Remove the ossec group if it exists
   if id -g ossec > /dev/null 2>&1; then

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -420,7 +420,6 @@ if [ $1 = 0 ]; then
     fi
   fi
 
-  rm -f %{_localstatedir}/ossec/etc/localtime || :
 fi
 
 %postun

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -552,6 +552,8 @@ rm -fr %{buildroot}
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/aws
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/aws/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/azure
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/azure/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.*
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/template*  

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -548,6 +548,7 @@ rm -fr %{buildroot}
 %attr(660,ossecm,ossec) %ghost %{_localstatedir}/ossec/logs/integrations.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
+%attr(600,root,ossec) %ghost %{_localstatedir}/ossec/queue/agents-timestamp
 %attr(660,root,ossec) %{_localstatedir}/ossec/etc/rootcheck/*.txt
 %attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/VERSION
 %attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/rules/*

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -456,115 +456,116 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,root)
 %doc BUGS CONFIG CONTRIBUTORS INSTALL LICENSE README.md CHANGELOG
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/active-response
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/active-response/bin
-%attr(750,root,ossec) %{_localstatedir}/ossec/agentless
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/backup
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/backup/agents
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/backup/groups
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/backup/shared
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/bin
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/etc
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/decoders
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/lists
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/etc/lists/amazon
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/shared
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/etc/shared/default
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/rootcheck
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/etc/rules
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/framework
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/framework/lib
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/framework/wazuh
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/framework/wazuh/cluster
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/integrations
-%attr(750,root,root) %dir %{_localstatedir}/ossec/lib
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/logs
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/archives
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/alerts
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/cluster
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/firewall
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/logs/ossec
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/queue
-%attr(770,ossecr,ossec) %dir %{_localstatedir}/ossec/queue/agent-info
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/queue/agent-groups
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/agentless
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/agents
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/queue/alerts
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/queue/cluster
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/db
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/diff
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/fts
-%attr(770,ossecr,ossec) %dir %{_localstatedir}/ossec/queue/rids
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/rootcheck
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/queue/syscheck
-%attr(770,ossec,ossec) %dir %{_localstatedir}/ossec/queue/ossec
-%attr(760,root,ossec) %dir %{_localstatedir}/ossec/queue/vulnerabilities
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/ruleset
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/ruleset/decoders
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/ruleset/rules
-%attr(700,root,ossec) %dir %{_localstatedir}/ossec/.ssh
-%attr(750,ossec,ossec) %dir %{_localstatedir}/ossec/stats
-%attr(1750,root,ossec) %dir %{_localstatedir}/ossec/tmp
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/var
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/db
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/db/agents
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/download
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/multigroups
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/run
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/selinux
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/upgrade
-%attr(770,root,ossec) %dir %{_localstatedir}/ossec/var/wodles
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/aws
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/oscap
-%attr(750,root,ossec) %dir %{_localstatedir}/ossec/wodles/oscap/content
-%attr(640,root,ossec) %{_localstatedir}/ossec/framework/lib/*
-%attr(640,root,ossec) %{_localstatedir}/ossec/framework/wazuh/*.py
-%attr(640,root,ossec) %{_localstatedir}/ossec/framework/wazuh/cluster/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/integrations/*
-%attr(750,root,root) %{_localstatedir}/ossec/bin/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/bin/agent_groups
-%attr(750,root,ossec) %{_localstatedir}/ossec/bin/agent_upgrade
-%attr(750,root,ossec) %{_localstatedir}/ossec/bin/cluster_control
-%attr(750,root,ossec) %{_localstatedir}/ossec/bin/wazuh-clusterd
-%{_initrddir}/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/active-response/bin/*
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
-%attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/decoders/local_decoder.xml
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/internal_options*
-%attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
+%attr(640, root, ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec
+%attr(750, root, ossec) %{_localstatedir}/ossec/agentless
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/active-response
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/active-response/bin
+%attr(750, root, ossec) %{_localstatedir}/ossec/active-response/bin/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/backup
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/backup/agents
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/backup/groups
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/backup/shared
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/bin
+%attr(750, root, root) %{_localstatedir}/ossec/bin/*
+%attr(750, root, ossec) %{_localstatedir}/ossec/bin/agent_groups
+%attr(750, root, ossec) %{_localstatedir}/ossec/bin/agent_upgrade
+%attr(750, root, ossec) %{_localstatedir}/ossec/bin/cluster_control
+%attr(750, root, ossec) %{_localstatedir}/ossec/bin/wazuh-clusterd
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc
+%attr(640, root, ossec)  %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
+%attr(640, root, ossec)  %{_localstatedir}/ossec/etc/internal_options*
+%attr(640, root, ossec)  %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
 %{_localstatedir}/ossec/etc/ossec-init.conf
-%attr(640,root,root) %config(noreplace) %{_localstatedir}/ossec/etc/sslmanager*
-%attr(640,root,ossec) %{_localstatedir}/ossec/etc/localtime
-%attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/rules/local_rules.xml
-%attr(660,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/shared/default/*
-%attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-*
-%attr(660,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/amazon/*
-%attr(750,root,root) %{_localstatedir}/ossec/lib/*
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/active-responses.log
-%attr(660,ossecm,ossec) %ghost %{_localstatedir}/ossec/logs/integrations.log
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
-%attr(600,root,ossec) %ghost %{_localstatedir}/ossec/queue/agents-timestamp
-%attr(660,root,ossec) %{_localstatedir}/ossec/etc/rootcheck/*.txt
-%attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/VERSION
-%attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/rules/*
-%attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/decoders/*
-%attr(640,root,ossec) %{_localstatedir}/ossec/var/selinux/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws/*
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.*
-%attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
-%attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
+%attr(640, root, root) %config(noreplace) %{_localstatedir}/ossec/etc/sslmanager*
+%attr(640, root, ossec) %{_localstatedir}/ossec/etc/localtime
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/decoders
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/decoders/local_decoder.xml
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/lists
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-*
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/amazon
+%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/amazon/*
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/shared
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/shared/default
+%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/shared/default/*
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/rootcheck
+%attr(660, root, ossec) %{_localstatedir}/ossec/etc/rootcheck/*.txt
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/rules
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/rules/local_rules.xml
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/framework
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/framework/lib
+%attr(640, root, ossec) %{_localstatedir}/ossec/framework/lib/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/framework/wazuh
+%attr(640, root, ossec) %{_localstatedir}/ossec/framework/wazuh/*.py
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/framework/wazuh/cluster
+%attr(640, root, ossec) %{_localstatedir}/ossec/framework/wazuh/cluster/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/integrations
+%attr(750, root, ossec) %{_localstatedir}/ossec/integrations/*
+%dir %attr(750, root, root) %{_localstatedir}/ossec/lib
+%attr(750, root, root) %{_localstatedir}/ossec/lib/*
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/logs
+%attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/active-responses.log
+%attr(660, ossecm, ossec) %ghost %{_localstatedir}/ossec/logs/integrations.log
+%attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/ossec.log
+%attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/ossec.json
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/archives
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/alerts
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/cluster
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/firewall
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/ossec
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/queue
+%attr(600, root, ossec) %ghost %{_localstatedir}/ossec/queue/agents-timestamp
+%dir %attr(770, ossecr, ossec) %{_localstatedir}/ossec/queue/agent-info
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/queue/agent-groups
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/agentless
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/agents
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/alerts
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/cluster
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/db
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/diff
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/fts
+%dir %attr(770, ossecr, ossec) %{_localstatedir}/ossec/queue/rids
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/rootcheck
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/syscheck
+%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/ossec
+%dir %attr(760, root, ossec) %{_localstatedir}/ossec/queue/vulnerabilities
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset
+%attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/VERSION
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/decoders
+%attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/decoders/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/rules
+%attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/rules/*
+%dir %attr(700, root, ossec) %{_localstatedir}/ossec/.ssh
+%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/stats
+%dir %attr(1750, root, ossec) %{_localstatedir}/ossec/tmp
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/var
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db/agents
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/download
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/multigroups
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/run
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/selinux
+%attr(640, root, ossec) %{_localstatedir}/ossec/var/selinux/*
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/upgrade
+%dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/wodles
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/aws
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/aws/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.*
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/template*  
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content
+%attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
+
+%{_initrddir}/*
 
 %changelog
 * Fri Sep 7 2018 support <info@wazuh.com> - 3.7.0

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -454,11 +454,38 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/backup/groups
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/backup/shared
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/bin
-%attr(750, root, root) %{_localstatedir}/ossec/bin/*
+%attr(750, root, root) %{_localstatedir}/ossec/bin/agent_control
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/agent_groups
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/agent_upgrade
+%attr(750, root, root) %{_localstatedir}/ossec/bin/clear_stats
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/cluster_control
+%attr(750, root, root) %{_localstatedir}/ossec/bin/manage_agents
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-agentlessd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-analysisd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-authd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-control
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-csyslogd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-dbd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-execd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-integratord
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-logcollector
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-logtest
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-maild
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-makelists
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-monitord
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-regex
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-remoted
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-reportd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/ossec-syscheckd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/rootcheck_control
+%attr(750, root, root) %{_localstatedir}/ossec/bin/syscheck_control
+%attr(750, root, root) %{_localstatedir}/ossec/bin/syscheck_update
+%attr(750, root, root) %{_localstatedir}/ossec/bin/update_ruleset
+%attr(750, root, root) %{_localstatedir}/ossec/bin/util.sh
+%attr(750, root, root) %{_localstatedir}/ossec/bin/verify-agent-conf
 %attr(750, root, ossec) %{_localstatedir}/ossec/bin/wazuh-clusterd
+%attr(750, root, root) %{_localstatedir}/ossec/bin/wazuh-db
+%attr(750, root, root) %{_localstatedir}/ossec/bin/wazuh-modulesd
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
@@ -528,7 +555,11 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/LOCATION
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/REVISION
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/VERSION
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/init/
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/init/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/
 %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -269,9 +269,10 @@ if [ $1 = 1 ]; then
     fi
   fi
 
-  touch %{_localstatedir}/ossec/logs/active-responses.log
-  chown ossec:ossec %{_localstatedir}/ossec/logs/active-responses.log
-  chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log
+  touch %{_localstatedir}/ossec/logs/active-responses.log %{_localstatedir}/ossec/logs/integrations.log
+  chown ossec:ossec %{_localstatedir}/ossec/logs/active-responses.log 
+  chown ossecm:ossec %{_localstatedir}/ossec/logs/integrations.log
+  chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log %{_localstatedir}/ossec/logs/integrations.log
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/ossec/tmp/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
@@ -396,7 +397,7 @@ if [ $1 = 0 ]; then
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
-      if [ $(getenforce) !=  "Disabled" ]; then
+      if [ $(getenforce) != "Disabled" ]; then
         if (semodule -l | grep wazuh > /dev/null); then
           semodule -r wazuh
         fi
@@ -490,8 +491,8 @@ rm -fr %{buildroot}
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/logs
 %attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/active-responses.log
 %attr(660, ossecm, ossec) %ghost %{_localstatedir}/ossec/logs/integrations.log
-%attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/ossec.log
-%attr(660, ossec, ossec)  %ghost %{_localstatedir}/ossec/logs/ossec.json
+%attr(660, ossec, ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
+%attr(660, ossec, ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/archives
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/alerts
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/cluster

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -206,12 +206,11 @@ fi
 
 # If the package is being installed 
 if [ $1 = 1 ]; then
-  # Generating osse.conf file
+  # Generating ossec.conf file
   . %{_localstatedir}/ossec/tmp/src/init/dist-detect.sh
   %{_localstatedir}/ossec/tmp/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
   chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
   chmod 0640 %{_localstatedir}/ossec/etc/ossec.conf
-
 
   ETC_DECODERS="%{_localstatedir}/ossec/etc/decoders"
   ETC_RULES="%{_localstatedir}/ossec/etc/rules"
@@ -286,7 +285,7 @@ if [ $1 = 1 ]; then
     systemctl stop wazuh-manager
     systemctl enable wazuh-manager > /dev/null 2>&1
   fi
-  
+
 fi
 
 if [ -f "%{_localstatedir}/ossec/etc/shared/agent.conf" ]; then
@@ -305,11 +304,6 @@ fi
 
 rm %{_localstatedir}/ossec/etc/shared/ar.conf  >/dev/null 2>&1 || true
 rm %{_localstatedir}/ossec/etc/shared/merged.mg  >/dev/null 2>&1 || true
-
-ln -sf %{_sysconfdir}/ossec-init.conf %{_localstatedir}/ossec/etc/ossec-init.conf
-
-chmod 640 %{_sysconfdir}/ossec-init.conf
-chown root:ossec %{_sysconfdir}/ossec-init.conf
 
 if [ $1 = 2 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.bck ]; then

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -269,7 +269,8 @@ if [ $1 = 1 ]; then
     fi
   fi
 
-  touch %{_localstatedir}/ossec/logs/active-responses.log %{_localstatedir}/ossec/logs/integrations.log
+  touch %{_localstatedir}/ossec/logs/active-responses.log 
+  touch %{_localstatedir}/ossec/logs/integrations.log
   chown ossec:ossec %{_localstatedir}/ossec/logs/active-responses.log 
   chown ossecm:ossec %{_localstatedir}/ossec/logs/integrations.log
   chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log %{_localstatedir}/ossec/logs/integrations.log

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -534,7 +534,7 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/ossec.conf
 %attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/decoders/local_decoder.xml
 %attr(640,root,ossec) %{_localstatedir}/ossec/etc/internal_options*
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
+%attr(640,ossec,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/client.keys
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/ossec/etc/local_internal_options.conf
 %{_localstatedir}/ossec/etc/ossec-init.conf
 %attr(640,root,root) %config(noreplace) %{_localstatedir}/ossec/etc/sslmanager*
@@ -548,7 +548,6 @@ rm -fr %{buildroot}
 %attr(660,ossecm,ossec) %ghost %{_localstatedir}/ossec/logs/integrations.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
 %attr(660,ossec,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
-%attr(600,ossec,ossec) %config(missingok) %{_localstatedir}/ossec/queue/agents-timestamp
 %attr(660,root,ossec) %{_localstatedir}/ossec/etc/rootcheck/*.txt
 %attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/VERSION
 %attr(640,root,ossec) %{_localstatedir}/ossec/ruleset/rules/*

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -272,6 +272,10 @@ if [ $1 = 1 ]; then
     fi
   fi
 
+  touch %{_localstatedir}/ossec/logs/active-responses.log
+  chown ossec:ossec %{_localstatedir}/ossec/logs/active-responses.log
+  chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log
+
   # Add default local_files to ossec.conf
   %{_localstatedir}/ossec/tmp/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
    /sbin/chkconfig --add wazuh-manager


### PR DESCRIPTION
Hi team,

in this PR I made several improvements to the RPM specs of Wazuh (issue #21). Those improvements are:
- Use the `install.sh` script to build the packages.
- Remove all the files from `/tmp` and `/usr/share/wazuh-****`. Now all the files are stored inside of `/var/ossec` directory.
- Remove unnecessary lines from the RPM specs.
- Improved the %file section for each spec.

Best regards,
Braulio.