### PR TITLE
Avoid errors uninstalling the package when /var/ossec/etc is missing

### DIFF
--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
@@ -41,8 +41,12 @@ case "$1" in
         mkdir -p ${DIR}/etc
     fi
 
-    mv ${DIR}/tmp/conffiles/* ${DIR}/etc
+    # If the directory is not empty, copy the files into ${DIR}/etc
+    if [ "$(ls -A ${DIR}/tmp/conffiles)" ]; then
+        mv ${DIR}/tmp/conffiles/* ${DIR}/etc
+    fi
     rm -rf ${DIR}/tmp/conffiles
+    # Rename the files
     find /var/ossec/etc/ -type f -exec mv {} {}.save \;
 
     ;;

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
@@ -46,6 +46,8 @@ case "$1" in
         mv ${DIR}/tmp/conffiles/* ${DIR}/etc
     fi
     rm -rf ${DIR}/tmp/conffiles
+    rm -rf ${DIR}/tmp
+    
     # Rename the files
     find /var/ossec/etc/ -type f -exec mv {} {}.save \;
 

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/prerm
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/prerm
@@ -33,11 +33,22 @@ case "$1" in
       
       # Save the conffiles
       mkdir -p ${DIR}/tmp/conffiles
-
-      cp -p ${DIR}/etc/client.keys ${DIR}/tmp/conffiles
-      cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
-      cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
-      cp -pr ${DIR}/etc/shared ${DIR}/tmp/conffiles
+      # Save the client.keys
+      if [ -f ${DIR}/etc/client.keys ]; then
+        cp -p ${DIR}/etc/client.keys ${DIR}/tmp/conffiles
+      fi
+      # Save the local_internal_options.conf
+      if [ -f ${DIR}/etc/local_internal_options.conf ]; then
+        cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
+      fi
+      # Save the ossec.conf
+      if [ -f ${DIR}/etc/ossec.conf ]; then
+        cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
+      fi
+      # Save the shared configuration files
+      if [ -d ${DIR}/etc/shared ]; then
+        cp -pr ${DIR}/etc/shared ${DIR}/tmp/conffiles
+      fi
 
       if [ -d ${DIR}/etc/shared/ ]; then
         rm -rf ${DIR}/etc/shared/

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
@@ -56,7 +56,11 @@ case "$1" in
         mv ${DIR}/tmp/conffiles/shared/default/agent.conf ${DIR}/etc/shared/default/agent.conf.save
     fi
     rm -rf ${DIR}/tmp/conffiles/shared/
-    cp -Rf ${DIR}/tmp/conffiles/* ${DIR}/etc
+    
+    # If the directory is not empty, copy the files into ${DIR}/etc
+    if [ "$(ls -A ${DIR}/tmp/conffiles)" ]; then
+        cp -Rf ${DIR}/tmp/conffiles/* ${DIR}/etc
+    fi
     rm -rf ${DIR}/tmp/conffiles
 
     # Rename the files

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
@@ -62,6 +62,7 @@ case "$1" in
         cp -Rf ${DIR}/tmp/conffiles/* ${DIR}/etc
     fi
     rm -rf ${DIR}/tmp/conffiles
+    rm -rf ${DIR}/tmp
 
     # Rename the files
     find /var/ossec/etc/ -type f ! -name *shared* -exec mv {} {}.save \;

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/prerm
@@ -32,17 +32,42 @@ case "$1" in
       rm -rf ${DIR}/var/*
       rm -rf ${DIR}/framework/*
       
-      # Save the conffiles
+      # Save the configuration files in ${DIR}/tmp/conffiles
       mkdir -p ${DIR}/tmp/conffiles
-
-      cp -p ${DIR}/etc/client.keys ${DIR}/tmp/conffiles
-      cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
-      cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
-      cp -pr ${DIR}/etc/decoders ${DIR}/tmp/conffiles
-      cp -pr ${DIR}/etc/lists ${DIR}/tmp/conffiles
-      cp -pr ${DIR}/etc/rules ${DIR}/tmp/conffiles
+      
+      # Save the client.keys
+      if [ -f ${DIR}/etc/client.keys ]; then
+        cp -p ${DIR}/etc/client.keys ${DIR}/tmp/conffiles
+      fi
+      # Save the local_internal_options.conf
+      if [ -f ${DIR}/etc/local_internal_options.conf ]; then
+        cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
+      fi
+      # Save the ossec.conf
+      if [ -f ${DIR}/etc/ossec.conf ]; then
+        cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
+      fi
+      # Save the local decoders
+      if [ -d ${DIR}/etc/decoders ]; then
+        cp -pr ${DIR}/etc/decoders ${DIR}/tmp/conffiles
+      fi
+      # Save the lists
+      if [ -d ${DIR}/etc/lists ]; then
+        cp -pr ${DIR}/etc/lists ${DIR}/tmp/conffiles
+      fi
+      # Save the rootcheck files
+      if [ -d ${DIR}/etc/rootcheck ]; then
+        cp -pr ${DIR}/etc/rootcheck ${DIR}/tmp/conffiles
+      fi
+      # Save the local rules
+      if [ -d ${DIR}/etc/rules ]; then
+        cp -pr ${DIR}/etc/rules ${DIR}/tmp/conffiles
+      fi
+      # Save the agent.conf from the group default
       mkdir -p ${DIR}/tmp/conffiles/shared/default
-      cp -p ${DIR}/etc/shared/default/agent.conf ${DIR}/tmp/conffiles/shared/default
+      if [ -f ${DIR}/etc/shared/default/agent.conf ]; then
+        cp -p ${DIR}/etc/shared/default/agent.conf ${DIR}/tmp/conffiles/shared/default
+      fi
       
     ;;
 


### PR DESCRIPTION
Hi team,

with the latest changes in the .deb packages to save the _conffiles_ of the package, if the `${DIR}\etc` is missing, the package will fail if you execute `apt remove wazuh-manager` or `apt remove wazuh-agent`.

This PR fix this error.

Regards,
Braulio.