### PR TITLE
Keep the content of the configuration files when downgrading from 3.7.0

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -187,7 +187,7 @@ if [ $1 = 1 ]; then
   if [ -d /run/systemd/system ]; then
     install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-agent.service /etc/systemd/system/
     systemctl daemon-reload
-    systemctl stop wazuh-agent
+    systemctl stop wazuh-agent 
     systemctl enable wazuh-agent > /dev/null 2>&1
   fi
 
@@ -235,23 +235,23 @@ elif [ ${add_selinux} == "no" ]; then
 fi
 
 if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
-   /sbin/service wazuh-agent restart || :
+   /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
 fi
 
 if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<server-hostname>).*(?=</server-hostname>)' > /dev/null 2>&1; then
-   /sbin/service wazuh-agent restart || :
+   /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
 fi
 
 if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<address>).*(?=</address>)' | grep -v 'MANAGER_IP' > /dev/null 2>&1; then
-   /sbin/service wazuh-agent restart || :
+   /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
 fi
 
 %preun
 
 if [ $1 = 0 ]; then
 
-  /sbin/service wazuh-agent stop || :
-  %{_localstatedir}/ossec/bin/ossec-control stop 2>/dev/null
+  /sbin/service wazuh-agent stop > /dev/null 2>&1 || :
+  %{_localstatedir}/ossec/bin/ossec-control stop > /dev/null 2>&1
   /sbin/chkconfig wazuh-agent off
   /sbin/chkconfig --del wazuh-agent
 
@@ -329,6 +329,18 @@ if [ $1 == 1 ]; then
       mv %{_localstatedir}/ossec/etc/ossec.conf.rpmsave %{_localstatedir}/ossec/etc/ossec.conf
       chmod 640 %{_localstatedir}/ossec/etc/ossec.conf
       chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
+    fi
+    # Restart the agent
+    if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
+      /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
+    fi
+
+    if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<server-hostname>).*(?=</server-hostname>)' > /dev/null 2>&1; then
+      /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
+    fi
+
+    if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<address>).*(?=</address>)' | grep -v 'MANAGER_IP' > /dev/null 2>&1; then
+      /sbin/service wazuh-agent restart > /dev/null 2>&1 || :
     fi
   fi
 fi

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -252,7 +252,7 @@ if [ $1 = 0 ]; then
 
   /sbin/service wazuh-agent stop > /dev/null 2>&1 || :
   %{_localstatedir}/ossec/bin/ossec-control stop > /dev/null 2>&1
-  /sbin/chkconfig wazuh-agent off
+  /sbin/chkconfig wazuh-agent off > /dev/null 2>&1
   /sbin/chkconfig --del wazuh-agent
 
   # Check if Wazuh SELinux policy is installed

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -307,6 +307,32 @@ if [ $1 == 0 ];then
   fi
 fi
 
+# If the package is been downgraded
+if [ $1 == 1 ]; then
+  # Load the ossec-init.conf file to get the current version
+  . /etc/ossec-init.conf
+
+  # Get the major and minor version
+  MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
+  MINOR=$(echo $VERSION | cut -d. -f2)
+
+  # Restore the configuration files from the .rpmsave file
+  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+    # Restore client.keys file
+    if [ -f %{_localstatedir}/ossec/etc/client.keys.rpmsave ]; then
+      mv %{_localstatedir}/ossec/etc/client.keys.rpmsave %{_localstatedir}/ossec/etc/client.keys
+      chmod 640 %{_localstatedir}/ossec/etc/client.keys
+      chown root:ossec %{_localstatedir}/ossec/etc/client.keys
+    fi
+    # Restore the ossec.conf file
+    if [ -f %{_localstatedir}/ossec/etc/ossec.conf.rpmsave ]; then
+      mv %{_localstatedir}/ossec/etc/ossec.conf.rpmsave %{_localstatedir}/ossec/etc/ossec.conf
+      chmod 640 %{_localstatedir}/ossec/etc/ossec.conf
+      chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
+    fi
+  fi
+fi
+
 
 %clean
 rm -fr %{buildroot}

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -379,7 +379,7 @@ if [ $1 = 0 ]; then
 
   /sbin/service wazuh-manager stop > /dev/null 2>&1 || :
   %{_localstatedir}/ossec/bin/ossec-control stop > /dev/null 2>&1
-  /sbin/chkconfig wazuh-manager off
+  /sbin/chkconfig wazuh-manager off > /dev/null 2>&1
   /sbin/chkconfig --del wazuh-manager
 
   /sbin/service wazuh-manager stop > /dev/null 2>&1 || :

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -140,7 +140,7 @@ fi
 
 # Ensure that the wazuh-manager is stopped
 if [ -d %{_localstatedir}/ossec ] && [ -f %{_localstatedir}/ossec/bin/ossec-control ] ; then
-  %{_localstatedir}/ossec/bin/ossec-control stop
+  %{_localstatedir}/ossec/bin/ossec-control stop > /dev/null 2>&1
 fi
 
 if ! id -g ossec > /dev/null 2>&1; then
@@ -366,7 +366,7 @@ rm -rf %{_localstatedir}/ossec/tmp/src
 rm -rf %{_localstatedir}/ossec/tmp/etc
 
 if %{_localstatedir}/ossec/bin/ossec-logtest 2>/dev/null ; then
-  /sbin/service wazuh-manager restart 2>&1
+  /sbin/service wazuh-manager restart > /dev/null 2>&1
 else
   echo "================================================================================================================"
   echo "Something in your actual rules configuration is wrong, please review your configuration and restart the service."
@@ -377,12 +377,12 @@ fi
 
 if [ $1 = 0 ]; then
 
-  /sbin/service wazuh-manager stop || :
-  %{_localstatedir}/ossec/bin/ossec-control stop 2>/dev/null
+  /sbin/service wazuh-manager stop > /dev/null 2>&1 || :
+  %{_localstatedir}/ossec/bin/ossec-control stop > /dev/null 2>&1
   /sbin/chkconfig wazuh-manager off
   /sbin/chkconfig --del wazuh-manager
 
-  /sbin/service wazuh-manager stop || :
+  /sbin/service wazuh-manager stop > /dev/null 2>&1 || :
 
   # Check if Wazuh SELinux policy is installed
   if [ -r "/etc/centos-release" ]; then
@@ -462,6 +462,10 @@ if [ $1 == 1 ]; then
       mv %{_localstatedir}/ossec/etc/ossec.conf.rpmsave %{_localstatedir}/ossec/etc/ossec.conf
       chmod 640 %{_localstatedir}/ossec/etc/ossec.conf
       chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
+    fi
+    # Restart the manager
+    if %{_localstatedir}/ossec/bin/ossec-logtest 2>/dev/null ; then
+      /sbin/service wazuh-manager restart > /dev/null 2>&1
     fi
   fi
 fi

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -440,6 +440,23 @@ if [ $1 == 0 ];then
   fi
 fi
 
+# If the package is been downgraded
+if [ $1 == 1 ]; then
+  # Load the ossec-init.conf file to get the current version
+  . /etc/ossec-init.conf
+
+  # Get the major and minor version
+  MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
+  MINOR=$(echo $VERSION | cut -d. -f2)
+
+  # Restore the client.keys from the .rpmsave file
+  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ] && [ -f %{_localstatedir}/ossec/etc/client.keys.rpmsave ] ; then
+    mv %{_localstatedir}/ossec/etc/client.keys.rpmsave %{_localstatedir}/ossec/etc/client.keys
+    chmod 640 %{_localstatedir}/ossec/etc/client.keys
+    chown root:ossec %{_localstatedir}/ossec/etc/client.keys
+  fi
+fi
+
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/ossec/etc
  chown root:ossec %{_localstatedir}/ossec/etc/localtime

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -449,11 +449,20 @@ if [ $1 == 1 ]; then
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
   MINOR=$(echo $VERSION | cut -d. -f2)
 
-  # Restore the client.keys from the .rpmsave file
-  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ] && [ -f %{_localstatedir}/ossec/etc/client.keys.rpmsave ] ; then
-    mv %{_localstatedir}/ossec/etc/client.keys.rpmsave %{_localstatedir}/ossec/etc/client.keys
-    chmod 640 %{_localstatedir}/ossec/etc/client.keys
-    chown root:ossec %{_localstatedir}/ossec/etc/client.keys
+  # Restore the configuration files from the .rpmsave file
+  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+    # Restore client.keys file
+    if [ -f %{_localstatedir}/ossec/etc/client.keys.rpmsave ]; then
+      mv %{_localstatedir}/ossec/etc/client.keys.rpmsave %{_localstatedir}/ossec/etc/client.keys
+      chmod 640 %{_localstatedir}/ossec/etc/client.keys
+      chown root:ossec %{_localstatedir}/ossec/etc/client.keys
+    fi
+    # Restore the ossec.conf file
+    if [ -f %{_localstatedir}/ossec/etc/ossec.conf.rpmsave ]; then
+      mv %{_localstatedir}/ossec/etc/ossec.conf.rpmsave %{_localstatedir}/ossec/etc/ossec.conf
+      chmod 640 %{_localstatedir}/ossec/etc/ossec.conf
+      chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
+    fi
   fi
 fi
 


### PR DESCRIPTION
Hi team,

this PR solves #72. In addition, I removed the output of some commands from the package to make it a cleaner installation.

Regards,
Braulio.