### PR TITLE
Improve download perfomance of the scripts

### DIFF
--- a/debs/generate_wazuh_debs.sh
+++ b/debs/generate_wazuh_debs.sh
@@ -32,7 +32,7 @@ build_deb() {
     SOURCES_DIRECTORY="/tmp/wazuh-builder/sources-$(( ( RANDOM % 1000 )  + 1 ))"
 
     # Download the sources
-    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY}
+    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1 --single-branch
     # Copy the necessary files
     cp build.sh ${DOCKERFILE_PATH}
     cp gen_permissions.sh ${SOURCES_DIRECTORY}

--- a/rpms/generate_wazuh_rpm.sh
+++ b/rpms/generate_wazuh_rpm.sh
@@ -35,7 +35,7 @@ build_rpm() {
     SOURCES_DIRECTORY="/tmp/wazuh-builder/sources-$(( ( RANDOM % 1000000 )  + 1 ))" 
 
     # Download the sources
-    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY}
+    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1 --single-branch
     
     # Copy the necessary files
     cp build.sh ${DOCKERFILE_PATH}


### PR DESCRIPTION
Hi team,

in order to improve the download speed of the scripts when running `git clone`, I've added the following parameters `--depth=1 --single-branch`.

Using these parameters, `git` will download the last commit from the specified branch, instead of downloading the full history of the repository.

Regards,
Braulio.