### PR TITLE
Avoid errors when upgrading the Wazuh API from previous versions

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec
@@ -83,21 +83,20 @@ if [ -d ${API_PATH_BACKUP} ]; then
   rm -rf ${API_PATH_BACKUP}
 fi
 
-#veriy python version
+# Verify if Python is installed and its version
 if python -V >/dev/null 2>&1; then
    python_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' | cut -c1-3)
    if [ ! $python_version == '2.7' ]; then
-      echo "Warning: Minimal supported version is 2.7"
+      echo "Warning: Minimal supported version is 2.7."
    fi
 else
-   echo "Warning: You need python 2.7 or above"
+   echo "Warning: You need Python 2.7 or greater."
 fi
 
+# Restart the Wazuh API service
 if [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
-  systemctl stop wazuh-api.service
   systemctl daemon-reload
   systemctl restart wazuh-api.service
-
 elif [ -n "$(ps -e | egrep ^\ *1\ .*init$)" ]; then
   service wazuh-api restart
 fi


### PR DESCRIPTION
Hi team,

this PR solves the issue https://github.com/wazuh/wazuh-api/issues/224. The caused of the problem was this line: https://github.com/wazuh/wazuh-packages/blob/df85f4028bc66238121f3be3eeaf82a2e41dae32/rpms/SPECS/3.7.0/wazuh-api-3.7.0.spec#L96-L99

After installing the new files from the new package, the wazuh-api service must be reloaded before executing `systemctl stop wazuh-api.service` or any other command, otherwise, the `stop` will fail.

What I've done, is to remove the `systemctl stop wazuh-api.service` line, execute the `systemctl daemon-reload` and then, restart the service.

Regards,
Braulio.