### PR TITLE
Fix Depends field for Wazuh API package

### DIFF
--- a/debs/SPECS/3.7.0/wazuh-api/debian/control
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/control
@@ -8,5 +8,5 @@ Homepage: http://www.wazuh.com
 
 Package: wazuh-api
 Architecture: any
-Depends: ${shlibs:Depends}, npm, nodejs (>= 4.6.1), wazuh-manager (= 3.7.0), curl
+Depends: ${shlibs:Depends}, npm, nodejs (>= 4.6.1), wazuh-manager (>= 3.7.0), wazuh-manager (<< 3.7.1), curl
 Description: Wazuh API is an open source RESTful API to interact with Wazuh from your own application or with a simple web browser or tools like cURL.


### PR DESCRIPTION
Hi team, 

this PR solves the issue #87. The fix consists on setting the wazuh-manager version using a range instead of setting to an exact version. This change allows the compatibility between package's revisions.

Regards,
Braulio.