### PR TITLE
Fix wrong context of .service files in Fedora 28

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -197,6 +197,7 @@ if [ $1 = 1 ]; then
       fi
     fi
     systemctl daemon-reload
+    systemctl stop wazuh-agent
     systemctl enable wazuh-agent > /dev/null 2>&1
   fi
 

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -193,7 +193,7 @@ if [ $1 = 1 ]; then
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
     if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then
       if command -v restorecon > /dev/null 2>&1 ; then
-        restorecon -v /etc/systemd/system/wazuh-agent.service
+        restorecon -v /etc/systemd/system/wazuh-agent.service > /dev/null 2>&1
       fi
     fi
     systemctl daemon-reload

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -185,10 +185,18 @@ if [ $1 = 1 ]; then
   /sbin/chkconfig --add wazuh-agent
   /sbin/chkconfig wazuh-agent on
 
+  # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
     install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-agent.service /etc/systemd/system/
+
+    # Fix for Fedora 28
+    # Check if SELinux is installed. If it is installed, restore the context of the .service file
+    if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then
+      if command -v restorecon > /dev/null 2>&1 ; then
+        restorecon -v /etc/systemd/system/wazuh-agent.service
+      fi
+    fi
     systemctl daemon-reload
-    systemctl stop wazuh-agent 
     systemctl enable wazuh-agent > /dev/null 2>&1
   fi
 

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -311,6 +311,7 @@ if [ $1 = 1 ]; then
       fi
     fi
     systemctl daemon-reload
+    systemctl stop wazuh-manager
     systemctl enable wazuh-manager > /dev/null 2>&1
   fi
 

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -302,8 +302,15 @@ if [ $1 = 1 ]; then
   # If systemd is installed, add the wazuh-manager.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
     install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-manager.service /etc/systemd/system/
+
+    # Fix for Fedora 28
+    # Check if SELinux is installed. If it is installed, restore the context of the .service file
+    if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then
+      if command -v restorecon > /dev/null 2>&1 ; then
+        restorecon -v /etc/systemd/system/wazuh-manager.service
+      fi
+    fi
     systemctl daemon-reload
-    systemctl stop wazuh-manager
     systemctl enable wazuh-manager > /dev/null 2>&1
   fi
 

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -307,7 +307,7 @@ if [ $1 = 1 ]; then
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
     if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then
       if command -v restorecon > /dev/null 2>&1 ; then
-        restorecon -v /etc/systemd/system/wazuh-manager.service
+        restorecon -v /etc/systemd/system/wazuh-manager.service > /dev/null 2>&1
       fi
     fi
     systemctl daemon-reload


### PR DESCRIPTION
Hi team,

this PR offers a first solution to the issue #86. In Fedora 28, when systemd tries to read `/etc/systemd/system/wazuh-manager.service` or `/etc/systemd/system/wazuh-agent.service`, it fails because SELinux blocks `systemd`. 

The problem is caused by a wrong context in those files. So, the solution is to restore the context of the file using `restorecon`. This will set the correct context, allowing systemd to read the .service files.

BTW, the best solution is to change the directory of the .service files in DEB and RPM packages as you can see https://github.com/wazuh/wazuh-packages/pull/77#issuecomment-431381933 and #86 .

Regards,
Braulio.