### PR TITLE
Silence SE module unload: Removing last wazuh module (no other wazuh module exists at another priority).

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -219,7 +219,7 @@ if [ ${add_selinux} == "yes" ]; then
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       if ! (semodule -l | grep wazuh > /dev/null); then
-        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp > /dev/null
+        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
         semodule -e wazuh
       fi
     fi

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -219,7 +219,7 @@ if [ ${add_selinux} == "yes" ]; then
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       if ! (semodule -l | grep wazuh > /dev/null); then
-        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
+        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp > /dev/null
         semodule -e wazuh
       fi
     fi

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -282,7 +282,7 @@ if [ $1 = 0 ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
       if [ $(getenforce) !=  "Disabled" ]; then
         if (semodule -l | grep wazuh > /dev/null); then
-          semodule -r wazuh
+          semodule -r wazuh > /dev/null
         fi
       fi
     fi

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -346,7 +346,7 @@ if [ ${add_selinux} == "yes" ]; then
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       if ! (semodule -l | grep wazuh > /dev/null); then
-        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp > /dev/null
+        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
         semodule -e wazuh
       fi
     fi

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -346,7 +346,7 @@ if [ ${add_selinux} == "yes" ]; then
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       if ! (semodule -l | grep wazuh > /dev/null); then
-        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
+        semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp > /dev/null
         semodule -e wazuh
       fi
     fi

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -411,7 +411,7 @@ if [ $1 = 0 ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
       if [ $(getenforce) != "Disabled" ]; then
         if (semodule -l | grep wazuh > /dev/null); then
-          semodule -r wazuh
+          semodule -r wazuh > /dev/null
         fi
       fi
     fi


### PR DESCRIPTION
Getting rid of useless messages when uninstalling the packages.


> libsemanage.semanage_direct_remove_key: Removing last wazuh module (no other wazuh module exists at another priority).


The message prompts everytime the packages remove Wazuh SE module:

> semodule -r wazuh