### PR TITLE
Remove unnecessary files when removing the packages

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -296,6 +296,13 @@ if [ $1 = 0 ]; then
       fi
     fi
   fi
+
+  # Remove the wazuh-agent.service file
+  rm -f /etc/systemd/system/wazuh-agent.service
+  # Remove the socket files from the agent
+  find /var/ossec/queue/ -type s -exec rm -f {} \;
+  # Remove the unnecessary files from the agent
+  find /var/ossec/queue/ -type f -exec rm -f {} \;
 fi
 
 %triggerin -- glibc

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -425,6 +425,8 @@ if [ $1 = 0 ]; then
     fi
   fi
 
+  # Remove framework's .pyc files 
+  find %{_localstatedir}/ossec/framework -name *.pyc -exec rm -f {} \; 
   # Remove the stats 
   rm -rf %{_localstatedir}/ossec/stats/* 
   # Remove the databases and the .template.db

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -429,17 +429,13 @@ if [ $1 = 0 ]; then
   find %{_localstatedir}/ossec/framework -name *.pyc -exec rm -f {} \; 
   # Remove the stats 
   rm -rf %{_localstatedir}/ossec/stats/* 
-  # Remove the databases and the .template.db
-  find %{_localstatedir}/ossec/var/db -type f -exec rm -f {} \; 
-  find %{_localstatedir}/ossec/queue/db -type f -exec rm -f {} \;
-  rm -f %{_localstatedir}/ossec/var/db/.template.db
-  # Remove the merged.mg file
-  rm -f %{_localstatedir}/ossec/etc/shared/default/merged.mg
-  # Remove all the unused sockets files, db files, etc.
+  # Remove the databases, merged file and the active response file
+  find %{_localstatedir}/ossec/{var,queue}/db -type f -exec rm -f {} \; 
+  rm -f %{_localstatedir}/ossec/var/db/.template.db %{_localstatedir}/ossec/etc/shared/default/merged.mg
+  rm -f %{_localstatedir}/ossec/etc/shared/ar.conf 
+  # Remove all the unused sockets files, agent-info files, groups, etc.
   rm -rf %{_localstatedir}/ossec/queue/{agent-info,agent-groups,agentless,alerts,cluster}/*
   rm -rf %{_localstatedir}/ossec/queue/{diff,fts,rids,rootcheck,ossec,vulnerabilities}/*
-  # Remove the active response file
-  rm -f %{_localstatedir}/ossec/etc/shared/ar.conf 
   # Remove all the unncessary files from %{_localstatedir}/ossec/var except wazuh.pp
   find %{_localstatedir}/ossec/var/ ! -name *wazuh.pp -type f -exec rm -f {} \;
   # Remove the service files

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -425,6 +425,23 @@ if [ $1 = 0 ]; then
     fi
   fi
 
+  # Remove the stats 
+  rm -rf %{_localstatedir}/ossec/stats/* 
+  # Remove the databases and the .template.db
+  find %{_localstatedir}/ossec/var/db -type f -exec rm -f {} \; 
+  find %{_localstatedir}/ossec/queue/db -type f -exec rm -f {} \;
+  rm -f %{_localstatedir}/ossec/var/db/.template.db
+  # Remove the merged.mg file
+  rm -f %{_localstatedir}/ossec/etc/shared/default/merged.mg
+  # Remove all the unused sockets files, db files, etc.
+  rm -rf %{_localstatedir}/ossec/queue/{agent-info,agent-groups,agentless,alerts,cluster}/*
+  rm -rf %{_localstatedir}/ossec/queue/{diff,fts,rids,rootcheck,ossec,vulnerabilities}/*
+  # Remove the active response file
+  rm -f %{_localstatedir}/ossec/etc/shared/ar.conf 
+  # Remove all the unncessary files from %{_localstatedir}/ossec/var except wazuh.pp
+  find %{_localstatedir}/ossec/var/ ! -name *wazuh.pp -type f -exec rm -f {} \;
+  # Remove the service files
+  rm -f /etc/systemd/system/wazuh-manager.service
 fi
 
 %postun


### PR DESCRIPTION
Hi team,

this PR solves the issue #76. The problem is that the package can't remove the files that are not listed or included in the package. Those files are the databases, socket files, and all the information generated by the managers or the agents. 

So, this fix, remove all the unnecessary files in the preinstall section. This will allow the rpm package to remove all the unnecessary directories.

In addition, this PR will remove the wazuh-manager.service and wazuh-agent.service when you execute `yum remove`.

Regards,
Braulio.