### PR TITLE
3.7 installation scripts

### DIFF
--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
@@ -14,7 +14,7 @@ case "$1" in
     GROUP="ossec"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
-    SCRIPTS_DIR="${DIR}/tmp"
+    SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
 
     OSMYSHELL="/sbin/nologin"
 

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
@@ -12,7 +12,8 @@ case "$1" in
     DIR="/var/ossec"
     USER="ossec"
     GROUP="ossec"
-    WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+    WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
+    WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
     SCRIPTS_DIR="${DIR}/tmp"
 
     OSMYSHELL="/sbin/nologin"

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
@@ -107,6 +107,10 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -rf ${WAZUH_TMP_DIR}
+        # If the parent directory is empty, delete it
+        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
+        fi
     fi
 
     # Delete installation scripts

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
@@ -104,6 +104,11 @@ case "$1" in
         update-rc.d wazuh-agent defaults > /dev/null 2>&1
     fi
 
+    # Delete installation scripts
+    if [ -d ${SCRIPTS_DIR} ]; then
+        rm -rf ${SCRIPTS_DIR}
+    fi
+
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -rf ${WAZUH_TMP_DIR}
@@ -111,13 +116,6 @@ case "$1" in
         if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
             rm -rf ${WAZUH_GLOBAL_TMP_DIR}
         fi
-    fi
-
-    # Delete installation scripts
-    if [ -d ${SCRIPTS_DIR} ]; then
-        rm -f ${DIR}/tmp/add_localfiles.sh gen_ossec.sh
-        rm -rf ${DIR}/tmp/src
-        rm -rf ${DIR}/tmp/etc
     fi
 
     if cat ${DIR}/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postinst
@@ -112,10 +112,11 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -rf ${WAZUH_TMP_DIR}
-        # If the parent directory is empty, delete it
-        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
-            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
-        fi
+    fi
+    
+    # If the parent directory is empty, delete it
+    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+        rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 
     if cat ${DIR}/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/postrm
@@ -5,7 +5,7 @@
 set -e
 
 DIR="/var/ossec"
-WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/preinst
@@ -5,7 +5,7 @@ set -e
 
 # configuration variables
 DIR="/var/ossec"
-WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then

--- a/debs/SPECS/3.7.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.7.0/wazuh-agent/debian/rules
@@ -20,6 +20,7 @@ export TARGET_DIR=${CURDIR}/debian/wazuh-agent
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
+export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/agent_installation_scripts"
 export JOBS="5"
 
 %:
@@ -65,28 +66,28 @@ override_dh_install:
 	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 
 	# Generating permission restoration file for postinstall
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/restore-permissions.sh
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
+	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 	# Copying to target
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/
 	cp -r $(INSTALLATION_DIR)/. $(TARGET_DIR)$(INSTALLATION_DIR)/
 
 	# Copying install scripts to /usr/share
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src
-	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
-	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
-	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src
+	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
+	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
+	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/init
-	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/init
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
+	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/etc/templates/config/generic
-	cp -r etc/templates/config/generic/* ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/etc/templates/config/generic
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/generic
+	cp -r etc/templates/config/generic/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/generic
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postinst
@@ -15,7 +15,7 @@ case "$1" in
     USER="ossec"
     GROUP="ossec"
     OSMYSHELL="/sbin/nologin"
-    SCRIPTS_DIR="${DIR}/tmp/api_scripts"
+    SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/api_installation_scripts"
 
     if [ ! -f ${OSMYSHELL} ]; then
         if [ -f "/bin/false" ]; then

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postinst
@@ -53,6 +53,10 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}
+        # If the parent directory is empty, delete it
+        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
+        fi
     fi
 
     # Remove installation scripts directory

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postinst
@@ -58,10 +58,11 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}
-        # If the parent directory is empty, delete it
-        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
-            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
-        fi
+    fi
+
+    # If the parent directory is empty, delete it
+    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+        rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 
     ${WAZUH_API_DIR}/scripts/install_daemon.sh

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postinst
@@ -10,7 +10,8 @@ case "$1" in
     OS=$(lsb_release -si)
     DIR="/var/ossec"
     WAZUH_API_DIR="${DIR}/api"
-    WAZUH_TMP_DIR="${DIR}/tmp/api_installation_files"
+    WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
+    WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/api_config_files"
     USER="ossec"
     GROUP="ossec"
     OSMYSHELL="/sbin/nologin"

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postinst
@@ -50,6 +50,11 @@ case "$1" in
       echo "Warning: Minimal supported version is 2.7"
     fi
 
+    # Remove installation scripts directory
+    if [ -d ${SCRIPTS_DIR} ]; then
+        rm -rf ${SCRIPTS_DIR}
+    fi
+
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}
@@ -57,11 +62,6 @@ case "$1" in
         if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
             rm -rf ${WAZUH_GLOBAL_TMP_DIR}
         fi
-    fi
-
-    # Remove installation scripts directory
-    if [ -d ${SCRIPTS_DIR} ]; then
-        rm -rf ${SCRIPTS_DIR}
     fi
 
     ${WAZUH_API_DIR}/scripts/install_daemon.sh

--- a/debs/SPECS/3.7.0/wazuh-api/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/postrm
@@ -5,7 +5,7 @@
 
 DIR="/var/ossec"
 WAZUH_API_DIR="${DIR}/api"
-WAZUH_TMP_DIR="${DIR}/tmp/api_installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/api_config_files"
 
 set -e
 

--- a/debs/SPECS/3.7.0/wazuh-api/debian/preinst
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/preinst
@@ -7,7 +7,7 @@ set -e
 
 # configuration variables
 DIR="/var/ossec"
-WAZUH_TMP_DIR="${DIR}/tmp/api_installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/api_config_files"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then

--- a/debs/SPECS/3.7.0/wazuh-api/debian/rules
+++ b/debs/SPECS/3.7.0/wazuh-api/debian/rules
@@ -20,6 +20,7 @@ export TARGET_DIR=${CURDIR}/debian/wazuh-api
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
+export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/api_installation_scripts"
 export JOBS="5"
 
 %:
@@ -56,9 +57,9 @@ override_dh_auto_install:
 	cp ./scripts/wazuh-api.service $(TARGET_DIR)/etc/systemd/system
 
 	# Generating permission restoration file for postinstall
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/api_scripts/
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 	# Generating permission restoration file for postinstall
-	./gen_permissions.sh "$(INSTALLATION_DIR)/api/ $(INSTALLATION_DIR)/logs/*" ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/api_scripts/restore-permissions.sh
+	./gen_permissions.sh "$(INSTALLATION_DIR)/api/ $(INSTALLATION_DIR)/logs/*" ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 
 override_dh_auto_clean:

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
@@ -12,7 +12,8 @@ case "$1" in
     USER_MAIL="ossecm"
     USER_REM="ossecr"
     GROUP="ossec"
-    WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+    WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
+    WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
     OSMYSHELL="/sbin/nologin"
     SCRIPTS_DIR="${DIR}/tmp"
 

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
@@ -15,7 +15,7 @@ case "$1" in
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
     OSMYSHELL="/sbin/nologin"
-    SCRIPTS_DIR="${DIR}/tmp"
+    SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_installation_scripts"
 
     if [ ! -f ${OSMYSHELL} ]; then
         if [ -f "/bin/false" ]; then

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
@@ -289,10 +289,11 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}
-        # If the parent directory is empty, delete it
-        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
-            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
-        fi
+    fi
+
+    # If the parent directory is empty, delete it
+    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+        rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 
     # Fix /etc/ossec-init.conf

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
@@ -213,7 +213,6 @@ case "$1" in
     if [ -d ${WAZUH_TMP_DIR}/group ]; then
         cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
         rm -rf ${WAZUH_TMP_DIR}/group/
-
     fi
 
     # More files
@@ -264,13 +263,6 @@ case "$1" in
         fi
     fi
 
-    # Delete installation scripts
-    if [ -d ${SCRIPTS_DIR} ]; then
-        rm -f ${DIR}/tmp/add_localfiles.sh gen_ossec.sh
-        rm -rf ${DIR}/tmp/src
-        rm -rf ${DIR}/tmp/etc
-    fi
-
     # Service
     if [ -x /etc/init.d/wazuh-manager ]; then
         if [ -d /run/systemd/system ]; then
@@ -288,6 +280,12 @@ case "$1" in
             echo "================================================================================================================"
         fi
     fi
+
+    # Delete installation scripts
+    if [ -d ${SCRIPTS_DIR} ]; then
+        rm -rf ${SCRIPTS_DIR}
+    fi
+
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postinst
@@ -291,6 +291,10 @@ case "$1" in
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -r ${WAZUH_TMP_DIR}
+        # If the parent directory is empty, delete it
+        if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+            rm -rf ${WAZUH_GLOBAL_TMP_DIR}
+        fi
     fi
 
     # Fix /etc/ossec-init.conf

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/postrm
@@ -3,7 +3,7 @@
 # Wazuh, Inc 2016
 set -e
 DIR="/var/ossec"
-WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/preinst
@@ -5,7 +5,7 @@ set -e
 
 # configuration variables
 DIR="/var/ossec"
-WAZUH_TMP_DIR="${DIR}/tmp/installation_files"
+WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then

--- a/debs/SPECS/3.7.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/3.7.0/wazuh-manager/debian/rules
@@ -20,6 +20,7 @@ export TARGET_DIR=${CURDIR}/debian/wazuh-manager
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
+export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/manager_installation_scripts"
 export JOBS="5"
 
 %:
@@ -69,27 +70,27 @@ override_dh_install:
 	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 
 	# Generating permission restoration file for postinstall
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/restore-permissions.sh
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 	# Copying to target
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/
 	cp -r $(INSTALLATION_DIR)/. $(TARGET_DIR)$(INSTALLATION_DIR)/
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
-	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src
-	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
-	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
-	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src
+	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
+	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
+	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/init
-	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/src/init
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
+	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/etc/templates/config/generic
-	cp -r etc/templates/config/generic/* ${TARGET_DIR}$(INSTALLATION_DIR)/tmp/etc/templates/config/generic
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/generic
+	cp -r etc/templates/config/generic/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/generic
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -99,31 +99,31 @@ install -m 0640 wodles/oscap/content/*fedora* ${RPM_BUILD_ROOT}%{_localstatedir}
 cp CHANGELOG.md CHANGELOG
 
 # Add configuration scripts
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
-cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
-cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/
+cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/
+cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/
 
 # Templates for initscript
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/init
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/systemd
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/generic
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/centos
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/fedora
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/rhel
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/generic
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/centos
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/fedora
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/rhel
 
 # Copy scap templates
-cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/generic
-cp -rp  etc/templates/config/centos/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/centos
-cp -rp  etc/templates/config/fedora/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/fedora
-cp -rp  etc/templates/config/rhel/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/rhel
+cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/generic
+cp -rp  etc/templates/config/centos/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/centos
+cp -rp  etc/templates/config/fedora/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/fedora
+cp -rp  etc/templates/config/rhel/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/rhel
 
-install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/init
+install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init
 
 # Add installation scripts
-cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/systemd
+cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/
+cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/
+cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/
+cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd
 
 exit 0
 %pre
@@ -162,7 +162,7 @@ if [ $1 = 1 ]; then
   if [ -f /etc/os-release ]; then
     sles=$(grep "\"sles" /etc/os-release)
     if [ ! -z "$sles" ]; then
-      install -m 755 %{_localstatedir}/ossec/tmp/src/init/ossec-hids-suse.init /etc/rc.d/wazuh-agent
+      install -m 755 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/rc.d/wazuh-agent
     fi
   fi
 
@@ -171,15 +171,15 @@ if [ $1 = 1 ]; then
   chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log
 
   # Generating osse.conf file
-  . %{_localstatedir}/ossec/tmp/src/init/dist-detect.sh
-  %{_localstatedir}/ossec/tmp/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
+  . %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init/dist-detect.sh
+  %{_localstatedir}/ossec/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
   chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
   chmod 0640 %{_localstatedir}/ossec/etc/ossec.conf
 
   # Add default local_files to ossec.conf
-  %{_localstatedir}/ossec/tmp/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
+  %{_localstatedir}/ossec/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
   if [ -f %{_localstatedir}/ossec/etc/ossec.conf.rpmorig ]; then
-      %{_localstatedir}/ossec/tmp/src/init/replace_manager_ip.sh %{_localstatedir}/ossec/etc/ossec.conf.rpmorig %{_localstatedir}/ossec/etc/ossec.conf
+      %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init/replace_manager_ip.sh %{_localstatedir}/ossec/etc/ossec.conf.rpmorig %{_localstatedir}/ossec/etc/ossec.conf
   fi
 
   /sbin/chkconfig --add wazuh-agent
@@ -187,7 +187,7 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-agent.service /etc/systemd/system/
+    install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
 
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
@@ -207,9 +207,8 @@ if [ ! -d /run/systemd/system ]; then
   update-rc.d wazuh-agent defaults > /dev/null 2>&1
 fi
 
-rm -rf %{_localstatedir}/ossec/tmp/etc
-rm -rf %{_localstatedir}/ossec/tmp/src
-rm -f %{_localstatedir}/ossec/tmp/add_localfiles.sh
+# Delete the installation files used to configure the agent
+rm -rf %{_localstatedir}/ossec/packages_files
 
 if [ $1 = 2 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.bck ]; then
@@ -396,6 +395,15 @@ rm -fr %{buildroot}
 %attr(660,root,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.log
 %attr(660,root,ossec) %ghost %{_localstatedir}/ossec/logs/ossec.json
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/logs/ossec
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/add_localfiles.sh
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/gen_ossec.sh
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/generic/*
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/centos/*
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/fedora/*
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/rhel/*
+%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/queue
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/agents
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/ossec
@@ -403,13 +411,6 @@ rm -fr %{buildroot}
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/alerts
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/rids
 %dir %attr(1750,root,ossec) %{_localstatedir}/ossec/tmp
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/src/*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/var
 %dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/incoming
 %dir %attr(770,root,ossec) %{_localstatedir}/ossec/var/run

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -103,31 +103,31 @@ install -m 0640 wodles/oscap/content/*fedora* ${RPM_BUILD_ROOT}%{_localstatedir}
 cp CHANGELOG.md CHANGELOG
 
 # Add configuration scripts
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
-cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
-cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/
+cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/
+cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/
 
 # Templates for initscript
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/init
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/systemd
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/generic
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/centos
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/fedora
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/rhel
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/generic
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/centos
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/fedora
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/rhel
 
 # Copy scap templates
-cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/generic
-cp -rp  etc/templates/config/centos/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/centos
-cp -rp  etc/templates/config/fedora/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/fedora
-cp -rp  etc/templates/config/rhel/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/etc/templates/config/rhel
+cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/generic
+cp -rp  etc/templates/config/centos/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/centos
+cp -rp  etc/templates/config/fedora/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/fedora
+cp -rp  etc/templates/config/rhel/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/rhel
 
-install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/init
+install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init
 
 # Add installation scripts
-cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/
-cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src/systemd
+cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
+cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
+cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
+cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd
 
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc/sslmanager*
 
@@ -226,8 +226,8 @@ fi
 # If the package is being installed 
 if [ $1 = 1 ]; then
   # Generating ossec.conf file
-  . %{_localstatedir}/ossec/tmp/src/init/dist-detect.sh
-  %{_localstatedir}/ossec/tmp/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
+  . %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init/dist-detect.sh
+  %{_localstatedir}/ossec/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
   chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
   chmod 0640 %{_localstatedir}/ossec/etc/ossec.conf
 
@@ -295,13 +295,13 @@ if [ $1 = 1 ]; then
   chmod 0640 %{_localstatedir}/ossec/logs/integrations.log
 
   # Add default local_files to ossec.conf
-  %{_localstatedir}/ossec/tmp/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
+  %{_localstatedir}/ossec/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir}/ossec >> %{_localstatedir}/ossec/etc/ossec.conf
    /sbin/chkconfig --add wazuh-manager
    /sbin/chkconfig wazuh-manager on
 
   # If systemd is installed, add the wazuh-manager.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/tmp/src/systemd/wazuh-manager.service /etc/systemd/system/
+    install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/
 
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
@@ -370,9 +370,8 @@ elif [ ${add_selinux} == "no" ]; then
   fi
 fi
 
-rm -f %{_localstatedir}/ossec/tmp/add_localfiles.sh
-rm -rf %{_localstatedir}/ossec/tmp/src
-rm -rf %{_localstatedir}/ossec/tmp/etc
+# Delete the installation files used to configure the manager
+rm -rf %{_localstatedir}/ossec/packages_files
 
 if %{_localstatedir}/ossec/bin/ossec-logtest 2>/dev/null ; then
   /sbin/service wazuh-manager restart > /dev/null 2>&1
@@ -587,6 +586,28 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/cluster
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/firewall
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/logs/ossec
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/add_localfiles.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/gen_ossec.sh
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/LOCATION
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/REVISION
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/VERSION
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init/
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/generic
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/generic/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/centos
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/centos/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/fedora
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/fedora/*
+%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/rhel
+%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/queue
 %attr(600, root, ossec) %ghost %{_localstatedir}/ossec/queue/agents-timestamp
 %dir %attr(770, ossecr, ossec) %{_localstatedir}/ossec/queue/agent-info
@@ -611,26 +632,6 @@ rm -fr %{buildroot}
 %dir %attr(700, root, ossec) %{_localstatedir}/ossec/.ssh
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/stats
 %dir %attr(1750, root, ossec) %{_localstatedir}/ossec/tmp
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/add_localfiles.sh
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/gen_ossec.sh
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/LOCATION
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/REVISION
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/VERSION
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/init/
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/init/*
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/src/systemd/*
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/centos/*
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/fedora/*
-%dir %attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel
-%attr(750, root, root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/var
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db/agents


### PR DESCRIPTION
Hi team,

this PR solves two problems of the wazuh-api package:
1. The wazuh-api and wazuh-manager shared the `/var/ossec/tmp` directory to store the configuration files from both packages while they perform and upgrade. When the wazuh-manager finish its installation, it will be restarted and this action will delete all the files and directories stored in `/var/ossec/tmp`. This action destroys the configuration files of the wazuh-api.
2. There's a permissions problem with the wazuh-api package after upgrade from 3.2.x to 3.7.0 version. The script `restore-permissions.sh` is not executed, so the permissions can't be restored, and it is missing because it was destroyed due to the problem explained in 1. 

To solve these problems, I changed the directory where the configuration files are stored from `/var/ossec/tmp` to `/var/ossec/packages_files/target_config_files`, where `target` can be `manager`, `api` or `agent`. This directory will live only while the process of upgrading the packages is running. After that, it is deleted. This solves the first problem.

To solve the second one, I changed the installation directory of the scripts that are used to generate the ossec.conf file from `/var/ossec/tmp` to `/var/ossec/packages_files/target_installation_scripts`. This solves the second problem.

Regards,
Braulio.
