### PR TITLE
Fix SELinux check in CentOS 5

### DIFF
--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -157,6 +157,7 @@ if [ $1 = 2 ]; then
 fi
 
 %post
+. %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 # If the package is being installed 
 if [ $1 = 1 ]; then
   if [ -f /etc/os-release ]; then
@@ -171,7 +172,6 @@ if [ $1 = 1 ]; then
   chmod 0660 %{_localstatedir}/ossec/logs/active-responses.log
 
   # Generating osse.conf file
-  . %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/init/dist-detect.sh
   %{_localstatedir}/ossec/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
   chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
   chmod 0640 %{_localstatedir}/ossec/etc/ossec.conf

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -224,9 +224,9 @@ fi
 %post
 
 # If the package is being installed 
+. %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init/dist-detect.sh
 if [ $1 = 1 ]; then
   # Generating ossec.conf file
-  . %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/init/dist-detect.sh
   %{_localstatedir}/ossec/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir}/ossec > %{_localstatedir}/ossec/etc/ossec.conf
   chown root:ossec %{_localstatedir}/ossec/etc/ossec.conf
   chmod 0640 %{_localstatedir}/ossec/etc/ossec.conf


### PR DESCRIPTION
Hi team,

this PR fix a problem when upgrading the wazuh-manager and wazuh-agent packages if SELinux is installed and enabled in CentOS 5. The problem was that this check: https://github.com/wazuh/wazuh-packages/blob/2501b2d888479a0bc10073b3a63b82a9d563acc8/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec#L412-L414 didn't work when upgrading the package because `gen_ossec.sh` is only loaded when you install the package for the first time.

The fix consists on loading this script always.

Regards,
Braulio.