### PR TITLE
Fix typo causing weird file name with a space at the end.

### DIFF
--- a/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
@@ -145,7 +145,7 @@ case "$1" in
 
     # Move existing agent.conf to new target
     if [ -f "${DIR}/etc/shared/agent.conf" ]; then
-        mv "${DIR}/etc/shared/agent.conf" "${DIR}/etc/shared/default/agent.conf "
+        mv "${DIR}/etc/shared/agent.conf" "${DIR}/etc/shared/default/agent.conf"
     fi
 
     # For the etc dir


### PR DESCRIPTION
 Hi, Team,

This PR solves the issue https://github.com/wazuh/wazuh/issues/1855. This is also related to the issue   https://github.com/wazuh/wazuh/issues/1314.

Best regards.