### PR TITLE
Removing .template.db 

### DIFF
--- a/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
@@ -105,6 +105,7 @@ case "$1" in
     fi
 
     # Remove existing SQLite databases
+    rm -f ${DIR}/var/db/.template.db* || true
     rm -f ${DIR}/var/db/global.db* || true
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -171,6 +171,7 @@ if [ -d ${DIR}/var/db/agents ]; then
 fi
 
 # Remove existing SQLite databases
+rm -f %{_localstatedir}/ossec/var/db/template.db* || true
 rm -f %{_localstatedir}/ossec/var/db/global.db* || true
 rm -f %{_localstatedir}/ossec/var/db/cluster.db* || true
 rm -f %{_localstatedir}/ossec/var/db/.profile.db* || true

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -171,7 +171,7 @@ if [ -d ${DIR}/var/db/agents ]; then
 fi
 
 # Remove existing SQLite databases
-rm -f %{_localstatedir}/ossec/var/db/template.db* || true
+rm -f %{_localstatedir}/ossec/var/db/.template.db* || true
 rm -f %{_localstatedir}/ossec/var/db/global.db* || true
 rm -f %{_localstatedir}/ossec/var/db/cluster.db* || true
 rm -f %{_localstatedir}/ossec/var/db/.profile.db* || true


### PR DESCRIPTION
Packages installation must be consistent with sources installation.
We were not removing essential templates files that are designed to be recreated with the new schema when the manager first starts.
It was causing more than one error related to SQL update and inserts after Wazuh upgrade.

install.sh
https://github.com/wazuh/wazuh/blob/master/src/init/wazuh/wazuh.sh#L44-L50
```
    # Remove existing SQLite databases

    rm -f $DIRECTORY/var/db/global.db*
    rm -f $DIRECTORY/var/db/.profile.db*
    rm -f $DIRECTORY/var/db/.template.db*
    rm -f $DIRECTORY/var/db/agents/*
```
