### PR TITLE
Update always the SELinux policy

### DIFF
--- a/debs/SPECS/3.7.1/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.7.1/wazuh-agent/debian/postinst
@@ -36,7 +36,7 @@ case "$1" in
     chmod 640 ${DIR}/etc/ossec-init.conf
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
-    
+
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
         ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
 
@@ -89,10 +89,8 @@ case "$1" in
     # Check if SELinux is installed and enabled
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
         if [ $(getenforce) !=  "Disabled" ]; then
-            if ! (semodule -l | grep wazuh > /dev/null); then
-                semodule -i ${DIR}/var/selinux/wazuh.pp
-                semodule -e wazuh
-            fi
+            semodule -i ${DIR}/var/selinux/wazuh.pp
+            semodule -e wazuh
         fi
     fi
 
@@ -113,9 +111,9 @@ case "$1" in
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -rf ${WAZUH_TMP_DIR}
     fi
-    
+
     # If the parent directory is empty, delete it
-    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 

--- a/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postinst script for Wazuh 
+# postinst script for Wazuh
 # Wazuh, Inc 2016
 set -e
 case "$1" in
@@ -257,10 +257,8 @@ case "$1" in
     # Check if SELinux is installed and enabled
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
         if [ $(getenforce) !=  "Disabled" ]; then
-            if ! (semodule -l | grep wazuh > /dev/null); then
-                semodule -i ${DIR}/var/selinux/wazuh.pp
-                semodule -e wazuh
-            fi
+            semodule -i ${DIR}/var/selinux/wazuh.pp
+            semodule -e wazuh
         fi
     fi
 
@@ -293,7 +291,7 @@ case "$1" in
     fi
 
     # If the parent directory is empty, delete it
-    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then 
+    if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 

--- a/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
@@ -220,10 +220,8 @@ fi
 # Add the SELinux policy
 if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
   if [ $(getenforce) != "Disabled" ]; then
-    if ! (semodule -l | grep wazuh > /dev/null); then
-      semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
-      semodule -e wazuh
-    fi
+    semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
+    semodule -e wazuh
   fi
 fi
 

--- a/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
@@ -347,10 +347,8 @@ chown ossecr:ossec %{_localstatedir}/ossec/queue/agent-info/* 2>/dev/null || tru
 # Add the SELinux policy
 if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
   if [ $(getenforce) != "Disabled" ]; then
-    if ! (semodule -l | grep wazuh > /dev/null); then
-      semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
-      semodule -e wazuh
-    fi
+    semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
+    semodule -e wazuh
   fi
 fi
 


### PR DESCRIPTION
Hi team,

this PR solves the issue #101. The SELinux policy wasn't updated when you upgrade the package, because the packages only add the SELinux policy if it wasn't present when you run `semodule -e` https://github.com/wazuh/wazuh-packages/blob/5a1c23546b81b94e90fc757db547cf8da6e1dffa/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec#L220-L228
So, to update the SELinux policy, I just remove the `if ! (semodule -l | grep wazuh > /dev/null); then` check. 

Here you can see the output of testing the wazuh-manager and wazuh-agent RPM packages:
* Manager:
```shellsession
Installed:
  wazuh-manager.x86_64 0:3.6.1-1                                                                                          

Complete!
[root@localhost vagrant]# semodule -l | grep wazuh
wazuh   1.0
[root@localhost vagrant]# rpm -Uvh /vagrant/wazuh-manager-3.7.1-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-manager-3.7.1-1            warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
################################# [ 50%]
Cleaning up / removing...
   2:wazuh-manager-3.6.1-1            ################################# [100%]
[root@localhost vagrant]# semodule -l | grep wazuh
wazuh   1.1
[root@localhost vagrant]#
```
* Agent:
```shellsession
Installed:
  wazuh-agent.x86_64 0:3.6.1-1                                                                                          

Complete!
[root@localhost vagrant]# semodule -l | grep wazuh
wazuh   1.0
[root@localhost vagrant]# rpm -Uvh /vagrant/wazuh-agent-3.7.1-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-3.7.1-1              warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
################################# [ 50%]
Cleaning up / removing...
   2:wazuh-agent-3.6.1-1              ################################# [100%]
[root@localhost vagrant]# semodule -l | grep wazuh
wazuh   1.1
[root@localhost vagrant]#
```

Regards,
Braulio.