### PR TITLE
Add USER_CREATE_SSL_CERT option to maanger specs

### DIFF
--- a/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/postinst
@@ -130,6 +130,15 @@ case "$1" in
     # Restoring file permissions
     . ${SCRIPTS_DIR}/restore-permissions.sh
 
+    # Restore sslmanager.key and sslmanager.cert
+    if [ -f ${WAZUH_TMP_DIR}/sslmanager.cert ]; then
+        mv ${WAZUH_TMP_DIR}/sslmanager.cert ${DIR}/etc/sslmanager.cert
+    fi
+
+    # Restore ossec.conf configuration
+    if [ -f ${WAZUH_TMP_DIR}/sslmanager.key ]; then
+        mv ${WAZUH_TMP_DIR}/sslmanager.key ${DIR}/etc/sslmanager.key
+    fi
 
     # Correct permission on existing certificates
     if [ -f "${DIR}/etc/sslmanager.key" ] && [ -f "${DIR}/etc/sslmanager.cert" ]; then

--- a/debs/SPECS/3.7.1/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/preinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# preinst script for Wazuh 
+# preinst script for Wazuh
 
 set -e
 
@@ -10,14 +10,14 @@ WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then
     mkdir -p ${WAZUH_TMP_DIR}
-else 
+else
     rm -rf ${WAZUH_TMP_DIR}
     mkdir -p ${WAZUH_TMP_DIR}
 fi
 
 case "$1" in
     install|upgrade)
-        
+
         if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/ossec.conf ] ; then
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
@@ -104,6 +104,14 @@ case "$1" in
 
         if [ -f ${DIR}/etc/ossec.conf ]; then
             cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
+        fi
+
+        if [ -f ${DIR}/etc/sslmanager.cert ]; then
+          cp -p ${DIR}/etc/sslmanager.cert ${WAZUH_TMP_DIR}/sslmanager.cert
+        fi
+
+        if [ -f ${DIR}/etc/sslmanager.key ]; then
+          cp -p ${DIR}/etc/sslmanager.key ${WAZUH_TMP_DIR}/sslmanager.key
         fi
 
         if [ -d ${DIR}/var/db/agents ]; then

--- a/debs/SPECS/3.7.1/wazuh-manager/debian/rules
+++ b/debs/SPECS/3.7.1/wazuh-manager/debian/rules
@@ -59,6 +59,7 @@ override_dh_install:
 	USER_CA_STORE="/path/to/my_cert.pem" \
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
+	USER_CREATE_SSL_CERT="n" \
 	./install.sh
 
 	# Copying debian & ubuntu OSCAP xml files

--- a/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
@@ -83,6 +83,7 @@ echo 'USER_SERVER_IP="MANAGER_IP"' >> ./etc/preloaded-vars.conf
 echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
+echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories
@@ -128,8 +129,6 @@ cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_i
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd
-
-rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/etc/sslmanager*
 
 exit 0
 %pre


### PR DESCRIPTION
Hi team,

this PR solves #100. Now, this option is included in the `rules` files in deb package and in the `%install` section of the RPM package. 

Regards,
Braulio.