### PR TITLE
Avoid the installation of SELinux policy for CentOS 5

### DIFF
--- a/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
@@ -225,22 +225,35 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-# Add the SELinux policy
-if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
-  if [ $(getenforce) != "Disabled" ]; then
-    semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
-    semodule -e wazuh
+# CentOS
+if [ -r "/etc/centos-release" ]; then
+  DIST_NAME="centos"
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
+# RedHat
+elif [ -r "/etc/redhat-release" ]; then
+  if grep -q "CentOS" /etc/redhat-release; then
+      DIST_NAME="centos"
+  else
+      DIST_NAME="rhel"
   fi
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
 fi
 
- # SELINUX Policy for CentOS 5 and RHEL 5 to use the Wazuh Lib
-%if 0%{?el} == 5 || 0%{?rhel} == 5
+if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ "${DIST_VER}" == "5" ]; then
   if command -v getenforce > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       chcon -t textrel_shlib_t  %{_localstatedir}/ossec/lib/libwazuhext.so
     fi
   fi
-%endif
+else
+  # Add the SELinux policy
+  if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
+    if [ $(getenforce) != "Disabled" ]; then
+      semodule -i %{_localstatedir}/ossec/var/selinux/wazuh.pp
+      semodule -e wazuh
+    fi
+  fi
+fi
 
 if cat %{_localstatedir}/ossec/etc/ossec.conf | grep -o -P '(?<=<server-ip>).*(?=</server-ip>)' | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
    /sbin/service wazuh-agent restart > /dev/null 2>&1 || :


### PR DESCRIPTION
Hi team,

this PR solves a problem when installing the v3.7.1 packages in CentOS 5. The solution consists of checking if the hosts is a CentOS/RHEL 5 and avoid the installation of the SELinux policy.

Regards,
Braulio.

