### PR TITLE
Fixed regex for Centos version detection in Wazuh Agent

### DIFF
--- a/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
@@ -228,7 +228,7 @@ fi
 # CentOS
 if [ -r "/etc/centos-release" ]; then
   DIST_NAME="centos"
-  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/centos-release`
 # RedHat
 elif [ -r "/etc/redhat-release" ]; then
   if grep -q "CentOS" /etc/redhat-release; then
@@ -236,7 +236,7 @@ elif [ -r "/etc/redhat-release" ]; then
   else
       DIST_NAME="rhel"
   fi
-  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/redhat-release`
 fi
 
 if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ "${DIST_VER}" == "5" ]; then

--- a/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
@@ -356,7 +356,7 @@ chown ossecr:ossec %{_localstatedir}/ossec/queue/agent-info/* 2>/dev/null || tru
 # CentOS
 if [ -r "/etc/centos-release" ]; then
   DIST_NAME="centos"
-  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/centos-release`
 # RedHat
 elif [ -r "/etc/redhat-release" ]; then
   if grep -q "CentOS" /etc/redhat-release; then
@@ -364,7 +364,7 @@ elif [ -r "/etc/redhat-release" ]; then
   else
       DIST_NAME="rhel"
   fi
-  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
+  DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/redhat-release`
 fi
 
 if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ "${DIST_VER}" == "5" ]; then


### PR DESCRIPTION
Hello team

  This PR solve the Centos 5 version detection. 

Best regards, 