### PR TITLE
Remove always Vuln-detector's db

### DIFF
--- a/debs/SPECS/3.8.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.8.0/wazuh-manager/debian/postinst
@@ -110,6 +110,8 @@ case "$1" in
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true
     rm -f ${DIR}/var/db/agents/* || true
+    # Remove Vuln-detector database
+    rm -f ${DIR}/queue/vulnerabilities/cve.db || true
 
     # Remove existing SQLite databases for Wazuh DB when upgrading
     # Wazuh only if upgrading from 3.2..3.6

--- a/rpms/SPECS/3.8.0/wazuh-manager-3.8.0.spec
+++ b/rpms/SPECS/3.8.0/wazuh-manager-3.8.0.spec
@@ -174,6 +174,8 @@ rm -f %{_localstatedir}/ossec/var/db/global.db* || true
 rm -f %{_localstatedir}/ossec/var/db/cluster.db* || true
 rm -f %{_localstatedir}/ossec/var/db/.profile.db* || true
 rm -f %{_localstatedir}/ossec/var/db/agents/* || true
+# Remove Vuln-detector database
+rm -f %{_localstatedir}/ossec/queue/vulnerabilities/cve.db || true
 
 
 # Remove existing SQLite databases for Wazuh DB when upgrading


### PR DESCRIPTION
Hi team,
in Wazuh v3.8.0, the schema of the _Vulnerability detector_ db has changed, so the upgrade from previous versions to v3.8.0 will produce errors in this module. This PR removes the db and fix the problem.

Regards,
Braulio.