### PR TITLE
Fix cdbs permission from 770 to 640

### DIFF
--- a/debs/SPECS/3.8.2/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.8.2/wazuh-manager/debian/postinst
@@ -233,8 +233,10 @@ case "$1" in
     chmod 770 ${DIR}/etc/lists
     chmod 770 ${DIR}/etc/lists/amazon
     chmod 660 ${DIR}/etc/lists/amazon/*
-    chmod 770 ${DIR}/etc/lists/security-eventchannel
-    chmod 770 ${DIR}/etc/lists/security-eventchannel.cdb
+    chmod 640 ${DIR}/etc/lists/audit-keys
+    chmod 640 ${DIR}/etc/lists/audit-keys.cdb
+    chmod 640 ${DIR}/etc/lists/security-eventchannel
+    chmod 640 ${DIR}/etc/lists/security-eventchannel.cdb
     chmod 770 ${DIR}/etc/shared/default
 
     chown -R root:ossec ${DIR}/etc/client.keys

--- a/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
@@ -233,8 +233,10 @@ case "$1" in
     chmod 770 ${DIR}/etc/lists
     chmod 770 ${DIR}/etc/lists/amazon
     chmod 660 ${DIR}/etc/lists/amazon/*
-    chmod 770 ${DIR}/etc/lists/security-eventchannel
-    chmod 770 ${DIR}/etc/lists/security-eventchannel.cdb
+    chmod 640 ${DIR}/etc/lists/audit-keys
+    chmod 640 ${DIR}/etc/lists/audit-keys.cdb
+    chmod 640 ${DIR}/etc/lists/security-eventchannel
+    chmod 640 ${DIR}/etc/lists/security-eventchannel.cdb
     chmod 770 ${DIR}/etc/shared/default
 
     chown -R root:ossec ${DIR}/etc/client.keys

--- a/rpms/SPECS/3.8.2/wazuh-manager-3.8.2.spec
+++ b/rpms/SPECS/3.8.2/wazuh-manager-3.8.2.spec
@@ -578,8 +578,10 @@ rm -fr %{buildroot}
 %attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-*
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/amazon
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/amazon/*
-%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/security-eventchannel
-%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/security-eventchannel.cdb
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-keys
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-keys.cdb
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/security-eventchannel
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/security-eventchannel.cdb
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/shared
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/shared/default
 %attr(660, ossec, ossec) %{_localstatedir}/ossec/etc/shared/agent-template.conf

--- a/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
@@ -575,8 +575,10 @@ rm -fr %{buildroot}
 %attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-*
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/amazon
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/amazon/*
-%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/security-eventchannel
-%dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/lists/security-eventchannel.cdb
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-keys
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/audit-keys.cdb
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/security-eventchannel
+%attr(640, ossec, ossec) %config(noreplace) %{_localstatedir}/ossec/etc/lists/security-eventchannel.cdb
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/etc/shared
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/etc/shared/default
 %attr(660, ossec, ossec) %{_localstatedir}/ossec/etc/shared/agent-template.conf


### PR DESCRIPTION
Hi team,

We fix on this PR the permission to security-eventchannel list from 770 to 640 and, audit-keys list from 644 to 640 on both systems RPM/DEB.