### PR TITLE
Fix 3.9 RPM SPECs

### DIFF
--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -423,6 +423,7 @@ rm -fr %{buildroot}
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/diff
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/alerts
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/rids
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment
 %attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment/*
 %dir %attr(1770,root,ossec) %{_localstatedir}/ossec/tmp

--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -423,7 +423,7 @@ rm -fr %{buildroot}
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/diff
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/alerts
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/rids
-%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment
 %attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment/*
 %dir %attr(1770,root,ossec) %{_localstatedir}/ossec/tmp
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/var

--- a/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
@@ -628,7 +628,7 @@ rm -fr %{buildroot}
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/ossec
 %dir %attr(760, root, ossec) %{_localstatedir}/ossec/queue/vulnerabilities
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset
-%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment
 %attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/configuration-assessment/*
 %attr(640, root, ossec) %{_localstatedir}/ossec/ruleset/VERSION
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/ruleset/decoders


### PR DESCRIPTION
Hi team,

On this PR we fix a little issue with `configuration-assessment` folder owner and `ruleset` folder on agent that doesn't have right permissions.

Regards.