### PR TITLE
Fix Debian packages repository to build debian packages with archives

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -1,29 +1,31 @@
 FROM debian:7
 
-# Installing necessary packages
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y curl gcc make sudo expect gnupg fakeroot \
-    build-essential cdbs devscripts equivs automake autoconf \
-    libtool libaudit-dev selinux-basics
-
-# Add Debian's source repository
-RUN echo "deb-src http://deb.debian.org/debian wheezy main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get build-dep python3.2 -y
-
-# Install NodeJS 6
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
+
+# Installing necessary packages
+RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y apt-utils && \
+    apt-get install -y --force-yes \
+    curl gcc make sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 perl \
+    libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
+    cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
+    libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20
+
+
+# Add Debian's source repository and, Install NodeJS 6
+RUN apt-get update && apt-get build-dep python3.2 -y && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    chmod +x /usr/local/bin/build_package && \
+    useradd -ms /bin/bash wazuh-builder
+
 
 # Add the volumes
 VOLUME /var/local/wazuh
 VOLUME /etc/wazuh
-
-RUN useradd -ms /bin/bash wazuh-builder
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -1,27 +1,29 @@
 FROM i386/debian:7
 
-# Installing necessary packages
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y curl gcc-multilib make sudo expect \
-    gnupg fakeroot build-essential cdbs devscripts equivs \
-    automake autoconf libtool libaudit-dev selinux-basics \
-    util-linux
-
-# Add Debian's source repository
-RUN echo "deb-src http://deb.debian.org/debian wheezy main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get build-dep python3.2 -y
 
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
-RUN chmod +x /usr/local/bin/build_package
+
+# Installing necessary packages
+RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y apt-utils && \
+    apt-get install -y --force-yes \
+    curl gcc-multilib make sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 \
+    perl libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev \
+    build-essential cdbs devscripts equivs automake autoconf libtool \
+    libaudit-dev selinux-basics util-linux libdb5.1=5.1.29-5 libdb5.1-dev \
+    libssl1.0.0=1.0.1e-2+deb7u20
+
+# Add Debian's source repository
+RUN apt-get update && apt-get build-dep python3.2 -y && \
+    chmod +x /usr/local/bin/build_package && \
+    useradd -ms /bin/bash wazuh-builder
 
 # Add the volumes
 VOLUME /var/local/wazuh
 VOLUME /etc/wazuh
-
-RUN useradd -ms /bin/bash wazuh-builder
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/build_package"]


### PR DESCRIPTION
Hi team,

This PR closes #145, we have changed Debian repositories due to end of support of stable repositories so, we have added to sources the repository `archives.debian.org` that contains some of the packages that we was using, we have also applied a static version of some packages to avoid errors on dependencies.

Regards.