### PR TITLE
Removed unused directory /ossec/queue/agents from installation

### DIFF
--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -481,7 +481,6 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/etc/templates/config/suse/*
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/queue
-%dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/agents
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/ossec
 %dir %attr(750,ossec,ossec) %{_localstatedir}/ossec/queue/diff
 %dir %attr(770,ossec,ossec) %{_localstatedir}/ossec/queue/alerts

--- a/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
@@ -624,7 +624,6 @@ rm -fr %{buildroot}
 %dir %attr(770, ossecr, ossec) %{_localstatedir}/ossec/queue/agent-info
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/queue/agent-groups
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/agentless
-%dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/agents
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/alerts
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/queue/cluster
 %dir %attr(750, ossec, ossec) %{_localstatedir}/ossec/queue/db


### PR DESCRIPTION
Hi team, 

This PR closes #144. This issue is related to https://github.com/wazuh/wazuh/issues/2927 and resolves the problem at packaging level. To do this it was neccesary to remove `/queue/agents` references from rpms/SPECS/3.9.0/.

For the debian package generation it was not neccesary to make changes.

This was tested on:
Centos6, Centos7, fedora 22 to 29, suse12, ubuntu 14LTS, ubuntu 16LTS, ubuntu 18LTS, debian 8 and 9

Regards,
Daniel Folch.