### PR TITLE
Add new SCA files for Debian and Ubuntu hosts

### DIFF
--- a/debs/SPECS/3.9.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.0/wazuh-agent/debian/postinst
@@ -15,6 +15,7 @@ case "$1" in
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
+    SCA_FILES_DIR="${SCRIPTS_DIR}/sca"
 
     OSMYSHELL="/sbin/nologin"
 
@@ -66,6 +67,31 @@ case "$1" in
     # Restore client.keys configuration
     if [ -f ${WAZUH_TMP_DIR}/local_internal_options.conf ]; then
         mv ${WAZUH_TMP_DIR}/local_internal_options.conf ${DIR}/etc/local_internal_options.conf
+    fi
+
+    # Install the SCA files
+    if [ -d "${SCA_FILES_DIR}" ]; then
+
+        . ${SCRIPTS_DIR}/src/init/dist-detect.sh
+
+        if [ "DIST_NAME" != "debian" ] && [ "DIST_NAME" != "ubuntu" ]; then
+            DIST_NAME="generic"
+            DIST_VER=""
+        fi
+
+        CONF_ASSESMENT_DIR="${SCA_FILES_DIR}/${DIST_NAME}/${DIST_VER}"
+        mkdir -p ${DIR}/ruleset/sca
+
+        # Install the configuration files needed for this hosts
+        if [ -r ${CONF_ASSESMENT_DIR}/sca.files ]; then
+
+            for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
+                mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
+            done
+            # Delete the temporary directory
+            rm -rf ${SCA_FILES_DIR}
+
+        fi
     fi
 
     # logrotate configuration file

--- a/debs/SPECS/3.9.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.0/wazuh-agent/debian/postinst
@@ -74,7 +74,14 @@ case "$1" in
 
         . ${SCRIPTS_DIR}/src/init/dist-detect.sh
 
-        if [ "DIST_NAME" != "debian" ] && [ "DIST_NAME" != "ubuntu" ]; then
+        if [ "${DIST_NAME}" = "debian" ]; then
+            if [ "${DIST_VER}" = "9" ]; then
+                DIST_VER=""
+            fi
+        elif [ "${DIST_NAME}" = "ubuntu" ]; then
+            DIST_NAME="debian"
+            DIST_VER=""
+        else
             DIST_NAME="generic"
             DIST_VER=""
         fi
@@ -88,6 +95,9 @@ case "$1" in
             for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
                 mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
             done
+            # Set correct permissions, owner and group
+            chmod 640 ${DIR}/ruleset/sca/*
+            chown root:${GROUP} ${DIR}/ruleset/sca/*
             # Delete the temporary directory
             rm -rf ${SCA_FILES_DIR}
 

--- a/debs/SPECS/3.9.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.9.0/wazuh-agent/debian/rules
@@ -96,6 +96,18 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/ubuntu
 	cp -r etc/templates/config/ubuntu ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/
 
+	# Clean the preinstalled configuration assesment files
+	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/ruleset/sca/*
+
+	# Install configuration assesment files and files templates
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/{generic,debian,ubuntu}
+
+	cp -r etc/sca/debian ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r etc/sca/generic ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
+	cp etc/templates/config/debian/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian
+	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
+
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/
 	mkdir -p ${TARGET_DIR}/etc/systemd/

--- a/debs/SPECS/3.9.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.9.0/wazuh-agent/debian/rules
@@ -66,6 +66,9 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}/etc/init.d/
 	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 
+	# Clean the preinstalled configuration assesment files
+	rm -rf $(INSTALLATION_DIR)/ruleset/sca/*
+
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
 	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
@@ -84,6 +87,21 @@ override_dh_install:
 	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 
+	# Install configuration assesment files and files templates
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/9
+
+	cp -r etc/sca/debian ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r etc/sca/generic ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic/
+	cp etc/templates/config/debian/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/
+	cp etc/templates/config/debian/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7/
+	cp etc/templates/config/debian/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8/
+	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/
+
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 
@@ -96,21 +114,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/ubuntu
 	cp -r etc/templates/config/ubuntu ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/
 
-	# Clean the preinstalled configuration assesment files
-	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/ruleset/sca/*
-
-	# Install configuration assesment files and files templates
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/{generic,debian,ubuntu}
-
-	cp -r etc/sca/debian ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
-	cp -r etc/sca/generic ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
-	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
-	cp etc/templates/config/debian/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian
-	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
-
 	# Copying systemd file
-	mkdir -p ${TARGET_DIR}/etc/
-	mkdir -p ${TARGET_DIR}/etc/systemd/
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
 
 	cp src/systemd/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/


### PR DESCRIPTION
Hi team,

this PR closes #150 for Debian based hosts. The fix consists of adding all the SCA files and the `sca.files` templates, select the correct `sca.files` template for the current OS and install the files. Very similar to the solution added in https://github.com/wazuh/wazuh-packages/pull/130, but in Debian hosts. if you reinstall the package, the SCA files will be reinstalled.

This changes was tested in:
- Debian 7-9.
- Ubuntu 18.

Regards.