### PR TITLE
.template.db must be removed by wazuh-db

### DIFF
--- a/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
@@ -105,7 +105,6 @@ case "$1" in
     fi
 
     # Remove existing SQLite databases
-    rm -f ${DIR}/var/db/.template.db* || true
     rm -f ${DIR}/var/db/global.db* || true
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true


### PR DESCRIPTION
Hello team,

This PR closes #111. The fix consists of removing the line https://github.com/wazuh/wazuh-packages/blob/97150b3091368445db003ab9891c67c1d9e1f79b/debs/SPECS/3.9.0/wazuh-manager/debian/postinst#L108 because `wazuh-db` removes this file automatically.

I have done the following tests:

Compilation:
- [x] Centos 7
- [x] Debian 9

Instalation
- [x] Centos 7
- [x] Debian 9

Upgrade
- [x] Centos 7
- [x] Debian 9

Regards,
Daniel Folch