### PR TITLE
Wazuh agent RPM package generation be adapted for i386 compilation

### DIFF
--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -55,9 +55,9 @@ make clean
     make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
 %else
     %ifnarch x86_64
-      MSGPACK="USE_MSGPACK_OPT=yes"
-    %else
       MSGPACK="USE_MSGPACK_OPT=no"
+    %else
+      MSGPACK="USE_MSGPACK_OPT=yes"
     %endif
     make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} ${MSGPACK}

--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -54,8 +54,12 @@ make clean
     make deps
     make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
 %else
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
-    make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled}
+    %if %{_architecture} == "i386"
+      make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
+      make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} USE_MSGPACK_OPT=no
+    %else
+      make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
+      make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} USE_MSGPACK_OPT=yes
 %endif
 
 popd

--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -56,8 +56,6 @@ make clean
 %else
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
-    %else
-      MSGPACK="USE_MSGPACK_OPT=yes"
     %endif
     make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} ${MSGPACK}

--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -54,12 +54,14 @@ make clean
     make deps
     make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
 %else
-    %if %{_architecture} == "i386"
-      make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
-      make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} USE_MSGPACK_OPT=no
+    %ifnarch x86_64
+      MSGPACK="USE_MSGPACK_OPT=yes"
     %else
-      make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
-      make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} USE_MSGPACK_OPT=yes
+      MSGPACK="USE_MSGPACK_OPT=no"
+    %endif
+    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.9
+    make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} ${MSGPACK}
+
 %endif
 
 popd

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -40,7 +40,7 @@ fi
 # Building RPM
 $linux rpmbuild --define "_topdir ${rpm_build_dir}" --define "_threads ${threads}" \
         --define "_release ${package_release}" --define "_localstatedir ${directory_base}" \
-        --define "_debugenabled ${debug}" --target ${architecture_target} \
+        --define "_debugenabled ${debug}" --define "_architecture ${architecture_target}" --target ${architecture_target} \
         -ba ${rpm_build_dir}/SPECS/${package_name}.spec
 
 find ${rpm_build_dir} -name "*.rpm" -exec mv {} /var/local/wazuh \;

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -40,7 +40,7 @@ fi
 # Building RPM
 $linux rpmbuild --define "_topdir ${rpm_build_dir}" --define "_threads ${threads}" \
         --define "_release ${package_release}" --define "_localstatedir ${directory_base}" \
-        --define "_debugenabled ${debug}" --define "_architecture ${architecture_target}" --target ${architecture_target} \
+        --define "_debugenabled ${debug}" --define --target ${architecture_target} \
         -ba ${rpm_build_dir}/SPECS/${package_name}.spec
 
 find ${rpm_build_dir} -name "*.rpm" -exec mv {} /var/local/wazuh \;

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -40,7 +40,7 @@ fi
 # Building RPM
 $linux rpmbuild --define "_topdir ${rpm_build_dir}" --define "_threads ${threads}" \
         --define "_release ${package_release}" --define "_localstatedir ${directory_base}" \
-        --define "_debugenabled ${debug}" --define --target ${architecture_target} \
+        --define "_debugenabled ${debug}" --target ${architecture_target} \
         -ba ${rpm_build_dir}/SPECS/${package_name}.spec
 
 find ${rpm_build_dir} -name "*.rpm" -exec mv {} /var/local/wazuh \;


### PR DESCRIPTION
Hello team,

This PR closes #154. The fix consists of adding a conditional sentence that modifies the compilation flags depending on the architecture.
https://github.com/wazuh/wazuh-packages/blob/2de081d3fd90083b03e641bb814a6c0cc1763080/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec#L53-L63

I have run the following tests:

Compilation
- [x] Centos 5 i386

Installation 
- [x] Centos 5 i386

Upgrade
- [x] Centos 5 i386

Regards,
Daniel Folch