### PR TITLE
Fix python libraries and binaries permissions on postinstall in Manager

### DIFF
--- a/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.9.0/wazuh-manager/debian/postinst
@@ -313,6 +313,16 @@ case "$1" in
     chmod 640 /etc/ossec-init.conf
     chown root:ossec /etc/ossec-init.conf
 
+    # Fix python libraries and binaries permissions
+    chmod 755 ${DIR}/framework/python/bin/2to3-3.7
+    chmod 755 ${DIR}/framework/python/bin/pydoc3
+    chmod 755 ${DIR}/framework/python/bin/pydoc3.7
+    chmod 755 ${DIR}/framework/python/bin/python3-config
+    chmod 755 ${DIR}/framework/python/bin/python3.7-config
+    chmod 755 ${DIR}/framework/python/bin/python3.7m-config
+    chmod 555 ${DIR}/framework/python/lib/libpython3.7m.so
+    chmod 555 ${DIR}/framework/python/lib/libpython3.7m.so.1.0
+
     ;;
 
 


### PR DESCRIPTION
Hello team

  Thanks, @okynos for the commit, this PR pretends to fix the permissions discrepancies due to a Debian automatic overwrite permissions in the generation stage of the package. 

Best regards, 
Alberto R