### PR TITLE
Remove unncessary .rpmnew files after upgrading to v3.9.0

### DIFF
--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -262,6 +262,9 @@ fi
 # Delete the installation files used to configure the agent
 rm -rf %{_localstatedir}/ossec/packages_files
 
+# Remove unnecessary files from shared directory
+rm -f %{_localstatedir}/ossec/etc/shared/*.rpmnew
+
 if [ $1 = 2 ]; then
   if [ -f %{_localstatedir}/ossec/etc/ossec.bck ]; then
       mv %{_localstatedir}/ossec/etc/ossec.bck %{_localstatedir}/ossec/etc/ossec.conf

--- a/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
@@ -381,6 +381,9 @@ done
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/ossec/packages_files
 
+# Remove unnecessary files from default group
+rm -f %{_localstatedir}/ossec/etc/shared/default/*.rpmnew
+
 if %{_localstatedir}/ossec/bin/ossec-logtest 2>/dev/null ; then
   /sbin/service wazuh-manager restart > /dev/null 2>&1
 else


### PR DESCRIPTION
Hi team,

This PR closes #160. It consists of porting the changes from https://github.com/wazuh/wazuh-packages/pull/119 to v3.9.0 rpm specs.

Regards.