### PR TITLE
Fix the installation of SCA files for Ubuntu 14.04

### DIFF
--- a/debs/SPECS/3.9.1/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.1/wazuh-agent/debian/postinst
@@ -79,8 +79,13 @@ case "$1" in
                 DIST_VER=""
             fi
         elif [ "${DIST_NAME}" = "ubuntu" ]; then
-            DIST_NAME="debian"
-            DIST_VER=""
+            if [ "${DIST_VER}" != "14" ] || [ "${DIST_SUBVER}" != "04" ]; then
+                DIST_NAME="ubuntu"
+                DIST_VER=""
+            else
+                DIST_NAME="ubuntu"
+                DIST_VER="14_04"
+            fi
         else
             DIST_NAME="generic"
             DIST_VER=""

--- a/debs/SPECS/3.9.1/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.9.1/wazuh-agent/debian/rules
@@ -90,6 +90,7 @@ override_dh_install:
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/9
@@ -101,6 +102,7 @@ override_dh_install:
 	cp etc/templates/config/debian/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7/
 	cp etc/templates/config/debian/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8/
 	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/
+	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init


### PR DESCRIPTION
Hi team,

this PR closes #172 by adding the sca.files for Ubuntu 14.04 and a new if/else block to set the proper path to that file in the post-install script.

Tested on:
- Ubuntu 12.04
- Ubuntu 14.04
- Ubuntu 18.04

Regards.