### PR TITLE
Fix Wazuh services RHEL 8

### DIFF
--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -234,8 +234,14 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
-
+  
+    # Fix for RHEL 8
+    # Service must be installed in /usr/lib/systemd/system/
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+      install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /usr/lib/systemd/system/
+    else  
+      install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
+    fi
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
     if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then

--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -383,7 +383,12 @@ if [ $1 = 0 ]; then
     rm -f /etc/init.d/wazuh-agent
   fi
   # Remove the wazuh-agent.service file
-  rm -f /etc/systemd/system/wazuh-agent.service
+  # RHEL 8 service located in /usr/lib/systemd/system/ 
+  if [ -f /usr/lib/systemd/system/wazuh-agent.service ]; then
+    rm -f /usr/lib/systemd/system/wazuh-agent.service
+  else
+    rm -f /etc/systemd/system/wazuh-agent.service
+  fi
 
 fi
 

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -435,7 +435,12 @@ if [ $1 = 0 ]; then
   fi
 
   # Remove the service files
-  rm -f /etc/systemd/system/wazuh-manager.service
+  # RHEL 8 service located in /usr/lib/systemd/system/
+  if [ -f /usr/lib/systemd/system/wazuh-manager.service ]; then
+    rm -f /usr/lib/systemd/system/wazuh-manager.service
+  else
+    rm -f /etc/systemd/system/wazuh-manager.service
+  fi
 
 fi
 

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -302,7 +302,14 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-manager.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/
+
+    # Fix for RHEL 8
+    # Service must be installed in /usr/lib/systemd/system/
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+      install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /usr/lib/systemd/system/
+    else
+      install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/
+    fi
 
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file

--- a/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
@@ -383,7 +383,12 @@ if [ $1 = 0 ]; then
     rm -f /etc/init.d/wazuh-agent
   fi
   # Remove the wazuh-agent.service file
-  rm -f /etc/systemd/system/wazuh-agent.service
+  # RHEL 8 service located in /usr/lib/systemd/system/ 
+  if [ -f /usr/lib/systemd/system/wazuh-agent.service ]; then
+    rm -f /usr/lib/systemd/system/wazuh-agent.service
+  else
+    rm -f /etc/systemd/system/wazuh-agent.service
+  fi
 
 fi
 

--- a/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
@@ -234,8 +234,14 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
 
+    # Fix for RHEL 8
+    # Service must be installed in /usr/lib/systemd/system/
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+      install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /usr/lib/systemd/system/
+    else  
+      install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
+    fi
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file
     if [ "${DIST_NAME}" == "fedora" -a "${DIST_VER}" == "28" ]; then

--- a/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
@@ -435,7 +435,12 @@ if [ $1 = 0 ]; then
   fi
 
   # Remove the service files
-  rm -f /etc/systemd/system/wazuh-manager.service
+  # RHEL 8 service located in /usr/lib/systemd/system/
+  if [ -f /usr/lib/systemd/system/wazuh-manager.service ]; then
+    rm -f /usr/lib/systemd/system/wazuh-manager.service
+  else
+    rm -f /etc/systemd/system/wazuh-manager.service
+  fi
 
 fi
 

--- a/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
@@ -302,7 +302,14 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-manager.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-    install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/
+
+    # Fix for RHEL 8
+    # Service must be installed in /usr/lib/systemd/system/
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+      install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /usr/lib/systemd/system/
+    else
+      install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/
+    fi
 
     # Fix for Fedora 28
     # Check if SELinux is installed. If it is installed, restore the context of the .service file


### PR DESCRIPTION
Hello team

  This PR solves #180. 

### Test
Packages built: wazuh-agent & wazuh-manager x86_64


[Wazuh Manager 3.9.2](https://packages-dev.wazuh.com/warehouse/test/3.9/yum/wazuh-manager-3.9.2-redhat8.x86_64.rpm)
[Wazuh Manager 3.10](https://packages-dev.wazuh.com/warehouse/test/3.9/yum/wazuh-manager-3.10.0-redhat8.x86_64.rpm)

[Wazuh Agent 3.9.2](https://packages-dev.wazuh.com/warehouse/test/3.9/yum/wazuh-agent-3.9.2-redhat8.x86_64.rpm)
[Wazuh Agent 3.10](https://packages-dev.wazuh.com/warehouse/test/3.9/yum/wazuh-agent-3.10.0-redhat8.x86_64.rpm)

**Installation test**
- [X] Centos 7
- [X] Red Hat Enterprise Linux 8 

**Upgrade test (3.10)**
- [X] Centos 7
- [X] Red Hat Enterprise Linux 8 

**Uninstall test (3.9)**
- [X] Centos 7
- [X] Red Hat Enterprise Linux 8 