### PR TITLE
Fixed error message from openssl v1.1.1 debs and rpms packages

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
@@ -149,7 +149,7 @@ case "$1" in
 
     # Generation auto-signed certificate if not exists
     if type openssl >/dev/null 2>&1 && [ ! -f "${DIR}/etc/sslmanager.key" ] && [ ! -f "${DIR}/etc/sslmanager.cert" ]; then
-        openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout ${DIR}/etc/sslmanager.key -out ${DIR}/etc/sslmanager.cert
+        openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout ${DIR}/etc/sslmanager.key -out ${DIR}/etc/sslmanager.cert 2>/dev/null
         chmod 640 ${DIR}/etc/sslmanager.key
         chmod 640 ${DIR}/etc/sslmanager.cert
     fi

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -333,7 +333,7 @@ fi
 
 # Generation auto-signed certificate if not exists
 if type openssl >/dev/null 2>&1 && [ ! -f "%{_localstatedir}/ossec/etc/sslmanager.key" ] && [ ! -f "%{_localstatedir}/ossec/etc/sslmanager.cert" ]; then
-  openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout %{_localstatedir}/ossec/etc/sslmanager.key -out %{_localstatedir}/ossec/etc/sslmanager.cert
+  openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout %{_localstatedir}/ossec/etc/sslmanager.key -out %{_localstatedir}/ossec/etc/sslmanager.cert 2>/dev/null
   chmod 640 %{_localstatedir}/ossec/etc/sslmanager.key
   chmod 640 %{_localstatedir}/ossec/etc/sslmanager.cert
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#183|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the 
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

We discovered that we got an error message during **Wazuh manager installation in Ubuntu 18**.
~~~
Can't load /root/.rnd into RNG
139871618495552:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd
~~~
The error is due **OpenSSL version**, concretly **v1.1.1**. This error is fixed by OpenSSL in **v1.1.1a**.

Despite de error message, OpenSSL works well. It generates diferent keys and certificates values, so we have just **ignored the error message**.

At `wazuh-packages/debs/SPECS/3.10.0/wazuh-manager/debian/postinst` we have changed, for **debs** packages, **Generation auto-signed**, adding `2>/dev/null` when the key and certicate is created.
In the same way, we have changed `wazuh-packages/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec` for **rpms** packages.

## Logs/Alerts example
As we can see in the next picture, we have de error message.
~~~
Setting up wazuh-manager (3.9.1-1) ...
Can't load /root/.rnd into RNG
139871618495552:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd
Generating a RSA private key
.......+++++
.......................................+++++
writing new private key to '/var/ossec/etc/sslmanager.key'
-----
~~~

Afer the error fix, we don't see the message error.
~~~
Configurando wazuh-manager (3.10.0-0) ...
Generating a 2048 bit RSA private key
.....................................................................................................+++
.................................................................................+++
writing new private key to '/var/ossec/etc/sslmanager.key'
-----
~~~

## Tests

<!--
At least, the following checks should be marked to accept the PR.
-->

- Compilation without warnings in every supported platform
  - [x] Linux
  - Windows (not aplicable)
  - MAC OS X (not aplicable)
- [x] Source installation
- [x] Package installation
- Source upgrade (not aplicable)
- Package upgrade (not aplicable)
- Memory tests
  - Valgrind report for affected components (not aplicable)
  - CPU impact (not aplicable)
  - RAM usage impact (not aplicable)
- Retrocompatibility with older Wazuh versions (not aplicable)
- Working on cluster enviroments (not aplicable)
- Configuration on demand reports new parameters (not aplicable)
- [x] Review logs syntax and correct language
- QA templates contemplate the added capabilities (not aplicable)