### PR TITLE
Add Ubuntu 12.04 specific policies

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
@@ -79,8 +79,16 @@ case "$1" in
                 DIST_VER=""
             fi
         elif [ "${DIST_NAME}" = "ubuntu" ]; then
-            DIST_NAME="debian"
-            DIST_VER=""
+            if [ "${DIST_VER}" = "12" ] && [ "${DIST_SUBVER}" = "04" ]; then
+                DIST_NAME="ubuntu"
+                DIST_VER="12_04"
+            elif [ "${DIST_VER}" = "14" ] && [ "${DIST_SUBVER}" = "04" ]; then
+                DIST_NAME="ubuntu"
+                DIST_VER="14_04"
+            else
+                DIST_NAME="ubuntu"
+                DIST_VER=""
+            fi
         else
             DIST_NAME="generic"
             DIST_VER=""

--- a/debs/SPECS/3.10.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/rules
@@ -90,6 +90,8 @@ override_dh_install:
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12_04
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/9
@@ -101,6 +103,8 @@ override_dh_install:
 	cp etc/templates/config/debian/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7/
 	cp etc/templates/config/debian/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8/
 	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/
+	cp etc/templates/config/ubuntu/12/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12_04
+	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init
 	cp -r src/init/*  ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init

--- a/debs/SPECS/3.9.2/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.2/wazuh-agent/debian/postinst
@@ -79,12 +79,15 @@ case "$1" in
                 DIST_VER=""
             fi
         elif [ "${DIST_NAME}" = "ubuntu" ]; then
-            if [ "${DIST_VER}" != "14" ] || [ "${DIST_SUBVER}" != "04" ]; then
+            if [ "${DIST_VER}" = "12" ] && [ "${DIST_SUBVER}" = "04" ]; then
                 DIST_NAME="ubuntu"
-                DIST_VER=""
-            else
+                DIST_VER="12_04"
+            elif [ "${DIST_VER}" = "14" ] && [ "${DIST_SUBVER}" = "04" ]; then
                 DIST_NAME="ubuntu"
                 DIST_VER="14_04"
+            else
+                DIST_NAME="ubuntu"
+                DIST_VER=""
             fi
         else
             DIST_NAME="generic"

--- a/debs/SPECS/3.9.2/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.9.2/wazuh-agent/debian/rules
@@ -90,6 +90,7 @@ override_dh_install:
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12_04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8
@@ -102,6 +103,7 @@ override_dh_install:
 	cp etc/templates/config/debian/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7/
 	cp etc/templates/config/debian/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8/
 	cp etc/templates/config/ubuntu/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/
+	cp etc/templates/config/ubuntu/12/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12_04
 	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14_04
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/init


### PR DESCRIPTION
Hi team,

This PR closes #174. I've added this enhancement to v3.9.2 and v3.10.0 specs.

**Installation tests**
- [x] Fresh install on Ubuntu 12.04.
- [x] Fresh install on Ubuntu 14.04.
- [x] Fresh install on Ubuntu 18.04.
- [x] Fresh install on Debian 9.

**Upgrade tests**
- [x] Ubuntu 12.04: Upgrade 3.9.1 to 3.9.2.
- [x] Ubuntu 14.04: Upgrade 3.9.1 to 3.9.2.
- [x] Ubuntu 18.04: Upgrade 3.9.1 to 3.9.2.
- [x] Debian 9: Upgrade 3.9.1 to 3.9.2.
- [x] Ubuntu 12.04: Upgrade 3.9.2 to 3.10.0.
- [x] Ubuntu 14.04: Upgrade 3.9.2 to 3.10.0.
- [x] Ubuntu 18.04: Upgrade 3.9.2 to 3.10.0.
- [x] Debian 9: Upgrade 3.9.2 to 3.10.0.

**Notes**

On Ubuntu 12.04 hosts, the upgrade from 3.9.1 to 3.9.2 or greater, you will find the following configuration and files:
```
root@bebb7f1f57dc:/# more /var/ossec/etc/ossec.conf
...
  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>

    <policies>
      <policy>cis_debian_linux_rcl.yml</policy>
      <policy>system_audit_rcl.yml</policy>
      <policy>system_audit_ssh.yml</policy>
      <policy>system_audit_pw.yml</policy>
    </policies>
  </sca>
...
root@bebb7f1f57dc:/# ls -1 /var/ossec/ruleset/sca/
cis_debian_linux_rcl.yml
cis_debianlinux7-8_L1_rcl.yml
cis_debianlinux7-8_L2_rcl.yml
system_audit_pw.yml
system_audit_rcl.yml
system_audit_ssh.yml
```

This is the expected behavior. The package will save the `ossec.conf` from the previous version and it won't delete the SCA files from the previous version to avoid any errors.

Regards,
Braulio.