### PR TITLE
Added exit to docker build & docker run on rpm & deb

### DIFF
--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -53,14 +53,14 @@ build_deb() {
     cp -rp SPECS/${VERSION}/wazuh-${TARGET} ${DOCKERFILE_PATH}/
 
     # Build the Docker image
-    docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH}
+    docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH} || exit 1
 
     # Build the Debian package with a Docker container
     docker run -t --rm -v ${OUTDIR}:/var/local/wazuh \
         -v ${SOURCES_DIRECTORY}:/build_wazuh/${TARGET}/wazuh-${TARGET}-${VERSION} \
         -v ${DOCKERFILE_PATH}/wazuh-${TARGET}:/${TARGET} \
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
-        ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG}
+        ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} || exit 1
 
     echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -78,13 +78,13 @@ build_rpm() {
         ${DOWNLOAD_TAR}
     fi
     # Build the Docker image
-    docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH}
+    docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH} || exit 1
 
     # Build the RPM package with a Docker container
     docker run -t --rm -v ${OUTDIR}:/var/local/wazuh \
         -v ${SOURCES_DIRECTORY}:/build_wazuh/wazuh-${TARGET}-${VERSION} \
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
-        $JOBS ${RELEASE} ${INSTALLATION_PATH} ${DEBUG}
+        $JOBS ${RELEASE} ${INSTALLATION_PATH} ${DEBUG} || exit 1
 
     echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
 


### PR DESCRIPTION
Hello team,

This PR closes #204.
We have added `exit 1` to docker build and docker run calls in order to receive the error code.
We have tested and it works as expected.

Regards.