### PR TITLE
Create deb and rpm packages with debugging symbols

### DIFF
--- a/debs/README.md
+++ b/debs/README.md
@@ -25,10 +25,10 @@ Building a .deb package is pretty similar to build a .rpm package. You need to d
       Usage: ./generate_debian_package.sh [OPTIONS]
 
           -b, --branch <branch>     [Required] Select Git branch or tag e.g.
-          -s, --store <path>        [Required] Set the destination path of package.
+          -s, --store <path>        [Optional] Set the destination path of package.
           -t, --target <target>     [Required] Target package to build [manager/api/agent].
-          -a, --architecture <arch> [Required] Target architecture of the package [amd64/i386].
-          -r, --revision <rev>      [Required] Package revision that append to version e.g. x.x.x-rev
+          -a, --architecture <arch> [Optional] Target architecture of the package [amd64/i386].
+          -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev
           -j, --jobs <number>       [Optional] Number of parallel jobs when compiling.
           -p, --path <path>         [Optional] Installation path for the package. By default: /var/ossec.
           -d, --debug               [Optional] Build the binaries with debug symbols. By default: no.

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -42,6 +42,10 @@ if [ "${build_target}" == "api" ]; then
     sed -i "s:DIR=\"/var/ossec\":DIR=\"${dir_path}\":g" ${build_dir}/${build_target}/${package_full_name}/debian/wazuh-api.init
 fi
 
+if [[ "${debug}" == "yes" ]]; then
+    sed -i "s:dh_strip --no-automatic-dbgsym::g" ${build_dir}/${build_target}/${package_full_name}/debian/rules
+fi
+
 # Installing build dependencies
 cd ${build_dir}/${build_target}/${package_full_name}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"

--- a/rpms/CentOS/6/i386/Dockerfile
+++ b/rpms/CentOS/6/i386/Dockerfile
@@ -6,7 +6,8 @@ RUN sed -i 's/$basearch/i386/g' /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y install util-linux-ng centos-release-scl \
     gcc-multilib make git openssh-clients rpm-build \
     sudo gnupg automake autoconf libtool \
-    policycoreutils-python yum-utils epel-release
+    policycoreutils-python yum-utils epel-release \
+    redhat-rpm-config rpm-devel
 
 RUN yum-builddep python34 -y
 

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -4,7 +4,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 RUN yum -y install centos-release-scl gcc make git \
     openssh-clients rpm-build sudo gnupg \
     automake autoconf libtool policycoreutils-python \
-    yum-utils epel-release
+    yum-utils epel-release redhat-rpm-config rpm-devel
 
 # Warning: this repo has been disabled by the vendor
 RUN mv /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo.old

--- a/rpms/README.md
+++ b/rpms/README.md
@@ -31,7 +31,7 @@ To build an RPM package, you need to download this repository and use the `gener
         -l, --legacy              [Optional] Build the package for CentOS 5.
         -r, --release             [Optional] Package release. By default: 1.
         -p, --path                [Optional] Installation path for the package. By default: /var.
-        -d, --debug               [Optional] Build the binaries with debug symbols. By default: no.
+        -d, --debug               [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no.
         -h, --help                Show this help.
     ```
     * To build a wazuh-manager package for x86_64, revision 3821 and store it in `/tmp`:
@@ -42,6 +42,9 @@ To build an RPM package, you need to download this repository and use the `gener
         `# ./generate_rpm_package.sh -b 3.9 -s /tmp -t api -a x86_64 -r 0`.
     * To build a wazuh-manager x86_64 package for `/opt/ossec` directory and store it in `/tmp`:
         `# ./generate_rpm_package.sh -b v3.8.2 -s /tmp -t manager -a x86_64 -r 0.1 -p /opt`.
+
+    If you build a package using `-d` parameter, you need to install the `wazuh-xxxxx` and the `wazuh-xxxxx-debuginfo` package in order to install the debugging symbols of the package if you want to debug the binaries using `gdb` for example.
+
 3. When the execution finishes, you can find your `.src.rpm` and the `.rpm` packages in specified folder.
 
 ## More Packages

--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -18,17 +18,9 @@ AutoReqProv: no
 
 Requires: coreutils
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
-BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python
+BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python perl
 %else
-BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils
-%endif
-
-%if 0%{?fc25}
-BuildRequires: perl
-%endif
-
-%if 0%{?el5}
-BuildRequires: perl
+BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils perl
 %endif
 
 ExclusiveOS: linux
@@ -46,13 +38,14 @@ echo "Vendor is %_vendor"
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir}/ossec > etc/ossec-agent.conf
 ./gen_ossec.sh init agent %{_localstatedir}/ossec > ossec-init.conf
 
+%build
 pushd src
 # Rebuild for agent
 make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
     make deps
-    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
+    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled}
 %else
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
@@ -158,6 +151,9 @@ cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_in
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd
 
+if [ %{_debugenabled} == "yes" ]; then
+  %{_rpmconfigdir}/find-debuginfo.sh
+fi
 exit 0
 %pre
 
@@ -234,12 +230,12 @@ if [ $1 = 1 ]; then
 
   # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
-  
+
     # Fix for RHEL 8
     # Service must be installed in /usr/lib/systemd/system/
     if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /usr/lib/systemd/system/
-    else  
+    else
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
     fi
     # Fix for Fedora 28
@@ -383,7 +379,7 @@ if [ $1 = 0 ]; then
     rm -f /etc/init.d/wazuh-agent
   fi
   # Remove the wazuh-agent.service file
-  # RHEL 8 service located in /usr/lib/systemd/system/ 
+  # RHEL 8 service located in /usr/lib/systemd/system/
   if [ -f /usr/lib/systemd/system/wazuh-agent.service ]; then
     rm -f /usr/lib/systemd/system/wazuh-agent.service
   else

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -32,6 +32,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 ./gen_ossec.sh conf manager centos %rhel %{_localstatedir}/ossec > etc/ossec-server.conf
 ./gen_ossec.sh init manager %{_localstatedir}/ossec > ossec-init.conf
 
+%build
 pushd src
 # Rebuild for server
 make clean
@@ -114,6 +115,9 @@ cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd
 
+if [ %{_debugenabled} == "yes" ]; then
+  %{_rpmconfigdir}/find-debuginfo.sh
+fi
 exit 0
 %pre
 

--- a/rpms/SPECS/3.9.3/wazuh-agent-3.9.3.spec
+++ b/rpms/SPECS/3.9.3/wazuh-agent-3.9.3.spec
@@ -18,17 +18,9 @@ AutoReqProv: no
 
 Requires: coreutils
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
-BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python
+BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python perl
 %else
-BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils
-%endif
-
-%if 0%{?fc25}
-BuildRequires: perl
-%endif
-
-%if 0%{?el5}
-BuildRequires: perl
+BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils perl
 %endif
 
 ExclusiveOS: linux
@@ -46,13 +38,14 @@ echo "Vendor is %_vendor"
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir}/ossec > etc/ossec-agent.conf
 ./gen_ossec.sh init agent %{_localstatedir}/ossec > ossec-init.conf
 
+%build
 pushd src
 # Rebuild for agent
 make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
     make deps
-    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
+    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled}
 %else
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
@@ -158,6 +151,9 @@ cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_in
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd
 
+if [ %{_debugenabled} == "yes" ]; then
+  %{_rpmconfigdir}/find-debuginfo.sh
+fi
 exit 0
 %pre
 

--- a/rpms/SPECS/3.9.3/wazuh-manager-3.9.3.spec
+++ b/rpms/SPECS/3.9.3/wazuh-manager-3.9.3.spec
@@ -32,6 +32,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 ./gen_ossec.sh conf manager centos %rhel %{_localstatedir}/ossec > etc/ossec-server.conf
 ./gen_ossec.sh init manager %{_localstatedir}/ossec > ossec-init.conf
 
+%build
 pushd src
 # Rebuild for server
 make clean
@@ -113,6 +114,10 @@ cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_i
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
 cp src/LOCATION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/
 cp -r src/systemd/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd
+
+if [ %{_debugenabled} == "yes" ]; then
+  %{_rpmconfigdir}/find-debuginfo.sh
+fi
 
 exit 0
 %pre

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -17,8 +17,15 @@ threads=$4
 package_release=$5
 directory_base=$6
 debug=$7
+
+disable_debug_flag='%debug_package %{nil}'
+
 if [ -z "${package_release}" ]; then
     package_release="1"
+fi
+
+if [ "${debug}" == "no" ]; then
+    echo ${disable_debug_flag} > /etc/rpm/macros
 fi
 
 # Build directories

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -133,13 +133,13 @@ help() {
     echo
     echo "    -b, --branch <branch>     [Required] Select Git branch or tag e.g. $BRANCH"
     echo "    -t, --target <target>     [Required] Target package to build [manager/api/agent]."
-    echo "    -a, --architecture <arch> [Required] Target architecture of the package [x86_64/i386]."
-    echo "    -r, --revision <rev>      [Required] Package revision that append to version e.g. x.x.x-rev"
+    echo "    -a, --architecture <arch> [Optional] Target architecture of the package [x86_64/i386]."
+    echo "    -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev"
     echo "    -l, --legacy              [Optional] Build package for CentOS 5."
-    echo "    -s, --store <path>        [Required] Set the destination path of package."
+    echo "    -s, --store <path>        [Optional] Set the destination path of package."
     echo "    -j, --jobs <number>       [Optional] Number of parallel jobs when compiling."
     echo "    -p, --path <path>         [Optional] Installation path for the package. By default: /var."
-    echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -d, --debug               [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
     echo "    -h, --help                Show this help."
     echo
     exit $1


### PR DESCRIPTION
Hi team,

This PR closes #201 by adding a feature to create deb packages with debugging symbols and _debuginfo_ rpm packages containing the debugging symbols from each binary.

Regards.