### PR TITLE
 pkginfo not updated solaris10

### DIFF
--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -11,7 +11,7 @@ PATH=$PATH:/opt/csw/bin:/usr/sfw/bin
 VERSION=""
 CURRENT_PATH=`pwd`
 REPOSITORY="https://github.com/wazuh/wazuh"
-ARCH=`uname -a | cut -d " " -f 6`
+ARCH=`uname -p`
 INSTALL="/var/ossec"
 THREADS=4
 PROFILE=agent
@@ -120,7 +120,7 @@ installation(){
     fi
     arch="$(uname -p)"
     # Build the binaries
-    if [ "$arch" == "sparc" ]; then
+    if [ "$arch" = "sparc" ]; then
         gmake -j $THREADS TARGET=agent PREFIX=$INSTALL USE_SELINUX=no USE_BIG_ENDIAN=yes DISABLE_SHARED=yes
     else
         gmake -j $THREADS TARGET=agent PREFIX=$INSTALL USE_SELINUX=no DISABLE_SHARED=yes

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -163,7 +163,7 @@ package(){
     cd ${CURRENT_PATH}
     find /var/ossec | awk 'length > 0' > "wazuh-agent_$VERSION.list"
     ver=`echo $VERSION | cut -d'v' -f 2`
-    sed  "s:ARCH=:ARCH=\"${ARCH}\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
+    sed  "s:ARCH=\".*\":ARCH=\"$ARCH\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
     sed  "s:VERSION=\".*\":VERSION=\"$ver\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
     echo "i pkginfo=pkginfo" > "wazuh-agent_$VERSION.proto"
     echo "i checkinstall=checkinstall.sh" >> "wazuh-agent_$VERSION.proto"
@@ -180,6 +180,7 @@ package(){
     echo $VERSION
     pkgmk -o -r / -d . -f "wazuh-agent_$VERSION.proto"
     pkgtrans -s ${CURRENT_PATH} "wazuh-agent_$VERSION-sol10-$ARCH.pkg" wazuh-agent
+
 }
 
 clean(){

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -163,7 +163,8 @@ package(){
     cd ${CURRENT_PATH}
     find /var/ossec | awk 'length > 0' > "wazuh-agent_$VERSION.list"
     ver=`echo $VERSION | cut -d'v' -f 2`
-    sed "s:VERSION=\".*\":VERSION=\"$ver\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
+    sed  "s:ARCH=:ARCH=\"${ARCH}\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
+    sed  "s:VERSION=\".*\":VERSION=\"$ver\":g" pkginfo > pkginfo.new && mv pkginfo.new pkginfo
     echo "i pkginfo=pkginfo" > "wazuh-agent_$VERSION.proto"
     echo "i checkinstall=checkinstall.sh" >> "wazuh-agent_$VERSION.proto"
     echo "i preinstall=preinstall.sh" >> "wazuh-agent_$VERSION.proto"

--- a/solaris/solaris10/pkginfo
+++ b/solaris/solaris10/pkginfo
@@ -1,7 +1,7 @@
 NAME=Wazuh - Improved OSSEC agent for Intrusion Detection, File Integrity Monitoring, Policy Monitoring and Rootkits Detection.
 PKG="wazuh-agent"
 VERSION="3.6.0"
-ARCH=
+ARCH="i386"
 CLASSES="none"
 CATEGORY="system"
 VENDOR="Wazuh, Inc <info@wazuh.com>"

--- a/solaris/solaris10/pkginfo
+++ b/solaris/solaris10/pkginfo
@@ -1,12 +1,12 @@
 NAME=Wazuh - Improved OSSEC agent for Intrusion Detection, File Integrity Monitoring, Policy Monitoring and Rootkits Detection.
 PKG="wazuh-agent"
 VERSION="3.6.0"
-ARCH="i386"
+ARCH=
 CLASSES="none"
 CATEGORY="system"
-VENDOR="Wazuh, Inc <support@wazuh.com>"
+VENDOR="Wazuh, Inc <info@wazuh.com>"
 PSTAMP="31Aug2018"
-EMAIL="support@wazuh.com"
+EMAIL="info@wazuh.com"
 ISTATES="S s 1 2 3"
 RSTATES="S s 1 2 3"
 BASEDIR="/var/ossec/"


### PR DESCRIPTION
Hello team,
This PR closes  #222, I have added a sed that changes the pkginfo file before creating the package:
https://github.com/wazuh/wazuh-packages/blob/7e78d1e481fde9fc76a0bf5e7b8b71a11dc5cddc/solaris/solaris10/generate_wazuh_packages.sh#L166

And changed the email in the pkginfo file.

Tested in:
- [x] Solaris 10 i386
- [x] Solaris 10 sparc

Regards,
Daniel Folch