### PR TITLE
Fix missing SCA files on Debian 10 and RHEL 8

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
@@ -75,7 +75,7 @@ case "$1" in
         . ${SCRIPTS_DIR}/src/init/dist-detect.sh
 
         if [ "${DIST_NAME}" = "debian" ]; then
-            if [ "${DIST_VER}" = "9" ]; then
+            if [ "${DIST_VER}" = "9" ] || [ "${DIST_VER}" = "10" ]; then
                 DIST_VER=""
             fi
         elif [ "${DIST_NAME}" = "ubuntu" ]; then

--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
@@ -98,18 +98,19 @@ case "$1" in
         mkdir -p ${DIR}/ruleset/sca
 
         # Install the configuration files needed for this hosts
-        if [ -r ${CONF_ASSESMENT_DIR}/sca.files ]; then
-
-            for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
-                mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
-            done
-            # Set correct permissions, owner and group
-            chmod 640 ${DIR}/ruleset/sca/*
-            chown root:${GROUP} ${DIR}/ruleset/sca/*
-            # Delete the temporary directory
-            rm -rf ${SCA_FILES_DIR}
-
+        if [ ! -d ${CONF_ASSESMENT_DIR} ]; then
+            CONF_ASSESMENT_DIR="${SCA_FILES_DIR}/generic"
         fi
+
+        for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
+            mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
+        done
+        # Set correct permissions, owner and group
+        chmod 640 ${DIR}/ruleset/sca/*
+        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # Delete the temporary directory
+        rm -rf ${SCA_FILES_DIR}
+
     fi
 
     # logrotate configuration file

--- a/debs/SPECS/3.9.4/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.4/wazuh-agent/debian/postinst
@@ -75,7 +75,7 @@ case "$1" in
         . ${SCRIPTS_DIR}/src/init/dist-detect.sh
 
         if [ "${DIST_NAME}" = "debian" ]; then
-            if [ "${DIST_VER}" = "9" ]; then
+            if [ "${DIST_VER}" = "9" ] || [ "${DIST_VER}" = "10" ]; then
                 DIST_VER=""
             fi
         elif [ "${DIST_NAME}" = "ubuntu" ]; then

--- a/debs/SPECS/3.9.4/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.4/wazuh-agent/debian/postinst
@@ -98,18 +98,19 @@ case "$1" in
         mkdir -p ${DIR}/ruleset/sca
 
         # Install the configuration files needed for this hosts
-        if [ -r ${CONF_ASSESMENT_DIR}/sca.files ]; then
-
-            for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
-                mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
-            done
-            # Set correct permissions, owner and group
-            chmod 640 ${DIR}/ruleset/sca/*
-            chown root:${GROUP} ${DIR}/ruleset/sca/*
-            # Delete the temporary directory
-            rm -rf ${SCA_FILES_DIR}
-
+        if [ ! -d ${CONF_ASSESMENT_DIR} ]; then
+            CONF_ASSESMENT_DIR="${SCA_FILES_DIR}/generic"
         fi
+
+        for sca_file in $(cat ${CONF_ASSESMENT_DIR}/sca.files); do
+            mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
+        done
+        # Set correct permissions, owner and group
+        chmod 640 ${DIR}/ruleset/sca/*
+        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # Delete the temporary directory
+        rm -rf ${SCA_FILES_DIR}
+
     fi
 
     # logrotate configuration file

--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -304,20 +304,23 @@ fi
 SCA_DIR="${DIST_NAME}/${DIST_VER}"
 mkdir -p %{_localstatedir}/ossec/ruleset/sca
 
+SCA_TMP_DIR="%{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}"
+
 # Install the configuration files
-if [ -r %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}/sca.files ]; then
-
-  for sca_file in $(cat %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}/sca.files); do
-    mv %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${sca_file} %{_localstatedir}/ossec/ruleset/sca
-  done
-  # Fix sca permissions, group and owner
-  chmod 640 %{_localstatedir}/ossec/ruleset/sca/*
-  chown root:ossec %{_localstatedir}/ossec/ruleset/sca/*
-  # Delete the temporary directory
-  rm -rf %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp
-
+if [ ! -d ${SCA_TMP_DIR} ]; then
+  SCA_TMP_DIR="%{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/generic" 
 fi
 
+SCA_TMP_FILE="${SCA_TMP_DIR}/sca.files"
+
+for sca_file in $(cat ${SCA_TMP_FILE}); do
+  mv %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+done
+# Fix sca permissions, group and owner
+chmod 640 %{_localstatedir}/ossec/ruleset/sca/*
+chown root:ossec %{_localstatedir}/ossec/ruleset/sca/*
+# Delete the temporary directory
+rm -rf %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp
 
 # Set the proper selinux context
 if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ "${DIST_VER}" == "5" ]; then

--- a/rpms/SPECS/3.9.4/wazuh-agent-3.9.4.spec
+++ b/rpms/SPECS/3.9.4/wazuh-agent-3.9.4.spec
@@ -304,20 +304,23 @@ fi
 SCA_DIR="${DIST_NAME}/${DIST_VER}"
 mkdir -p %{_localstatedir}/ossec/ruleset/sca
 
+SCA_TMP_DIR="%{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}"
+
 # Install the configuration files
-if [ -r %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}/sca.files ]; then
-
-  for sca_file in $(cat %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${SCA_DIR}/sca.files); do
-    mv %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${sca_file} %{_localstatedir}/ossec/ruleset/sca
-  done
-  # Fix sca permissions, group and owner
-  chmod 640 %{_localstatedir}/ossec/ruleset/sca/*
-  chown root:ossec %{_localstatedir}/ossec/ruleset/sca/*
-  # Delete the temporary directory
-  rm -rf %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp
-
+if [ ! -d ${SCA_TMP_DIR} ]; then
+  SCA_TMP_DIR="%{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/generic" 
 fi
 
+SCA_TMP_FILE="${SCA_TMP_DIR}/sca.files"
+
+for sca_file in $(cat ${SCA_TMP_FILE}); do
+  mv %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+done
+# Fix sca permissions, group and owner
+chmod 640 %{_localstatedir}/ossec/ruleset/sca/*
+chown root:ossec %{_localstatedir}/ossec/ruleset/sca/*
+# Delete the temporary directory
+rm -rf %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp
 
 # Set the proper selinux context
 if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]) && [ "${DIST_VER}" == "5" ]; then


### PR DESCRIPTION
Hi team,

This PR closes #229, #226. The .deb packages now include a check for Debian 10 that will install the generic SCA file for Debian based OS. RPM packages now include a check to improve the detection of the OS. If there aren't any SCA files for the host where the package is installed, the generic SCA files are installed.

Tests:
- [x] Fresh install.
- [x] Upgrade from previous version.
- [x] Upgrade to future version.

Regards.