### PR TITLE
Include Wazuh and Elastic repos in the OVA

### DIFF
--- a/ova/Libraries/elastic_functions.sh
+++ b/ova/Libraries/elastic_functions.sh
@@ -8,7 +8,7 @@ RAW_TEMPLATE_URL2="https://raw.githubusercontent.com/wazuh/wazuh/v${WAZUH_VERSIO
 set_elastic_repository(){
 
     rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
-    echo -e "[elasticsearch-${ELK_MAJOR}.x]\nname=Elasticsearch repository for ${ELK_MAJOR}.x packages\nbaseurl=https://artifacts.elastic.co/packages/${ELK_MAJOR}.x/yum\ngpgcheck=1\ngpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch\nenabled=1\nautorefresh=1\ntype=rpm-md" | tee /etc/yum.repos.d/elastic.repo
+    echo -e "[elasticsearch-${ELK_MAJOR}.x]\nname=Elasticsearch repository for ${ELK_MAJOR}.x packages\nbaseurl=https://artifacts.elastic.co/packages/${ELK_MAJOR}.x/yum\ngpgcheck=1\ngpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch\nenabled=1\nautorefresh=1\ntype=rpm-md" | tee -a /etc/yum.repos.d/elastic.repo
 }
 
 install_elasticsearch(){
@@ -215,8 +215,12 @@ configure_logstash_6(){
 disable_repos_and_clean(){
 
     # Disable repositories
-    sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
-    sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
+    yum-config-manager --disable elasticsearch-${ELK_MAJOR}.x
+    if [ "${STATUS_PACKAGES}" = "stable" ]; then
+        yum-config-manager --disable wazuh_repo
+    else
+        yum-config-manager --disable wazuh_repo_dev
+    fi
 
     # Cleaning tasks
     yum clean all && rm -rf /var/cache/yum

--- a/ova/Libraries/wazuh_functions.sh
+++ b/ova/Libraries/wazuh_functions.sh
@@ -12,12 +12,12 @@ set_wazuh_repository(){
 
     if [ "${STATUS_PACKAGES}" = "stable" ]; then
         # Wazuh production repository
-        echo -e '[wazuh_repo]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=Wazuh repository \nbaseurl=https://packages.wazuh.com/3.x/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo
+        echo -e '[wazuh_repo]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=Wazuh repository \nbaseurl=https://packages.wazuh.com/3.x/yum/\nprotect=1' | tee -a /etc/yum.repos.d/wazuh.repo
     fi
 
     if [ "${STATUS_PACKAGES}" = "unstable" ]; then
         # Wazuh pre-release repository
-        echo -e '[wazuh_repo_dev]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages-dev.wazuh.com/pre-release/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo
+        echo -e '[wazuh_repo_dev]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages-dev.wazuh.com/pre-release/yum/\nprotect=1' | tee -a /etc/yum.repos.d/wazuh.repo
     fi
 }
 

--- a/ova/generate_ova.sh
+++ b/ova/generate_ova.sh
@@ -74,7 +74,7 @@ build_ova() {
     # Vagrant will provision the VM with all the software. (See vagrant file)
     vagrant destroy -f
     vagrant up || clean 1
-    vagrant halt
+    vagrant suspend
     VM_EXPORT=$(vboxmanage list vms | grep -i vm_wazuh | cut -d "\"" -f2)
     # OVA creation with all metadata information.
     vboxmanage export ${VM_EXPORT} -o ${OVA_VM} --vsys 0 --product "Wazuh v${WAZUH_VERSION} OVA" --producturl "https://packages.wazuh.com/vm/wazuh${OVA_VERSION}.ova" --vendor "Wazuh, inc <info@wazuh.com>" --vendorurl "https://wazuh.com" --version "$OVA_VERSION" --description "Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring." || clean 1


### PR DESCRIPTION
Hi team,

This PR closes #239. The vagrant halt command wasn't working properly because the vagrant user no longer exists on the box after running vagrant up. This forces vagrant to force the halt in the box which may cause errors like missing files.

Using `vagrant suspend` we can "stop" the box and create the OVA without generating errors.

Regards.