### PR TITLE
WPK don't add the templates

### DIFF
--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -100,7 +100,6 @@ clean() {
     rm -rf src/*.a
     rm -rf etc/{decoders,lists,rules}
 
-    find etc/templates/* -maxdepth 0 -not -name "en" | xargs rm -rf
 }
 
 preload() {

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -100,6 +100,8 @@ clean() {
     rm -rf src/*.a
     rm -rf etc/{decoders,lists,rules}
 
+    find etc/templates/config -not -name "sca.files" -delete 2>/dev/null
+    find etc/templates/* -maxdepth 0 -not -name "en" -not -name "config" | xargs rm -rf
 }
 
 preload() {


### PR DESCRIPTION
|Related issue|
|----------|
[3753](https://github.com/wazuh/wazuh/issues/3753)

## Description
At the moment, when we generate the packages WPK, the templates are deleted at the start of the funcion `clean` . This causses that, the policies SCA, aren't added to the packages. To resolve this problem, I am going to prevent that the  files `sca.files` are deleted of the folder `templates`. 

## Logs
When we updates the agent with `upgrade_agents` we receive the next message at the instalation of the SCA policies
```
Stopping Wazuh...
Wait for success...
success
SCA policies not available for this OS version centos 7 6.
Starting Wazuh...
```
The message told us, that the templates of the SCA policies are not available. If we check the folder `/var/ossec/ruleset/sca` we can see:
```
ls -la /var/ossec/ruleset/sca/
total 0
drwxr-x---. 2 root ossec  6 jul 26 10:21 .
drwxr-x---. 3 root ossec 17 jul 26 10:21 ..
```

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Package upgrade
- [x] Custom test (linux)
First create a wpk package and upgrade the agent from 3.8 to 3.9, check if the folder `/var/ossec/ruleset/sca` have the templates required or is empty.
```
ls -la /var/ossec/ruleset/sca/
total 88
drwxr-x---. 2 root ossec   120 jul 26 09:26 .
drwxr-x---. 3 root ossec    17 jul 26 09:02 ..
-rw-r-----. 1 root ossec 60289 jul 26 09:26 cis_rhel7_linux_rcl.yml
-rw-r-----. 1 root ossec 11622 jul 26 09:26 system_audit_pw.yml
-rw-r-----. 1 root ossec  4189 jul 26 09:26 system_audit_rcl.yml
-rw-r-----. 1 root ossec  5635 jul 26 09:26 system_audit_ssh.yml
```
We can see that that the system have the SCA policies.
- [x] Custom test (windows)
First create a wpk package and upgrade the agent from 3.8 to 3.9, check if we have the `sca.files` and the folder en.
![Captura de pantalla de 2019-08-02 12-08-03](https://user-images.githubusercontent.com/50922228/62362901-528b0680-b51e-11e9-85f2-64772e9e83b9.png)

In the first image we see that the folders en and config are in the templates, and the second image show that `sca.files` are in the templates

![Captura de pantalla de 2019-08-02 12-08-20](https://user-images.githubusercontent.com/50922228/62362912-561e8d80-b51e-11e9-96d5-0b504e242eba.png)
