### PR TITLE
Change wildcards in installation scripts Debian

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
@@ -106,8 +106,8 @@ case "$1" in
             mv ${SCA_FILES_DIR}/${sca_file} ${DIR}/ruleset/sca
         done
         # Set correct permissions, owner and group
-        chmod 640 ${DIR}/ruleset/sca/*
-        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        find ${DIR}/ruleset/sca -maxdepth 1 -exec chmod 640 {} \;
+        find ${DIR}/ruleset/sca -maxdepth 1 -exec chown root:${GROUP} {} \;
         # Delete the temporary directory
         rm -rf ${SCA_FILES_DIR}
 
@@ -122,12 +122,10 @@ case "$1" in
 
     # Restore group files
     if [ -d ${WAZUH_TMP_DIR}/group ]; then
-        for file in ${WAZUH_TMP_DIR}/group/* ; do
-            mv ${file} ${DIR}/etc/shared/
-        done
+        find ${WAZUH_TMP_DIR}/group -maxdepth 1 -type f -exec mv {} ${DIR}/etc/shared/ \;
         rm -rf ${WAZUH_TMP_DIR}/group
     fi
-    chmod 660 ${DIR}/etc/shared/*
+    find ${DIR}/etc/shared -maxdepth 1 -exec chmod 660 {} \;
     chown -R root:ossec ${DIR}/etc/shared/
     chown root:ossec ${DIR}/logs/ossec.log ${DIR}/logs/ossec.json
 

--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postrm
@@ -38,7 +38,7 @@ case "$1" in
 
     # If the directory is not empty, copy the files into ${DIR}/etc
     if [ "$(ls -A ${DIR}/tmp/conffiles)" ]; then
-        mv ${DIR}/tmp/conffiles/* ${DIR}/etc
+        find ${DIR}/tmp/conffiles -maxdepth 1 -exec mv {} ${DIR}/etc \;
     fi
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
@@ -56,8 +56,7 @@ case "$1" in
     if getent group | grep -q "^ossec" ; then
         delgroup ossec > /dev/null 2>&1
     fi
-    rm -rf ${DIR}/*
-    
+    find ${DIR} -maxdepth 1 -exec rm -rf {} \;
     ;;
 
     upgrade)

--- a/debs/SPECS/3.10.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/preinst
@@ -10,7 +10,7 @@ WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then
     mkdir -p ${WAZUH_TMP_DIR}
-else 
+else
     rm -rf ${WAZUH_TMP_DIR}
     mkdir -p ${WAZUH_TMP_DIR}
 fi
@@ -49,13 +49,11 @@ case "$1" in
             cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
         fi
 
-        if [ -d ${DIR}/etc/shared ]; then
-            files="$(ls -A ${DIR}/etc/shared/*)"
-        fi
 
-        if [ ! -z "$files" ]; then
+
+        if [ -d ${DIR}/etc/shared ]; then
             mkdir -p ${WAZUH_TMP_DIR}/group
-            cp -rp ${DIR}/etc/shared/* ${WAZUH_TMP_DIR}/group/
+            find ${DIR}/etc/shared -maxdepth 1 -exec cp -rp {} ${WAZUH_TMP_DIR}/group/ \;
         fi
     ;;
 

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
@@ -188,9 +188,9 @@ case "$1" in
     chown -R root:${GROUP} ${DIR}/var
     chown -R ${USER}:${GROUP} ${DIR}/var/multigroups
     chmod 770 ${DIR}/var/selinux > /dev/null 2>&1 || true
-    find ${DIR}/var/selinux -maxdepth 1 -exec chmod -R 640 -rf {} \; || true
+    find ${DIR}/var/selinux -maxdepth 1 -exec chmod -R 640 \; || true
     chmod 770 ${DIR}/var/db > /dev/null 2>&1 || true
-    find ${DIR}/var/db -maxdepth 1 -exec chmod -R 660 -rf {} \; || true
+    find ${DIR}/var/db -maxdepth 1 -exec chmod -R 660 \; || true
     chmod 660 ${DIR}/var/db/.profile.db > /dev/null 2>&1 || true
     chmod 770 ${DIR}/var/db/agents > /dev/null 2>&1 || true
     # Restore client.keys configuration

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
@@ -108,7 +108,7 @@ case "$1" in
     rm -f ${DIR}/var/db/global.db* || true
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true
-    rm -f ${DIR}/var/db/agents/* || true
+    find ${DIR}/var/db/agents -maxdepth 1 -exec rm -f {} \; || true
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
 
@@ -188,9 +188,9 @@ case "$1" in
     chown -R root:${GROUP} ${DIR}/var
     chown -R ${USER}:${GROUP} ${DIR}/var/multigroups
     chmod 770 ${DIR}/var/selinux > /dev/null 2>&1 || true
-    chmod -R 640 ${DIR}/var/selinux/* > /dev/null 2>&1 || true
+    find ${DIR}/var/selinux -maxdepth 1 -exec chmod -R 640 -rf {} \; || true
     chmod 770 ${DIR}/var/db > /dev/null 2>&1 || true
-    chmod -R 660 ${DIR}/var/db/* > /dev/null 2>&1 || true
+    find ${DIR}/var/db -maxdepth 1 -exec chmod -R 660 -rf {} \; || true
     chmod 660 ${DIR}/var/db/.profile.db > /dev/null 2>&1 || true
     chmod 770 ${DIR}/var/db/agents > /dev/null 2>&1 || true
     # Restore client.keys configuration
@@ -223,7 +223,7 @@ case "$1" in
 
     # Restore group files
     if [ -d ${WAZUH_TMP_DIR}/group ]; then
-        cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
+        find ${WAZUH_TMP_DIR}/group -maxdepth 1 -exec cp -rfp {} ${DIR}/etc/shared \;
         rm -rf ${WAZUH_TMP_DIR}/group/
     fi
 
@@ -235,20 +235,19 @@ case "$1" in
 
     chmod 770 ${DIR}/etc/lists
     chmod 770 ${DIR}/etc/lists/amazon
-    chmod 660 ${DIR}/etc/lists/amazon/*
+    find ${DIR}/etc/lists/amazon -maxdepth 1 -exec chmod 660 {} \;
     chmod 660 ${DIR}/etc/lists/audit-keys
     chmod 660 ${DIR}/etc/lists/audit-keys.cdb
     chmod 660 ${DIR}/etc/lists/security-eventchannel
     chmod 660 ${DIR}/etc/lists/security-eventchannel.cdb
     chmod 770 ${DIR}/etc/shared/default
-    chmod 660 ${DIR}/etc/decoders/*
-    chmod 660 ${DIR}/etc/rules/*
+    find ${DIR}/etc/decoders -maxdepth 1 -exec chmod 660 {} \;
+    find ${DIR}/etc/rules -maxdepth 1 -exec chmod 660 {} \;
 
-    chown -R root:ossec ${DIR}/etc/client.keys
-    chown -R ossec:ossec ${DIR}/etc/lists/*
-    chown -R ossec:ossec ${DIR}/etc/decoders/*
-    chown -R ossec:ossec ${DIR}/etc/rules/*
-    chown -R ossec:ossec ${DIR}/etc/shared/*
+    find ${DIR}/etc/lists -maxdepth 1 -exec chown -R ossec:ossec {} \;
+    find ${DIR}/etc/decoders -maxdepth 1 -exec chown -R ossec:ossec {} \;
+    find ${DIR}/etc/rules -maxdepth 1 -exec chown -R ossec:ossec {} \;
+    find ${DIR}/etc/shared -maxdepth 1 -exec chown -R ossec:ossec {} \;
     if [ -f ${DIR}/etc/shared/ar.conf ]; then
         chown root:ossec ${DIR}/etc/shared/ar.conf
     fi

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postrm
@@ -48,7 +48,7 @@ case "$1" in
 
     # If the directory is not empty, copy the files into ${DIR}/etc
     if [ "$(ls -A ${DIR}/tmp/conffiles)" ]; then
-        cp -Rf ${DIR}/tmp/conffiles/* ${DIR}/etc
+        find ${DIR}/tmp/conffiles -maxdepth 1 -exec  cp -Rf {} ${DIR}/etc \;
     fi
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
@@ -71,7 +71,7 @@ case "$1" in
     if getent group | grep -q "^ossec" ; then
         delgroup ossec  > /dev/null 2>&1
     fi
-    rm -rf ${DIR}/*
+    find ${DIR} -maxdepth 1 -exec rm -rf {} \;
     ;;
 
     upgrade)

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/preinst
@@ -115,7 +115,7 @@ case "$1" in
         fi
 
         if [ -d ${DIR}/var/db/agents ]; then
-          rm -f ${DIR}/var/db/agents/*
+          find ${DIR}/var/db/agents -maxdepth 1 -exec  rm -f {} ${DIR}/etc \;
         fi
     ;;
 

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/prerm
@@ -31,10 +31,10 @@ case "$1" in
       rm -rf ${DIR}/queue/*
       rm -rf ${DIR}/var/*
       rm -rf ${DIR}/framework/*
-      
+
       # Save the configuration files in ${DIR}/tmp/conffiles
       mkdir -p ${DIR}/tmp/conffiles
-      
+
       # Save the client.keys
       if [ -f ${DIR}/etc/client.keys ]; then
         cp -p ${DIR}/etc/client.keys ${DIR}/tmp/conffiles
@@ -68,7 +68,7 @@ case "$1" in
       if [ -f ${DIR}/etc/shared/default/agent.conf ]; then
         cp -p ${DIR}/etc/shared/default/agent.conf ${DIR}/tmp/conffiles/shared/default
       fi
-      
+
     ;;
 
     failed-upgrade)


### PR DESCRIPTION
Hello team,

This PR closes #248 by changing the * wildcard, that caused problems in some cases due to the system looking for a file called *, by find orders as suggested in the issue.

I have created a package to test this and tested it in:

Install
- [x] Ubuntu 16
- [x] Ubuntu 18

Upgrade
- [x] Ubuntu 16
- [x] Ubuntu 18

Regards,
Daniel Folch