### PR TITLE
Remove Solaris11 dependencies

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -146,9 +146,7 @@ create_package() {
     echo "group groupname=ossec" >> wazuh-agent.p5m.1
     echo "user username=ossec group=ossec" >> wazuh-agent.p5m.1
     pkgmogrify -DARCH=`uname -p` wazuh-agent.p5m.1 wazuh-agent.mog | pkgfmt > wazuh-agent.p5m.2
-    pkgdepend generate -md /var/ossec -d /etc/init.d -d /etc/rc2.d -d /etc/rc3.d wazuh-agent.p5m.2 > wazuh-agent.p5m.3
-    pkgdepend resolve -m wazuh-agent.p5m.3
-    pkgsend -s http://localhost:9001 publish -d /var/ossec -d /etc/init.d -d /etc/rc2.d -d /etc/rc3.d wazuh-agent.p5m.3.res > pack
+    pkgsend -s http://localhost:9001 publish -d /var/ossec -d /etc/init.d -d /etc/rc2.d -d /etc/rc3.d wazuh-agent.p5m.2 > pack
     package=`cat pack | grep wazuh | cut -c 13-` # This extracts the name of the package generated in the previous step
     rm -f *.p5p
     pkgrecv -s http://localhost:9001 -a -d wazuh-agent_$VERSION-sol11-${arch}.p5p $package


### PR DESCRIPTION
Hello team,

This PR closes #247, in this PR we are removing the dependencies of the Solaris 11 package.

These dependencies that are calculated here:
https://github.com/wazuh/wazuh-packages/blob/d5997c5aeb8d04a0f8eec8da0350ca2782b99d41/solaris/solaris11/generate_wazuh_packages.sh#L149-L150
Are not really needed, and make it impossible to install the package in older versions of Solaris 11 than the one where we build the package.
For this reason, we have decided to remove the dependencies.

I have tested the new package in:
- [x] Solaris 11.2
- [x] Solaris 11.3
- [x] Solaris 11.4

Regards,
Daniel Folch
