### PR TITLE
Wrong elastic version in OVA readme

### DIFF
--- a/ova/README.md
+++ b/ova/README.md
@@ -30,7 +30,7 @@ OPTIONS:
 
 To build an OVA with version 3.9.0 using elastic 6.6.2 and the stable repositories you can use:
 
-`# ./generate_ova.sh -b -v 3.9.0 -e 6.6.2 -r stable`
+`# ./generate_ova.sh -b -v 3.9.5 -e 7.3.0 -r stable`
 
    * **Stable:** The OVA uses released packages.
    * **Unstable:** The OVA uses unstable packages.


### PR DESCRIPTION
Hello team,

This PR closes #264. I have changed the old combination of elastic and wazuh versions that didn't have a corresponding app version for one that does.

Regards,
Daniel Folch