### PR TITLE
Delete old .save files in Debian installation

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postrm
@@ -43,6 +43,9 @@ case "$1" in
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
 
+    # Delete old .save
+    find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
+
     # Rename the files
     find ${DIR}/etc/ -type f -exec mv {} {}.save \;
 
@@ -57,7 +60,7 @@ case "$1" in
         delgroup ossec > /dev/null 2>&1
     fi
     rm -rf ${DIR}/*
-    
+
     ;;
 
     upgrade)

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postrm
@@ -53,6 +53,9 @@ case "$1" in
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
 
+    # Delete old .save
+    find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
+
     # Rename the files
     find ${DIR}/etc/ -type f ! -name *shared* -exec mv {} {}.save \;
 

--- a/debs/SPECS/3.11.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/3.11.0/wazuh-agent/debian/postrm
@@ -43,6 +43,9 @@ case "$1" in
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
 
+    # Delete old .save
+    find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
+
     # Rename the files
     find ${DIR}/etc/ -type f -exec mv {} {}.save \;
 
@@ -57,7 +60,7 @@ case "$1" in
         delgroup ossec > /dev/null 2>&1
     fi
     rm -rf ${DIR}/*
-    
+
     ;;
 
     upgrade)

--- a/debs/SPECS/3.11.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/3.11.0/wazuh-manager/debian/postrm
@@ -53,6 +53,9 @@ case "$1" in
     rm -rf ${DIR}/tmp/conffiles
     rm -rf ${DIR}/tmp
 
+    # Delete old .save
+    find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
+
     # Rename the files
     find ${DIR}/etc/ -type f ! -name *shared* -exec mv {} {}.save \;
 


### PR DESCRIPTION
Hello team,

This PR closes #262, I have added a find command that deletes the old .save files before creating the new ones:

https://github.com/wazuh/wazuh-packages/blob/d5415a37d6c72af58a920fa860c88a531ac3d473/debs/SPECS/3.10.0/wazuh-manager/debian/postrm#L57

I have generated packages and tested them in the following systems:

|                          | Ubuntu 14 LTS       |  Ubuntu 16 LTS       |  Ubuntu 18 LTS        |
|:--------------------|-------------------------:|:-------------------------:|:-------------------------:|  
|   Agent              |  <ul><li>- [x] </li>    |  <ul><li>- [x] </li>      |  <ul><li>- [x] </li>     |
|   Manager         |  <ul><li>- [x] </li>    |  <ul><li>- [x] </li>      |  <ul><li>- [x] </li>     |

Regards,
Daniel Folch