### PR TITLE
273 redundant gmake

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -98,12 +98,12 @@ compile() {
 
     arch="$(uname -p)"
     # Build the binaries
-    if [ "$arch" == "sparc" ]; then
+    if [ "$arch" = "sparc" ]; then
         gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes
     else
         gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no
     fi
-    gmake -j $THREADS TARGET=$TARGET
+
     $SOURCE/install.sh
 }
 


### PR DESCRIPTION
Hello team, 

In this PR I have performed the followings changes:

- [x] Removed redundant `gmake` command from [generate_wazuh_packages.sh](https://github.com/wazuh/wazuh-packages/blob/master/solaris/solaris11/generate_wazuh_packages.sh) 
- [x] Fixed syntax error '=='  from [generate_wazuh_packages.sh](https://github.com/wazuh/wazuh-packages/blob/master/solaris/solaris11/generate_wazuh_packages.sh) 

Regards.
Jonathan M.V