### PR TITLE
Debian packages overwrite ossec.log file while upgrading

### DIFF
--- a/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/postinst
@@ -125,10 +125,12 @@ case "$1" in
     fi
     chmod 660 ${DIR}/etc/shared/*
     chown -R root:ossec ${DIR}/etc/shared/
-    chown root:ossec ${DIR}/logs/ossec.log ${DIR}/logs/ossec.json
-
     chmod 660 ${DIR}/etc/ossec.conf
     chown -R root:ossec ${DIR}/etc/ossec.conf
+
+    touch ${DIR}/logs/active-responses.log
+    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chmod 0660 ${DIR}/logs/active-responses.log
 
     # Check if SELinux is installed and enabled
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then

--- a/debs/SPECS/3.10.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.10.0/wazuh-agent/debian/rules
@@ -68,6 +68,15 @@ override_dh_install:
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
+
+	# Remove preinstalled log files
+	rm -rf $(INSTALLATION_DIR)/logs/*.log
+	rm -rf $(INSTALLATION_DIR)/logs/*.json
+
+	# Clean the preinstalled configuration assesment files
+	rm -rf ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+
 	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 	# Copying to target
@@ -83,10 +92,6 @@ override_dh_install:
 	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
-
-	# Clean the preinstalled configuration assesment files
-	rm -rf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
 
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/applications

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/postinst
@@ -231,6 +231,13 @@ case "$1" in
     # More files
     touch ${DIR}/etc/client.keys
 
+    touch ${DIR}/logs/active-responses.log
+    touch ${DIR}/logs/integrations.log
+    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chown ossecm:ossec ${DIR}/logs/integrations.log
+    chmod 0660 ${DIR}/logs/active-responses.log
+    chmod 0640 ${DIR}/logs/integrations.log
+
     # Restore file permissions after upgrading
     chmod 0660 ${DIR}/etc/ossec.conf
 

--- a/debs/SPECS/3.10.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/3.10.0/wazuh-manager/debian/rules
@@ -73,6 +73,15 @@ override_dh_install:
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+
+	# Remove preinstalled log files
+	rm -rf $(INSTALLATION_DIR)/logs/*.log
+	rm -rf $(INSTALLATION_DIR)/logs/*.json
+
+	# Clean the preinstalled configuration assesment files
+	rm -rf ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+
 	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 	# Copying to target
@@ -99,10 +108,6 @@ override_dh_install:
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/ubuntu
 	cp -r etc/templates/config/ubuntu ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/
-
-	# Clean the preinstalled configuration assesment files
-	rm -rf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
 
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/applications

--- a/debs/SPECS/3.11.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.11.0/wazuh-agent/debian/postinst
@@ -125,8 +125,6 @@ case "$1" in
     fi
     chmod 660 ${DIR}/etc/shared/*
     chown -R root:ossec ${DIR}/etc/shared/
-    chown root:ossec ${DIR}/logs/ossec.log ${DIR}/logs/ossec.json
-
     chmod 660 ${DIR}/etc/ossec.conf
     chown -R root:ossec ${DIR}/etc/ossec.conf
 

--- a/debs/SPECS/3.11.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.11.0/wazuh-agent/debian/rules
@@ -66,6 +66,14 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}/etc/init.d/
 	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 
+	# Remove preinstalled log files
+	rm -rf $(INSTALLATION_DIR)/logs/*.log
+	rm -rf $(INSTALLATION_DIR)/logs/*.json
+
+	# Clean the preinstalled configuration assesment files
+	rm -rf ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
 	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
@@ -83,10 +91,6 @@ override_dh_install:
 	cp src/VERSION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 	cp src/REVISION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
 	cp src/LOCATION ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src/
-
-	# Clean the preinstalled configuration assesment files
-	rm -rf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
 
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/applications

--- a/debs/SPECS/3.11.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.11.0/wazuh-manager/debian/postinst
@@ -231,6 +231,13 @@ case "$1" in
     # More files
     touch ${DIR}/etc/client.keys
 
+    touch ${DIR}/logs/active-responses.log
+    touch ${DIR}/logs/integrations.log
+    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chown ossecm:ossec ${DIR}/logs/integrations.log
+    chmod 0660 ${DIR}/logs/active-responses.log
+    chmod 0640 ${DIR}/logs/integrations.log
+
     # Restore file permissions after upgrading
     chmod 0660 ${DIR}/etc/ossec.conf
 

--- a/debs/SPECS/3.11.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/3.11.0/wazuh-manager/debian/rules
@@ -73,6 +73,15 @@ override_dh_install:
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+
+	# Remove preinstalled log files
+	rm -rf $(INSTALLATION_DIR)/logs/*.log
+	rm -rf $(INSTALLATION_DIR)/logs/*.json
+
+	# Clean the preinstalled configuration assesment files
+	rm -rf ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_DIR)/ruleset/sca
+
 	./gen_permissions.sh $(INSTALLATION_DIR)/ ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/restore-permissions.sh
 
 	# Copying to target
@@ -99,10 +108,6 @@ override_dh_install:
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/ubuntu
 	cp -r etc/templates/config/ubuntu ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/etc/templates/config/
-
-	# Clean the preinstalled configuration assesment files
-	rm -rf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/ruleset/sca
 
 	# Install configuration assesment files and files templates
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/applications


### PR DESCRIPTION
Hi team,

This issue closes #279. The fix consists of removing the logs file from the package and now, those logs files are created by the binaries. This makes the logs files unknown for the package, so they won't be overwritten by it.

In addition, this fix only will be applied if you upgrade the packages from 3.10.0 to a greater version.

Tests:
- [x] Fresh install manager.
- [x] Fresh install agent.
- [x] Upgrade manager from 3.10.0 to 3.11.0.
- [x] Upgrade agent from 3.10.0 to 3.11.0.
- [x] Upgrade manager from 3.9.5 to 3.10.0 and then, to 3.11.0.
- [x] Upgrade agent from 3.9.5 to 3.10.0 and then, to 3.11.0.
- [x] Uninstall (apt remove).
- [x] Uninstall (apt purge).