### PR TITLE
Added DISABLE_SHARED=yes flag

### DIFF
--- a/debs/SPECS/3.9.5/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.9.5/wazuh-agent/debian/postinst
@@ -32,8 +32,8 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    ${SCRIPTS_DIR}/gen_ossec.sh init agent ${DIR} > ${DIR}/etc/ossec-init.conf
-    chown root:${GROUP} ${DIR}/etc/ossec-init.conf
+    #${SCRIPTS_DIR}/gen_ossec.sh init agent ${DIR} > ${DIR}/etc/ossec-init.conf
+    #chown root:${GROUP} ${DIR}/etc/ossec-init.conf
     chmod 640 ${DIR}/etc/ossec-init.conf
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then

--- a/solaris/solaris11/SPECS/template_agent_v3.10.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.10.0.json
@@ -664,22 +664,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/lib": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "drwxr-x---",
-        "type": "directory",
-        "user": "root"
-    },
-    "/var/ossec/lib/libwazuhext.so": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v3.10.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.10.0.json
@@ -672,14 +672,6 @@
         "type": "directory",
         "user": "root"
     },
-    "/var/ossec/lib/libwazuhext.so": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v3.10.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.10.0.json
@@ -664,6 +664,22 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/lib/libwazuhext.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v3.11.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.11.0.json
@@ -664,22 +664,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/lib": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "drwxr-x---",
-        "type": "directory",
-        "user": "root"
-    },
-    "/var/ossec/lib/libwazuhext.so": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v3.11.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.11.0.json
@@ -672,14 +672,6 @@
         "type": "directory",
         "user": "root"
     },
-    "/var/ossec/lib/libwazuhext.so": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v3.11.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.11.0.json
@@ -664,6 +664,22 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/lib/libwazuhext.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -72,9 +72,11 @@ check_version(){
     if [ "${major_version}" -eq "3" ]; then
         if [ "${minor_version}" -ge "5" ]; then
             deps_version="true"
+            disa_share="true"
         fi
     elif [ "${major_version}" -gt "3" ]; then
         deps_version="true"
+        disa_share="true"
     fi
 }
 
@@ -99,12 +101,20 @@ compile() {
     arch="$(uname -p)"
     # Build the binaries
     if [ "$arch" = "sparc" ]; then
-        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes
+        if [ "${disa_share}" == "true" ]; then
+            gmake -j $THREADS TARGET=agent DISABLE_SHARED=yes PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes || exit 1
+        else
+            gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes || exit 1
+        fi
     else
-        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no
+        if [ "${disa_share}" == "true" ]; then
+            gmake -j $THREADS TARGET=agent DISABLE_SHARED=yes PREFIX=${install_path} USE_SELINUX=no || exit 1
+        else
+            gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no || exit 1
+        fi      
     fi
 
-    DISABLE_SHARED=yes .$SOURCE/install.sh
+    $SOURCE/install.sh || exit 1
 }
 
 create_package() {
@@ -316,4 +326,4 @@ main() {
   return 0
 }
 
-main "$@"
+main "$@" 

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -11,7 +11,7 @@ THREADS="4"
 TARGET="agent"
 PATH=$PATH:/opt/csw/bin/
 current_path="$( cd $(dirname $0) ; pwd -P )"
-share_lib="no"
+shared_lib="no"
 arch=`uname -p`
 SOURCE=${current_path}/repository
 CONFIG="$SOURCE/etc/preloaded-vars.conf"
@@ -75,11 +75,11 @@ check_version(){
             deps_version="true"
         fi
         if [ "${minor_version}" -ge "10" ]; then
-            share_lib="yes"
+            shared_lib="yes"
         fi
     elif [ "${major_version}" -gt "3" ]; then
         deps_version="true"
-        share_lib="yes"
+        shared_lib="yes"
     fi
 }
 
@@ -104,12 +104,12 @@ compile() {
     arch="$(uname -p)"
     # Build the binaries
     if [ "$arch" = "sparc" ]; then
-        gmake -j $THREADS TARGET=agent DISABLE_SHARED=${share_lib} PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes || exit 1
+        gmake -j $THREADS TARGET=agent DISABLE_SHARED=${shared_lib} PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes || exit 1
     else
-        gmake -j $THREADS TARGET=agent DISABLE_SHARED=${share_lib} PREFIX=${install_path} USE_SELINUX=no || exit 1   
+        gmake -j $THREADS TARGET=agent DISABLE_SHARED=${shared_lib} PREFIX=${install_path} USE_SELINUX=no || exit 1   
     fi
 
-    DISABLE_SHARED=${share_lib} .$SOURCE/install.sh || exit 1
+    DISABLE_SHARED=${shared_lib} .$SOURCE/install.sh || exit 1
 }
 
 create_package() {

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -104,7 +104,7 @@ compile() {
         gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no
     fi
 
-    $SOURCE/install.sh
+    DISABLE_SHARED=yes .$SOURCE/install.sh
 }
 
 create_package() {

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -109,7 +109,7 @@ compile() {
         gmake -j $THREADS TARGET=agent DISABLE_SHARED=${shared_lib} PREFIX=${install_path} USE_SELINUX=no || exit 1   
     fi
 
-    DISABLE_SHARED=${shared_lib} .$SOURCE/install.sh || exit 1
+    DISABLE_SHARED=${shared_lib} $SOURCE/install.sh || exit 1
 }
 
 create_package() {


### PR DESCRIPTION
Hello team.

In reply to Issue #268. To generate a Solaris 11 package without library dependencies error, I add the build flag DISABLE_SHARED=yes in generate process to create the pkg.

Best regards.
Alejandro Alguacil