### PR TITLE
Fixed error messages in the building of the Solaris 10 package

### DIFF
--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -189,13 +189,13 @@ clean(){
     cd ${CURRENT_PATH}
     rm -rf ${SOURCE}
     rm -rf wazuh-agent wazuh *.list *proto
-    rm -f /etc/ossec-init.conf
     rm -f *.new
 
     ## Stop and remove application
     ${install_path}/bin/ossec-control stop
     rm -r ${install_path}*
- 
+    rm -f /etc/ossec-init.conf
+    
      # remove launchdaemons
     rm -f /etc/init.d/wazuh-agent
     rm -f /etc/rc2.d/S97wazuh-agent

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -190,17 +190,14 @@ clean(){
     rm -rf ${SOURCE}
     rm -rf wazuh-agent wazuh *.list *proto
     rm -f /etc/ossec-init.conf
-    rm *.new
+    rm -f *.new
 
     ## Stop and remove application
     ${install_path}/bin/ossec-control stop
     rm -r ${install_path}*
-    rm /etc/ossec-init.conf
-
-    # remove launchdaemons
+ 
+     # remove launchdaemons
     rm -f /etc/init.d/wazuh-agent
-    rm -f /etc/ossec-init.conf
-
     rm -f /etc/rc2.d/S97wazuh-agent
     rm -f /etc/rc3.d/S97wazuh-agent
 


### PR DESCRIPTION
Hello team, in this PR I have fixed the error messages in the building of the Solaris 10 package.

The solution has been to eliminate the redundant lines and modify the position in which the file `/etc/ossec.init.conf` is deleted since this file must be deleted after stopping the Wazuh services.

These changes have been tested on Jenkins, and can be checked at the following link: https://jenkins-staging.wazuh.info/job/Packages_builder_solaris/41/console

In the following image, we can see how the errors indicated in the issue description are no longer shown

![imagen](https://user-images.githubusercontent.com/23462183/64333940-dfbaf280-cfd7-11e9-8902-710a93280d30.png)

close #285 

Best regards.