### PR TITLE
Removed unnecessary ssh-keyscan command

### DIFF
--- a/wpk/unified/linux/Dockerfile
+++ b/wpk/unified/linux/Dockerfile
@@ -2,13 +2,11 @@ FROM centos:6
 ENV PATH=/opt/rh/python27/root/usr/bin:$PATH
 
 RUN yum -y install centos-release-scl && \
-    yum -y install gcc make git openssh-clients python27 && \
+    yum -y install gcc make git python27 && \
     echo -e "/opt/rh/python27/root/usr/lib64/" | tee  -a /etc/ld.so.conf && \
     ldconfig && \
     pip install --upgrade pip && \
-    pip install --upgrade cryptography && \
-    mkdir -p ~/.ssh && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
+    pip install --upgrade cryptography
 
 RUN yum install -y automake autoconf libtool
 ADD wpkpack.py /usr/local/bin/wpkpack

--- a/wpk/windows/Dockerfile
+++ b/wpk/windows/Dockerfile
@@ -7,9 +7,7 @@ RUN apt-get update && \
       curl && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && \
-    pip install --upgrade cryptography && \
-    mkdir -p ~/.ssh && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
+    pip install --upgrade cryptography 
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run


### PR DESCRIPTION
Hi team

This PR closes #289 by removing the unnecessary ssh-keyscan from the Dockerfiles. This command was used to gather the GitHub's public ssh key, allowing the Docker image to clone the GitHub repository by using `git clone git@github:...`.

This wasn't necessary because the Docker images clone the repository using `git clone https://github...` and this method doesn't need any ssh key.

Regards.