### PR TITLE
Enable HTTPS by default in API

### DIFF
--- a/debs/SPECS/3.11.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.11.0/wazuh-api/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 # postinst script for Wazuh
-# Wazuh, Inc 2016
+# Wazuh, Inc 2019
 
 set -e
 
@@ -43,6 +43,21 @@ case "$1" in
     # Remove installation scripts directory
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}
+    fi
+
+    # Generate and enable a new SSL certificate for clean installs
+    if [ ! -f ${WAZUH_TMP_DIR}/api/configuration/config.js ] && command -v openssl > /dev/null 2>&1; then
+        HTTPS="Y"
+        PASSWORD="wazuh"
+        COUNTRY="XX"
+        STATE="XX"
+        LOCALITY="XX"
+        ORG_NAME="XX"
+        ORG_UNIT="XX"
+        COMMON_NAME="XX"
+        API_PATH=${WAZUH_API_DIR}
+        . ${WAZUH_API_DIR}/scripts/configure_api.sh
+        change_https > /dev/null 2>&1
     fi
 
     # Delete tmp directory

--- a/debs/SPECS/3.11.0/wazuh-api/debian/rules
+++ b/debs/SPECS/3.11.0/wazuh-api/debian/rules
@@ -37,8 +37,8 @@ override_dh_auto_install:
 	groupadd ossec
 	useradd ossec -g ossec
 
-	# Installing api by its own script
-	DIRECTORY="$(INSTALLATION_DIR)" ./install_api.sh
+	# Installing api by its own script with HTTPS disabled
+	DIRECTORY="$(INSTALLATION_DIR)" DISABLE_HTTPS=Y  ./install_api.sh
 	
 	# Remove "fake" framework directory
 	rmdir $(INSTALLATION_DIR)/framework

--- a/rpms/SPECS/3.11.0/wazuh-api-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-api-3.11.0.spec
@@ -106,16 +106,16 @@ fi
 
 # Generate and enable a new SSL certificate for clean installs
 if [ $1 = 1 ] && command -v openssl > /dev/null 2>&1; then
-  HTTPS="Y" \
-  PASSWORD="wazuh" \
-  COUNTRY="XX" \
-  STATE="XX" \
-  LOCALITY="XX" \
-  ORG_NAME="XX" \
-  ORG_UNIT="XX" \
-  COMMON_NAME="XX" \
+  HTTPS="Y"
+  PASSWORD="wazuh"
+  COUNTRY="XX"
+  STATE="XX"
+  LOCALITY="XX"
+  ORG_NAME="XX"
+  ORG_UNIT="XX"
+  COMMON_NAME="XX"
   . %{_localstatedir}/ossec/api/scripts/configure_api.sh
-  change_https
+  change_https > /dev/null 2>&1
 fi
 
 %preun

--- a/rpms/SPECS/3.11.0/wazuh-api-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-api-3.11.0.spec
@@ -48,7 +48,8 @@ rm -fr %{buildroot}
 # Create the directories needed to install the wazuh-api
 mkdir -p %{_localstatedir}/ossec/{framework,logs}
 echo 'DIRECTORY="%{_localstatedir}/ossec"' > /etc/ossec-init.conf
-# Install the wazuh-api
+# Install Wazuh API with HTTPS disabled. It will be enabled in post installation
+DISABLE_HTTPS=Y \
 ./install_api.sh --no-service
 # Remove the framework directory
 rmdir %{_localstatedir}/ossec/framework
@@ -101,6 +102,20 @@ API_PATH_BACKUP="${RPM_BUILD_ROOT}%{_localstatedir}/ossec/~api"
 if [ -d ${API_PATH_BACKUP} ]; then
   cp -rfnp ${API_PATH_BACKUP}/configuration ${API_PATH_BACKUP_BACKUP}/configuration
   rm -rf ${API_PATH_BACKUP}
+fi
+
+# Generate and enable a new SSL certificate for clean installs
+if [ $1 = 1 ] && command -v openssl > /dev/null 2>&1; then
+  HTTPS="Y" \
+  PASSWORD="wazuh" \
+  COUNTRY="XX" \
+  STATE="XX" \
+  LOCALITY="XX" \
+  ORG_NAME="XX" \
+  ORG_UNIT="XX" \
+  COMMON_NAME="XX" \
+  . %{_localstatedir}/ossec/api/scripts/configure_api.sh
+  change_https
 fi
 
 %preun


### PR DESCRIPTION
Hi team,

I edited the SPECS of `.deb` and `.rpm` packages for configuring `HTTPS` in API post installation. `HTTPS` only will be enabled in clean installs.

This PR should be merged after API PR [#422](https://github.com/wazuh/wazuh-api/pull/442).

Below there are different use cases of installations/upgradings:

**Clean install (Ubuntu)**
```bash
# apt-get install /wazuh-api_3.11.0-0_amd64.deb            
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-api' instead of '/wazuh-api_3.11.0-0_amd64.deb'
The following NEW packages will be installed:
  wazuh-api
0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
Need to get 0 B/2230 kB of archives.
After this operation, 9887 kB of additional disk space will be used.
Get:1 /wazuh-api_3.11.0-0_amd64.deb wazuh-api amd64 3.11.0-0 [2230 kB]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package wazuh-api.
(Reading database ... 24224 files and directories currently installed.)
Preparing to unpack /wazuh-api_3.11.0-0_amd64.deb ...
Unpacking wazuh-api (3.11.0-0) ...
Setting up wazuh-api (3.11.0-0) ...
root@2390279aaa15:/# node /var/ossec/api/app.js &
[1] 27962
root@2390279aaa15:/# curl -u foo:bar https://localhost:55000 -k
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.11.0","hostname":"2390279aaa15","timestamp":"Mon Sep 09 2019 10:55:01 GMT+0000 (UTC)"}}
```

**Clean install (CentOS)**
```bash
# rpm -i wazuh-api-3.11.0-0.x86_64.rpm 
[root@7392b0f5fdf2 /]# node /var/ossec/api/app.js &
[1] 115
[root@7392b0f5fdf2 /]# curl -u foo:bar https://localhost:55000 -k
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.11.0","hostname":"7392b0f5fdf2","timestamp":"Mon Sep 09 2019 10:58:21 GMT+0000 (UTC)"}}
```

**Upgrade from `3.9` version (HTTPS disabled, Ubuntu)**
```bash
# curl -u foo:bar http://localhost:55000
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.9.5","hostname":"2390279aaa15","timestamp":"Mon Sep 09 2019 11:03:22 GMT+0000 (UTC)"}}
```

```bash
# apt-get install /wazuh-manager_3.11.0-0_amd64.deb /wazuh-api_3.11.0-0_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-manager' instead of '/wazuh-manager_3.11.0-0_amd64.deb'
Note, selecting 'wazuh-api' instead of '/wazuh-api_3.11.0-0_amd64.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-api wazuh-manager
2 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
Need to get 0 B/72.9 MB of archives.
After this operation, 2735 kB of additional disk space will be used.
Get:1 /wazuh-api_3.11.0-0_amd64.deb wazuh-api amd64 3.11.0-0 [2230 kB]
Get:2 /wazuh-manager_3.11.0-0_amd64.deb wazuh-manager amd64 3.11.0-0 [70.6 MB]
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 26733 files and directories currently installed.)
Preparing to unpack /wazuh-api_3.11.0-0_amd64.deb ...
Unpacking wazuh-api (3.11.0-0) over (3.9.5-1) ...
Preparing to unpack .../wazuh-manager_3.11.0-0_amd64.deb ...
Unpacking wazuh-manager (3.11.0-0) over (3.9.5-1) ...
Setting up wazuh-manager (3.11.0-0) ...
wazuh-clusterd not running...
wazuh-modulesd not running...
ossec-monitord not running...
ossec-logcollector not running...
ossec-remoted not running...
ossec-syscheckd not running...
ossec-analysisd not running...
ossec-maild not running...
ossec-execd not running...
wazuh-db not running...
ossec-authd not running...
ossec-agentlessd not running...
ossec-integratord not running...
ossec-dbd not running...
ossec-csyslogd not running...
Wazuh v3.11.0 Stopped
Starting Wazuh v3.11.0...
Started ossec-csyslogd...
Started ossec-dbd...
2019/09/09 11:04:46 ossec-integratord: INFO: Remote integrations not configured. Clean exit.
Started ossec-integratord...
Started ossec-agentlessd...
Started ossec-authd...
Started wazuh-db...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-syscheckd...
Started ossec-remoted...
Started ossec-logcollector...
Started ossec-monitord...
Started wazuh-modulesd...
Completed.
Setting up wazuh-api (3.11.0-0) ...
[1]+  Killed                  node /var/ossec/api/app.js
# node /var/ossec/api/app.js &
[1] 25637
root@2390279aaa15:/# curl -u foo:bar http://localhost:55000
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.11.0","hostname":"2390279aaa15","timestamp":"Mon Sep 09 2019 11:06:24 GMT+0000 (UTC)"}}
# curl -u foo:bar https://localhost:55000 -k
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to localhost:55000 
```

**Upgrade from `3.9` version (HTTPS disabled, CentOS)**
```bash
# curl -u foo:bar http://localhost:55000
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.9.5","hostname":"7392b0f5fdf2","timestamp":"Mon Sep 09 2019 11:09:37 GMT+0000 (UTC)"}}
```

```bash
# rpm -U wazuh-manager-3.11.0-0.x86_64.rpm wazuh-api-3.11.0-0.x86_64.rpm 
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
# node /var/ossec/api/app.js &
[1] 3010
[root@7392b0f5fdf2 /]# curl -u foo:bar http://localhost:55000
{"error":0,"data":{"msg":"Welcome to Wazuh HIDS API","api_version":"v3.11.0","hostname":"7392b0f5fdf2","timestamp":"Mon Sep 09 2019 11:11:35 GMT+0000 (UTC)"}}[root@7392b0f5fdf2 /]# curl -u foo:bar https://localhost:55000 -k
curl: (35) Encountered end of file
```

Best regards,

Demetrio.