### PR TITLE
Add a tool to notarize macOS package

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -6,32 +6,44 @@ In this repository, you can find the necessary tools to build a Wazuh package fo
 ## Tools needed to build the package
 
 To build a Wazuh package you need to install the following tools:
-- [Packages](http://s.sudre.free.fr/Software/Packages/about.html): You can install this on macOS using the `generate_wazuh_packages.sh` script in this repo.
-- [brew](https://brew.sh/): You can install this on macOS using the `generate_wazuh_packages.sh` script in this repo.
-- `git`: on macOS install with homebrew use `brew install git`
+- [Packages](http://s.sudre.free.fr/Software/Packages/about.html): You can install this on macOS using the `generate_wazuh_packages.sh` script in this repository.
+- [brew](https://brew.sh/): You can install this on macOS using the `generate_wazuh_packages.sh` script in this repository.
+- `git`: on macOS install with homebrew use `brew install git`.
 
 ## Building macOS packages
 
-To build an macOS package, you need to download this repository and use the `generate_wazuh_packages.sh` script. This script will download the source code from the [wazuh/wazuh](https://github.com/wazuh/wazuh) repository and automatize the package generation.
+To build a macOS package, you need to download this repository and use the `generate_wazuh_packages.sh` script. This script will download the source code from the [wazuh/wazuh](https://github.com/wazuh/wazuh) repository and automatize the package generation.
 
 1. Download this repository and go to the rpm directory:
     ```bash
     $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/macos
     ```
 
-2. Execute the `generate_wazuh_packages.sh` script to build the package. There are multiple parameters for selecting which package is going to be built, such as install destination, etc. Also you can install `Packages` using the script. Here you can see all the different parameters:
+2. Execute the `generate_wazuh_packages.sh` script to build the package. There are multiple parameters for selecting which package is going to be built, such as the install destination, etc. Also, you can install `Packages` using the script. Here you can see all the different parameters:
     ```shellsession
     $ ./generate_wazuh_packages.sh -h
 
-    Usage: $0 [OPTIONS]
-        -b, --branch <branch>     [Required] Select Git branch or tag e.g. $BRANCH"
-        -s, --store-path <path>   [Optional] Set the destination absolute path of package."
-        -j, --jobs <number>       [Optional] Number of parallel jobs when compiling."
-        -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev"
-        -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package).
-        -h, --help                [  Util  ] Show this help."
-        -i, --install-deps        [  Util  ] Install build dependencies (Packages)."
-        -x, --install-xcode       [  Util  ] Install X-Code and brew. Can't be executed as root."
+    Usage: ./generate_wazuh_packages.sh [OPTIONS]
+
+    Build options:
+        -b, --branch <branch>         [Required] Select Git branch or tag e.g.
+        -s, --store-path <path>       [Optional] Set the destination absolute path of package.
+        -j, --jobs <number>           [Optional] Number of parallel jobs when compiling.
+        -r, --revision <rev>          [Optional] Package revision that append to version e.g. x.x.x-rev
+        -c, --checksum <path>         [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package).
+        -h, --help                    [  Util  ] Show this help.
+        -i, --install-deps            [  Util  ] Install build dependencies (Packages).
+        -x, --install-xcode           [  Util  ] Install X-Code and brew. Can't be executed as root.
+
+    Signing options:
+        --keychain                    [Optional] Keychain where the Certificates are installed.
+        --keychain-password           [Optional] Password of the keychain.
+        --application-certificate     [Optional] Apple Developer ID certificate name to sign Apps and binaries.
+        --installer-certificate       [Optional] Apple Developer ID certificate name to sign pkg.
+        --notarize                    [Optional] Notarize the package for its distribution on macOS Catalina .
+        --developer-id                [Optional] Your Apple Developer ID.
+        --altool-password             [Optional] Temporary password to use altool from Xcode.
+
 
     ```
     * To build a wazuh-agent package for tag v3.7.2 with 4 jobs:
@@ -43,16 +55,65 @@ To build an macOS package, you need to download this repository and use the `gen
     * To install `brew` and `X-Code` tool:
         `$ ./generate_wazuh_packages.sh -x`.
 
-3. When the execution finishes, you can find your `.pkg` packages in specified folder (with parameter `-s`), by default in the script path.
+3. When the execution finishes, you can find your `.pkg` packages in the specified folder (with the parameter `-s`), by default in the script path.
 
 
-# Aditional information
+## Aditional information
+
+### Building information
 
 Use the `generate_wazuh_packages.sh` script for build packages for macOS.
 
-The `package_files` contains some files used by the `Buildpackages` tool to generate the package. The most important file is `wazuh-agent-pkgproj`, which is used by `Buildpackages` to generate the package and have to be updated by the script with the specs and default Wazuh configurations. Also, there are two scripts, `postinstall.sh` and `preinstall.sh` that are loaded in the package to be executed during the installation, and the `build.sh` scripts defines how to compile the Wazuh Agent.
+The `package_files` contains some files used by the `Buildpackages` tool to generate the package. The most important file is `wazuh-agent-pkgproj`, which is used by `Buildpackages` to generate the package and have to be updated by the script with the specs and default Wazuh configurations. Also, there are two scripts, `postinstall.sh` and `preinstall.sh` that are loaded in the package to be executed during the installation, and the `build.sh` script defines how to compile the Wazuh Agent.
 
 The specs folder contains the `pkgproj` files which are used to generate the `wazuh-agent.pkgproj` file.
+
+### Apple notarization process
+
+With macOS Mojave, Apple introduced the notarization process to improve the security of the final users. With macOS Mojave is recommended to notarize any installer/app, but with the release of macOS Catalina, it is mandatory to notarize any app or installer distributed outside of the App Store. To successfully notarize your package, you must have the following items:
+
+- **Apple Developer ID**: this is used to request the certificates used to sign the binaries, the .pkg file and notarize the package. You can request one using this link. Besides, you need to enable two-factor authentication (_2FA_) and enroll in the Apple Developer program.
+- **Apple Application Certificate** and **Apple Installer Certificate**: these certificates are used to sign the code and sign the .pkg file. In this [link](https://help.apple.com/developer-account/#/dev04fd06d56) you can find more information about how to request them. Once you have downloaded them, you must add them to your login keychain and make sure that `codesign` and `productsign` can access to the certificates and the private key.
+- **Xcode 10 or greater**: to properly sign the binaries, sign the package and notarize it, you must install and download it.
+- **Generate a temporary password for xcrun altool**: to notarize the package, you must use your Apple Developer ID and your password, but, for security reasons, only application specific passwords are allowed. To request one, you can follow this [link](https://support.apple.com/en-us/HT204397).
+
+Once you have set up the environment, you can build and notarize the package as follows:
+
+```shellsession
+$ sudo ./generate_wazuh_packages.sh -b v3.10.2 -j 4 -r 1 --notarize \
+    --keychain "/Users/your-user/Library/Keychains/login.keychain-db" \
+    --application-certificate "Your Developer ID Application" \
+    --installer-certificate "Your Developer ID Installer" \
+    --developer-id "your_apple_id@email.com" --keychain-password "login_password" \
+    --altool-password "temporary-password-for-altool"
+```
+
+The script will automatically sign the code and enable the _hardened runtime_, build the package and sign it, upload the package for its notarization and once it is notarized, the script will staple the notarization ticket to the package. Thanks to this, the package will be able to be installed in those hosts without an internet connection.
+
+Finally, you can find the notarization result in the `wazuh-packages/macos/request_result.txt`.
+
+### Additional information
+
+- [Enable hardened runtime (macOS)](https://help.apple.com/xcode/mac/current/#/devf87a2ac8f).
+- [About Code Signing](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html).
+- [Code Signing Tasks](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW26).
+- [Customizing the Notarization Workflow](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow?language=objc).
+- [Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements).
+- [Hardened Runtime Entitlements](https://developer.apple.com/documentation/security/hardened_runtime_entitlements?language=objc).
+- [Resolving Common Notarization Issues](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/resolving_common_notarization_issues).
+
+### Common issues
+
+- `xcrun: error: unable to find utility "altool", not a developer tool or in PATH`: this error appears when `xcrun` is unable to find altool. To solve it you will need to run:
+    ```
+    $ sudo xcode-select -r
+    ```
+    If this doesn't solve the issue, you will need to specify the path where Xcode is installed or unpacked:
+    ```
+    $ sudo xcode-select -s /path/to/Xcode.app
+    ```
+- `errSecInternalComponent` when running `codesign`: check the status of the login keychain. To solve it, you will need to close all the keychains and then run again the script.
+- `error: The specified item could not be found in the keychain`: this error may appear if `codesign` or `productsign` can't access to the Certificates, the private key or both. Check in the Keychain of your Mac hosts if they can be read by `codesign` and `productsign`.
 
 ## More Packages
 

--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-only</key>
+    <true/>
+    <key>com.apple.security.assets.pictures.read-only</key>
+    <true/>
+    <key>com.apple.security.assets.music.read-only</key>
+    <true/>
+    <key>com.apple.security.assets.movies.read-only</key>
+    <true/>
+  </dict>
+</plist>

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -21,8 +21,16 @@ BRANCH_TAG="master"                   # Branch that will be downloaded to build 
 DESTINATION="${CURRENT_PATH}/output/" # Where package will be stored.
 JOBS="2"                              # Compilation jobs.
 DEBUG="no"                            # Enables the full log by using `set -exf`.
-CHECKSUMDIR=""
-CHECKSUM="no"
+CHECKSUMDIR=""                        # Directory to store the checksum of the package.
+CHECKSUM="no"                         # Enables the checksum generation.
+CERT_APPLICATION_ID=""                # Apple Developer ID certificate to sign Apps and binaries.
+CERT_INSTALLER_ID=""                  # Apple Developer ID certificate to sign pkg.
+KEYCHAIN=""                           # Keychain where the Apple Developer ID certificate is.
+KC_PASS=""                            # Password of the keychain.
+NOTARIZE="no"                         # Notarize the package for macOS Catalina.
+DEVELOPER_ID=""                       # Apple Developer ID.
+ALTOOL_PASS=""                        # Temporary Application password for altool.
+pkg_name=""
 
 function clean_and_exit() {
     exit_code=$1
@@ -32,7 +40,78 @@ function clean_and_exit() {
     exit ${exit_code}
 }
 
+function notarize_pkg() {
+    # Notarize the macOS package
+    if [ "${NOTARIZE}" = "yes" ]; then
+        if sudo xcrun altool --notarize-app --primary-bundle-id "com.wazuh.agent.v${VERSION}.${REVISION}.testwppkg" \
+            --username "${DEVELOPER_ID}" --password "${ALTOOL_PASS}" --file ${DESTINATION}/${pkg_name} > request_info.txt ; then
+            echo "The package ${DESTINATION}/${pkg_name} was successfully upload for notarization."
+            echo "Waiting to 120s to get the results"
+            sleep 120
+
+            uuid="$(grep -i requestuuid request_info.txt | cut -d' ' -f 3)"
+
+            # Check notarization status
+            for i in {2..0} ; do
+                xcrun altool --notarization-info ${uuid} -u "${DEVELOPER_ID}" --password "${ALTOOL_PASS}" > request_result.txt
+                if grep "Status: success" request_result.txt > /dev/null 2>&1 ; then
+                    echo "Package is notarized and ready to go."
+                    echo "Adding the ticket to the package."
+                    if xcrun stapler staple -v ${DESTINATION}/${pkg_name} ; then
+                        echo "Ticket added. Ready to release the package."
+                        return 0
+                    else
+                        echo "Something went wrong while adding the package."
+                        clean_and_exit 1
+                    fi
+                else
+                    echo "Package is not notarized. Retries left: $i. "
+                    echo "Retrying in 120s."
+                    sleep 120
+                fi
+            done
+
+            clean_and_exit 1
+
+        else
+            echo "Error while uploading the app to be notarized."
+            clean_and_exit 1
+        fi
+    fi
+
+    return 0
+}
+
+function sign_binaries() {
+    if [ ! -z "${KEYCHAIN}" ] && [ ! -z "${CERT_APPLICATION_ID}" ] ; then
+        security -v unlock-keychain -p "${KC_PASS}" "${KEYCHAIN}" > /dev/null
+        # Sign every single binary in Wazuh's installation. This also includes library files.
+        for bin in $(find ${INSTALLATION_PATH} -exec file {} \; | grep bit | cut -d: -f1); do
+            codesign -f --sign "${CERT_APPLICATION_ID}" --deep --timestamp  --options=runtime --verbose=4 "${bin}"
+        done
+        security -v lock-keychain "${KEYCHAIN}" > /dev/null
+    fi
+}
+
+function sign_pkg() {
+    if [ ! -z "${KEYCHAIN}" ] && [ ! -z "${CERT_INSTALLER_ID}" ] ; then
+        # Unlock the keychain to use the certificate
+        security -v unlock-keychain -p "${KC_PASS}" "${KEYCHAIN}"  > /dev/null
+
+        # Sign the package
+        productsign --sign "${CERT_INSTALLER_ID}" --timestamp ${DESTINATION}/${pkg_name} ${DESTINATION}/${pkg_name}.signed
+        mv ${DESTINATION}/${pkg_name}.signed ${DESTINATION}/${pkg_name}
+
+        security -v lock-keychain "${KEYCHAIN}" > /dev/null
+    fi
+}
+
 function build_package() {
+
+    # Download source code
+    git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
+
+    get_pkgproj_specs
 
     VERSION=$(cat ${WAZUH_PATH}/src/VERSION | cut -d "-" -f1 | cut -c 2-)
 
@@ -56,11 +135,16 @@ function build_package() {
     cp ${packages_script_path}/*.sh ${CURRENT_PATH}/package_files/
     ${CURRENT_PATH}/package_files/build.sh "${INSTALLATION_PATH}" "${WAZUH_PATH}" ${JOBS}
 
+    # sign the binaries and the libraries
+    sign_binaries
+
     # create package
     if packagesbuild ${AGENT_PKG_FILE} --build-folder ${DESTINATION} ; then
         echo "The wazuh agent package for MacOS X has been successfully built."
+        pkg_name="wazuh-agent-${VERSION}-${REVISION}.pkg"
+        sign_pkg
+        notarize_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
-            pkg_name="wazuh-agent-${VERSION}-${REVISION}.pkg"
             mkdir -p ${CHECKSUMDIR}
             cd ${DESTINATION} && shasum -a512 "${pkg_name}" > "${CHECKSUMDIR}/${pkg_name}.sha512"
         fi
@@ -75,28 +159,26 @@ function help() {
 
     echo "Usage: $0 [OPTIONS]"
     echo
-    echo "    -b, --branch <branch>     [Required] Select Git branch or tag e.g. $BRANCH"
-    echo "    -s, --store-path <path>   [Optional] Set the destination absolute path of package."
-    echo "    -j, --jobs <number>       [Optional] Number of parallel jobs when compiling."
-    echo "    -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev"
-    echo "    -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    -h, --help                [  Util  ] Show this help."
-    echo "    -i, --install-deps        [  Util  ] Install build dependencies (Packages)."
-    echo "    -x, --install-xcode       [  Util  ] Install X-Code and brew. Can't be executed as root."
+    echo "  Build options:"
+    echo "    -b, --branch <branch>         [Required] Select Git branch or tag e.g. $BRANCH"
+    echo "    -s, --store-path <path>       [Optional] Set the destination absolute path of package."
+    echo "    -j, --jobs <number>           [Optional] Number of parallel jobs when compiling."
+    echo "    -r, --revision <rev>          [Optional] Package revision that append to version e.g. x.x.x-rev"
+    echo "    -c, --checksum <path>         [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
+    echo "    -h, --help                    [  Util  ] Show this help."
+    echo "    -i, --install-deps            [  Util  ] Install build dependencies (Packages)."
+    echo "    -x, --install-xcode           [  Util  ] Install X-Code and brew. Can't be executed as root."
+    echo
+    echo "  Signing options:"
+    echo "    --keychain                    [Optional] Keychain where the Certificates are installed."
+    echo "    --keychain-password           [Optional] Password of the keychain."
+    echo "    --application-certificate     [Optional] Apple Developer ID certificate name to sign Apps and binaries."
+    echo "    --installer-certificate       [Optional] Apple Developer ID certificate name to sign pkg."
+    echo "    --notarize                    [Optional] Notarize the package for its distribution on macOS Catalina ."
+    echo "    --developer-id                [Optional] Your Apple Developer ID."
+    echo "    --altool-password             [Optional] Temporary password to use altool from Xcode."
     echo
     exit "$1"
-}
-
-function download_source(){
-
-    mkdir -p "${SOURCES_DIRECTORY}"
-
-    if git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}" ; then
-        echo "Successfully downloaded source code from GitHub from ${BRANCH_TAG}"
-    else
-        echo "Error: Source code from ${BRANCH_TAG} could not be downloaded"
-        exit 1
-    fi
 }
 
 function get_pkgproj_specs() {
@@ -233,6 +315,58 @@ function main() {
                 shift 1
             fi
             ;;
+        "--keychain")
+            if [ -n "$2" ]; then
+                KEYCHAIN="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--keychain-password")
+            if [ -n "$2" ]; then
+                KC_PASS="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--application-certificate")
+            if [ -n "$2" ]; then
+                CERT_APPLICATION_ID="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--installer-certificate")
+            if [ -n "$2" ]; then
+                CERT_INSTALLER_ID="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--notarize")
+            NOTARIZE="yes"
+            shift 1
+            ;;
+        "--developer-id")
+            if [ -n "$2" ]; then
+                DEVELOPER_ID="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--altool-password")
+            if [ -n "$2" ]; then
+                ALTOOL_PASS="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
         *)
             help 1
         esac
@@ -250,8 +384,6 @@ function main() {
 
     if [[ "$BUILD" != "no" ]]; then
         check_root
-        download_source
-        get_pkgproj_specs
         build_package
         "${CURRENT_PATH}/uninstall.sh"
     else

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -42,8 +42,9 @@ function clean_and_exit() {
 
 function notarize_pkg() {
     # Notarize the macOS package
+    build_timestamp="$(date +"date.%m.%d.%Y.%H.time.%H.%M.%S")"
     if [ "${NOTARIZE}" = "yes" ]; then
-        if sudo xcrun altool --notarize-app --primary-bundle-id "com.wazuh.agent.v${VERSION}.${REVISION}.testwppkg" \
+        if sudo xcrun altool --notarize-app --primary-bundle-id "com.wazuh.agent.v${VERSION}.${REVISION}.${build_timestamp}" \
             --username "${DEVELOPER_ID}" --password "${ALTOOL_PASS}" --file ${DESTINATION}/${pkg_name} > request_info.txt ; then
             echo "The package ${DESTINATION}/${pkg_name} was successfully upload for notarization."
             echo "Waiting to 120s to get the results"

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -14,6 +14,7 @@ WAZUH_PATH="${SOURCES_DIRECTORY}/wazuh"
 WAZUH_SOURCE_REPOSITORY="https://github.com/wazuh/wazuh"
 AGENT_PKG_FILE="${CURRENT_PATH}/package_files/wazuh-agent.pkgproj"
 export CONFIG="${WAZUH_PATH}/etc/preloaded-vars.conf"
+ENTITLEMENTS_PATH="${CURRENT_PATH}/entitlements.plist"
 INSTALLATION_PATH="/Library/Ossec"    # Installation path
 VERSION=""                            # Default VERSION (branch/tag)
 REVISION="1"                          # Package revision.
@@ -88,7 +89,7 @@ function sign_binaries() {
         security -v unlock-keychain -p "${KC_PASS}" "${KEYCHAIN}" > /dev/null
         # Sign every single binary in Wazuh's installation. This also includes library files.
         for bin in $(find ${INSTALLATION_PATH} -exec file {} \; | grep bit | cut -d: -f1); do
-            codesign -f --sign "${CERT_APPLICATION_ID}" --deep --timestamp  --options=runtime --verbose=4 "${bin}"
+            codesign -f --sign "${CERT_APPLICATION_ID}" --entitlements ${ENTITLEMENTS_PATH} --deep --timestamp  --options=runtime --verbose=4 "${bin}"
         done
         security -v lock-keychain "${KEYCHAIN}" > /dev/null
     fi


### PR DESCRIPTION
Hi team,

This PR closes #316 by adding to `macos/generate_wazuh_packages.sh` a new feature to sign binaries, packages and notarize them. 

You can find more info about this in the attached issue.

Regads.