### PR TITLE
Fixed service's installation path for CentOS 8

### DIFF
--- a/rpms/SPECS/3.11.0/wazuh-agent-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-agent-3.11.0.spec
@@ -256,9 +256,9 @@ if [ $1 = 1 ]; then
   # If systemd is installed, add the wazuh-agent.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
 
-    # Fix for RHEL 8
+    # Fix for RHEL 8 and CentOS 8
     # Service must be installed in /usr/lib/systemd/system/
-    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ] || [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "8" ]; then
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /usr/lib/systemd/system/
     else
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/

--- a/rpms/SPECS/3.11.0/wazuh-manager-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-manager-3.11.0.spec
@@ -358,9 +358,9 @@ if [ $1 = 1 ]; then
   # If systemd is installed, add the wazuh-manager.service file to systemd files directory
   if [ -d /run/systemd/system ]; then
 
-    # Fix for RHEL 8
+    # Fix for RHEL 8 and CentOS 8
     # Service must be installed in /usr/lib/systemd/system/
-    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
+    if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ] || [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "8" ]; then
       install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /usr/lib/systemd/system/
     else
       install -m 644 %{_localstatedir}/ossec/packages_files/manager_installation_scripts/src/systemd/wazuh-manager.service /etc/systemd/system/


### PR DESCRIPTION
Hi team,

This PR closes #323 by installing the services files in `/usr/lib/systemd/system/`. This allows using systemd to manage the service of the manager and the agent in CentOS 8.

Tests:
- [x] Fresh install.
- [x] Upgrade.
- [x] Start the service.
- [x] Stop the service.
- [x] Restart the service.
- [x] Enable/disable the service.

Regards.