### PR TITLE
Remove repository folder in build package startup

### DIFF
--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -77,7 +77,7 @@ build_deb() {
 
     echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
 
-    return IS_BUILD
+    return ${IS_BUILD}
 }
 
 build() {
@@ -116,7 +116,7 @@ build() {
         IS_CORRECT=1
     fi
 
-    return IS_CORRECT
+    return ${IS_CORRECT}
 }
 
 help() {

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -75,7 +75,7 @@ build_deb() {
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} ${CHECKSUM} || IS_BUILD=1
 
-    if [ ${IS_BUILD}=="0" ]
+    if [[ ${IS_BUILD}=="0" ]]; then
         echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
     else
         echo "ERROR. Package not built"

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -26,6 +26,8 @@ CHECKSUMDIR=""
 CHECKSUM="no"
 DEB_PPC64LE_BUILDER_DOCKERFILE="${CURRENT_PATH}/Debian/ppc64le"
 
+trap ctrl_c INT
+
 clean() {
     exit_code=$1
 
@@ -35,13 +37,20 @@ clean() {
     exit ${exit_code}
 }
 
+function ctrl_c() {
+    clean 0
+}
+
 build_deb() {
     CONTAINER_NAME="$1"
     DOCKERFILE_PATH="$2"
 
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 
-    rm -rf ${SOURCES_DIRECTORY}
+    if [ -d ${SOURCES_DIRECTORY} ]; then
+        echo "Removing repository folder."
+        clean 1
+    fi
 
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b ${BRANCH} ${SOURCES_DIRECTORY} --depth=1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -107,7 +107,7 @@ build() {
             echo "Invalid architecture. Choose: x86_64 (amd64 is accepted too) or i386 or ppc64le."
             return 1
         fi
-        build_deb ${BUILD_NAME} ${FILE_PATH} || IS_CORRECT=1
+        build_deb ${BUILD_NAME} ${FILE_PATH} || return 1
     else
         echo "Invalid target. Choose: manager, agent or api."
         return 1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -74,7 +74,6 @@ build_deb() {
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} ${CHECKSUM} || return 1
 
-
     echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
 
     return 0

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -38,7 +38,7 @@ clean() {
 }
 
 ctrl_c() {
-    clean 0
+    clean 1
 }
 
 build_deb() {
@@ -48,7 +48,7 @@ build_deb() {
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 
     # Download the sources
-    git clone ${SOURCE_REPOSITORY} -b ${BRANCH} ${SOURCES_DIRECTORY} --depth=1
+    git clone ${SOURCE_REPOSITORY} -b ${BRANCH} ${SOURCES_DIRECTORY} --depth=1 || clean 1
     # Copy the necessary files
     cp build.sh ${DOCKERFILE_PATH}
     cp gen_permissions.sh ${SOURCES_DIRECTORY}

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -75,7 +75,8 @@ build_deb() {
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} ${CHECKSUM} || IS_BUILD=1
 
-    echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
+    if [ ${IS_BUILD}=="0" ]
+        echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
 
     return ${IS_BUILD}
 }

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -45,7 +45,6 @@ build_deb() {
     CONTAINER_NAME="$1"
     DOCKERFILE_PATH="$2"
 
-
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 
     # Download the sources

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -11,7 +11,7 @@
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ARCHITECTURE="amd64"
 OUTDIR="${CURRENT_PATH}/output/"
-BRANCH="master"
+BRANCH=""
 REVISION="1"
 TARGET=""
 JOBS="2"

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -37,7 +37,7 @@ clean() {
     exit ${exit_code}
 }
 
-function ctrl_c() {
+ctrl_c() {
     clean 0
 }
 
@@ -46,11 +46,6 @@ build_deb() {
     DOCKERFILE_PATH="$2"
 
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
-
-    if [ -d ${SOURCES_DIRECTORY} ]; then
-        echo "Removing repository folder."
-        clean 1
-    fi
 
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b ${BRANCH} ${SOURCES_DIRECTORY} --depth=1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -77,6 +77,8 @@ build_deb() {
 
     if [ ${IS_BUILD}=="0" ]
         echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
+    else
+        echo "ERROR. Package not built"
 
     return ${IS_BUILD}
 }

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -227,7 +227,8 @@ main() {
     fi
 
     if [[ "$BUILD" != "no" ]]; then
-        BUILT=build
+        BUILT=0
+        build || BUILT=1
         clean ${BUILT}
     else
         clean 1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -41,6 +41,8 @@ build_deb() {
 
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 
+    rm -rf ${SOURCES_DIRECTORY}
+
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b ${BRANCH} ${SOURCES_DIRECTORY} --depth=1
     # Copy the necessary files

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -79,6 +79,7 @@ build_deb() {
         echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
     else
         echo "ERROR. Package not built"
+    fi
 
     return ${IS_BUILD}
 }

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -82,15 +82,13 @@ build_deb() {
 }
 
 build() {
-    # Marks if there is an error in the process
-    IS_CORRECT=0
     if [[ "${TARGET}" = "api" ]]; then
 
         SOURCE_REPOSITORY="https://github.com/wazuh/wazuh-api"
         if [[ "${ARCHITECTURE}" = "ppc64le" ]]; then
-	    build_deb ${DEB_PPC64LE_BUILDER} ${DEB_PPC64LE_BUILDER_DOCKERFILE} || IS_CORRECT=1
+	    build_deb ${DEB_PPC64LE_BUILDER} ${DEB_PPC64LE_BUILDER_DOCKERFILE} || return 1
         else
-	    build_deb ${DEB_AMD64_BUILDER} ${DEB_AMD64_BUILDER_DOCKERFILE} || IS_CORRECT=1
+	    build_deb ${DEB_AMD64_BUILDER} ${DEB_AMD64_BUILDER_DOCKERFILE} || return 1
         fi
     elif [[ "${TARGET}" = "manager" ]] || [[ "${TARGET}" = "agent" ]]; then
 
@@ -109,15 +107,15 @@ build() {
             FILE_PATH="${DEB_PPC64LE_BUILDER_DOCKERFILE}"
         else
             echo "Invalid architecture. Choose: x86_64 (amd64 is accepted too) or i386 or ppc64le."
-            IS_CORRECT=1
+            return 1
         fi
         build_deb ${BUILD_NAME} ${FILE_PATH} || IS_CORRECT=1
     else
         echo "Invalid target. Choose: manager, agent or api."
-        IS_CORRECT=1
+        return 1
     fi
 
-    return ${IS_CORRECT}
+    return 0
 }
 
 help() {
@@ -228,12 +226,12 @@ main() {
     fi
 
     if [[ "$BUILD" != "no" ]]; then
-        BUILT=0
-        build || BUILT=1
-        clean ${BUILT}
+        build || clean 1
     else
         clean 1
     fi
+
+    clean 0
 }
 
 main "$@"

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -126,7 +126,7 @@ function sign_pkg() {
 function build_package() {
 
     # Download source code
-    git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
+    git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}" || clean_and_exit 1
 
     get_pkgproj_specs
 
@@ -170,8 +170,6 @@ function build_package() {
         echo "ERROR: something went wrong while building the package."
         clean_and_exit 1
     fi
-
-    return 0
 }
 
 function help() {

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -126,7 +126,7 @@ function sign_pkg() {
 function build_package() {
 
     # Download source code
-    git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}" || clean_and_exit 1
+    git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
 
     get_pkgproj_specs
 

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -33,6 +33,8 @@ DEVELOPER_ID=""                       # Apple Developer ID.
 ALTOOL_PASS=""                        # Temporary Application password for altool.
 pkg_name=""
 
+trap ctrl_c INT
+
 function clean_and_exit() {
     exit_code=$1
     rm -f ${AGENT_PKG_FILE} ${CURRENT_PATH}/package_files/*.sh
@@ -40,6 +42,11 @@ function clean_and_exit() {
     ${CURRENT_PATH}/uninstall.sh
     exit ${exit_code}
 }
+
+ctrl_c() {
+    clean 0
+}
+
 
 function notarize_pkg() {
 

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -170,6 +170,8 @@ function build_package() {
         echo "ERROR: something went wrong while building the package."
         clean_and_exit 1
     fi
+
+    return 0
 }
 
 function help() {

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -43,8 +43,8 @@ function clean_and_exit() {
     exit ${exit_code}
 }
 
-ctrl_c() {
-    clean_and_exit 0
+function ctrl_c() {
+    clean_and_exit 1
 }
 
 

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -44,7 +44,7 @@ function clean_and_exit() {
 }
 
 ctrl_c() {
-    clean 0
+    clean_and_exit 0
 }
 
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -12,7 +12,7 @@ CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ARCHITECTURE="x86_64"
 LEGACY="no"
 OUTDIR="${CURRENT_PATH}/output/"
-BRANCH="master"
+BRANCH=""
 REVISION="1"
 TARGET=""
 JOBS="2"
@@ -53,6 +53,7 @@ build_rpm() {
 
     rm -rf ${SOURCES_DIRECTORY}
 
+    if ( $BRANCH ==  )
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -47,8 +47,8 @@ clean() {
     exit ${exit_code}
 }
 
-function ctrl_c() {
-    clean 0
+ctrl_c() {
+    clean 1
 }
 
 build_rpm() {
@@ -57,13 +57,7 @@ build_rpm() {
 
 
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
-    
-    if [ -d ${SOURCES_DIRECTORY} ]; then
-        echo "Removing repository folder."
-        clean 1
-    fi
 
-    rm -rf ${SOURCES_DIRECTORY}
 
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -51,6 +51,8 @@ build_rpm() {
 
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 
+    rm -rf ${SOURCES_DIRECTORY}
+
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -60,7 +60,7 @@ build_rpm() {
 
 
     # Download the sources
-    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1
+    git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1 || clean 1
 
     # Copy the necessary files
     cp build.sh ${DOCKERFILE_PATH}

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -55,9 +55,7 @@ build_rpm() {
     CONTAINER_NAME="$1"
     DOCKERFILE_PATH="$2"
 
-
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
-
 
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1 || clean 1
@@ -266,8 +264,6 @@ main() {
         build || exit 1
     fi
 
-
     clean 0
 }
-
 main "$@"

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -30,6 +30,8 @@ INSTALLATION_PATH="/var"
 CHECKSUMDIR=""
 CHECKSUM="no"
 
+trap ctrl_c INT
+
 if command -v curl > /dev/null 2>&1 ; then
     DOWNLOAD_TAR="curl ${TAR_URL} -o ${LEGACY_TAR_FILE} -s"
 elif command -v wget > /dev/null 2>&1 ; then
@@ -45,11 +47,21 @@ clean() {
     exit ${exit_code}
 }
 
+function ctrl_c() {
+    clean 0
+}
+
 build_rpm() {
     CONTAINER_NAME="$1"
     DOCKERFILE_PATH="$2"
 
+
     SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
+    
+    if [ -d ${SOURCES_DIRECTORY} ]; then
+        echo "Removing repository folder."
+        clean 1
+    fi
 
     rm -rf ${SOURCES_DIRECTORY}
 
@@ -259,6 +271,7 @@ main() {
     if [[ "$BUILD" != "no" ]]; then
         build || exit 1
     fi
+
 
     clean 0
 }

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -53,7 +53,6 @@ build_rpm() {
 
     rm -rf ${SOURCES_DIRECTORY}
 
-    if ( $BRANCH ==  )
     # Download the sources
     git clone ${SOURCE_REPOSITORY} -b $BRANCH ${SOURCES_DIRECTORY} --depth=1
 

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -245,9 +245,8 @@ show_help() {
 }
 
 build_package(){
-    clone
-    build
-    clean
+    clone || return 1
+    build || return 1
 
     return 0
 }
@@ -326,8 +325,10 @@ main() {
   fi
 
   if [[ "${build_pkg}" = "yes" ]]; then
-    build_package || exit 1
+    build_package || clean 1
   fi
+
+  clean 0
 
   return 0
 }

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -210,7 +210,7 @@ clean(){
 }
 
 ctrl_c() {
-    clean
+    clean 1
 }
 
 build(){

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -20,6 +20,7 @@ SOURCE=${CURRENT_PATH}/repository
 CONFIG="$SOURCE/etc/preloaded-vars.conf"
 target_dir="${CURRENT_PATH}/output"
 
+trap ctrl_c INT
 
 if [ -z "${wazuh_branch}" ]; then
     wazuh_branch="master"
@@ -206,6 +207,10 @@ clean(){
     ## Remove User and Groups
     userdel ossec
     groupdel ossec
+}
+
+ctrl_c() {
+    clean 0
 }
 
 build(){

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -122,15 +122,15 @@ installation(){
     arch="$(uname -p)"
     # Build the binaries
     if [ "$arch" = "sparc" ]; then
-        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes DISABLE_SHARED=yes || exit 1
+        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no USE_BIG_ENDIAN=yes DISABLE_SHARED=yes || return 1
     else
-        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no DISABLE_SHARED=yes || exit 1
+        gmake -j $THREADS TARGET=agent PREFIX=${install_path} USE_SELINUX=no DISABLE_SHARED=yes || return 1
     fi
 
     cd $SOURCE
     ${CURRENT_PATH}/solaris10_patch.sh
     config
-    /bin/bash $SOURCE/install.sh || exit 1
+    /bin/bash $SOURCE/install.sh || return 1
     cd ${CURRENT_PATH}
 }
 
@@ -147,11 +147,13 @@ compute_version_revision()
 
 clone(){
     cd ${CURRENT_PATH}
-    git clone $REPOSITORY ${SOURCE} || clean
+    git clone $REPOSITORY ${SOURCE} || return 1
     cd $SOURCE
     git checkout $wazuh_branch
     cp ${CURRENT_PATH}/solaris10_patch.sh ${CURRENT_PATH}/wazuh
     compute_version_revision
+
+    return 0
 }
 
 package(){

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -147,7 +147,7 @@ compute_version_revision()
 
 clone(){
     cd ${CURRENT_PATH}
-    git clone $REPOSITORY ${SOURCE}
+    git clone $REPOSITORY ${SOURCE} || clean
     cd $SOURCE
     git checkout $wazuh_branch
     cp ${CURRENT_PATH}/solaris10_patch.sh ${CURRENT_PATH}/wazuh
@@ -210,7 +210,7 @@ clean(){
 }
 
 ctrl_c() {
-    clean 0
+    clean
 }
 
 build(){

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -19,6 +19,8 @@ target_dir="${current_path}/output"
 checksum_dir=""
 compute_checksums="no"
 
+trap ctrl_c INT
+
 build_environment() {
     echo "Installing dependencies."
 
@@ -210,6 +212,10 @@ clean() {
     rm -f wazuh-agent.mog
     rm -f wazuh-agent.mog-aux
     rm -f pack
+}
+
+ctrl_c() {
+    clean 0
 }
 
 

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -215,7 +215,7 @@ clean() {
 }
 
 ctrl_c() {
-    clean 0
+    clean 1
 }
 
 

--- a/splunkapp/generate_wazuh_splunk_app.sh
+++ b/splunkapp/generate_wazuh_splunk_app.sh
@@ -91,7 +91,7 @@ clean(){
 }
 
 ctrl_c() {
-    clean 0
+    clean 1
 }
 
 main() {

--- a/splunkapp/generate_wazuh_splunk_app.sh
+++ b/splunkapp/generate_wazuh_splunk_app.sh
@@ -26,6 +26,8 @@ SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
 REPOSITORY="wazuh-splunk"
 WAZUH_VERSION=""
 
+trap ctrl_c INT
+
 help() {
 
     echo
@@ -86,6 +88,10 @@ clean(){
     exit_code=$1
     rm -rf ${SOURCES_DIRECTORY}
     exit ${exit_code}
+}
+
+ctrl_c() {
+    clean 0
 }
 
 main() {

--- a/wazuhapp/generate_wazuh_app.sh
+++ b/wazuhapp/generate_wazuh_app.sh
@@ -67,7 +67,7 @@ compute_version_revision(){
 
 download_sources(){
 
-    git clone https://github.com/wazuh/wazuh-kibana-app -b ${BRANCH_TAG} --depth=1 ${SOURCES_DIRECTORY}
+    git clone https://github.com/wazuh/wazuh-kibana-app -b ${BRANCH_TAG} --depth=1 ${SOURCES_DIRECTORY} || clean 1
 
     compute_version_revision
 }
@@ -79,7 +79,7 @@ clean(){
 }
 
 ctrl_c() {
-    clean 0
+    clean 1
 }
 
 main(){

--- a/wazuhapp/generate_wazuh_app.sh
+++ b/wazuhapp/generate_wazuh_app.sh
@@ -19,6 +19,8 @@ CHECKSUMDIR=""
 WAZUH_VERSION=""
 KIBANA_VERSION=""
 
+trap ctrl_c INT
+
 help() {
 
     echo
@@ -74,6 +76,10 @@ clean(){
     exit_code=$1
     rm -rf ${SOURCES_DIRECTORY}
     exit ${exit_code}
+}
+
+ctrl_c() {
+    clean 0
 }
 
 main(){

--- a/wazuhapp/generate_wazuh_app.sh
+++ b/wazuhapp/generate_wazuh_app.sh
@@ -67,9 +67,11 @@ compute_version_revision(){
 
 download_sources(){
 
-    git clone https://github.com/wazuh/wazuh-kibana-app -b ${BRANCH_TAG} --depth=1 ${SOURCES_DIRECTORY} || clean 1
+    git clone https://github.com/wazuh/wazuh-kibana-app -b ${BRANCH_TAG} --depth=1 ${SOURCES_DIRECTORY} || return 1
 
     compute_version_revision
+
+    return 0
 }
 clean(){
 

--- a/wpk/generate_wpk_package.sh
+++ b/wpk/generate_wpk_package.sh
@@ -16,6 +16,7 @@ WIN_BUILDER="windows_wpk_builder"
 WIN_BUILDER_DOCKERFILE="${CURRENT_PATH}/windows"
 CHECKSUM="no"
 
+trap ctrl_c INT
 
 function build_wpk_windows() {
   local BRANCH="$1"
@@ -94,6 +95,9 @@ function clean() {
   return 0
 }
 
+ctrl_c() {
+    clean 1
+}
 
 function main() {
   local TARGET=""


### PR DESCRIPTION
Hello team,

This PR closes #326, I have added instruction to remove the folder repository if this exists in the startup build package deb and rpm.

The problem is if the repository folder exists, it caused problems to recreate the package. The solution was to manually delete the folder. Now, this is automatic.

Tests were done for:
- [x] Deb package generation.
![image](https://user-images.githubusercontent.com/14923861/66742953-23c3d180-ee79-11e9-9214-128cc9a8d8bd.png)
- [x] RPM package generation. 
![image](https://user-images.githubusercontent.com/14923861/66743516-6043fd00-ee7a-11e9-8d77-1b808616ce61.png)
- [x] Tested all `git ls-remote --tag https://github.com/wazuh/wazuh.git refs/tags/*` tags  in several generate_debian_package.sh and generate_rpm_package.sh .
Example:
![image](https://user-images.githubusercontent.com/14923861/66756186-bd02e000-ee99-11e9-855c-1290e9838103.png)
![image](https://user-images.githubusercontent.com/14923861/66756193-c2f8c100-ee99-11e9-8a22-eea684fc5837.png)



Regards.
Alejandro Alguacil
