### PR TITLE
Error executing 'ps' command when generating API package

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
+    apt-get update && apt-get install procps && apt-get install -y apt-utils && \
     apt-get install -y --force-yes \
     curl gcc make sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 perl \
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \

--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -5,12 +5,12 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install procps && apt-get install -y apt-utils && \
+    apt-get update && apt-get install -y apt-utils && \
     apt-get install -y --force-yes \
     curl gcc make sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 perl \
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
-    libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20
+    libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps
 
 
 # Add Debian's source repository and, Install NodeJS 6

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     perl libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
     libaudit-dev selinux-basics util-linux libdb5.1=5.1.29-5 libdb5.1-dev \
-    libssl1.0.0=1.0.1e-2+deb7u20
+    libssl1.0.0=1.0.1e-2+deb7u20 procps
 
 # Add Debian's source repository
 RUN apt-get update && apt-get build-dep python3.2 -y

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /et
     curl gcc make sudo expect gnupg fakeroot perl-base perl wget \
     libc-bin libc6 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
-    libdb5.3 libdb5.3 libssl1.0.2
+    libdb5.3 libdb5.3 libssl1.0.2 procps
 
 # Add Debian's source repository and, Install NodeJS 10
 RUN apt-get update &&  apt-get build-dep python3.5 -y &&\


### PR DESCRIPTION
Hello team,

This PR closes #293. I have added in the Dockerfile debian generation file new command for install  `ps` package.

Tests were done in:
- [x] Ubuntu 16.04
- [x] Debian 9

Best regards,
Alejandro Alguacil
