### PR TITLE
Added relabel file objects suffixe in docker run

### DIFF
--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -60,10 +60,10 @@ build_deb() {
     docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH} || exit 1
 
     # Build the Debian package with a Docker container
-    docker run -t --rm -v ${OUTDIR}:/var/local/wazuh \
-        -v ${CHECKSUMDIR}:/var/local/checksum \
-        -v ${SOURCES_DIRECTORY}:/build_wazuh/${TARGET}/wazuh-${TARGET}-${VERSION} \
-        -v ${DOCKERFILE_PATH}/wazuh-${TARGET}:/${TARGET} \
+    docker run -t --rm -v ${OUTDIR}:/var/local/wazuh:Z \
+        -v ${CHECKSUMDIR}:/var/local/checksum:Z \
+        -v ${SOURCES_DIRECTORY}:/build_wazuh/${TARGET}/wazuh-${TARGET}-${VERSION}:Z \
+        -v ${DOCKERFILE_PATH}/wazuh-${TARGET}:/${TARGET}:Z \
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} ${CHECKSUM} || exit 1
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -83,9 +83,9 @@ build_rpm() {
     docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH} || exit 1
 
     # Build the RPM package with a Docker container
-    docker run -t --rm -v ${OUTDIR}:/var/local/wazuh \
-        -v ${CHECKSUMDIR}:/var/local/checksum \
-        -v ${SOURCES_DIRECTORY}:/build_wazuh/wazuh-${TARGET}-${VERSION} \
+    docker run -t --rm -v ${OUTDIR}:/var/local/wazuh:Z \
+        -v ${CHECKSUMDIR}:/var/local/checksum:Z \
+        -v ${SOURCES_DIRECTORY}:/build_wazuh/wazuh-${TARGET}-${VERSION}:Z \
         ${CONTAINER_NAME} ${TARGET} ${VERSION} ${ARCHITECTURE} \
         $JOBS ${REVISION} ${INSTALLATION_PATH} ${DEBUG} ${CHECKSUM} || exit 1
 

--- a/splunkapp/generate_wazuh_splunk_app.sh
+++ b/splunkapp/generate_wazuh_splunk_app.sh
@@ -47,9 +47,9 @@ build_package() {
     docker build -t ${CONTAINER_NAME} ./Docker/
     # Run Docker and build package
 
-    docker run -t --rm -v ${SOURCES_DIRECTORY}:/pkg \
-            -v ${OUTDIR}:/wazuh_splunk_app \
-            -v ${CHECKSUMDIR}:/var/local/checksum \
+    docker run -t --rm -v ${SOURCES_DIRECTORY}:/pkg:Z \
+            -v ${OUTDIR}:/wazuh_splunk_app:Z \
+            -v ${CHECKSUMDIR}:/var/local/checksum:Z \
             ${CONTAINER_NAME} ${WAZUH_VERSION} ${SPLUNK_VERSION} ${REVISION} ${CHECKSUM}
 
 

--- a/wazuhapp/generate_wazuh_app.sh
+++ b/wazuhapp/generate_wazuh_app.sh
@@ -38,9 +38,9 @@ build_package(){
     # Build the Docker image
     docker build -t ${CONTAINER_NAME} ./Docker/
     # Build the Wazuh Kibana app package using the build docker image
-    docker run --rm -t  -v ${SOURCES_DIRECTORY}:/source \
-        -v "${OUTDIR}":/wazuh_app \
-        -v ${CHECKSUMDIR}:/var/local/checksum \
+    docker run --rm -t  -v ${SOURCES_DIRECTORY}:/source:Z \
+        -v "${OUTDIR}":/wazuh_app:Z \
+        -v ${CHECKSUMDIR}:/var/local/checksum:Z \
         ${CONTAINER_NAME} ${WAZUH_VERSION} ${KIBANA_VERSION} ${REVISION} ${CHECKSUM}
 
     if [ "$?" = "0" ]; then

--- a/wpk/generate_wpk_package.sh
+++ b/wpk/generate_wpk_package.sh
@@ -28,8 +28,8 @@ function build_wpk_windows() {
   local CHECKSUM="$8"
   local CHECKSUMDIR="$9"
 
-  docker run -t --rm -v ${KEYDIR}:/etc/wazuh -v ${DESTINATION}:/var/local/wazuh -v ${PKG_PATH}:/var/pkg\
-      -v ${CHECKSUMDIR}:/var/local/checksum \
+  docker run -t --rm -v ${KEYDIR}:/etc/wazuh:Z -v ${DESTINATION}:/var/local/wazuh:Z -v ${PKG_PATH}:/var/pkg:Z \
+      -v ${CHECKSUMDIR}:/var/local/checksum:Z \
       ${CONTAINER_NAME} ${BRANCH} ${JOBS} ${OUT_NAME} ${CHECKSUM} ${PACKAGE_NAME}
 
   return $?
@@ -45,8 +45,8 @@ function build_wpk_linux() {
   local CHECKSUM="$7"
   local CHECKSUMDIR="$8"
 
-  docker run -t --rm -v ${KEYDIR}:/etc/wazuh -v ${DESTINATION}:/var/local/wazuh \
-      -v ${CHECKSUMDIR}:/var/local/checksum \
+  docker run -t --rm -v ${KEYDIR}:/etc/wazuh:Z -v ${DESTINATION}:/var/local/wazuh:Z \
+      -v ${CHECKSUMDIR}:/var/local/checksum:Z \
       ${CONTAINER_NAME} ${BRANCH} ${JOBS} ${OUT_NAME} ${CHECKSUM}
 
   return $?


### PR DESCRIPTION
Hello team.

This PR closes  #320. I have added a new flag in `docker run` call to grant container write SELinux permission in the host.

Tests `generate_rpm_package.sh`, `generate_debian_package.sh`,  `generate_wazuh_splunk_app.sh`, `generate_wpk_package.sh` were done in:
- [x] Fedora 30
- [x] Centos 7
- [x] Ubuntu 18.04

Thanks to @timhughes.

Regards.
Alejandro Alguacil