### PR TITLE
Fix regex that checks for 2.x version

### DIFF
--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -32,7 +32,7 @@ NOTARIZE="no"                         # Notarize the package for macOS Catalina.
 DEVELOPER_ID=""                       # Apple Developer ID.
 ALTOOL_PASS=""                        # Temporary Application password for altool.
 pkg_name=""
-set -x
+
 trap ctrl_c INT
 
 function clean_and_exit() {

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -32,7 +32,7 @@ NOTARIZE="no"                         # Notarize the package for macOS Catalina.
 DEVELOPER_ID=""                       # Apple Developer ID.
 ALTOOL_PASS=""                        # Temporary Application password for altool.
 pkg_name=""
-
+set -x
 trap ctrl_c INT
 
 function clean_and_exit() {
@@ -143,7 +143,7 @@ function build_package() {
     packages_script_path=""
 
     # build the sources
-    if [[ "${VERSION}" =~ "^2\." ]]; then
+    if [[ "${VERSION}" =~ ^2\. ]]; then
         packages_script_path="package_files/2.x"
     else
         packages_script_path="package_files/${VERSION}"

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -143,7 +143,7 @@ function build_package() {
     packages_script_path=""
 
     # build the sources
-    if [[ "${VERSION}" =~ "2." ]]; then
+    if [[ "${VERSION}" =~ "^2\." ]]; then
         packages_script_path="package_files/2.x"
     else
         packages_script_path="package_files/${VERSION}"


### PR DESCRIPTION
Hello team,

This PR closes #347, I have changed the wrong REGEX for `^2\.` the expression to start with `2` and be followed by the literal `.` .

Regards,
Daniel Folch