### PR TITLE
Enable HTTPS by default in Wazuh API

### DIFF
--- a/debs/SPECS/3.12.0/wazuh-api/debian/postinst
+++ b/debs/SPECS/3.12.0/wazuh-api/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 # postinst script for Wazuh
-# Wazuh, Inc 2016
+# Wazuh, Inc 2019
 
 set -e
 
@@ -43,6 +43,21 @@ case "$1" in
     # Remove installation scripts directory
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}
+    fi
+
+    # Generate and enable a new SSL certificate for clean installs
+    if [ ! -f ${WAZUH_TMP_DIR}/api/configuration/config.js ] && command -v openssl > /dev/null 2>&1; then
+        HTTPS="Y"
+        PASSWORD="wazuh"
+        COUNTRY="XX"
+        STATE="XX"
+        LOCALITY="XX"
+        ORG_NAME="XX"
+        ORG_UNIT="XX"
+        COMMON_NAME="XX"
+        API_PATH=${WAZUH_API_DIR}
+        . ${WAZUH_API_DIR}/scripts/configure_api.sh
+        change_https > /dev/null 2>&1
     fi
 
     # Delete tmp directory

--- a/debs/SPECS/3.12.0/wazuh-api/debian/rules
+++ b/debs/SPECS/3.12.0/wazuh-api/debian/rules
@@ -37,8 +37,8 @@ override_dh_auto_install:
 	groupadd ossec
 	useradd ossec -g ossec
 
-	# Installing api by its own script
-	DIRECTORY="$(INSTALLATION_DIR)" ./install_api.sh
+	# Installing api by its own script with HTTPS disabled
+	DIRECTORY="$(INSTALLATION_DIR)" DISABLE_HTTPS=Y ./install_api.sh
 	
 	# Remove "fake" framework directory
 	rmdir $(INSTALLATION_DIR)/framework

--- a/rpms/SPECS/3.12.0/wazuh-api-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-api-3.12.0.spec
@@ -48,7 +48,8 @@ rm -fr %{buildroot}
 # Create the directories needed to install the wazuh-api
 mkdir -p %{_localstatedir}/ossec/{framework,logs}
 echo 'DIRECTORY="%{_localstatedir}/ossec"' > /etc/ossec-init.conf
-# Install the wazuh-api
+# Install Wazuh API with HTTPS disabled. It will be enabled in post installation
+DISABLE_HTTPS=Y \
 ./install_api.sh --no-service
 # Remove the framework directory
 rmdir %{_localstatedir}/ossec/framework
@@ -101,6 +102,20 @@ API_PATH_BACKUP="${RPM_BUILD_ROOT}%{_localstatedir}/ossec/~api"
 if [ -d ${API_PATH_BACKUP} ]; then
   cp -rfnp ${API_PATH_BACKUP}/configuration ${API_PATH_BACKUP_BACKUP}/configuration
   rm -rf ${API_PATH_BACKUP}
+fi
+
+# Generate and enable a new SSL certificate for clean installs
+if [ $1 = 1 ] && command -v openssl > /dev/null 2>&1; then
+  HTTPS="Y"
+  PASSWORD="wazuh"
+  COUNTRY="XX"
+  STATE="XX"
+  LOCALITY="XX"
+  ORG_NAME="XX"
+  ORG_UNIT="XX"
+  COMMON_NAME="XX"
+  . %{_localstatedir}/ossec/api/scripts/configure_api.sh
+  change_https > /dev/null 2>&1
 fi
 
 %preun


### PR DESCRIPTION
Hi team,

This PR updates #297 to `3.12`. `HTTPS` will be enabled in Wazuh API from `3.12` version. 

Best regards,

Demetrio.