### PR TITLE
Make HP-UX build compatible with C99

### DIFF
--- a/hpux/generate_wazuh_packages.sh
+++ b/hpux/generate_wazuh_packages.sh
@@ -47,6 +47,7 @@ build_environment() {
   /usr/local/bin/depothelper -f coreutils
   /usr/local/bin/depothelper -f gdb
   /usr/local/bin/depothelper -f perl-5.10.1
+  /usr/local/bin/depothelper -f regex
   cp /usr/bin/perl /tmp/perl
   cp /usr/local/bin/perl5.10.1 /usr/bin/perl
 }


### PR DESCRIPTION
|Related issue comment|
|---|
|https://github.com/wazuh/wazuh/issues/3319#issuecomment-537429699|

This rework of FIM needs the C99 standard. GCC 4.2.3 (as installed in HP-UX) is compatible with it. However the library _regex_ needs to be updated.

This change aims to do that.