### PR TITLE
Renamed compiled windows agent zip

### DIFF
--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -6,6 +6,7 @@ BRANCH=$1
 JOBS=$2
 DEBUG=$3
 REVISION=$4
+ZIP_NAME="compiled_agent.zip"
 
 URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
 
@@ -25,5 +26,5 @@ make -C /wazuh-*/src TARGET=winagent ${FLAGS}
 rm -rf /wazuh-*/src/external
 
 # Zip the compiled agent and move it to the shared folder
-zip -r wazuh-${BRANCH}.zip wazuh-*
-cp  wazuh-${BRANCH}.zip /shared
+zip -r ${ZIP_NAME} wazuh-*
+cp ${ZIP_NAME} /shared

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 
-CURRENT_PATH=$(pwd)
 BRANCH="master"
 JOBS="4"
 REVISION="1"
@@ -33,7 +32,7 @@ help() {
     echo "    -b, --branch <branch>     [Required] Select Git branch [${BRANCH}]. By default: master."
     echo "    -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4."
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
-    echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path"
+    echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored"
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -h, --help                Show this help."
     echo


### PR DESCRIPTION
Hello team,

This PR renames the zip with the windows compiled agent, since in production it is failing due to some characters in branch name. For instance:

![imagen](https://user-images.githubusercontent.com/23462183/67879391-3149ae80-fb3d-11e9-91fd-2638d051b397.png)

Now, the zip is called `compiled_agent.zip` instead of `wazuh-${BRANCH_NAME}`

An unused variable has also been removed from the script.

Greetings.