### PR TITLE
Add Mitre database file to Manager 3.12.0 SPEC file

### DIFF
--- a/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
@@ -212,6 +212,7 @@ rm -f %{_localstatedir}/ossec/var/db/global.db* || true
 rm -f %{_localstatedir}/ossec/var/db/cluster.db* || true
 rm -f %{_localstatedir}/ossec/var/db/.profile.db* || true
 rm -f %{_localstatedir}/ossec/var/db/agents/* || true
+
 # Remove Vuln-detector database
 rm -f %{_localstatedir}/ossec/queue/vulnerabilities/cve.db || true
 
@@ -894,6 +895,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/var
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db/agents
+%attr(660, root, ossec) %{_localstatedir}/ossec/var/db/mitre.db
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/download
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/var/multigroups
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/run


### PR DESCRIPTION
| Branch | Related issue |
|---|---|
| [3.11-mitre](https://github.com/wazuh/wazuh-packages/compare/3.11-mitre) |No issue related|

## Description

Mitre database is created during the installation process and it has to be declared in SPEC file in order to avoid errors concerning rpm packages building.
