### PR TITLE
Rework to generate wazuh msi script

### DIFF
--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -5,29 +5,35 @@ param (
     [string]$READY_TO_RELEASE = "",
     [string]$OPTIONAL_REVISION = "",
     [string]$SIGN = "",
+    [string]$WIX_TOOLS_PATH = "",
+    [string]$SIGN_TOOLS_PATH = "",
     [switch]$help
     )
 
-
 $MSI_NAME = ""
 $VERSION = ""
+$CANDLE_EXE = "candle.exe"
+$LIGHT_EXE = "light.exe"
+$SIGNTOOL_EXE = "signtool.exe"
 
 if(($help.isPresent)) {
     "
     This tool can be used to generate the Windows Wazuh agent msi package.
 
     PARAMETERS TO BUILD WAZUH-AGENT MSI:
-        1. READY_TO_RELEASE: yes or no.
-        2. OPTIONAL_REVISION: 1 or different
-        3. SIGN: yes or no.
+        1. OPTIONAL_REVISION: 1 or different
+        2. SIGN: yes or no.
+    OPTIONAL PARAMETERS:
+        3. WIX_TOOLS_PATH: Wix tools path
+        4. SIGN_TOOLS_PATH: sign tools path
 
     USAGE:
 
         * WAZUH:
-          $ ./generate_wazuh_msi.ps1 -READY_TO_RELEASE {{ yes|no }} -OPTIONAL_REVISION {{ BRANCH_TAG }} -SIGN {{ yes|no }}
+          $ ./generate_wazuh_msi.ps1  -OPTIONAL_REVISION {{ BRANCH_TAG }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }}
 
-            Build a devel msi:    $ ./generate_wazuh_msi.ps1 -READY_TO_RELEASE no -SIGN no
-            Build a prod msi:     $ ./generate_wazuh_msi.ps1 -READY_TO_RELEASE yes -OPTIONAL_REVISION 2 -SIGN yes
+            Build a devel msi:    $ ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION 2 -SIGN no
+            Build a prod msi:     $ ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION 1 -SIGN yes -
     "
     Exit
 }
@@ -38,25 +44,12 @@ if ($PSversion -eq $null) {
     $PSversion = 1 # $PSVersionTable is new with Powershell 2.0
 }
 
-## Checking arguments
-if($READY_TO_RELEASE -eq ""){
-    "-READY_TO_RELEASE is required. Try -help to display arguments list."
-    Write-Host "Press any key to continue ..."
-    $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-    Exit
-}
-
 function ComputeMsiName() {
 
     ## Checking arguments
     if($OPTIONAL_REVISION -eq ""){
         Write-Host "-OPTIONAL_REVISION empty. Using default value."
-        if($READY_TO_RELEASE -eq "yes"){
-            $OPTIONAL_REVISION="1"
-        }
-        else{
-            $OPTIONAL_REVISION = Get-Content REVISION
-        }
+        $OPTIONAL_REVISION = "1"
     }
     $VERSION = Get-Content VERSION
     $VERSION = $VERSION -replace '[v]',''
@@ -69,25 +62,33 @@ function BuildWazuhMsi(){
     $MSI_NAME = ComputeMsiName
     Write-Host "MSI_NAME = $MSI_NAME"
 
+    if($WIX_TOOLS_PATH -ne ""){
+        $CANDLE_EXE = $WIX_TOOLS_PATH + "/" + $CANDLE_EXE
+        $LIGHT_EXE = $WIX_TOOLS_PATH + "/" + $LIGHT_EXE
+    }
+
+    if($SIGN_TOOLS_PATH -ne ""){
+        $SIGNTOOL_EXE = $SIGN_TOOLS_PATH + "/" + $SIGNTOOL_EXE
+    }
+
     if($SIGN -eq "yes"){
         # Sign .exe files and the InstallerScripts.vbs
         Write-Host "Signing .exe files..."
-        & 'signtool.exe' sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 ".\*.exe"
+        & $SIGNTOOL_EXE sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 ".\*.exe"
         Write-Host "Signing .vbs files..."
-        & 'signtool.exe' sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 ".\InstallerScripts.vbs"
+        & $SIGNTOOL_EXE sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 ".\InstallerScripts.vbs"
     }
 
     Write-Host "Building MSI installer..."
 
-    & 'candle.exe' -nologo .\wazuh-installer.wxs -out "wazuh-installer.wixobj" -ext WixUtilExtension -ext WixUiExtension
-    & 'light.exe' ".\wazuh-installer.wixobj" -out $MSI_NAME  -ext WixUtilExtension -ext WixUiExtension
+    & $CANDLE_EXE -nologo .\wazuh-installer.wxs -out "wazuh-installer.wixobj" -ext WixUtilExtension -ext WixUiExtension
+    & $LIGHT_EXE ".\wazuh-installer.wixobj" -out $MSI_NAME  -ext WixUtilExtension -ext WixUiExtension
 
     if($SIGN -eq "yes"){
-        # Write-Host "Signing $MSI_NAME..."
-        & 'signtool.exe' sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /d $MSI_NAME /td SHA256 $MSI_NAME
+        Write-Host "Signing $MSI_NAME..."
+        & $SIGNTOOL_EXE sign /a /tr http://rfc3161timestamp.globalsign.com/advanced /d $MSI_NAME /td SHA256 $MSI_NAME
     }
 }
-
 
 ############################
 # MAIN

--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -2,7 +2,6 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 param (
-    [string]$READY_TO_RELEASE = "",
     [string]$OPTIONAL_REVISION = "",
     [string]$SIGN = "",
     [string]$WIX_TOOLS_PATH = "",
@@ -30,7 +29,7 @@ if(($help.isPresent)) {
     USAGE:
 
         * WAZUH:
-          $ ./generate_wazuh_msi.ps1  -OPTIONAL_REVISION {{ BRANCH_TAG }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }}
+          $ ./generate_wazuh_msi.ps1  -OPTIONAL_REVISION {{ REVISION }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }}
 
             Build a devel msi:    $ ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION 2 -SIGN no
             Build a prod msi:     $ ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION 1 -SIGN yes -


### PR DESCRIPTION
Hello team,

This PR adds the necessary changes to the `generate_wazuh_msi.ps1` file to perform the `build win packages` rework proposed in this issue https://github.com/wazuh/wazuh-jenkins/issues/885 and done in this PR https://github.com/wazuh/wazuh-jenkins/pull/994.

The changes made to this PR are as follows:

- Removed unused param `READY_TO_RELEASE`
- Added a new param to specify the path of the executables.

Best regards
