### PR TITLE
Added gcloud SPECS

### DIFF
--- a/aix/SPECS/3.12.0/wazuh-agent-3.12.0-aix.spec
+++ b/aix/SPECS/3.12.0/wazuh-agent-3.12.0-aix.spec
@@ -254,6 +254,8 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 
 
 %changelog

--- a/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
@@ -647,6 +647,8 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 
 
 %changelog

--- a/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
@@ -642,13 +642,13 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/aws/*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/docker
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/docker/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.py
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
-%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 
 
 %changelog

--- a/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
@@ -909,14 +909,15 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/azure/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/docker
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/docker/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/oscap
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.*
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
-%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
+
 
 %{_initrddir}/*
 

--- a/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
@@ -915,6 +915,8 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
+%dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud
+%attr(750, root, ossec) %{_localstatedir}/ossec/wodles/gcloud/*
 
 %{_initrddir}/*
 

--- a/solaris/solaris11/SPECS/template_agent_v3.12.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.12.0.json
@@ -1256,6 +1256,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/ruleset/sca/cis_solaris11_rcl.yml": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0640",
+        "prot": "-rwxr-----",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/ruleset/sca/system_audit_pw.yml": {
         "class": "static",
         "group": "ossec",
@@ -1480,6 +1488,46 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/gcloud": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/gcloud": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/gcloud.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/integration.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/tools.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/oscap": {
         "class": "static",
         "group": "ossec",
@@ -1617,54 +1665,6 @@
         "user": "root"
     },
     "/var/ossec/wodles/oscap/template_xccdf.xsl": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
-    "/var/ossec/ruleset/sca/cis_solaris11_rcl.yml": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0640",
-        "prot": "-rwxr-----",
-        "type": "file",
-        "user": "root"
-    },
-    "/var/ossec/wodles/gcloud": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "drwxr-x---",
-        "type": "directory",
-        "user": "root"
-    },
-    "/var/ossec/wodles/gcloud/gcloud.py": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
-    "/var/ossec/wodles/gcloud/integration.py": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
-    "/var/ossec/wodles/gcloud/tools.py": {
-        "class": "static",
-        "group": "ossec",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
-    "/var/ossec/wodles/gcloud/gcloud": {
         "class": "static",
         "group": "ossec",
         "mode": "0750",

--- a/solaris/solaris11/SPECS/template_agent_v3.12.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v3.12.0.json
@@ -1631,5 +1631,45 @@
         "prot": "-rwxr-----",
         "type": "file",
         "user": "root"
+    },
+    "/var/ossec/wodles/gcloud": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/gcloud.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/integration.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/tools.py": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/gcloud": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
     }
 }


### PR DESCRIPTION
Hello team,

This PR added the new `GCP wodle` files indicated in the https://github.com/wazuh/wazuh-packages/issues/364 issue.

The files that have been modified are the following:

- RPM
  -   wazuh-manager-3.12.0.spec 
  -  wazuh-agent-3.12.0.spec

- AIX
  +  wazuh-agent-3.12.0-aix.spec

- Solaris 11
  + template_agent_v3.12.0.json 

**Checks**

- Debian:
  + [x] manager
  + [x] agent

- RPM:
  + [x] manager
  + [x] agent

- Solaris 11:
  + [x] agent

- macOS:
  + [x] agent
