### PR TITLE
Fixed the line used to list the package name

### DIFF
--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -62,7 +62,7 @@ build_deb() {
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} || return 1
 
-    echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
     return 0
 }

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -78,7 +78,7 @@ build_rpm() {
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} || return 1
 
-    echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
     return 0
 }

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -21,7 +21,7 @@ generate_compiled_win_agent() {
 
     docker build -t ${DOCKER_IMAGE_NAME} ./ || exit 1
     docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
-    echo "Package $(ls ${OUTDIR} -Art | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 }
 
 


### PR DESCRIPTION
Hi team,

This PR closes #372 by changing the position of the arguments used by `ls`. Now, the arguments appear before the directory, improving the compatibility between Linux and other UNIX systems.

Regards.