### PR TITLE
Update changelog to fix typo

### DIFF
--- a/debs/SPECS/3.11.3/wazuh-manager/debian/changelog
+++ b/debs/SPECS/3.11.3/wazuh-manager/debian/changelog
@@ -1,4 +1,4 @@
-wazuh-agent (3.11.3-RELEASE) stable; urgency=low
+wazuh-manager (3.11.3-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 


### PR DESCRIPTION
Hello Team, we've detected a typo in the changelog that is breaking the package generation. This PR aims to fix it. 