### PR TITLE
Added dist macros to our custom rpmmacros file

### DIFF
--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -79,6 +79,11 @@ fi
 if [ "${legacy}" = "no" ]; then
     echo "%_source_filedigest_algorithm 8" >> /root/.rpmmacros
     echo "%_binary_filedigest_algorithm 8" >> /root/.rpmmacros
+    echo " %rhel 6" >> /root/.rpmmacros
+    echo " %centos 6" >> /root/.rpmmacros
+    echo " %centos_ver 6" >> /root/.rpmmacros
+    echo " %dist .el6" >> /root/.rpmmacros
+    echo " %el6 1" >> /root/.rpmmacros
     rpmbuild="/usr/local/bin/rpmbuild"
 fi
 


### PR DESCRIPTION
Hi team,

This PR closes https://github.com/wazuh/wazuh/issues/4505 by adding the _dist macros_ to our custom `.rpmmacros` file. 

With this change, the generic wazuh-agent rpm package is properly compiled, fixing the issue related to whodata.

Regards.