### PR TITLE
Fix generation of rpm packages with debug info

### DIFF
--- a/rpms/SPECS/3.0.0/wazuh-agent-3.0.0.spec
+++ b/rpms/SPECS/3.0.0/wazuh-agent-3.0.0.spec
@@ -347,6 +347,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Nov 07 2017 support <support@wazuh.com> - 3.0.0

--- a/rpms/SPECS/3.0.0/wazuh-manager-3.0.0.spec
+++ b/rpms/SPECS/3.0.0/wazuh-manager-3.0.0.spec
@@ -559,6 +559,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Nov 06 2017 support <support@wazuh.com> - 3.0.0

--- a/rpms/SPECS/3.1.0/wazuh-agent-3.1.0.spec
+++ b/rpms/SPECS/3.1.0/wazuh-agent-3.1.0.spec
@@ -412,6 +412,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/wazuh.sh
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Dec 21 2017 support <support@wazuh.com> - 3.1.0

--- a/rpms/SPECS/3.1.0/wazuh-manager-3.1.0.spec
+++ b/rpms/SPECS/3.1.0/wazuh-manager-3.1.0.spec
@@ -639,6 +639,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Dec 19 2017 support <support@wazuh.com> - 3.1.0

--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -611,7 +611,7 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos/*
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/suse/sca.files

--- a/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-agent-3.10.0.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Aug 26 2019 support <support@wazuh.com> - 3.10.0

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -868,7 +868,6 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos/*
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/suse/sca.files

--- a/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
+++ b/rpms/SPECS/3.10.0/wazuh-manager-3.10.0.spec
@@ -910,6 +910,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Aug 26 2019 support <support@wazuh.com> - 3.10.0

--- a/rpms/SPECS/3.10.1/wazuh-agent-3.10.1.spec
+++ b/rpms/SPECS/3.10.1/wazuh-agent-3.10.1.spec
@@ -611,7 +611,7 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos/*
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/suse/sca.files

--- a/rpms/SPECS/3.10.1/wazuh-agent-3.10.1.spec
+++ b/rpms/SPECS/3.10.1/wazuh-agent-3.10.1.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Sep 19 2019 support <support@wazuh.com> - 3.10.1

--- a/rpms/SPECS/3.10.1/wazuh-manager-3.10.1.spec
+++ b/rpms/SPECS/3.10.1/wazuh-manager-3.10.1.spec
@@ -868,7 +868,7 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/11/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sles/12/*
 %dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/sunos/*
 %attr(640, root, ossec) %config(missingok) %{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/suse/sca.files

--- a/rpms/SPECS/3.10.1/wazuh-manager-3.10.1.spec
+++ b/rpms/SPECS/3.10.1/wazuh-manager-3.10.1.spec
@@ -911,6 +911,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Sep 19 2019 support <support@wazuh.com> - 3.10.1

--- a/rpms/SPECS/3.10.2/wazuh-agent-3.10.2.spec
+++ b/rpms/SPECS/3.10.2/wazuh-agent-3.10.2.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Sep 23 2019 support <support@wazuh.com> - 3.10.2

--- a/rpms/SPECS/3.10.2/wazuh-manager-3.10.2.spec
+++ b/rpms/SPECS/3.10.2/wazuh-manager-3.10.2.spec
@@ -915,6 +915,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Sep 23 2019 support <support@wazuh.com> - 3.10.2

--- a/rpms/SPECS/3.11.0/wazuh-agent-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-agent-3.11.0.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Oct 7 2019 support <info@wazuh.com> - 3.11.0

--- a/rpms/SPECS/3.11.0/wazuh-manager-3.11.0.spec
+++ b/rpms/SPECS/3.11.0/wazuh-manager-3.11.0.spec
@@ -920,6 +920,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Oct 7 2019 support <info@wazuh.com> - 3.11.0

--- a/rpms/SPECS/3.11.1/wazuh-agent-3.11.1.spec
+++ b/rpms/SPECS/3.11.1/wazuh-agent-3.11.1.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Dec 26 2019 support <info@wazuh.com> - 3.11.1

--- a/rpms/SPECS/3.11.1/wazuh-manager-3.11.1.spec
+++ b/rpms/SPECS/3.11.1/wazuh-manager-3.11.1.spec
@@ -920,6 +920,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Dec 26 2019 support <info@wazuh.com> - 3.11.1

--- a/rpms/SPECS/3.11.2/wazuh-agent-3.11.2.spec
+++ b/rpms/SPECS/3.11.2/wazuh-agent-3.11.2.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jan 7 2020 support <info@wazuh.com> - 3.11.2

--- a/rpms/SPECS/3.11.2/wazuh-manager-3.11.2.spec
+++ b/rpms/SPECS/3.11.2/wazuh-manager-3.11.2.spec
@@ -920,6 +920,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jan 7 2020 support <info@wazuh.com> - 3.11.2

--- a/rpms/SPECS/3.11.3/wazuh-agent-3.11.3.spec
+++ b/rpms/SPECS/3.11.3/wazuh-agent-3.11.3.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 22 2020 support <info@wazuh.com> - 3.11.3

--- a/rpms/SPECS/3.11.3/wazuh-manager-3.11.3.spec
+++ b/rpms/SPECS/3.11.3/wazuh-manager-3.11.3.spec
@@ -920,6 +920,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 22 2020 support <info@wazuh.com> - 3.11.3

--- a/rpms/SPECS/3.11.4/wazuh-agent-3.11.4.spec
+++ b/rpms/SPECS/3.11.4/wazuh-agent-3.11.4.spec
@@ -648,6 +648,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Feb 24 2020 support <info@wazuh.com> - 3.11.4

--- a/rpms/SPECS/3.11.4/wazuh-manager-3.11.4.spec
+++ b/rpms/SPECS/3.11.4/wazuh-manager-3.11.4.spec
@@ -920,6 +920,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Feb 24 2020 support <info@wazuh.com> - 3.11.4

--- a/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
@@ -652,6 +652,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Jan 7 2020 support <info@wazuh.com> - 3.12.0

--- a/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
@@ -926,6 +926,11 @@ rm -fr %{buildroot}
 
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jan 7 2020 support <info@wazuh.com> - 3.12.0

--- a/rpms/SPECS/3.2.0/wazuh-agent-3.2.0.el5.spec
+++ b/rpms/SPECS/3.2.0/wazuh-agent-3.2.0.el5.spec
@@ -451,6 +451,11 @@ rm -fr %{buildroot}
 
 
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 07 2018 support <support@wazuh.com> - 3.2.0

--- a/rpms/SPECS/3.2.0/wazuh-agent-3.2.0.spec
+++ b/rpms/SPECS/3.2.0/wazuh-agent-3.2.0.spec
@@ -419,6 +419,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 07 2018 support <support@wazuh.com> - 3.2.0

--- a/rpms/SPECS/3.2.0/wazuh-manager-3.2.0.el5.spec
+++ b/rpms/SPECS/3.2.0/wazuh-manager-3.2.0.el5.spec
@@ -722,6 +722,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 07 2018 support <support@wazuh.com> - 3.2.0

--- a/rpms/SPECS/3.2.0/wazuh-manager-3.2.0.spec
+++ b/rpms/SPECS/3.2.0/wazuh-manager-3.2.0.spec
@@ -658,6 +658,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 07 2018 support <support@wazuh.com> - 3.2.0

--- a/rpms/SPECS/3.2.1/wazuh-agent-3.2.1.spec
+++ b/rpms/SPECS/3.2.1/wazuh-agent-3.2.1.spec
@@ -430,6 +430,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-agent/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 21 2018 support <support@wazuh.com> - 3.2.1

--- a/rpms/SPECS/3.2.1/wazuh-manager-3.2.1.spec
+++ b/rpms/SPECS/3.2.1/wazuh-manager-3.2.1.spec
@@ -652,6 +652,11 @@ rm -fr %{buildroot}
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/deprecated_ruleset.txt
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/upgrade.py
 /usr/share/wazuh-manager/scripts/tmp/src/init/wazuh/wazuh.sh
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Feb 21 2018 support <support@wazuh.com> - 3.2.1

--- a/rpms/SPECS/3.2.2/wazuh-agent-3.2.2.spec
+++ b/rpms/SPECS/3.2.2/wazuh-agent-3.2.2.spec
@@ -356,6 +356,11 @@ rm -fr %{buildroot}
 
 /usr/share/wazuh-agent/scripts/tmp/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Apr 09 2018 support <support@wazuh.com> - 3.2.2

--- a/rpms/SPECS/3.2.2/wazuh-manager-3.2.2.spec
+++ b/rpms/SPECS/3.2.2/wazuh-manager-3.2.2.spec
@@ -577,6 +577,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Apr 09 2018 support <support@wazuh.com> - 3.2.2

--- a/rpms/SPECS/3.2.3/wazuh-agent-3.2.3.spec
+++ b/rpms/SPECS/3.2.3/wazuh-agent-3.2.3.spec
@@ -356,6 +356,11 @@ rm -fr %{buildroot}
 
 /usr/share/wazuh-agent/scripts/tmp/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu May 10 2018 support <support@wazuh.com> - 3.2.3

--- a/rpms/SPECS/3.2.3/wazuh-manager-3.2.3.spec
+++ b/rpms/SPECS/3.2.3/wazuh-manager-3.2.3.spec
@@ -603,6 +603,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu May 10 2018 support <support@wazuh.com> - 3.2.3

--- a/rpms/SPECS/3.2.4/wazuh-agent-3.2.4.spec
+++ b/rpms/SPECS/3.2.4/wazuh-agent-3.2.4.spec
@@ -356,6 +356,11 @@ rm -fr %{buildroot}
 
 /usr/share/wazuh-agent/scripts/tmp/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed May 30 2018 support <support@wazuh.com> - 3.2.4

--- a/rpms/SPECS/3.2.4/wazuh-manager-3.2.4.spec
+++ b/rpms/SPECS/3.2.4/wazuh-manager-3.2.4.spec
@@ -603,6 +603,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed May 30 2018 support <support@wazuh.com> - 3.2.4

--- a/rpms/SPECS/3.3.0/wazuh-agent-3.3.0.spec
+++ b/rpms/SPECS/3.3.0/wazuh-agent-3.3.0.spec
@@ -357,6 +357,11 @@ rm -fr %{buildroot}
 
 /usr/share/wazuh-agent/scripts/tmp/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed May 30 2018 support <support@wazuh.com> - 3.2.4

--- a/rpms/SPECS/3.3.0/wazuh-manager-3.3.0.spec
+++ b/rpms/SPECS/3.3.0/wazuh-manager-3.3.0.spec
@@ -603,6 +603,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed May 30 2018 support <support@wazuh.com> - 3.2.4

--- a/rpms/SPECS/3.3.1/wazuh-agent-3.3.1.spec
+++ b/rpms/SPECS/3.3.1/wazuh-agent-3.3.1.spec
@@ -357,6 +357,11 @@ rm -fr %{buildroot}
 
 /usr/share/wazuh-agent/scripts/tmp/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Jun 18 2018 support <support@wazuh.com> - 3.3.1

--- a/rpms/SPECS/3.3.1/wazuh-manager-3.3.1.spec
+++ b/rpms/SPECS/3.3.1/wazuh-manager-3.3.1.spec
@@ -603,6 +603,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Jun 18 2018 support <support@wazuh.com> - 3.3.1

--- a/rpms/SPECS/3.4.0/wazuh-agent-3.4.0.spec
+++ b/rpms/SPECS/3.4.0/wazuh-agent-3.4.0.spec
@@ -324,7 +324,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -340,7 +340,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -421,6 +421,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
 
 /usr/share/wazuh-agent/scripts/tmp/*
+
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
 
 
 %changelog

--- a/rpms/SPECS/3.4.0/wazuh-manager-3.4.0.spec
+++ b/rpms/SPECS/3.4.0/wazuh-manager-3.4.0.spec
@@ -525,7 +525,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -541,7 +541,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -670,6 +670,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jul 11 2018 support <support@wazuh.com> - 3.4.0

--- a/rpms/SPECS/3.5.0/wazuh-agent-3.5.0.spec
+++ b/rpms/SPECS/3.5.0/wazuh-agent-3.5.0.spec
@@ -328,7 +328,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -344,7 +344,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -420,6 +420,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
 
 /usr/share/wazuh-agent/scripts/tmp/*
+
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
 
 
 %changelog

--- a/rpms/SPECS/3.5.0/wazuh-manager-3.5.0.spec
+++ b/rpms/SPECS/3.5.0/wazuh-manager-3.5.0.spec
@@ -535,7 +535,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -551,7 +551,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -676,6 +676,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jul 25 2018 support <support@wazuh.com> - 3.5.0

--- a/rpms/SPECS/3.6.0/wazuh-agent-3.6.0.spec
+++ b/rpms/SPECS/3.6.0/wazuh-agent-3.6.0.spec
@@ -52,7 +52,7 @@ make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
     make deps
-    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec 
+    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
 %else
     make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.5
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec
@@ -96,7 +96,7 @@ install -m 0640 src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src
 install -m 0640 add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp
 
 # AWS wodle
-install -m 0750 wodles/aws/aws-s3.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/aws/aws-s3 
+install -m 0750 wodles/aws/aws-s3.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/aws/aws-s3
 
 # Wazuh lib
 install -m 0750 src/libwazuhext.so ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/lib
@@ -328,7 +328,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -344,7 +344,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -420,6 +420,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
 
 /usr/share/wazuh-agent/scripts/tmp/*
+
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
 
 
 %changelog

--- a/rpms/SPECS/3.6.0/wazuh-manager-3.6.0.spec
+++ b/rpms/SPECS/3.6.0/wazuh-manager-3.6.0.spec
@@ -536,7 +536,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -552,7 +552,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -678,6 +678,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Aug 23 2018 support <support@wazuh.com> - 3.6.0

--- a/rpms/SPECS/3.6.1/wazuh-agent-3.6.1.spec
+++ b/rpms/SPECS/3.6.1/wazuh-agent-3.6.1.spec
@@ -52,7 +52,7 @@ make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
     make deps
-    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec 
+    make -j%{_threads} TARGET=agent USE_SELINUX=yes PREFIX=%{_localstatedir}/ossec
 %else
     make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.5
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec
@@ -96,7 +96,7 @@ install -m 0640 src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/src
 install -m 0640 add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp
 
 # AWS wodle
-install -m 0750 wodles/aws/aws-s3.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/aws/aws-s3 
+install -m 0750 wodles/aws/aws-s3.py ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/aws/aws-s3
 
 # Wazuh lib
 install -m 0750 src/libwazuhext.so ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/lib
@@ -328,7 +328,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -344,7 +344,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/generic/*
 
 /usr/share/wazuh-agent/scripts/tmp/*
+
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
 
 
 %changelog

--- a/rpms/SPECS/3.6.1/wazuh-manager-3.6.1.spec
+++ b/rpms/SPECS/3.6.1/wazuh-manager-3.6.1.spec
@@ -536,7 +536,7 @@ if [ $1 = 0 ]; then
   if [ -r "/etc/centos-release" ]; then
     DIST_NAME="centos"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/centos-release`
-  
+
   elif [ -r "/etc/redhat-release" ]; then
     DIST_NAME="rhel"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/redhat-release`
@@ -552,7 +552,7 @@ if [ $1 = 0 ]; then
   if [ "${DIST_NAME}" == "centos" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "5" ] || [ "${DIST_NAME}" == "suse" -a "${DIST_VER}" == "11" ] ; then
     add_selinux="no"
   fi
-  
+
   # If it is a valid system, remove the policy if it is installed
   if [ ${add_selinux} == "yes" ]; then
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
@@ -700,6 +700,11 @@ rm -fr %{buildroot}
 %attr(750,root,root) %config(missingok) %{_localstatedir}/ossec/tmp/etc/templates/config/rhel/*
 
 /usr/share/wazuh-manager/scripts/tmp/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Sep 3 2018 support <info@wazuh.com> - 3.6.1

--- a/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-agent-3.7.0.spec
@@ -458,6 +458,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Fri Sep 7 2018 support <info@wazuh.com> - 3.7.0

--- a/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
+++ b/rpms/SPECS/3.7.0/wazuh-manager-3.7.0.spec
@@ -703,6 +703,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Fri Sep 7 2018 support <info@wazuh.com> - 3.7.0

--- a/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-agent-3.7.1.spec
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Nov 12 2018 support <info@wazuh.com> - 3.7.1

--- a/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
+++ b/rpms/SPECS/3.7.1/wazuh-manager-3.7.1.spec
@@ -675,6 +675,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Nov 12 2018 support <info@wazuh.com> - 3.7.1

--- a/rpms/SPECS/3.7.2/wazuh-agent-3.7.2.spec
+++ b/rpms/SPECS/3.7.2/wazuh-agent-3.7.2.spec
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Dec 10 2018 support <info@wazuh.com> - 3.7.2

--- a/rpms/SPECS/3.7.2/wazuh-manager-3.7.2.spec
+++ b/rpms/SPECS/3.7.2/wazuh-manager-3.7.2.spec
@@ -675,6 +675,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Dec 10 2018 support <info@wazuh.com> - 3.7.2

--- a/rpms/SPECS/3.8.0/wazuh-agent-3.8.0.spec
+++ b/rpms/SPECS/3.8.0/wazuh-agent-3.8.0.spec
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 16 2019 support <info@wazuh.com> - 3.8.0

--- a/rpms/SPECS/3.8.0/wazuh-manager-3.8.0.spec
+++ b/rpms/SPECS/3.8.0/wazuh-manager-3.8.0.spec
@@ -679,6 +679,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 16 2019 support <info@wazuh.com> - 3.8.0

--- a/rpms/SPECS/3.8.1/wazuh-agent-3.8.1.spec
+++ b/rpms/SPECS/3.8.1/wazuh-agent-3.8.1.spec
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Jan 24 2019 support <info@wazuh.com> - 3.8.1

--- a/rpms/SPECS/3.8.1/wazuh-manager-3.8.1.spec
+++ b/rpms/SPECS/3.8.1/wazuh-manager-3.8.1.spec
@@ -682,6 +682,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Jan 24 2019 support <info@wazuh.com> - 3.8.1

--- a/rpms/SPECS/3.8.2/wazuh-agent-3.8.2.spec
+++ b/rpms/SPECS/3.8.2/wazuh-agent-3.8.2.spec
@@ -435,6 +435,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 30 2019 support <info@wazuh.com> - 3.8.2

--- a/rpms/SPECS/3.8.2/wazuh-manager-3.8.2.spec
+++ b/rpms/SPECS/3.8.2/wazuh-manager-3.8.2.spec
@@ -684,6 +684,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Wed Jan 30 2019 support <info@wazuh.com> - 3.8.2

--- a/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-agent-3.9.0.spec
@@ -545,6 +545,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Feb 25 2019 support <info@wazuh.com> - 3.9.0

--- a/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
+++ b/rpms/SPECS/3.9.0/wazuh-manager-3.9.0.spec
@@ -689,6 +689,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Feb 25 2019 support <info@wazuh.com> - 3.9.0

--- a/rpms/SPECS/3.9.1/wazuh-agent-3.9.1.spec
+++ b/rpms/SPECS/3.9.1/wazuh-agent-3.9.1.spec
@@ -542,6 +542,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon May 6 2019 support <info@wazuh.com> - 3.9.1

--- a/rpms/SPECS/3.9.1/wazuh-manager-3.9.1.spec
+++ b/rpms/SPECS/3.9.1/wazuh-manager-3.9.1.spec
@@ -686,6 +686,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon May 6 2019 support <info@wazuh.com> - 3.9.1

--- a/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-agent-3.9.2.spec
@@ -239,7 +239,7 @@ if [ $1 = 1 ]; then
     # Service must be installed in /usr/lib/systemd/system/
     if [ "${DIST_NAME}" == "rhel" -a "${DIST_VER}" == "8" ]; then
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /usr/lib/systemd/system/
-    else  
+    else
       install -m 644 %{_localstatedir}/ossec/packages_files/agent_installation_scripts/src/systemd/wazuh-agent.service /etc/systemd/system/
     fi
     # Fix for Fedora 28
@@ -383,7 +383,7 @@ if [ $1 = 0 ]; then
     rm -f /etc/init.d/wazuh-agent
   fi
   # Remove the wazuh-agent.service file
-  # RHEL 8 service located in /usr/lib/systemd/system/ 
+  # RHEL 8 service located in /usr/lib/systemd/system/
   if [ -f /usr/lib/systemd/system/wazuh-agent.service ]; then
     rm -f /usr/lib/systemd/system/wazuh-agent.service
   else
@@ -552,6 +552,11 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
+
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
 
 
 %changelog

--- a/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
+++ b/rpms/SPECS/3.9.2/wazuh-manager-3.9.2.spec
@@ -698,6 +698,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Mon Jun 6 2019 support <info@wazuh.com> - 3.9.2

--- a/rpms/SPECS/3.9.3/wazuh-agent-3.9.3.spec
+++ b/rpms/SPECS/3.9.3/wazuh-agent-3.9.3.spec
@@ -549,6 +549,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jun 11 2019 support <info@wazuh.com> - 3.9.3

--- a/rpms/SPECS/3.9.3/wazuh-manager-3.9.3.spec
+++ b/rpms/SPECS/3.9.3/wazuh-manager-3.9.3.spec
@@ -703,6 +703,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jun 11 2019 support <info@wazuh.com> - 3.9.3

--- a/rpms/SPECS/3.9.4/wazuh-agent-3.9.4.spec
+++ b/rpms/SPECS/3.9.4/wazuh-agent-3.9.4.spec
@@ -554,6 +554,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jul 12 2019 support <info@wazuh.com> - 3.9.4

--- a/rpms/SPECS/3.9.4/wazuh-manager-3.9.4.spec
+++ b/rpms/SPECS/3.9.4/wazuh-manager-3.9.4.spec
@@ -710,6 +710,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Tue Jul 12 2019 support <info@wazuh.com> - 3.9.4

--- a/rpms/SPECS/3.9.5/wazuh-agent-3.9.5.spec
+++ b/rpms/SPECS/3.9.5/wazuh-agent-3.9.5.spec
@@ -554,6 +554,11 @@ rm -fr %{buildroot}
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
 %attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Aug 8 2019 support <info@wazuh.com> - 3.9.5

--- a/rpms/SPECS/3.9.5/wazuh-manager-3.9.5.spec
+++ b/rpms/SPECS/3.9.5/wazuh-manager-3.9.5.spec
@@ -710,6 +710,11 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %{_initrddir}/*
+%if %{_debugenabled} == "yes"
+/usr/lib/debug/%{_localstatedir}/ossec/*
+/usr/src/debug/%{name}-%{version}/*
+%endif
+
 
 %changelog
 * Thu Aug 8 2019 support <info@wazuh.com> - 3.9.5


### PR DESCRIPTION
Hi team,

While developing this issue https://github.com/wazuh/wazuh-packages/issues/367 we updated the `rpm-build` version of our Docker images. This updated version packs the binaries and their debugging symbols in the same package instead of creating two separate packages for that as it did previously.

That change made mandatory to list in `%files` section any files in the package (as always) alongside the debugging symbols and the source code of the package.

This was done by adding an `if` block in this section that lists the debugging files if `_debugenabled` macro is set to `yes`.

```
%if %{_debugenabled} == "yes"
/usr/lib/debug/%{_localstatedir}/ossec/*
/usr/src/debug/%{name}-%{version}/*
%endif
```

Regards.