### PR TITLE
Update owner, group and permissions of Python's directory

### DIFF
--- a/debs/SPECS/3.12.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.12.0/wazuh-manager/debian/postinst
@@ -384,14 +384,8 @@ case "$1" in
     chown root:ossec /etc/ossec-init.conf
 
     # Fix python libraries and binaries permissions
-    chmod 755 ${DIR}/framework/python/bin/2to3-3.7
-    chmod 755 ${DIR}/framework/python/bin/pydoc3
-    chmod 755 ${DIR}/framework/python/bin/pydoc3.7
-    chmod 755 ${DIR}/framework/python/bin/python3-config
-    chmod 755 ${DIR}/framework/python/bin/python3.7-config
-    chmod 755 ${DIR}/framework/python/bin/python3.7m-config
-    chmod 555 ${DIR}/framework/python/lib/libpython3.7m.so
-    chmod 555 ${DIR}/framework/python/lib/libpython3.7m.so.1.0
+    chown -R root:${OSSEC_GROUP} ${DIR}/framework/python
+    chmod -R o=- ${DIR}/framework/python/*
 
     ;;
 

--- a/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-manager-3.12.0.spec
@@ -686,7 +686,7 @@ fi
 rm -fr %{buildroot}
 
 %files
-%defattr(-,root,root)
+%defattr(-,root,ossec)
 %attr(640, root, ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec
 %attr(750, root, ossec) %{_localstatedir}/ossec/agentless


### PR DESCRIPTION
Hi team,

This commit https://github.com/wazuh/wazuh/commit/f6dd306cf1a56b113924bc0b919106f190da1ac7 updated the owner, group and permissions of all the files stored in the Python's interpreter directory (`${WAZUH_HOME}/framework/python`). This also has to be changed in our binary packages to avoid bugs or inconsistencies.

Regards.