### PR TITLE
Change makedeps version in 3.12.x versions

### DIFF
--- a/aix/SPECS/3.12.0/wazuh-agent-3.12.0-aix.spec
+++ b/aix/SPECS/3.12.0/wazuh-agent-3.12.0-aix.spec
@@ -22,7 +22,7 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 %prep
 %setup -q
 ./gen_ossec.sh init agent %{_localstatedir}/ossec > ossec-init.conf
-cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/3.11
+cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/3.12
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir}/ossec DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
 

--- a/aix/SPECS/3.12.1/wazuh-agent-3.12.1-aix.spec
+++ b/aix/SPECS/3.12.1/wazuh-agent-3.12.1-aix.spec
@@ -22,7 +22,7 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 %prep
 %setup -q
 ./gen_ossec.sh init agent %{_localstatedir}/ossec > ossec-init.conf
-cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/3.11
+cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/3.12
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir}/ossec DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
 

--- a/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
+++ b/rpms/SPECS/3.12.0/wazuh-agent-3.12.0.spec
@@ -50,7 +50,7 @@ make clean
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
     %endif
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.11
+    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.12
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} ${MSGPACK}
 
 %endif

--- a/rpms/SPECS/3.12.1/wazuh-agent-3.12.1.spec
+++ b/rpms/SPECS/3.12.1/wazuh-agent-3.12.1.spec
@@ -50,7 +50,7 @@ make clean
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
     %endif
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.11
+    make deps RESOURCES_URL=http://packages.wazuh.com/deps/3.12
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no PREFIX=%{_localstatedir}/ossec DEBUG=%{_debugenabled} ${MSGPACK}
 
 %endif


### PR DESCRIPTION
Hello team,

In this PR I changed make deps version in the AIX and  RPM SPECS from3.11 to 3.12

Regards,
Daniel Folch