### PR TITLE
Added a new parameter to build binary packages using local code

### DIFF
--- a/debs/build.sh
+++ b/debs/build.sh
@@ -21,16 +21,21 @@ debug=$7
 checksum=$8
 wazuh_packages_branch=$9
 use_local_specs=${10}
+local_source_code=${11}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
 fi
 
 if [ ${build_target} = "api" ]; then
-    curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
+    if [ -z "${local_source_code}" ]; then
+        curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
+    fi
     wazuh_version="$(grep version wazuh*/package.json | cut -d '"' -f 4)"
 else
-    curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
+    if [ -z "${local_source_code}" ]; then
+        curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
+    fi
     wazuh_version="$(cat wazuh*/src/VERSION | cut -d 'v' -f 2)"
 fi
 
@@ -40,7 +45,7 @@ package_full_name="wazuh-${build_target}-${wazuh_version}"
 sources_dir="${build_dir}/${build_target}/${package_full_name}"
 
 mkdir -p ${build_dir}/${build_target}
-mv wazuh* ${build_dir}/${build_target}/wazuh-${build_target}-${wazuh_version}
+cp -R wazuh* ${build_dir}/${build_target}/wazuh-${build_target}-${wazuh_version}
 
 if [ "${use_local_specs}" = "no" ]; then
     curl -sL https://github.com/wazuh/wazuh-packages/tarball/${wazuh_packages_branch} | tar zx

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -28,6 +28,7 @@ DEB_PPC64LE_BUILDER_DOCKERFILE="${CURRENT_PATH}/Debian/ppc64le"
 PACKAGES_BRANCH="master"
 USE_LOCAL_SPECS="no"
 LOCAL_SPECS="${CURRENT_PATH}"
+LOCAL_SOURCE_CODE=""
 
 trap ctrl_c INT
 
@@ -51,6 +52,11 @@ build_deb() {
     # Copy the necessary files
     cp build.sh ${DOCKERFILE_PATH}
 
+    # Create an optional parameter to share the local source code as a volume
+    if [ ! -z "${LOCAL_SOURCE_CODE}" ]; then
+        CUSTOM_CODE_VOL="-v ${LOCAL_SOURCE_CODE}:/wazuh-local-src:Z"
+    fi
+
     # Build the Docker image
     docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH} || return 1
 
@@ -58,9 +64,10 @@ build_deb() {
     docker run -t --rm -v ${OUTDIR}:/var/local/wazuh:Z \
         -v ${CHECKSUMDIR}:/var/local/checksum:Z \
         -v ${LOCAL_SPECS}:/specs:Z \
+        ${CUSTOM_CODE_VOL} \
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
-        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} || return 1
+        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${LOCAL_SOURCE_CODE} || return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -117,6 +124,7 @@ help() {
     echo "    -p, --path <path>         [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
+    echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --dev                     [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
     echo "    -h, --help                Show this help."
     echo
@@ -212,6 +220,14 @@ main() {
         "--dev")
             USE_LOCAL_SPECS="yes"
             shift 1
+            ;;
+        "--sources")
+            if [ -n "$2" ]; then
+                LOCAL_SOURCE_CODE="$2"
+                shift 2
+            else
+                help 1
+            fi
             ;;
         *)
             help 1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -124,7 +124,7 @@ help() {
     echo "    -p, --path <path>         [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
+    echo "    --sources <path>          [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --dev                     [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
     echo "    -h, --help                Show this help."
     echo

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -22,6 +22,7 @@ wazuh_packages_branch=$9
 use_local_specs=${10}
 src=${11}
 legacy=${12}
+local_source_code=${13}
 wazuh_version=""
 rpmbuild="rpmbuild"
 
@@ -36,10 +37,14 @@ if [ "${debug}" = "no" ]; then
 fi
 
 if [ ${build_target} = "api" ]; then
-    curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
+    if [ -z "${local_source_code}" ]; then
+        curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
+    fi
     wazuh_version="$(grep version wazuh*/package.json | cut -d '"' -f 4)"
 else
-    curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
+    if [ -z "${local_source_code}" ]; then
+        curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
+    fi
     wazuh_version="$(cat wazuh*/src/VERSION | cut -d 'v' -f 2)"
 fi
 
@@ -56,7 +61,7 @@ mkdir -p ${rpm_build_dir}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 # Prepare the sources directory to build the source tar.gz
 package_name=wazuh-${build_target}-${wazuh_version}
-mv wazuh-* ${build_dir}/${package_name}
+cp -R wazuh-* ${build_dir}/${package_name}
 
 # Including spec file
 if [ "${use_local_specs}" = "no" ]; then


### PR DESCRIPTION
Hi team,

This PR closes #358 by adding a new parameter `--sources` to the Debian and RPM build scripts. This parameter receives the path where the Wazuh or Wazuh API sources are stored and uses them to build the binary package instead of downloading it from GitHub.

Regards.