### PR TITLE
Add Mitre database file to Manager 3.13.0 SPEC file

### DIFF
--- a/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
@@ -902,6 +902,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/var
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/db/agents
+%attr(660, root, ossec) %{_localstatedir}/ossec/var/db/mitre.db
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/download
 %dir %attr(770, ossec, ossec) %{_localstatedir}/ossec/var/multigroups
 %dir %attr(770, root, ossec) %{_localstatedir}/ossec/var/run


### PR DESCRIPTION
| Related issue |
|---|
|#282|

## Description

Mitre database is created during the installation process and it has to be declared in the SPEC file in order to avoid errors concerning rpm packages building.