### PR TITLE
Remove OpenSCAP policies in Debian packages

### DIFF
--- a/debs/SPECS/3.13.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/postinst
@@ -153,6 +153,7 @@ case "$1" in
         ${SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
     fi
 
+    # Restore OpenSCAP policies files
     if [ -d ${WAZUH_TMP_DIR}/oscap ]; then
         cp ${WAZUH_TMP_DIR}/oscap/* ${DIR}/wodles/oscap/content/
     fi

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/postinst
@@ -153,6 +153,10 @@ case "$1" in
         ${SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
     fi
 
+    if [ -d ${WAZUH_TMP_DIR}/oscap ]; then
+        cp ${WAZUH_TMP_DIR}/oscap/* ${DIR}/wodles/oscap/content/
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
@@ -60,14 +60,37 @@ case "$1" in
 
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
-            start_config="$(grep -n '<wodle name="open-scap">' ${WAZUH_TMP_DIR}/ossec.conf | cut -d':' -f 1)"
-            end_config="$(sed -n '/open-scap/,$p' ${WAZUH_TMP_DIR}/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"
-            end_config="$((start_config + end_config))"
-            if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-                sed -n "${start_config},${end_config}p" ${WAZUH_TMP_DIR}/ossec.conf | grep "disabled>no"
-                if [ $? = 0 ]; then
-                    mkdir -p ${WAZUH_TMP_DIR}/oscap/
-                    cp ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap/
+            if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
+                if grep -n '<wodle name="open-scap">' ${DIR}/etc/ossec.conf > /dev/null ; then
+                    is_disabled="no"
+                else
+                    is_disabled="yes"
+                fi
+
+                end_config_limit="99999999"
+                for start_config in $(grep -n '<wodle name="open-scap">'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
+                    end_config="$(sed -n "${start_config},${end_config_limit}p"  ${DIR}/etc/ossec.conf | sed -n '/open-scap/,$p' | grep -n '</wodle>' | head -n 1 | cut -d':' -f 1)"
+                    end_config="$((start_config + end_config))"
+
+                    if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                        open_scap_conf="$(sed -n "${start_config},${end_config}p"  ${DIR}/etc/ossec.conf)"
+
+                        for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
+                            # Check if OpenSCAP is enabled
+                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+                                is_disabled="no"
+
+                            # Check if OpenSCAP is disabled
+                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+                                is_disabled="yes"
+                            fi
+                        done
+                    fi
+                done
+
+                if [ "${is_disabled}" = "no" ]; then
+                    mkdir -p ${WAZUH_TMP_DIR}/oscap
+                    cp -r ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap
                 fi
             fi
         fi

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
@@ -10,7 +10,7 @@ WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then
     mkdir -p ${WAZUH_TMP_DIR}
-else 
+else
     rm -rf ${WAZUH_TMP_DIR}
     mkdir -p ${WAZUH_TMP_DIR}
 fi
@@ -61,14 +61,14 @@ case "$1" in
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
             if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
-                if grep -n '<wodle name="open-scap">' ${DIR}/etc/ossec.conf > /dev/null ; then
+                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null ; then
                     is_disabled="no"
                 else
                     is_disabled="yes"
                 fi
 
                 end_config_limit="99999999"
-                for start_config in $(grep -n '<wodle name="open-scap">'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
+                for start_config in $(grep -E -n '<wodle.*name="open-scap".*>'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
                     end_config="$(sed -n "${start_config},${end_config_limit}p"  ${DIR}/etc/ossec.conf | sed -n '/open-scap/,$p' | grep -n '</wodle>' | head -n 1 | cut -d':' -f 1)"
                     end_config="$((start_config + end_config))"
 

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
@@ -58,6 +58,7 @@ case "$1" in
             cp -rp ${DIR}/etc/shared/* ${WAZUH_TMP_DIR}/group/
         fi
 
+        # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
             start_config="$(grep -n '<wodle name="open-scap">' ${WAZUH_TMP_DIR}/ossec.conf | cut -d':' -f 1)"
             end_config="$(sed -n '/open-scap/,$p' ${WAZUH_TMP_DIR}/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/preinst
@@ -57,6 +57,19 @@ case "$1" in
             mkdir -p ${WAZUH_TMP_DIR}/group
             cp -rp ${DIR}/etc/shared/* ${WAZUH_TMP_DIR}/group/
         fi
+
+        if [ ! -z "$2" ]; then
+            start_config="$(grep -n '<wodle name="open-scap">' ${WAZUH_TMP_DIR}/ossec.conf | cut -d':' -f 1)"
+            end_config="$(sed -n '/open-scap/,$p' ${WAZUH_TMP_DIR}/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"
+            end_config="$((start_config + end_config))"
+            if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                sed -n "${start_config},${end_config}p" ${WAZUH_TMP_DIR}/ossec.conf | grep "disabled>no"
+                if [ $? = 0 ]; then
+                    mkdir -p ${WAZUH_TMP_DIR}/oscap/
+                    cp ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap/
+                fi
+            fi
+        fi
     ;;
 
     abort-upgrade)

--- a/debs/SPECS/3.13.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/3.13.0/wazuh-agent/debian/rules
@@ -58,9 +58,8 @@ override_dh_install:
 	USER_AUTO_START="n" \
 	./install.sh
 
-	# Copying debian & ubuntu OSCAP xml files
-	install -v -m 0640 -o root -g ossec wodles/oscap/content/*debian*.xml $(INSTALLATION_DIR)/wodles/oscap/content/
-	install -v -m 0640 -o root -g ossec wodles/oscap/content/*ubuntu*.xml $(INSTALLATION_DIR)/wodles/oscap/content/
+	# Remove OpenSCAP policies
+	rm -rf $(INSTALLATION_DIR)/wodles/oscap/content/*
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/

--- a/debs/SPECS/3.13.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.13.0/wazuh-manager/debian/postinst
@@ -228,6 +228,11 @@ case "$1" in
         rm -rf ${WAZUH_TMP_DIR}/group/
     fi
 
+    # Restore OpenSCAP policies files
+    if [ -d ${WAZUH_TMP_DIR}/oscap ]; then
+        cp ${WAZUH_TMP_DIR}/oscap/* ${DIR}/wodles/oscap/content/
+    fi
+
     # More files
     touch ${DIR}/etc/client.keys
 

--- a/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
@@ -117,6 +117,20 @@ case "$1" in
         if [ -d ${DIR}/var/db/agents ]; then
           rm -f ${DIR}/var/db/agents/*
         fi
+
+        # Backup the OpenSCAP policies if the module is enabled
+        if [ ! -z "$2" ]; then
+            start_config="$(grep -n '<wodle name="open-scap">' ${WAZUH_TMP_DIR}/ossec.conf | cut -d':' -f 1)"
+            end_config="$(sed -n '/open-scap/,$p' ${WAZUH_TMP_DIR}/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"
+            end_config="$((start_config + end_config))"
+            if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                sed -n "${start_config},${end_config}p" ${WAZUH_TMP_DIR}/ossec.conf | grep "disabled>no"
+                if [ $? = 0 ]; then
+                    mkdir -p ${WAZUH_TMP_DIR}/oscap/
+                    cp ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap/
+                fi
+            fi
+        fi
     ;;
 
     abort-upgrade)

--- a/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
@@ -120,14 +120,37 @@ case "$1" in
 
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
-            start_config="$(grep -n '<wodle name="open-scap">' ${WAZUH_TMP_DIR}/ossec.conf | cut -d':' -f 1)"
-            end_config="$(sed -n '/open-scap/,$p' ${WAZUH_TMP_DIR}/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"
-            end_config="$((start_config + end_config))"
-            if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-                sed -n "${start_config},${end_config}p" ${WAZUH_TMP_DIR}/ossec.conf | grep "disabled>no"
-                if [ $? = 0 ]; then
-                    mkdir -p ${WAZUH_TMP_DIR}/oscap/
-                    cp ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap/
+            if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
+                if grep -n '<wodle name="open-scap">' ${DIR}/etc/ossec.conf > /dev/null ; then
+                    is_disabled="no"
+                else
+                    is_disabled="yes"
+                fi
+
+                end_config_limit="99999999"
+                for start_config in $(grep -n '<wodle name="open-scap">'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
+                    end_config="$(sed -n "${start_config},${end_config_limit}p"  ${DIR}/etc/ossec.conf | sed -n '/open-scap/,$p' | grep -n '</wodle>' | head -n 1 | cut -d':' -f 1)"
+                    end_config="$((start_config + end_config))"
+
+                    if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+                        open_scap_conf="$(sed -n "${start_config},${end_config}p"  ${DIR}/etc/ossec.conf)"
+
+                        for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
+                            # Check if OpenSCAP is enabled
+                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+                                is_disabled="no"
+
+                            # Check if OpenSCAP is disabled
+                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+                                is_disabled="yes"
+                            fi
+                        done
+                    fi
+                done
+
+                if [ "${is_disabled}" = "no" ]; then
+                    mkdir -p ${WAZUH_TMP_DIR}/oscap
+                    cp -r ${DIR}/wodles/oscap/content/* ${WAZUH_TMP_DIR}/oscap
                 fi
             fi
         fi

--- a/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.13.0/wazuh-manager/debian/preinst
@@ -121,14 +121,14 @@ case "$1" in
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
             if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
-                if grep -n '<wodle name="open-scap">' ${DIR}/etc/ossec.conf > /dev/null ; then
+                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null ; then
                     is_disabled="no"
                 else
                     is_disabled="yes"
                 fi
 
                 end_config_limit="99999999"
-                for start_config in $(grep -n '<wodle name="open-scap">'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
+                for start_config in $(grep -E -n '<wodle.*name="open-scap".*>'  ${DIR}/etc/ossec.conf | cut -d':' -f 1); do
                     end_config="$(sed -n "${start_config},${end_config_limit}p"  ${DIR}/etc/ossec.conf | sed -n '/open-scap/,$p' | grep -n '</wodle>' | head -n 1 | cut -d':' -f 1)"
                     end_config="$((start_config + end_config))"
 

--- a/debs/SPECS/3.13.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/3.13.0/wazuh-manager/debian/rules
@@ -63,9 +63,8 @@ override_dh_install:
 	USER_CREATE_SSL_CERT="n" \
 	./install.sh
 
-	# Copying debian & ubuntu OSCAP xml files
-	install -v -m 0640 -o root -g ossec wodles/oscap/content/*debian*.xml $(INSTALLATION_DIR)/wodles/oscap/content/
-	install -v -m 0640 -o root -g ossec wodles/oscap/content/*ubuntu*.xml $(INSTALLATION_DIR)/wodles/oscap/content/
+	# Remove OpenSCAP policies
+	rm -rf $(INSTALLATION_DIR)/wodles/oscap/content/*
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/


### PR DESCRIPTION
Hi team,

This PR references #426 and it implements the changes for the Debian packages.

Checks:
- [x] Remove the policy files from .deb packages.
- [x] Remove the policy files from .rpm packages.
- [x] Remove the configuration block from the `ossec.conf`.
- [x] The upgrade process must keep these files installed.
- [x] Fresh install works.
- [x] Re-install works.
- [x] Upgrade works.

Regards.