### PR TITLE
Remove OpenSCAP policies in RPM packages

### DIFF
--- a/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
@@ -69,7 +69,7 @@ echo 'USER_DELETE_DIR="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_SYSCHECK="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_ROOTCHECK="y"' >> ./etc/preloaded-vars.conf
-echo 'USER_ENABLE_OPENSCAP="y"' >> ./etc/preloaded-vars.conf
+echo 'USER_ENABLE_OPENSCAP="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_SYSCOLLECTOR="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_CISCAT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_UPDATE="n"' >> ./etc/preloaded-vars.conf
@@ -87,14 +87,9 @@ cp -pr %{_localstatedir}/ossec/* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 
-# Install oscap files
-install -m 0640 wodles/oscap/content/*redhat* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*rhel* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*centos* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*fedora* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-
 # Clean the preinstalled configuration assesment files
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/ruleset/sca/*
+rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content/*
 
 # Install configuration assesment files and files templates
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/tmp/sca-%{version}-%{release}-tmp/{applications,generic}
@@ -650,7 +645,6 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.py
 %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content
-%attr(640,root,ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/ossec/*

--- a/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
@@ -359,7 +359,9 @@ if [ -r ${SCA_TMP_FILE} ]; then
   rm -f %{_localstatedir}/ossec/ruleset/sca/* || true
 
   for sca_file in $(cat ${SCA_TMP_FILE}); do
-    mv ${SCA_BASE_DIR}/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+    if [ -f ${SCA_BASE_DIR}/${sca_file} ]; then
+      mv ${SCA_BASE_DIR}/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+    fi
   done
 fi
 

--- a/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-agent-3.13.0.spec
@@ -390,16 +390,36 @@ fi
 
 if [ $1 = 2 ]; then
   # Remove OpenSCAP policies if the module is disabled
-  start_config="$(grep -n '<wodle name="open-scap">' %{_localstatedir}/ossec/etc/ossec.conf | cut -d':' -f 1)"
-  end_config="$(sed -n '/open-scap/,$p' %{_localstatedir}/ossec/etc/ossec.conf | grep -n '</wodle>' | head -n1 | cut -d':' -f 1)"
-  end_config="$((start_config + end_config))"
-  if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-    sed -n "${start_config},${end_config}p" %{_localstatedir}/ossec/etc/ossec.conf | grep "disabled>yes" > /dev/null
-    if [ $? = 0 ]; then
-      rm -f %{_localstatedir}/ossec/wodles/oscap/content/*redhat*
-      rm -f %{_localstatedir}/ossec/wodles/oscap/content/*rhel*
-      rm -f %{_localstatedir}/ossec/wodles/oscap/content/*centos*
-      rm -f %{_localstatedir}/ossec/wodles/oscap/content/*fedora*
+  if stat %{_localstatedir}/ossec/wodles/oscap/content/* > /dev/null ; then
+    if grep -E -n '<wodle.*name="open-scap".*>' %{_localstatedir}/ossec/etc/ossec.conf > /dev/null ; then
+      is_disabled="no"
+    else
+      is_disabled="yes"
+    fi
+
+    end_config_limit="99999999"
+    for start_config in $(grep -E -n '<wodle.*name="open-scap".*>'  %{_localstatedir}/ossec/etc/ossec.conf | cut -d':' -f 1); do
+      end_config="$(sed -n "${start_config},${end_config_limit}p"  %{_localstatedir}/ossec/etc/ossec.conf | sed -n '/open-scap/,$p' | grep -n '</wodle>' | head -n 1 | cut -d':' -f 1)"
+      end_config="$((start_config + end_config))"
+
+      if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
+        open_scap_conf="$(sed -n "${start_config},${end_config}p"  %{_localstatedir}/ossec/etc/ossec.conf)"
+
+        for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
+          # Check if OpenSCAP is enabled
+          if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+            is_disabled="no"
+
+          # Check if OpenSCAP is disabled
+          elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+            is_disabled="yes"
+          fi
+        done
+      fi
+    done
+
+    if [ "${is_disabled}" = "yes" ]; then
+        rm -f %{_localstatedir}/ossec/wodles/oscap/content/*
     fi
   fi
 fi

--- a/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
@@ -55,7 +55,7 @@ echo 'USER_DELETE_DIR="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_SYSCHECK="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_ROOTCHECK="y"' >> ./etc/preloaded-vars.conf
-echo 'USER_ENABLE_OPENSCAP="y"' >> ./etc/preloaded-vars.conf
+echo 'USER_ENABLE_OPENSCAP="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_CISCAT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_ENABLE_SYSCOLLECTOR="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_UPDATE="n"' >> ./etc/preloaded-vars.conf
@@ -85,12 +85,6 @@ rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/ruleset/sca/*
 # Install frameworks sqlite lib
 install -o root -g ossec -m 0750 -d ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/framework/lib
 install -o root -g ossec -m 0640 framework/libsqlite3.so.0 ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/framework/lib/
-
-# Install oscap files
-install -m 0640 wodles/oscap/content/*redhat* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*rhel* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*centos* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
-install -m 0640 wodles/oscap/content/*fedora* ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content
 
 # Install Vulnerability Detector files
 install -m 0440 src/wazuh_modules/vulnerability_detector/*.json ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/queue/vulnerabilities/dictionaries
@@ -924,8 +918,6 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/oscap.*
 %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/template*
 %dir %attr(750, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content
-%attr(640, root, ossec) %{_localstatedir}/ossec/wodles/oscap/content/*
-
 
 %{_initrddir}/*
 %if %{_debugenabled} == "yes"

--- a/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
+++ b/rpms/SPECS/3.13.0/wazuh-manager-3.13.0.spec
@@ -86,6 +86,9 @@ rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/ruleset/sca/*
 install -o root -g ossec -m 0750 -d ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/framework/lib
 install -o root -g ossec -m 0640 framework/libsqlite3.so.0 ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/framework/lib/
 
+# Remove OpenSCAP policies
+rm -rf ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/wodles/oscap/content/*
+
 # Install Vulnerability Detector files
 install -m 0440 src/wazuh_modules/vulnerability_detector/*.json ${RPM_BUILD_ROOT}%{_localstatedir}/ossec/queue/vulnerabilities/dictionaries
 
@@ -485,7 +488,9 @@ if [ -r ${SCA_TMP_FILE} ] && [ -r ${SCA_BASE_DIR}/generic/sca.manager.files ]; t
   rm -f %{_localstatedir}/ossec/ruleset/sca/* || true
 
   for sca_file in $(cat ${SCA_TMP_FILE}); do
-    mv ${SCA_BASE_DIR}/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+    if [ -f ${SCA_BASE_DIR}/${sca_file} ]; then
+      mv ${SCA_BASE_DIR}/${sca_file} %{_localstatedir}/ossec/ruleset/sca
+    fi
   done
 
   for sca_file in $(cat ${SCA_BASE_DIR}/generic/sca.manager.files); do


### PR DESCRIPTION
Hi team,

This PR references #426 and it implements the changes for the RPM packages.

Checks:
- [x] Remove the policy files from .deb packages.
- [x] Remove the policy files from .rpm packages.
- [x] Remove the configuration block from the `ossec.conf`.
- [x] The upgrade process must keep these files installed.
- [x] Fresh install works.
- [x] Re-install works.
- [x] Upgrade works.

Regards.