### PR TITLE
Improve ARM build tools

### DIFF
--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -3,13 +3,13 @@ FROM arm64v8/debian:stretch
 ENV DEBIAN_FRONTEND noninteractive
 
 # Installing necessary packages
-RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt=1.4.9 apt-utils --allow-downgrades && \
-    apt-get install -y --force-yes \
-    curl gcc make sudo expect gnupg fakeroot perl-base perl wget \
-    libc-bin libc6 libc6-dev build-essential \
-    cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
+    apt-get update && apt-get install -y apt apt-utils  \
+    curl gcc make sudo expect gnupg fakeroot \
+    perl-base perl wget libc-bin libc6 libc6-dev \
+    build-essential cdbs devscripts equivs automake \
+    autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 12

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -3,10 +3,9 @@ FROM arm32v7/debian:stretch
 ENV DEBIAN_FRONTEND noninteractive
 
 # Installing necessary packages
-RUN echo "deb http://deb.debian.org/debian/ stretch contrib main non-free" > /etc/apt/sources.list && \
-    echo "deb-src http://deb.debian.org/debian/ stretch contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt=1.4.9 apt-utils --allow-downgrades && \
-    apt-get install -y --force-yes \
+RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y apt-utils \
     curl gcc make sudo expect gnupg fakeroot perl-base \
     perl libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \


### PR DESCRIPTION
Hi team,

This PR solves some issues reported in #365 by @Corruptsector. Here you can see what is changed by this PR:

### arm64
- Removed duplicated repositories: `debian stretch main` was duplicated in `sources.list` file. 
- Removed `apt` specific version.
- Removed `--allow-downgrades` and `--force-yes` flags.

### armhf
- Fixed the addition of new repositories. `sources.list` file was overwritten previously, making mandatory setting `apt` version.
- Removed `apt` specific version.
- Removed `--allow-downgrades` and `--force-yes` flags.

Regards.