### PR TITLE
Fix solaris 11 SPARC python provisioning

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -31,9 +31,9 @@ build_environment() {
         /opt/csw/bin/pkgutil -y -U
     fi
 
-    python -V | grep "2.7"
+    python_version=$(python --version 2>&1)
     # Install python 2.7
-    if [[ "$?" != "0" ]] ; then
+    if [[ "$?" != "0" ]] || [[ $python_version != *"2.7"* ]]; then
         /opt/csw/bin/pkgutil -y -i python27
         ln -sf /opt/csw/bin/python2.7 /usr/bin/python
     fi


### PR DESCRIPTION
Hello team,

This PR fixes the python problem we were having when upgrading wazuh on the siteox Solaris 11 SPARC machine.

The problem was the condition to install python since it always returned `True` and installed even though it was already installed. This corrupted the installation and caused the next failure:

```
Fatal Python error: PyThreadState_Get: no current thread
```

The condition has been corrected and the changes have been successfully checked.

```
root@sossp152:~# pkg install -g wazuh-agent_v3.13.0-sol11-sparc.p5p wazuh-agent
            Packages to update:   1
       Create boot environment:  No
Create backup boot environment: Yes

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1         13/13    13.9/13.9  108M/s

PHASE                                          ITEMS
Updating modified actions                      16/16
Updating package state database                 Done 
Updating package cache                           1/1 
Updating image state                            Done 
Creating fast lookup database                   Done 
Updating package cache                           2/2 
```

Best regards.