### PR TITLE
Redirect stderr in deb SPECS

### DIFF
--- a/debs/SPECS/3.13.1/wazuh-agent/debian/preinst
+++ b/debs/SPECS/3.13.1/wazuh-agent/debian/preinst
@@ -60,8 +60,8 @@ case "$1" in
 
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
-            if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
-                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null ; then
+            if stat ${DIR}/wodles/oscap/content/* > /dev/null 2>&1; then
+                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null 2>&1 ; then
                     is_disabled="no"
                 else
                     is_disabled="yes"
@@ -77,11 +77,11 @@ case "$1" in
 
                         for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
                             # Check if OpenSCAP is enabled
-                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null 2>&1 ; then
                                 is_disabled="no"
 
                             # Check if OpenSCAP is disabled
-                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null 2>&1; then
                                 is_disabled="yes"
                             fi
                         done

--- a/debs/SPECS/3.13.1/wazuh-manager/debian/preinst
+++ b/debs/SPECS/3.13.1/wazuh-manager/debian/preinst
@@ -120,8 +120,8 @@ case "$1" in
 
         # Backup the OpenSCAP policies if the module is enabled
         if [ ! -z "$2" ]; then
-            if stat ${DIR}/wodles/oscap/content/* > /dev/null ; then
-                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null ; then
+            if stat ${DIR}/wodles/oscap/content/* > /dev/null 2>&1 ; then
+                if grep -E -n '<wodle.*name="open-scap".*>' ${DIR}/etc/ossec.conf > /dev/null 2>&1 ; then
                     is_disabled="no"
                 else
                     is_disabled="yes"
@@ -137,11 +137,11 @@ case "$1" in
 
                         for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
                             # Check if OpenSCAP is enabled
-                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+                            if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null 2>&1 ; then
                                 is_disabled="no"
 
                             # Check if OpenSCAP is disabled
-                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+                            elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null 2>&1; then
                                 is_disabled="yes"
                             fi
                         done

--- a/rpms/SPECS/3.13.1/wazuh-agent-3.13.1.spec
+++ b/rpms/SPECS/3.13.1/wazuh-agent-3.13.1.spec
@@ -390,8 +390,8 @@ fi
 
 if [ $1 = 2 ]; then
   # Remove OpenSCAP policies if the module is disabled
-  if stat %{_localstatedir}/ossec/wodles/oscap/content/* > /dev/null ; then
-    if grep -E -n '<wodle.*name="open-scap".*>' %{_localstatedir}/ossec/etc/ossec.conf > /dev/null ; then
+  if stat %{_localstatedir}/ossec/wodles/oscap/content/* > /dev/null 2>&1; then
+    if grep -E -n '<wodle.*name="open-scap".*>' %{_localstatedir}/ossec/etc/ossec.conf > /dev/null 2>&1; then
       is_disabled="no"
     else
       is_disabled="yes"
@@ -407,11 +407,11 @@ if [ $1 = 2 ]; then
 
         for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
           # Check if OpenSCAP is enabled
-          if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+          if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null 2>&1; then
             is_disabled="no"
 
           # Check if OpenSCAP is disabled
-          elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+          elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null 2>&1; then
             is_disabled="yes"
           fi
         done

--- a/rpms/SPECS/3.13.1/wazuh-manager-3.13.1.spec
+++ b/rpms/SPECS/3.13.1/wazuh-manager-3.13.1.spec
@@ -531,8 +531,8 @@ done
 
 if [ $1 = 2 ]; then
   # Remove OpenSCAP policies if the module is disabled
-  if stat %{_localstatedir}/ossec/wodles/oscap/content/* > /dev/null ; then
-    if grep -E -n '<wodle.*name="open-scap".*>' %{_localstatedir}/ossec/etc/ossec.conf > /dev/null ; then
+  if stat %{_localstatedir}/ossec/wodles/oscap/content/* > /dev/null 2>&1; then
+    if grep -E -n '<wodle.*name="open-scap".*>' %{_localstatedir}/ossec/etc/ossec.conf > /dev/null 2>&1; then
       is_disabled="no"
     else
       is_disabled="yes"
@@ -548,11 +548,11 @@ if [ $1 = 2 ]; then
 
         for line in $(echo ${open_scap_conf} | grep -n '<disabled>' | cut -d':' -f 1); do
           # Check if OpenSCAP is enabled
-          if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null ; then
+          if echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>no" > /dev/null 2>&1; then
             is_disabled="no"
 
           # Check if OpenSCAP is disabled
-          elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null; then
+          elif echo ${open_scap_conf} | sed -n ${line}p | grep "disabled>yes" > /dev/null 2>&1; then
             is_disabled="yes"
           fi
         done


### PR DESCRIPTION
Hello team, 

This PR redirects the stderr to avoid this message from showing when upgrading from 3.13.0 to 3.13.1 in Debian systems.

```
stat: cannot stat '/var/ossec/wodles/oscap/content/*': No such file or directory
```
Regards,
Daniel Folch