### PR TITLE
Update RPM packages SPEC to ensure API node process is stopped

### DIFF
--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -192,6 +192,11 @@ if [ -e %{_localstatedir}/api ]; then
   fi
 fi
 
+# Ensure old API node process is not running
+if ps aux | grep ${_localstatedir}/api/app.js | grep -v grep > /dev/null 2>&1; then
+  kill -9 `ps -ef | grep "${_localstatedir}/api/app.js" | grep -v grep | awk '{print $2}'` > /dev/null 2>&1
+fi
+
 # Stop Authd if it is running
 if ps aux | grep %{_localstatedir}/bin/ossec-authd | grep -v grep > /dev/null 2>&1; then
    kill `ps -ef | grep '%{_localstatedir}/bin/ossec-authd' | grep -v grep | awk '{print $2}'` > /dev/null 2>&1


### PR DESCRIPTION
Hello team,

This PR improves the RPM SPEC used for building the packages for Wazuh 4.0.0 by ensuring the old api node process will always be killed before installing the new API. This change fixes the issue reported in [[Development] Wazuh manager 4.0 uninstall doesn't stop the Wazuh API after upgrade from 3.13.1](https://github.com/wazuh/wazuh-api/issues/494).

Regards.