### PR TITLE
Update RPM spec

### DIFF
--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -795,9 +795,7 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/bin/agent_upgrade
 %attr(750, root, root) %{_localstatedir}/bin/clear_stats
 %attr(750, root, ossec) %{_localstatedir}/bin/cluster_control
-%attr(750, root, root) %{_localstatedir}/bin/configure_api
 %attr(750, root, root) %{_localstatedir}/bin/manage_agents
-%attr(750, root, root) %{_localstatedir}/bin/migration
 %attr(750, root, root) %{_localstatedir}/bin/ossec-agentlessd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-analysisd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-authd

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -872,6 +872,7 @@ rm -fr %{buildroot}
 %attr(640, ossecm, ossec) %ghost %{_localstatedir}/logs/integrations.log
 %attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.log
 %attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/api
 %dir %attr(750, ossec, ossec) %{_localstatedir}/logs/archives
 %dir %attr(750, ossec, ossec) %{_localstatedir}/logs/alerts
 %dir %attr(750, ossec, ossec) %{_localstatedir}/logs/cluster


### PR DESCRIPTION
Hello team,

This PR updates RPM spec file to not expect `migration` and `configure_api` files. Those were removed. Additionally, it ensures `{wazuh_path/logs/api/` folder is created.

Regards.