### PR TITLE
Remove msu from 4.0.0 RPM SPECs

### DIFF
--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -14,7 +14,7 @@ Requires(post):   /sbin/chkconfig
 Requires(preun):  /sbin/chkconfig /sbin/service
 Requires(postun): /sbin/service /usr/sbin/groupdel /usr/sbin/userdel
 Conflicts:   ossec-hids ossec-hids-agent wazuh-agent wazuh-local
-Obsoletes: wazuh-api
+Obsoletes: wazuh-api <= 3.13.1
 AutoReqProv: no
 
 Requires: coreutils
@@ -616,7 +616,6 @@ rm -fr %{buildroot}
 %dir %attr(660, root, ossec) %{_localstatedir}/queue/vulnerabilities
 %dir %attr(440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries
 %attr(0440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
-%attr(0440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
 %attr(640, root, ossec) %{_localstatedir}/ruleset/VERSION

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -616,6 +616,7 @@ rm -fr %{buildroot}
 %dir %attr(660, root, ossec) %{_localstatedir}/queue/vulnerabilities
 %dir %attr(440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries
 %attr(0440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
+%attr(0440, root, ossec) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
 %attr(640, root, ossec) %{_localstatedir}/ruleset/VERSION


### PR DESCRIPTION
Hello team, 

In this PR we have added version to the obsolete wazuh-api and removed an unnecessary file from the 4.0.0 RPM SPECS.

Regards,

Daniel Folch