### PR TITLE
 Fixed the stop and restart of the services of DEB and macOS packages

### DIFF
--- a/debs/SPECS/4.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-agent/debian/postinst
@@ -133,6 +133,20 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
+    
+    # Fix /etc/ossec-init.conf
+    chmod 640 /etc/ossec-init.conf
+    chown root:ossec /etc/ossec-init.conf
+
+    if [ ! -z "$2" ]; then
+        if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
+            if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 ; then
+                systemctl restart wazuh-manager.service > /dev/null 2>&1
+            elif command -v service > /dev/null 2>&1 ; then
+                service wazuh-manager restart > /dev/null 2>&1
+            fi
+        fi
+    fi
 
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
@@ -148,10 +162,6 @@ case "$1" in
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     ;;
 

--- a/debs/SPECS/4.0.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/4.0.0/wazuh-agent/debian/preinst
@@ -18,6 +18,16 @@ fi
 case "$1" in
     install|upgrade)
 
+        if [ "$1" = "upgrade" ]; then
+            if command -v systemctl > /dev/null 2>&1 && systemctl is-active wazuh-manager > /dev/null 2>&1 ; then
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
+                systemctl stop wazuh-manager.service > /dev/null 2>&1
+            elif command -v service > /dev/null 2>&1  && service wazuh-manager status | grep "is running" > /dev/null 2>&1; then
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
+                service wazuh-manager stop
+            fi
+        fi
+
         if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/ossec.conf ] ; then
             touch ${WAZUH_TMP_DIR}/create_conf
         fi

--- a/debs/SPECS/4.0.0/wazuh-agent/debian/prerm
+++ b/debs/SPECS/4.0.0/wazuh-agent/debian/prerm
@@ -5,24 +5,21 @@ set -e
 
 DIR="/var/ossec"
 
-# Stop the services before upgrading/uninstalling the package
-# Check for systemd
-if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    systemctl stop wazuh-agent > /dev/null 2>&1
-# Check for SysV
-elif command -v service > /dev/null 2>&1; then
-    service wazuh-agent stop > /dev/null 2>&1
-# Anything else
-else
-    ${DIR}/bin/ossec-control stop > /dev/null 2>&1
-fi
-
 case "$1" in
     upgrade|deconfigure)
 
     ;;
 
     remove)
+     
+      # Stop the services before uninstalling the package
+      # Check for systemd
+      if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
+          systemctl stop wazuh-agent > /dev/null 2>&1
+      # Check for SysV
+      elif command -v service > /dev/null 2>&1; then
+          service wazuh-agent stop > /dev/null 2>&1
+      fi
 
       # Purging files
       if [ -d ${DIR}/queue/ ]; then

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -199,24 +199,34 @@ case "$1" in
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
 
+    # Fix /etc/ossec-init.conf
+    chmod 640 /etc/ossec-init.conf
+    chown root:ossec /etc/ossec-init.conf
+
+    if [ ! -z "$2" ]; then
+        if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
+            if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 ; then
+                systemctl restart wazuh-manager.service > /dev/null 2>&1
+            elif command -v service > /dev/null 2>&1 ; then
+                service wazuh-manager restart > /dev/null 2>&1
+            fi
+        fi
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}
     fi
 
     # Delete tmp directory
-    if [ -d ${WAZUH_TMP_DIR} ]; then
-        rm -r ${WAZUH_TMP_DIR}
-    fi
+    # if [ -d ${WAZUH_TMP_DIR} ]; then
+    #     rm -r ${WAZUH_TMP_DIR}
+    # fi
 
     # If the parent directory is empty, delete it
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     ;;
 

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -219,9 +219,9 @@ case "$1" in
     fi
 
     # Delete tmp directory
-    # if [ -d ${WAZUH_TMP_DIR} ]; then
-    #     rm -r ${WAZUH_TMP_DIR}
-    # fi
+    if [ -d ${WAZUH_TMP_DIR} ]; then
+        rm -r ${WAZUH_TMP_DIR}
+    fi
 
     # If the parent directory is empty, delete it
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
@@ -20,7 +20,6 @@ fi
 case "$1" in
     install|upgrade)
 
-        # Delete old API backups
         if [ "$1" = "upgrade" ]; then
             if command -v systemctl > /dev/null 2>&1 && systemctl is-active wazuh-manager > /dev/null 2>&1 ; then
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
@@ -30,6 +29,7 @@ case "$1" in
                 service wazuh-manager stop
             fi
 
+            # Delete old API backups
             if [ -d ${DIR}/~api ]; then
                 rm -rf ${DIR}/~api
             fi

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
@@ -22,6 +22,14 @@ case "$1" in
 
         # Delete old API backups
         if [ "$1" = "upgrade" ]; then
+            if command -v systemctl > /dev/null 2>&1 && systemctl is-active wazuh-manager > /dev/null 2>&1 ; then
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
+                systemctl stop wazuh-manager.service > /dev/null 2>&1
+            elif command -v service > /dev/null 2>&1  && service wazuh-manager status | grep "is running" > /dev/null 2>&1; then
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
+                service wazuh-manager stop
+            fi
+
             if [ -d ${DIR}/~api ]; then
                 rm -rf ${DIR}/~api
             fi

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/prerm
@@ -4,24 +4,20 @@
 set -e
 DIR="/var/ossec"
 
-# Stop the services before upgrading/uninstalling the package
-# Check for systemd
-if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    systemctl stop wazuh-manager > /dev/null 2>&1
-# Check for SysV
-elif command -v service > /dev/null 2>&1; then
-    service wazuh-manager stop > /dev/null 2>&1
-# Anything else
-else
-    ${DIR}/bin/ossec-control stop > /dev/null 2>&1
-fi
-
 case "$1" in
     upgrade|deconfigure)
 
     ;;
 
     remove)
+      # Stop the services before uninstalling the package
+      # Check for systemd
+      if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
+          systemctl stop wazuh-manager > /dev/null 2>&1
+      # Check for SysV
+      elif command -v service > /dev/null 2>&1; then
+          service wazuh-manager stop > /dev/null 2>&1
+      fi
 
       # Purging files
       rm -rf ${DIR}/stats/*

--- a/macos/package_files/4.0.0/postinstall.sh
+++ b/macos/package_files/4.0.0/postinstall.sh
@@ -116,7 +116,7 @@ ${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh
 # Remove temporary directory
 rm -rf ${DIR}/packages_files
 
-if upgrade && restart; then
+if ${upgrade} && ${restart}; then
     ${DIR}/bin/ossec-control restart
 fi
 

--- a/macos/package_files/4.0.0/postinstall.sh
+++ b/macos/package_files/4.0.0/postinstall.sh
@@ -69,14 +69,16 @@ chown root:${GROUP} /etc/ossec-init.conf
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 
 upgrade=$(launchctl getenv WAZUH_PKG_UPGRADE)
+restart=$(launchctl getenv WAZUH_RESTART)
+
+launchctl unsetenv WAZUH_PKG_UPGRADE
+launchctl unsetenv WAZUH_RESTART
 
 if [ "${upgrade}" = "false" ]; then
     ${INSTALLATION_SCRIPTS_DIR}/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${DIR} > ${DIR}/etc/ossec.conf
     chown root:ossec ${DIR}/etc/ossec.conf
     chmod 0640 ${DIR}/etc/ossec.conf
 fi
-
-launchctl unsetenv WAZUH_PKG_UPGRADE
 
 SCA_DIR="${DIST_NAME}/${DIST_VER}"
 mkdir -p ${DIR}/ruleset/sca
@@ -114,6 +116,7 @@ ${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh
 # Remove temporary directory
 rm -rf ${DIR}/packages_files
 
-if [ -n "$(cat ${DIR}/etc/client.keys)" ]; then
+if upgrade && restart; then
     ${DIR}/bin/ossec-control restart
 fi
+

--- a/macos/package_files/4.0.0/preinstall.sh
+++ b/macos/package_files/4.0.0/preinstall.sh
@@ -15,6 +15,10 @@ if [ ! -d ${DIR} ]; then
     launchctl setenv WAZUH_PKG_UPGRADE false
 else
     launchctl setenv WAZUH_PKG_UPGRADE true
+    if ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
+        launchctl setenv WAZUH_RESTART true
+    else
+        launchctl setenv WAZUH_RESTART false
 fi
 
 if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then

--- a/macos/package_files/4.0.0/preinstall.sh
+++ b/macos/package_files/4.0.0/preinstall.sh
@@ -19,6 +19,7 @@ else
         launchctl setenv WAZUH_RESTART true
     else
         launchctl setenv WAZUH_RESTART false
+    fi
 fi
 
 if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then


### PR DESCRIPTION
Hi team,

This in PRs we implemented a solution for #480 in Debian and macOS. The installer will detect if the service is running, then stop it if necessary, upgrade and start the service again if it was previously running.

Regards.
Daniel Folch