### PR TITLE
Update Wazuh API permissions on rpm spec

### DIFF
--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -510,12 +510,12 @@ rm -fr %{buildroot}
 %dir %attr(750, root, ossec) %{_localstatedir}/active-response/bin
 %attr(750, root, ossec) %{_localstatedir}/active-response/bin/*
 %dir %attr(750, root, ossec) %{_localstatedir}/api
-%dir %attr(750, root, ossec) %{_localstatedir}/api/configuration
-%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
+%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration
+%attr(660, root, ossec) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
 %dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/security
 %dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/ssl
 %dir %attr(750, root, ossec) %{_localstatedir}/api/scripts
-%attr(750, root, ossec) %{_localstatedir}/api/scripts/wazuh-apid.py
+%attr(640, root, ossec) %{_localstatedir}/api/scripts/wazuh-apid.py
 %dir %attr(750, root, ossec) %{_localstatedir}/backup
 %dir %attr(750, ossec, ossec) %{_localstatedir}/backup/agents
 %dir %attr(750, ossec, ossec) %{_localstatedir}/backup/groups


### PR DESCRIPTION
|Related issue|
|---|
| #488 |

## Description

Hi team,

This PR closes #488 by updating the permissions of the Wazuh API directory and its files.

## Logs example

```shellsession
[root@357d9f8e5ee6 /]# ls -l /var/ossec/api/configuration/
total 12
-rw-rw---- 1 root ossec 1255 Sep  9 13:47 api.yaml
drwxrwx--- 2 root ossec 4096 Sep  9 13:47 security
drwxrwx--- 2 root ossec 4096 Sep  9 13:47 ssl
[root@357d9f8e5ee6 /]# ls -la ^C
[root@357d9f8e5ee6 /]# ls -la /var/ossec/api/configuration/
total 20
drwxrwx--- 4 root ossec 4096 Sep  9 13:49 .
drwxr-x--- 4 root ossec 4096 Sep  9 13:49 ..
-rw-rw---- 1 root ossec 1255 Sep  9 13:47 api.yaml
drwxrwx--- 2 root ossec 4096 Sep  9 13:47 security
drwxrwx--- 2 root ossec 4096 Sep  9 13:47 ssl
[root@357d9f8e5ee6 /]# ls -l /var/ossec/api/scripts/wazuh-apid.py
-rw-r----- 1 root ossec 9294 Sep  9 13:47 /var/ossec/api/scripts/wazuh-apid.py
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessar