### PR TITLE
Removed gen_versions.sh script and any reference to it

### DIFF
--- a/wpk/gen_versions.sh
+++ b/wpk/gen_versions.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-wpk_name="${1}"
-package_version="${2}"
-output="${3}"
-
-echo -ne "v${package_version} $(sha1sum ${wpk_name} | cut -d' ' -f1)\n$(grep -hv "v${package_version} " ./versions 2>/dev/null)" > ${output}

--- a/wpk/generate_wpk_package.sh
+++ b/wpk/generate_wpk_package.sh
@@ -91,7 +91,7 @@ function build_container() {
     local CONTAINER_NAME="${1}"
     local DOCKERFILE_PATH="${2}"
 
-    cp run.sh wpkpack.py gen_versions.sh ${DOCKERFILE_PATH}
+    cp run.sh wpkpack.py ${DOCKERFILE_PATH}
     docker build -t ${CONTAINER_NAME} ${DOCKERFILE_PATH}
 }
 

--- a/wpk/linux/aarch64/Dockerfile
+++ b/wpk/linux/aarch64/Dockerfile
@@ -17,5 +17,4 @@ RUN pip3 install --upgrade cryptography awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run
-ADD gen_versions.sh /usr/local/bin/gen_versions
 ENTRYPOINT ["/usr/local/bin/run"]

--- a/wpk/linux/armv7hl/Dockerfile
+++ b/wpk/linux/armv7hl/Dockerfile
@@ -10,6 +10,5 @@ RUN pip2 install cryptography awscli
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run
 ADD entrypoint.sh /usr/local/bin/entrypoint
-ADD gen_versions.sh /usr/local/bin/gen_versions
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -11,5 +11,4 @@ RUN yum -y install centos-release-scl epel-release && \
 RUN yum install -y automake autoconf libtool
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run
-ADD gen_versions.sh /usr/local/bin/gen_versions
 ENTRYPOINT ["/usr/local/bin/run"]

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -182,9 +182,10 @@ main() {
     else
 
       if [ "${HAVE_PKG_NAME}" == true ]; then
+          CURRENT_DIR=$(pwd)
           echo "wpkpack ${OUTPUT} ${WPKCERT} ${WPKKEY} ${PKG_NAME} upgrade.bat do_upgrade.ps1"
           cd ${OUTDIR}
-          cp /${DIRECTORY}/src/win32/{upgrade.bat,do_upgrade.ps1} .
+          cp ${CURRENT_DIR}/src/win32/{upgrade.bat,do_upgrade.ps1} .
           cp /var/pkg/${PKG_NAME} ${OUTDIR} 2>/dev/null
           wpkpack ${OUTPUT} ${WPKCERT} ${WPKKEY} ${PKG_NAME} upgrade.bat do_upgrade.ps1
           rm -f upgrade.bat do_upgrade.ps1 ${PKG_NAME}
@@ -194,14 +195,7 @@ main() {
       fi
     fi
     echo "PACKED FILE -> ${OUTPUT}"
-    # Update versions file
     cd ${OUTDIR}
-    if [ ${REVISION} -eq ${REVISION} ] 2>/dev/null && [ ${REVISION} -ge 1 ] && [ ${REVISION} -le 99 ]; then
-        VERSIONS_NAME="versions"
-    else
-        VERSIONS_NAME="versions-${REVISION}"
-    fi
-        gen_versions ${OUTPUT} ${SHORT_VERSION} ${VERSIONS_NAME}
     if [[ ${CHECKSUM} == "yes" ]]; then
         mkdir -p ${CHECKSUMDIR}
         sha512sum "${OUT_NAME}" > "${CHECKSUMDIR}/${OUT_NAME}.sha512"

--- a/wpk/windows/Dockerfile
+++ b/wpk/windows/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run
-ADD gen_versions.sh /usr/local/bin/gen_versions
 VOLUME /var/local/wazuh
 VOLUME /etc/wazuh
 VOLUME /etc/wazuh/checksum


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-jenkins/issues/1668|

## Description
Hello team,

We want to remove versions file generation from packages builder process.
This change is made because now this step is managed by Jenkins.

## Logs example

New versions log
```
./gen_versions.sh -n /one_path/wazuh_agent_v3.13.1_linux_x86_64.wpk -v 3.13.1 -o /one_path/versions -c /one_path/versions -r 1
Revision not set, skipping...
Versions file generated successfully at /one_path/versions
```

## Tests
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux WPK
  - [x] Windows WPK
