### PR TITLE
Adding upgrade logic for global database

### DIFF
--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -63,11 +63,21 @@ case "$1" in
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 
-    # Remove existing SQLite databases
-    rm -f ${DIR}/var/db/global.db* || true
+    # Remove/relocate existing SQLite databases
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true
     rm -f ${DIR}/var/db/agents/* || true
+
+    if [ -f ${DIR}/var/db/global.db ]; then
+        cp ${DIR}/var/db/global.db* ${DIR}/queue/db/
+        if [ -f ${DIR}/queue/db/global.db ]; then
+            chmod 640 ${DIR}/queue/db/global.db*
+            chown ossec:ossec ${DIR}/queue/db/global.db*
+            rm -f ${DIR}/var/db/global.db* || true
+        else
+            echo "Unable to move global.db during the upgrade"
+        fi
+    fi
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
 


### PR DESCRIPTION
|Related issue|
|---|
| [Wazuh 6020](https://github.com/wazuh/wazuh/issues/6020) |

## Description

This PR adds the logic to move the `global.db` database to the new location during the upgrade scenario. It also sets the proper permissions and ownership of the file in order to make `Wazuh DB` be able to manage it.

## Tests

- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade

- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386