### PR TITLE
Migration agent-info data to Wazuh DB packages upgrade

### DIFF
--- a/debs/SPECS/3.13.2/wazuh-manager/debian/postinst
+++ b/debs/SPECS/3.13.2/wazuh-manager/debian/postinst
@@ -389,12 +389,12 @@ case "$1" in
     chown root:ossec /etc/ossec-init.conf
 
     # Fix Python permissions
-    chmod 750 /var/ossec/framework/python/bin/2to3-3.8
-    chmod 750 /var/ossec/framework/python/bin/pydoc3.8
-    chmod 750 /var/ossec/framework/python/bin/python3-config
-    chmod 0640 /var/ossec/framework/python/lib/pkgconfig/python-3.8-embed.pc
-    chmod 0640 /var/ossec/framework/python/lib/pkgconfig/python-3.8.pc
-    chmod 0640 /var/ossec/framework/python/lib/pkgconfig/python3.pc
+    chmod 750 ${DIR}/framework/python/bin/2to3-3.8
+    chmod 750 ${DIR}/framework/python/bin/pydoc3.8
+    chmod 750 ${DIR}/framework/python/bin/python3-config
+    chmod 0640 ${DIR}/framework/python/lib/pkgconfig/python-3.8-embed.pc
+    chmod 0640 ${DIR}/framework/python/lib/pkgconfig/python-3.8.pc
+    chmod 0640 ${DIR}/framework/python/lib/pkgconfig/python3.pc
 
     ;;
 

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -69,10 +69,10 @@ case "$1" in
     rm -f ${DIR}/var/db/agents/* || true
 
     if [ -f ${DIR}/var/db/global.db ]; then
-        cp ${DIR}/var/db/global.db* ${DIR}/queue/db/
+        cp ${DIR}/var/db/global.db ${DIR}/queue/db/
         if [ -f ${DIR}/queue/db/global.db ]; then
-            chmod 640 ${DIR}/queue/db/global.db*
-            chown ossec:ossec ${DIR}/queue/db/global.db*
+            chmod 640 ${DIR}/queue/db/global.db
+            chown ossec:ossec ${DIR}/queue/db/global.db
             rm -f ${DIR}/var/db/global.db* || true
         else
             echo "Unable to move global.db during the upgrade"

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -78,8 +78,14 @@ case "$1" in
             echo "Unable to move global.db during the upgrade"
         fi
     fi
+
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
+
+    # Remove plain-text agent information if exists (it was migrated to Wazuh DB in v4.1)
+    if [ -d ${DIR}/queue/agent-info ]; then
+        rm -rf ${DIR}/queue/agent-info > /dev/null 2>&1
+    fi
 
     # Generation auto-signed certificate if not exists
     if type openssl >/dev/null 2>&1 && [ ! -f "${DIR}/etc/sslmanager.key" ] && [ ! -f "${DIR}/etc/sslmanager.cert" ]; then

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -69,23 +69,14 @@ case "$1" in
     rm -f ${DIR}/var/db/agents/* || true
 
     if [ -f ${DIR}/var/db/global.db ]; then
-        cp ${DIR}/var/db/global.db ${DIR}/queue/db/
-        if [ -f ${DIR}/queue/db/global.db ]; then
-            chmod 640 ${DIR}/queue/db/global.db
-            chown ossec:ossec ${DIR}/queue/db/global.db
-            rm -f ${DIR}/var/db/global.db* || true
-        else
-            echo "Unable to move global.db during the upgrade"
-        fi
+        mv ${DIR}/var/db/global.db ${DIR}/queue/db/
+        chmod 640 ${DIR}/queue/db/global.db
+        chown ossec:ossec ${DIR}/queue/db/global.db
+        rm -f ${DIR}/var/db/global.db* || true
     fi
 
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
-
-    # Remove plain-text agent information if exists (it was migrated to Wazuh DB in v4.1)
-    if [ -d ${DIR}/queue/agent-info ]; then
-        rm -rf ${DIR}/queue/agent-info > /dev/null 2>&1
-    fi
 
     # Generation auto-signed certificate if not exists
     if type openssl >/dev/null 2>&1 && [ ! -f "${DIR}/etc/sslmanager.key" ] && [ ! -f "${DIR}/etc/sslmanager.cert" ]; then

--- a/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/preinst
@@ -100,7 +100,12 @@ case "$1" in
         fi
 
         if [ -d ${DIR}/var/db/agents ]; then
-          rm -f ${DIR}/var/db/agents/*
+            rm -f ${DIR}/var/db/agents/*
+        fi
+
+        # Remove plain-text agent information if exists
+        if [ -d ${DIR}/queue/agent-info ]; then
+            rm -rf ${DIR}/queue/agent-info/* > /dev/null 2>&1
         fi
     ;;
 

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -224,6 +224,11 @@ fi
 # Remove Vuln-detector database
 rm -f %{_localstatedir}/queue/vulnerabilities/cve.db || true
 
+# Remove plain-text agent information if exists (it was migrated to Wazuh DB in v4.1)
+if [ -d %{_localstatedir}/queue/agent-info ]; then
+    rm -rf %{_localstatedir}/queue/agent-info > /dev/null 2>&1
+fi
+
 # Delete old API backups
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/~api ]; then

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -211,10 +211,10 @@ rm -f %{_localstatedir}/var/db/.profile.db* || true
 rm -f %{_localstatedir}/var/db/agents/* || true
 
 if [ -f %{_localstatedir}/var/db/global.db ]; then
-    cp %{_localstatedir}/var/db/global.db* %{_localstatedir}/queue/db/
+    cp %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
     if [ -f %{_localstatedir}/queue/db/global.db ]; then
-        chmod 640 %{_localstatedir}/queue/db/global.db*
-        chown ossec:ossec %{_localstatedir}/queue/db/global.db*
+        chmod 640 %{_localstatedir}/queue/db/global.db
+        chown ossec:ossec %{_localstatedir}/queue/db/global.db
         rm -f %{_localstatedir}/var/db/global.db* || true
     else
         echo "Unable to move global.db during the upgrade"

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -201,32 +201,24 @@ if ! id -u ossecm > /dev/null 2>&1; then
   useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossecm
 fi
 
-if [ -d %{_localstatedir}/var/db/agents ]; then
-  rm -f %{_localstatedir}/var/db/agents/*
-fi
-
 # Remove/relocate existing SQLite databases
 rm -f %{_localstatedir}/var/db/cluster.db* || true
 rm -f %{_localstatedir}/var/db/.profile.db* || true
 rm -f %{_localstatedir}/var/db/agents/* || true
 
 if [ -f %{_localstatedir}/var/db/global.db ]; then
-    cp %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
-    if [ -f %{_localstatedir}/queue/db/global.db ]; then
-        chmod 640 %{_localstatedir}/queue/db/global.db
-        chown ossec:ossec %{_localstatedir}/queue/db/global.db
-        rm -f %{_localstatedir}/var/db/global.db* || true
-    else
-        echo "Unable to move global.db during the upgrade"
-    fi
+  mv %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
+  chmod 640 %{_localstatedir}/queue/db/global.db
+  chown ossec:ossec %{_localstatedir}/queue/db/global.db
+  rm -f %{_localstatedir}/var/db/global.db* || true
 fi
 
 # Remove Vuln-detector database
 rm -f %{_localstatedir}/queue/vulnerabilities/cve.db || true
 
-# Remove plain-text agent information if exists (it was migrated to Wazuh DB in v4.1)
+# Remove plain-text agent information if exists
 if [ -d %{_localstatedir}/queue/agent-info ]; then
-    rm -rf %{_localstatedir}/queue/agent-info > /dev/null 2>&1
+  rm -rf %{_localstatedir}/queue/agent-info/* > /dev/null 2>&1
 fi
 
 # Delete old API backups


### PR DESCRIPTION
|Related issue|
|---|
| [Wazuh 5367](https://github.com/wazuh/wazuh/issues/5367) |

## Description

This PR includes all the packages changes required after **[Migration agent-info data to Wazuh DB epic](https://github.com/wazuh/wazuh/issues/5367)** is integrated.

It basically includes a logic to do the next things:

- Remove the `agent-info` folder and all its content if exists.
- Relocate the `global.db` database from `var/db/` folder to `queue/db`.
- Assign proper permissions and ownership to `global.db` in order to make `Wazuh DB` be able to manage it.

## Tests

- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade

- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386