### PR TITLE
Update obsolete wazuh-api 3.13.2 when upgrading to 4.0.0 in RPM

### DIFF
--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -14,7 +14,7 @@ Requires(post):   /sbin/chkconfig
 Requires(preun):  /sbin/chkconfig /sbin/service
 Requires(postun): /sbin/service /usr/sbin/groupdel /usr/sbin/userdel
 Conflicts:   ossec-hids ossec-hids-agent wazuh-agent wazuh-local
-Obsoletes: wazuh-api <= 3.13.1
+Obsoletes: wazuh-api <= 3.13.2
 AutoReqProv: no
 
 Requires: coreutils


### PR DESCRIPTION
|Related issue|
|---|
|closes #499 |

Hello team,

This PR updates the `wazuh-api` `3.13.2` obsolete version when upgrading to `4.0.0`

After applying this change, it is now possible to upgrade from `3.13.2` to `4.0.0` successfully.

```
[root@a9484a8bbf03 /]# cat /etc/ossec-init.conf 
DIRECTORY="/var/ossec"
NAME="Wazuh"
VERSION="v3.13.2"
REVISION="31310"
DATE="Fri Sep 18 18:04:25 UTC 2020"
TYPE="server"
[root@a9484a8bbf03 /]# rpm -U wazuh-manager-4.0.0-jmv74211.release.x86_64.rpm 
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
warning: /var/ossec/api/configuration/config.js saved as /var/ossec/api/configuration/config.js.rpmsave
```

Best regards.