### PR TITLE
Fix debian manager SPECS for 4.1.0

### DIFF
--- a/debs/SPECS/4.1.0/wazuh-manager/debian/changelog
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/changelog
@@ -1,28 +1,28 @@
-wazuh-agent (4.1.0-RELEASE) stable; urgency=low
+wazuh-manager (4.1.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
  -- Wazuh, Inc <info@wazuh.com>  Fri, 30 Oct 2020 06:25:59 +0000
 
-wazuh-agent (4.0.0-RELEASE) stable; urgency=low
+wazuh-manager (4.0.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
  -- Wazuh, Inc <info@wazuh.com>  Mon, 19 Oct 2020 06:59:39 +0000
 
- wazuh-agent (3.13.2-RELEASE) stable; urgency=low
+ wazuh-manager (3.13.2-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
  -- Wazuh, Inc <info@wazuh.com>  Fri, 21 Aug 2020 10:05:02 +0000
 
- wazuh-agent (3.13.1-RELEASE) stable; urgency=low
+ wazuh-manager (3.13.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
  -- Wazuh, Inc <info@wazuh.com>  Tue, 14 Jul 2020 10:05:02 +0000
 
-wazuh-agent (3.13.0-RELEASE) stable; urgency=low
+wazuh-manager (3.13.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
@@ -275,6 +275,6 @@ wazuh-manager (2.0.1-1) stable; urgency=low
 
 wazuh-manager (2.0-1) stable; urgency=low
 
-  * Wazuh-agent - base 2.0
+  * wazuh-manager - base 2.0
 
  -- Wazuh, Inc <info@wazuh.com>  Mon, 01 Jul 2016 08:43:10 +0000


### PR DESCRIPTION
We've detected some failures on Debian manager SPECS for 4.1.0

This PR aims to fix them. 