### PR TITLE
Remove fakeroot package from deb build-tools

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y apt-utils && \
     apt-get install -y --force-yes \
-    curl gcc make cmake sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 perl \
+    curl gcc make cmake sudo expect gnupg perl-base=5.14.2-21+deb7u3 perl \
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y apt apt-utils  \
-    curl gcc make cmake sudo expect gnupg fakeroot \
+    curl gcc make cmake sudo expect gnupg \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
     autoconf libtool libaudit-dev selinux-basics \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y apt-utils \
-    curl gcc make cmake sudo expect gnupg fakeroot perl-base \
+    curl gcc make cmake sudo expect gnupg perl-base \
     perl libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
     libaudit-dev selinux-basics util-linux libdb5.1 \

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y apt-utils && \
     apt-get install -y --force-yes \
-    curl gcc-multilib make cmake sudo expect gnupg fakeroot perl-base=5.14.2-21+deb7u3 \
+    curl gcc-multilib make cmake sudo expect gnupg perl-base=5.14.2-21+deb7u3 \
     perl libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
     libaudit-dev selinux-basics util-linux libdb5.1=5.1.29-5 libdb5.1-dev \

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /et
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y apt-utils && \
     apt-get install -y --force-yes \
-    curl gcc make cmake sudo expect gnupg fakeroot perl-base perl wget \
+    curl gcc make cmake sudo expect gnupg perl-base perl wget \
     libc-bin libc6 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -85,11 +85,11 @@ mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
 # Build package
 if [[ "${architecture_target}" == "amd64" ]] ||  [[ "${architecture_target}" == "ppc64le" ]] || \
     [[ "${architecture_target}" == "arm64" ]]; then
-    debuild -b -uc -us
+    debuild --rootcmd=sudo -b -uc -us
 elif [[ "${architecture_target}" == "armhf" ]]; then
-    linux32 debuild -b -uc -us
+    linux32 debuild --rootcmd=sudo -b -uc -us
 else
-    linux32 debuild -ai386 -b -uc -us
+    linux32 debuild --rootcmd=sudo -ai386 -b -uc -us
 fi
 
 deb_file="wazuh-${build_target}_${wazuh_version}-${package_release}_${architecture_target}.deb"


### PR DESCRIPTION
|Related issue|
|---|
| closes https://github.com/wazuh/wazuh-jenkins/issues/1775 |


## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hi team, 

This PR removes the package `fakeroot` and uses `sudo` as the default tool to grant root permissions to `debuild`. This improves the build process and removes these logs:
```
14:27:37  ERROR: ld.so: object 'libfakeroot-sysv.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
14:27:37  ERROR: ld.so: object 'libfakeroot-sysv.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
14:27:37  ERROR: ld.so: object 'libfakeroot-sysv.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
14:27:37  ERROR: ld.so: object 'libfakeroot-sysv.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
...
cp -r /var/ossec/. /build_wazuh/manager/wazuh-manager-4.0.0/debian/wazuh-manager/var/ossec/
cp: cannot open '/var/ossec/./framework/python/lib/pkgconfig/python3.pc' for reading: Too many levels of symbolic links
cp: cannot open '/var/ossec/./framework/python/lib/pkgconfig/python3-embed.pc' for reading: Too many levels of symbolic links
debian/rules:39: recipe for target 'override_dh_install' failed
```

## Logs example

NA

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
