### PR TITLE
Ensure DBs from Wazuh v3.6.1 or lower are deleted

### DIFF
--- a/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.0.0/wazuh-manager/debian/postinst
@@ -75,6 +75,21 @@ case "$1" in
         rm -f ${DIR}/var/db/global.db* || true
     fi
 
+    # Delete uncompatible DBs versions
+    if [ ! -z $2 ]; then
+
+        PREVIOUS_VERSION=$(echo $2 | cut -d"-" -f1)
+
+        # Get the major and minor version
+        MAJOR=$(echo $PREVIOUS_VERSION | cut -d. -f1)
+        MINOR=$(echo $PREVIOUS_VERSION | cut -d. -f2)
+
+        if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+            rm -f ${DIR}/queue/db/*.db*
+            rm -f ${DIR}/queue/db/.template.db
+        fi
+    fi
+
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
 

--- a/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
@@ -75,6 +75,21 @@ case "$1" in
         rm -f ${DIR}/var/db/global.db* || true
     fi
 
+    # Delete uncompatible DBs versions
+    if [ ! -z $2 ]; then
+
+        PREVIOUS_VERSION=$(echo $2 | cut -d"-" -f1)
+
+        # Get the major and minor version
+        MAJOR=$(echo $PREVIOUS_VERSION | cut -d. -f1)
+        MINOR=$(echo $PREVIOUS_VERSION | cut -d. -f2)
+
+        if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+            rm -f ${DIR}/queue/db/*.db*
+            rm -f ${DIR}/queue/db/.template.db
+        fi
+    fi
+
     # Remove Vuln-detector database
     rm -f ${DIR}/queue/vulnerabilities/cve.db || true
 

--- a/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
+++ b/rpms/SPECS/4.0.0/wazuh-manager-4.0.0.spec
@@ -233,6 +233,12 @@ if [ $1 = 2 ]; then
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
   MINOR=$(echo $VERSION | cut -d. -f2)
 
+  # Delete uncompatible DBs versions
+  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+    rm -f %{_localstatedir}/queue/db/*.db*
+    rm -f %{_localstatedir}/queue/db/.template.db
+  fi
+
   # Delete 3.X Wazuh API service
   if [ "$MAJOR" = "3" ] && [ -d %{_localstatedir}/api ]; then
     if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then

--- a/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
@@ -233,6 +233,12 @@ if [ $1 = 2 ]; then
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
   MINOR=$(echo $VERSION | cut -d. -f2)
 
+  # Delete uncompatible DBs versions
+  if [ $MAJOR = 3 ] && [ $MINOR -lt 7 ]; then
+    rm -f %{_localstatedir}/queue/db/*.db*
+    rm -f %{_localstatedir}/queue/db/.template.db
+  fi
+
   # Delete 3.X Wazuh API service
   if [ "$MAJOR" = "3" ] && [ -d %{_localstatedir}/api ]; then
     if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 ; then


### PR DESCRIPTION
Hi team, 
DBs files from these versions are incompatible with wazuh-db daemon, who is in charge of migrating and maintaining Wazuh's DBs.

Due to this incompatibility, they must be removed to ensure the correct upgrade and migration processes.

Regards.