### PR TITLE
Set ssl cetificates permissions in DEB packages

### DIFF
--- a/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
@@ -96,6 +96,8 @@ case "$1" in
     # Generation auto-signed certificate if not exists
     if type openssl >/dev/null 2>&1 && [ ! -f "${DIR}/etc/sslmanager.key" ] && [ ! -f "${DIR}/etc/sslmanager.cert" ]; then
         openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout ${DIR}/etc/sslmanager.key -out ${DIR}/etc/sslmanager.cert 2>/dev/null
+        chmod 640 ${DIR}/etc/sslmanager.key
+        chmod 640 ${DIR}/etc/sslmanager.key
     fi
 
     # For the etc dir

--- a/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
@@ -96,9 +96,8 @@ case "$1" in
     # Generation auto-signed certificate if not exists
     if type openssl >/dev/null 2>&1 && [ ! -f "${DIR}/etc/sslmanager.key" ] && [ ! -f "${DIR}/etc/sslmanager.cert" ]; then
         openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout ${DIR}/etc/sslmanager.key -out ${DIR}/etc/sslmanager.cert 2>/dev/null
-        chmod 640 ${DIR}/etc/sslmanager.key
-        chmod 640 ${DIR}/etc/sslmanager.key
     fi
+    chmod 640 ${DIR}/etc/sslmanager.cert ${DIR}/etc/sslmanager.key
 
     # For the etc dir
     if [ -f /etc/localtime ]; then


### PR DESCRIPTION
|Related issue|
|---|
| #515  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team, 

This PR closes #515, we have modified the Debian post installation script so the permissions of the ssl certificates are set correctly.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
- [X] Package installation
- [X] Package upgrade
- [X] Package downgrade
- [X] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package

