### PR TITLE
Add tools to generate future x.30.0 test packages

### DIFF
--- a/debs/build.sh
+++ b/debs/build.sh
@@ -21,7 +21,8 @@ debug=$7
 checksum=$8
 wazuh_packages_branch=$9
 use_local_specs=${10}
-local_source_code=${11}
+future=${11}
+local_source_code=${12}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
@@ -50,11 +51,37 @@ cp -R wazuh* ${build_dir}/${build_target}/wazuh-${build_target}-${wazuh_version}
 if [ "${use_local_specs}" = "no" ]; then
     curl -sL https://github.com/wazuh/wazuh-packages/tarball/${wazuh_packages_branch} | tar zx
     package_files="wazuh*/debs"
-    specs_path="${package_files}/SPECS"
+    specs_path=$(find . -type d -name "SPECS" -path "*debs*")
 else
     package_files="/specs"
     specs_path="${package_files}/SPECS"
 fi
+
+if [[ "${future}" == "yes" ]]; then    
+    # MODIFY VARIABLES
+    base_version=$wazuh_version
+    MAJOR=$(echo $base_version | cut -dv -f2 | cut -d. -f1)
+    MINOR=$(echo $base_version | cut -d. -f2)
+    wazuh_version="${MAJOR}.30.0"
+    file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+    old_name="wazuh-${build_target}-${base_version}-${package_release}"
+    package_full_name=wazuh-${build_target}-${wazuh_version}
+    old_package_name=wazuh-${build_target}-${base_version}
+    sources_dir="${build_dir}/${build_target}/${package_full_name}"
+
+    # PREPARE FUTURE SPECCS
+    cp -r "${specs_path}/${base_version}" "${specs_path}/${wazuh_version}"
+    cd "${specs_path}/${wazuh_version}"
+    rename "${base_version}" "${wazuh_version}" *${base_version}*
+    cd -
+    find "${specs_path}/${wazuh_version}" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
+
+    # PREPARE FUTURE SOURCES
+    mv ${build_dir}/${build_target}/${old_package_name} ${build_dir}/${build_target}/${package_full_name}
+    find "${build_dir}/${build_target}/${package_full_name}" -name "*VERSION*" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
+    sed -i "s/\$(VERSION)/${MAJOR}.${MINOR}/g" "${build_dir}/${build_target}/${package_full_name}/src/Makefile"
+fi
+ls ${specs_path}
 cp -pr ${specs_path}/${wazuh_version}/wazuh-${build_target}/debian ${sources_dir}/debian
 cp -p ${package_files}/gen_permissions.sh ${sources_dir}
 

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -21,8 +21,8 @@ debug=$7
 checksum=$8
 wazuh_packages_branch=$9
 use_local_specs=${10}
-future=${11}
-local_source_code=${12}
+local_source_code=${11}
+future=${12}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
@@ -69,19 +69,12 @@ if [[ "${future}" == "yes" ]]; then
     old_package_name=wazuh-${build_target}-${base_version}
     sources_dir="${build_dir}/${build_target}/${package_full_name}"
 
-    # PREPARE FUTURE SPECCS
+    # PREPARE FUTURE SPECS AND SOURCES
     cp -r "${specs_path}/${base_version}" "${specs_path}/${wazuh_version}"
-    cd "${specs_path}/${wazuh_version}"
-    rename "${base_version}" "${wazuh_version}" *${base_version}*
-    cd -
-    find "${specs_path}/${wazuh_version}" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
-
-    # PREPARE FUTURE SOURCES
     mv ${build_dir}/${build_target}/${old_package_name} ${build_dir}/${build_target}/${package_full_name}
-    find "${build_dir}/${build_target}/${package_full_name}" -name "*VERSION*" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
+    find "${build_dir}/${package_name}" "${specs_path}/${wazuh_version}" \( -name "*VERSION*" -o -name "*.spec" \) -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
     sed -i "s/\$(VERSION)/${MAJOR}.${MINOR}/g" "${build_dir}/${build_target}/${package_full_name}/src/Makefile"
 fi
-ls ${specs_path}
 cp -pr ${specs_path}/${wazuh_version}/wazuh-${build_target}/debian ${sources_dir}/debian
 cp -p ${package_files}/gen_permissions.sh ${sources_dir}
 

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -7,7 +7,6 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ARCHITECTURE="amd64"
 OUTDIR="${CURRENT_PATH}/output/"
@@ -75,7 +74,8 @@ build_deb() {
         ${CUSTOM_CODE_VOL} \
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
-        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${FUTURE} ${LOCAL_SOURCE_CODE} || return 1
+        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
+        "${LOCAL_SOURCE_CODE}" ${FUTURE} || return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -152,7 +152,7 @@ help() {
     echo "    --dont-build-docker       [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>          [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --dev                     [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
-    echo "    --future                  [Optional] Build test future package x.30.0."
+    echo "    --future                  [Optional] Build test future package x.30.0 Used for development purposes."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -149,9 +149,10 @@ help() {
     echo "    -p, --path <path>         [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    --dont-build-docker   [Optional] Locally built docker image will be used instead of generating a new one."
+    echo "    --dont-build-docker       [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>          [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --dev                     [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
+    echo "    --future                  [Optional] Build test future package x.30.0."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -34,6 +34,7 @@ PACKAGES_BRANCH="master"
 USE_LOCAL_SPECS="no"
 LOCAL_SPECS="${CURRENT_PATH}"
 LOCAL_SOURCE_CODE=""
+FUTURE="no"
 
 trap ctrl_c INT
 
@@ -74,7 +75,7 @@ build_deb() {
         ${CUSTOM_CODE_VOL} \
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
-        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${LOCAL_SOURCE_CODE} || return 1
+        ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${FUTURE} ${LOCAL_SOURCE_CODE} || return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -257,6 +258,10 @@ main() {
             else
                 help 1
             fi
+            ;;
+        "--future")
+            FUTURE="yes"
+            shift 1
             ;;
         *)
             help 1

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -22,8 +22,8 @@ wazuh_packages_branch=$9
 use_local_specs=${10}
 src=${11}
 legacy=${12}
-future=${13}
-local_source_code=${14}
+local_source_code=${13}
+future=${14}
 wazuh_version=""
 rpmbuild="rpmbuild"
 
@@ -45,7 +45,6 @@ if [ ${build_target} = "api" ]; then
 else
     if [ -z "${local_source_code}" ]; then
         curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
-        ls
     fi
     wazuh_version="$(cat wazuh*/src/VERSION | cut -d 'v' -f 2)"
 fi
@@ -74,7 +73,7 @@ else
 fi
 
 if [[ "${future}" == "yes" ]]; then    
-    # PREPARE FUTURE SPECCS
+    # MODIFY VARIABLES
     base_version=$wazuh_version
     MAJOR=$(echo $base_version | cut -dv -f2 | cut -d. -f1)
     MINOR=$(echo $base_version | cut -d. -f2)
@@ -87,12 +86,12 @@ if [[ "${future}" == "yes" ]]; then
     cd "${specs_path}/${wazuh_version}"
     rename "${base_version}" "${wazuh_version}" *${base_version}*
     cd -
-    find "${specs_path}/${wazuh_version}" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
 
-    # PREPARE FUTURE SOURCES
+    # PREPARE FUTURE SPECS AND SOURCES
     mv "${build_dir}/${old_package_name}" "${build_dir}/${package_name}"
-    find "${build_dir}/${package_name}" -name "*VERSION*" -type f -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
+    find "${build_dir}/${package_name}" "${specs_path}/${wazuh_version}" \( -name "*VERSION*" -o -name "*.spec" \) -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
     sed -i "s/\$(VERSION)/${MAJOR}.${MINOR}/g" "${build_dir}/${package_name}/src/Makefile"
+
 fi
 
 cp ${specs_path}/${wazuh_version}/wazuh-${build_target}-${wazuh_version}.spec ${rpm_build_dir}/SPECS/${package_name}.spec

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -41,6 +41,7 @@ CHECKSUMDIR=""
 CHECKSUM="no"
 USE_LOCAL_SPECS="no"
 LOCAL_SOURCE_CODE=""
+FUTURE="no"
 
 trap ctrl_c INT
 
@@ -93,7 +94,7 @@ build_rpm() {
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
-        ${LEGACY} ${LOCAL_SOURCE_CODE} || return 1
+        ${LEGACY} ${FUTURE} ${LOCAL_SOURCE_CODE}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -297,6 +298,10 @@ main() {
             ;;
         "--dev")
             USE_LOCAL_SPECS="yes"
+            shift 1
+            ;;
+        "--future")
+            FUTURE="yes"
             shift 1
             ;;
         *)

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -177,11 +177,12 @@ help() {
     echo "    -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
     echo "    -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    --dont-build-docker      [Optional] Locally built docker image will be used instead of generating a new one."
+    echo "    --dont-build-docker          [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --packages-branch <branch>   [Optional] Select Git branch or tag from wazuh-packages repository. e.g ${PACKAGES_BRANCH}"
     echo "    --dev                        [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
     echo "    --src                        [Optional] Generate the source package in the destination directory."
+    echo "    --future                     [Optional] Build test future package x.30.0."
     echo "    -h, --help                   Show this help."
     echo
     exit $1

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -94,7 +94,7 @@ build_rpm() {
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
-        ${LEGACY} ${FUTURE} ${LOCAL_SOURCE_CODE}|| return 1
+        ${LEGACY} "${LOCAL_SOURCE_CODE}" ${FUTURE} || return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -182,7 +182,7 @@ help() {
     echo "    --packages-branch <branch>   [Optional] Select Git branch or tag from wazuh-packages repository. e.g ${PACKAGES_BRANCH}"
     echo "    --dev                        [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
     echo "    --src                        [Optional] Generate the source package in the destination directory."
-    echo "    --future                     [Optional] Build test future package x.30.0."
+    echo "    --future                     [Optional] Build test future package x.30.0 Used for development purposes."
     echo "    -h, --help                   Show this help."
     echo
     exit $1


### PR DESCRIPTION
|Related issue|
|---|
|wj1844|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hello team,

In this PR we add the necessary tools to build future packages for testing purposes.

## Logs example

<!--
Paste here related logs
-->
### DEB upgrade
```
# apt install /vagrant/wazuh-manager_4.30.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-manager' instead of '/vagrant/wazuh-manager_4.30.0-1_amd64.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/103 MB of archives.
After this operation, 386 MB of additional disk space will be used.
Get:1 /vagrant/wazuh-manager_4.30.0-1_amd64.deb wazuh-manager amd64 4.30.0-1 [103 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 59775 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.30.0-1_amd64.deb ...
Unpacking wazuh-manager (4.30.0-1) ...
Setting up wazuh-manager (4.30.0-1) ...
Processing triggers for systemd (237-3ubuntu10.41) ...
Processing triggers for ureadahead (0.100.0-21) ...
```

### RPM upgrade
```
# yum install /vagrant/wazuh-manager-4.30.0-1.x86_64.rpm 
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Examining /vagrant/wazuh-manager-4.30.0-1.x86_64.rpm: wazuh-manager-4.30.0-1.x86_64
Marking /vagrant/wazuh-manager-4.30.0-1.x86_64.rpm as an update to wazuh-manager-4.0.0-1.x86_64
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.0.0-1 will be updated
---> Package wazuh-manager.x86_64 0:4.30.0-1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

========================================================================================================
 Package                Arch            Version           Repository                               Size
========================================================================================================
Updating:
 wazuh-manager          x86_64          4.30.0-1          /wazuh-manager-4.30.0-1.x86_64          367 M

Transaction Summary
========================================================================================================
Upgrade  1 Package

Total size: 367 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : wazuh-manager-4.30.0-1.x86_64                                                        1/2 
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
  Cleanup    : wazuh-manager-4.0.0-1.x86_64                                                         2/2 
  Verifying  : wazuh-manager-4.30.0-1.x86_64                                                        1/2 
  Verifying  : wazuh-manager-4.0.0-1.x86_64                                                         2/2 

Updated:
  wazuh-manager.x86_64 0:4.30.0-1   
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
