### PR TITLE
Fix HP-UX documentation links

### DIFF
--- a/aix/README.md
+++ b/aix/README.md
@@ -10,7 +10,7 @@ Please, visit the following link for the full AIX packages building documentatio
 ## More Packages
 
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/debs/README.md
+++ b/debs/README.md
@@ -10,7 +10,7 @@ Please, visit the following link for the full DEB packages building documentatio
 ## More Packages
 
 - [AIX](/aix/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/macos/README.md
+++ b/macos/README.md
@@ -12,7 +12,7 @@ Please, visit the following link for the full macOS packages building documentat
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [OVA](/ova/README.md)
 - [RPM](/rpms/README.md)

--- a/ova/README.md
+++ b/ova/README.md
@@ -12,7 +12,7 @@ Please, visit the following link for the full OVA building documentation: [Gener
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [RPM](/rpms/README.md)

--- a/rpms/README.md
+++ b/rpms/README.md
@@ -11,7 +11,7 @@ Please, visit the following link for the full RPM packages building documentatio
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/solaris/README.md
+++ b/solaris/README.md
@@ -15,7 +15,7 @@ Please, visit the following link for the full Solaris packages building document
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/solaris/package_generation/README.md
+++ b/solaris/package_generation/README.md
@@ -99,7 +99,7 @@ To build a Solaris package using vagrant, you need to download this repository c
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/solaris/packer/README.md
+++ b/solaris/packer/README.md
@@ -22,7 +22,7 @@ To build a Wazuh package you need to install the following tools:
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/splunkapp/README.md
+++ b/splunkapp/README.md
@@ -11,7 +11,7 @@ Please, visit the following link for the full Splunk App packages building docum
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/wazuhapp/README.md
+++ b/wazuhapp/README.md
@@ -11,7 +11,7 @@ Please, visit the following link for the full Wazuh Kibana plugin packages build
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)
 - [RPM](/rpms/README.md)

--- a/windows/README.md
+++ b/windows/README.md
@@ -11,7 +11,7 @@ Please, visit the following link for the full Windows packages building document
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)

--- a/wpk/README.md
+++ b/wpk/README.md
@@ -12,7 +12,7 @@ Please, visit the following link for the full WPK packages building documentatio
 
 - [AIX](/aix/README.md)
 - [Debian](/debs/README.md)
-- [HP-UX](/hpux/README.md)
+- [HP-UX](/hp-ux/README.md)
 - [KibanaApp](/wazuhapp/README.md)
 - [macOS](/macos/README.md)
 - [OVA](/ova/README.md)


### PR DESCRIPTION
Hello team,

This PR fixes the HP-UX documentation links in `readme` files.

Best regards.