### PR TITLE
Fix problem with Debian future package generation

### DIFF
--- a/debs/build.sh
+++ b/debs/build.sh
@@ -21,8 +21,8 @@ debug=$7
 checksum=$8
 wazuh_packages_branch=$9
 use_local_specs=${10}
-local_source_code=${11}
-future=${12}
+future=${11}
+local_source_code=${12}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
@@ -72,7 +72,7 @@ if [[ "${future}" == "yes" ]]; then
     # PREPARE FUTURE SPECS AND SOURCES
     cp -r "${specs_path}/${base_version}" "${specs_path}/${wazuh_version}"
     mv ${build_dir}/${build_target}/${old_package_name} ${build_dir}/${build_target}/${package_full_name}
-    find "${build_dir}/${package_name}" "${specs_path}/${wazuh_version}" \( -name "*VERSION*" -o -name "*.spec" \) -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
+    find "${build_dir}/${package_name}" "${specs_path}/${wazuh_version}" \( -name "*VERSION*" -o -name "*changelog*" \) -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
     sed -i "s/\$(VERSION)/${MAJOR}.${MINOR}/g" "${build_dir}/${build_target}/${package_full_name}/src/Makefile"
 fi
 cp -pr ${specs_path}/${wazuh_version}/wazuh-${build_target}/debian ${sources_dir}/debian
@@ -118,5 +118,4 @@ pkg_path="${build_dir}/${build_target}"
 if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${deb_file} > /var/local/checksum/${deb_file}.sha512
 fi
-
 mv ${pkg_path}/${deb_file} /var/local/wazuh

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -75,7 +75,7 @@ build_deb() {
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
-        "${LOCAL_SOURCE_CODE}" ${FUTURE} || return 1
+        ${FUTURE} ${LOCAL_SOURCE_CODE}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -22,8 +22,8 @@ wazuh_packages_branch=$9
 use_local_specs=${10}
 src=${11}
 legacy=${12}
-local_source_code=${13}
-future=${14}
+future=${13}
+local_source_code=${14}
 wazuh_version=""
 rpmbuild="rpmbuild"
 

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -94,7 +94,7 @@ build_rpm() {
         ${CONTAINER_NAME} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
-        ${LEGACY} "${LOCAL_SOURCE_CODE}" ${FUTURE} || return 1
+        ${LEGACY} ${FUTURE} "${LOCAL_SOURCE_CODE}"|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 


### PR DESCRIPTION
|Related issue|
|---|
|wj1844|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Hello team,

This PR fixes a problem with the future package generation of Debian packages where the x.30.0 package was not generated due to the changelog not being modified.

Regards,
Daniel Folch

## Tests


<!-- Minimum checks required -->
<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386

