### PR TITLE
Remove rootcheck directory RPM

### DIFF
--- a/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
@@ -648,7 +648,6 @@ rm -fr %{buildroot}
 %dir %attr(750, ossec,ossec) %{_localstatedir}/queue/fim/db
 %dir %attr(750, ossec, ossec) %{_localstatedir}/queue/fts
 %dir %attr(770, ossecr, ossec) %{_localstatedir}/queue/rids
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/rootcheck
 %dir %attr(770, ossec, ossec) %{_localstatedir}/queue/tasks
 %dir %attr(770, ossec, ossec) %{_localstatedir}/queue/ossec
 %dir %attr(660, root, ossec) %{_localstatedir}/queue/vulnerabilities


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6097|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR removes the rootcheck folder in the rpm manifiest since it is not needed anymore.

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
