### PR TITLE
Fix ossec.conf group in IBM AIX package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.0.2]
+
+### Added
+
+- Added a new welcome message to Wazuh VM ([#535](https://github.com/wazuh/wazuh-packages/pull/535)).
+
+### Fixed
+
+- Fixed the group of the `ossec.conf` in IBM AIX package ([#541](https://github.com/wazuh/wazuh-packages/pull/541)).
+
+## [v4.0.1]
+
+### Fixed
+
+- Added new SSL certificates to secure Kibana communications and ensure HTTPS access to the UI ([#534](https://github.com/wazuh/wazuh-packages/pull/534)).
+
 ## [v4.0.0]
 
 ### Added

--- a/aix/SPECS/4.0.2/wazuh-agent-4.0.2-aix.spec
+++ b/aix/SPECS/4.0.2/wazuh-agent-4.0.2-aix.spec
@@ -140,7 +140,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/tmp/src/init/register_configure_agent.sh > /dev/null || :
 
 fi
-
+chown root:ossec %{_localstatedir}/etc/ossec.conf
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc2.d/S97wazuh-agent
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc3.d/S97wazuh-agent
 

--- a/aix/SPECS/4.1.0/wazuh-agent-4.1.0-aix.spec
+++ b/aix/SPECS/4.1.0/wazuh-agent-4.1.0-aix.spec
@@ -112,7 +112,6 @@ if [ $1 = 1 ]; then
   # Generating ossec.conf file
   . %{_localstatedir}/tmp/src/init/dist-detect.sh
   %{_localstatedir}/tmp/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  chown root:ossec %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/tmp/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
@@ -140,7 +139,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/tmp/src/init/register_configure_agent.sh > /dev/null || :
 
 fi
-
+chown root:ossec %{_localstatedir}/etc/ossec.conf
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc2.d/S97wazuh-agent
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc3.d/S97wazuh-agent
 


### PR DESCRIPTION
|Related issue|
|---|
|#540|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hi team,

This PR closes #540 by fixing the group of the `ossec.conf` file using a `chown` line in the post-install script.

## Logs example

NA

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] AIX
- [x] Package installation
- [x] Package upgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md
