### PR TITLE
Changed wazuh-logtest group to ossec

### DIFF
--- a/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
@@ -548,7 +548,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/ossec-integratord
 %attr(750, root, root) %{_localstatedir}/bin/ossec-logcollector
 %attr(750, root, root) %{_localstatedir}/bin/ossec-logtest
-%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest
+%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/ossec-maild
 %attr(750, root, root) %{_localstatedir}/bin/ossec-makelists
 %attr(750, root, root) %{_localstatedir}/bin/ossec-monitord


### PR DESCRIPTION
|Related issue|
|---|
| closes #542 |

## Description

Hello team,

We have added a little fix to wazuh-logtest group, changed from `root` to `ossec`. 

## Tests

- Build the package in any supported platform
- [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] `%files` section is correctly updated if necessary

Regards.