### PR TITLE
Changed CentOS 6 x86_64 and i386 base repositories

### DIFF
--- a/rpms/CentOS/6/i386/CentOS-Base.repo
+++ b/rpms/CentOS/6/i386/CentOS-Base.repo
@@ -1,0 +1,47 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/os/i386/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/updates/i386/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/extras/i386/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/centosplus/i386/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/contrib/i386/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/rpms/CentOS/6/i386/Dockerfile
+++ b/rpms/CentOS/6/i386/Dockerfile
@@ -1,9 +1,11 @@
 FROM i386/centos:6
 
 # Install all the necessary tools to build the packages
+RUN rm /etc/yum.repos.d/* && echo "exactarch=1" >> /etc/yum.conf
+COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all && yum update -y
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-RUN sed -i 's/$basearch/i386/g' /etc/yum.repos.d/CentOS-Base.repo
-RUN yum -y install util-linux-ng centos-release-scl \
+RUN yum -y install util-linux-ng \
     gcc-multilib make wget git openssh-clients \
     sudo gnupg automake autoconf libtool \
     policycoreutils-python yum-utils epel-release \

--- a/rpms/CentOS/6/x86_64/CentOS-Base.repo
+++ b/rpms/CentOS/6/x86_64/CentOS-Base.repo
@@ -12,28 +12,28 @@
 
 [base]
 name=CentOS-$releasever - Base
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/os/$basearch/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #released updates
 [updates]
 name=CentOS-$releasever - Updates
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/updates/$basearch/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #additional packages that may be useful
 [extras]
 name=CentOS-$releasever - Extras
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/extras/$basearch/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 
 #additional packages that extend functionality of existing packages
 [centosplus]
 name=CentOS-$releasever - Plus
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/centosplus/$basearch/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/centosplus/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -41,7 +41,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 #contrib - packages by Centos Users
 [contrib]
 name=CentOS-$releasever - Contrib
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/contrib/$basearch/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/contrib/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
@@ -49,6 +49,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 # SCLO - packages
 [centos-sclo-sclo]
 name=CentOS-$releasever - SCLO
-baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/sclo/$basearch/rh/
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/sclo/$basearch/rh/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/rpms/CentOS/6/x86_64/CentOS-Base.repo
+++ b/rpms/CentOS/6/x86_64/CentOS-Base.repo
@@ -1,0 +1,54 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/contrib/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# SCLO - packages
+[centos-sclo-sclo]
+name=CentOS-$releasever - SCLO
+baseurl=http://linuxsoft.cern.ch/centos-vault/6.10/sclo/$basearch/rh/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -17,8 +17,6 @@ RUN yum install -y centos-release-scl gcc make wget git \
     libarchive-devel elfutils-libelf-devel \
     elfutils-libelf patchelf elfutils-devel libgcrypt-devel
 
-# Warning: this repo has been disabled by the vendor
-RUN mv /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo.old
 RUN yum-builddep python34 -y
 
 RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:6
 # Install all the necessary tools to build the packages
+RUN rm /etc/yum.repos.d/* && echo "exactarch=1" >> /etc/yum.conf
+COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all && yum update -y
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 RUN yum install -y centos-release-scl gcc make wget git \
     openssh-clients sudo gnupg \

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -1,10 +1,11 @@
 FROM centos:6
+
 # Install all the necessary tools to build the packages
 RUN rm /etc/yum.repos.d/* && echo "exactarch=1" >> /etc/yum.conf
 COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN yum clean all && yum update -y
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-RUN yum install -y centos-release-scl gcc make wget git \
+RUN yum install -y gcc make wget git \
     openssh-clients sudo gnupg \
     automake autoconf libtool policycoreutils-python \
     yum-utils epel-release redhat-rpm-config rpm-devel \


### PR DESCRIPTION
|Related issue|
|---|
| Closes #548 |

## Description

Hello team,

CentOS 6 repositories are down after November 30 so, we changed them to another mirror.

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386

Regards!