### PR TITLE
Revert cmake addition

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -19,25 +19,6 @@ RUN apt-get update && apt-get build-dep python3.2 -y && \
 RUN sed -i 's:https:http:g' /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && apt-get install nodejs -y
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
-    make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64:${LD_LIBRARY_PATH}"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CXX=/usr/local/gcc-5.5.0/bin/g++ \
-        CC=/usr/local/gcc-5.5.0/bin/gcc && \
-    make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
-    cd / && rm -rf cmake-*
-
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -17,12 +17,6 @@ RUN apt-get update &&  apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl && \
-    make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
-    cd / && rm -rf cmake-*
-
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -17,13 +17,6 @@ RUN apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl && \
-    linux32 make -j$(nproc) && linux32 make install && \
-    ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
-
-
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -17,25 +17,6 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
 RUN apt-get update && apt-get build-dep python3.2 -y
 RUN sed -i "s;/\* To add :#define SO_REUSEPORT 15 \*/;#define SO_REUSEPORT 15;g" /usr/include/asm-generic/socket.h
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib:${LD_LIBRARY_PATH}"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CXX=/usr/local/gcc-5.5.0/bin/g++ \
-        CC=/usr/local/gcc-5.5.0/bin/gcc && \
-    linux32 make -j$(nproc) && linux32 make install && \
-    ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
-
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -26,11 +26,5 @@ RUN apt-get update &&  apt-get build-dep python3.5 -y &&\
     ln -s /usr/local/lib/nodejs/node-v10.16.0-linux-ppc64le/bin/npx /usr/bin/npx &&\
     chmod +x /usr/local/bin/build_package
 
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl \
-    make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/debs/SPECS/4.1.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.1.0/wazuh-agent/debian/rules
@@ -23,8 +23,6 @@ export INSTALLATION_DIR="/var/ossec"
 export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/agent_installation_scripts"
 export JOBS="5"
 export DEBUG_ENABLED="no"
-export PATH="${PATH}"
-export LD_LIBRARY_PATH=""
 
 %:
 	dh $@

--- a/debs/SPECS/4.1.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/rules
@@ -24,8 +24,6 @@ export INSTALLATION_DIR="/var/ossec"
 export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/manager_installation_scripts"
 export JOBS="5"
 export DEBUG_ENABLED="no"
-export PATH="${PATH}"
-export LD_LIBRARY_PATH=""
 
 %:
 	dh $@

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -85,8 +85,6 @@ cd ${build_dir}/${build_target} && tar -czf ${package_full_name}.orig.tar.gz "${
 sed -i "s:RELEASE:${package_release}:g" ${sources_dir}/debian/changelog
 sed -i "s:export JOBS=.*:export JOBS=${jobs}:g" ${sources_dir}/debian/rules
 sed -i "s:export DEBUG_ENABLED=.*:export DEBUG_ENABLED=${debug}:g" ${sources_dir}/debian/rules
-sed -i "s#export PATH=.*#export PATH=/usr/local/gcc-5.5.0/bin:${PATH}#g" ${sources_dir}/debian/rules
-sed -i "s#export LD_LIBRARY_PATH=.*#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}#g" ${sources_dir}/debian/rules
 sed -i "s:export INSTALLATION_DIR=.*:export INSTALLATION_DIR=${dir_path}:g" ${sources_dir}/debian/rules
 sed -i "s:DIR=\"/var/ossec\":DIR=\"${dir_path}\":g" ${sources_dir}/debian/{preinst,postinst,prerm,postrm}
 if [ "${build_target}" == "api" ]; then

--- a/rpms/CentOS/5/i386/Dockerfile
+++ b/rpms/CentOS/5/i386/Dockerfile
@@ -23,22 +23,6 @@ RUN curl -OL http://packages.wazuh.com/utils/curl/curl-7.63.0.tar.gz && \
     linux32 ./configure --with-ssl=/usr/local/ssl && \
     linux32 make -j2 && linux32 make install && cd / && rm -rf curl*
 
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-2.6.4.tar.gz && \
-    tar -zxvf cmake-2.6.4.tar.gz && cd cmake-2.6.4 && \
-    linux32 ./bootstrap && linux32 make -j2 && linux32 make install && \
-    cd / && rm -rf cmake-*
-
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    linux32 make -j2 && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/5/x86_64/Dockerfile
+++ b/rpms/CentOS/5/x86_64/Dockerfile
@@ -29,22 +29,6 @@ RUN curl -OL http://packages.wazuh.com/utils/curl/curl-7.63.0.tar.gz && \
     tar xf curl-7.63.0.tar.gz && cd curl-7.63.0 && ./configure --with-ssl=/usr/local/ssl && \
     make -j2 && make install && cd / && rm -rf curl*
 
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-2.6.4.tar.gz && \
-    tar -zxvf cmake-2.6.4.tar.gz && cd cmake-2.6.4 && \
-    ./bootstrap && make -j2 && make install && cd / && rm -rf cmake-*
-
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    make -j2 && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/6/i386/Dockerfile
+++ b/rpms/CentOS/6/i386/Dockerfile
@@ -40,24 +40,6 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    linux32 make -j$(nproc) && linux32 make install && cd / && rm -rf cmake-*
-
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -40,24 +40,6 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/7/aarch64/Dockerfile
+++ b/rpms/CentOS/7/aarch64/Dockerfile
@@ -24,24 +24,6 @@ RUN yum install -y gcc make wget git \
     redhat-rpm-config sqlite-devel gdb tar tcl-devel tix-devel tk-devel \
     valgrind-devel python-rpm-macros python34 nodejs
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
-    make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
 RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     tar -xzf openssl-1.1.1a.tar.gz && cd openssl* && \
     ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' && \

--- a/rpms/CentOS/7/armv7hl/Dockerfile
+++ b/rpms/CentOS/7/armv7hl/Dockerfile
@@ -3,25 +3,6 @@ FROM arm32v7/centos:7
 ADD build_deps.sh /build_deps.sh
 RUN sh build_deps.sh
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --with-arch=armv7-a \
-        --with-float=hard --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
-    linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    linux32 make -j$(nproc) && linux32 make install && cd / && rm -rf cmake-*
-
 RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     tar -xzf openssl-1.1.1a.tar.gz && cd openssl* && \
     linux32 ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' && \
@@ -49,8 +30,6 @@ RUN echo "%_arch                  armv7hl" >> /root/.rpmmacros
 RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
-
-
 
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package

--- a/rpms/CentOS/7/ppc64le/Dockerfile
+++ b/rpms/CentOS/7/ppc64le/Dockerfile
@@ -21,25 +21,6 @@ RUN yum install -y \
     http://packages.wazuh.com/utils/nodejs/npm-5.6.0-1.8.9.4.2.el7.ppc64le.rpm \
     http://packages.wazuh.com/utils/nodejs/nodejs-debuginfo-8.9.4-2.el7.ppc64le.rpm
 
-
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,17 +1,9 @@
 FROM ubuntu:18.04
 
-VOLUME /shared
-
 # Installing necessary packages
 RUN apt-get update && \
     apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
     curl perl binutils zip libssl1.1 libssl-dev
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxvf cmake-3.18.3.tar.gz && \
-    cd cmake-3.18.3 && \
-    ./bootstrap && make -j$(nproc) && make install && \
-    ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
 
 ADD entrypoint.sh /
 

--- a/wpk/linux/x86_64/CentOS-Base.repo
+++ b/wpk/linux/x86_64/CentOS-Base.repo
@@ -1,0 +1,54 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/contrib/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# SCLO - packages
+[centos-sclo-sclo]
+name=CentOS-$releasever - SCLO
+baseurl=http://mirror.nsc.liu.se/centos-store/6.10/sclo/$basearch/rh/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -17,24 +17,6 @@ RUN yum -y install centos-release-scl epel-release && \
 RUN mv /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo.old
 RUN yum-builddep python34 -y
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
-    ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
-    make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
-
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
-
-RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
-    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
-    make -j$(nproc) && make install && cd / && rm -rf cmake-*
-
 RUN curl -OL http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     tar xf openssl-1.1.1a.tar.gz && cd openssl-1.1.1a && \
     ./config --prefix=/usr/ --openssldir=/usr/ shared zlib && \

--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -1,8 +1,11 @@
 FROM centos:6
 
-RUN yum -y install centos-release-scl epel-release && \
+RUN rm /etc/yum.repos.d/* && echo "exactarch=1" >> /etc/yum.conf
+COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+
+RUN yum -y install epel-release && \
     yum -y install gcc make git python34 python34-pip python34-devel python34-cffi \
-    jq centos-release-scl sudo gnupg automake \
+    jq sudo gnupg automake \
     autoconf wget libtool policycoreutils-python \
     yum-utils epel-release redhat-rpm-config rpm-devel \
     autopoint gettext nspr nspr-devel \
@@ -14,7 +17,6 @@ RUN yum -y install centos-release-scl epel-release && \
     libarchive-devel elfutils-libelf-devel \
     elfutils-libelf patchelf elfutils-devel libgcrypt-devel
 
-RUN mv /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo.old
 RUN yum-builddep python34 -y
 
 RUN curl -OL http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \

--- a/wpk/windows/Dockerfile
+++ b/wpk/windows/Dockerfile
@@ -1,14 +1,8 @@
 FROM debian:9
 
 RUN apt-get update && \
-    apt-get -y install \
-      python \
-      git \
-      curl \
-      jq && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    pip install --upgrade cryptography awscli
+    apt-get -y install python git curl jq python3 python3-pip && \
+    pip3 install --upgrade cryptography==2.9.2 awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run


### PR DESCRIPTION
Hi team,

Adding cmake and bumping GCC to newer versions need more testing. Some errors have been reported in CentOS 5 and to avoid any possible errors, we will roll back to the previous version and keep testing in elder OS.

Regards.