### PR TITLE
Update 4.2.0 SPECS files to rename and remove old wazuh tools

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -145,7 +145,7 @@ case "$1" in
             elif command -v service > /dev/null 2>&1 ; then
                 service wazuh-agent restart > /dev/null 2>&1
             else
-                ${DIR}/bin/ossec-control restart > /dev/null 2>&1
+                ${DIR}/bin/wazuh-control restart > /dev/null 2>&1
             fi
         fi
     fi

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/preinst
@@ -25,8 +25,8 @@ case "$1" in
             elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 service wazuh-agent stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
-            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
-                ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+            elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
         fi

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/prerm
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/prerm
@@ -20,7 +20,7 @@ case "$1" in
       elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
           service wazuh-agent stop > /dev/null 2>&1
       else
-          ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+          ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
 
       # Save the conffiles
@@ -49,8 +49,8 @@ case "$1" in
     ;;
 
     failed-upgrade)
-      if [ -f ${DIR}/bin/ossec-control ]; then
-        ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+      if [ -f ${DIR}/bin/wazuh-control ]; then
+        ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
     ;;
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -234,7 +234,7 @@ case "$1" in
             elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
                 service wazuh-manager restart > /dev/null 2>&1
             else
-                ${DIR}/bin/ossec-control restart /dev/null 2>&1
+                ${DIR}/bin/wazuh-control restart /dev/null 2>&1
             fi
         fi
     fi

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
@@ -27,8 +27,8 @@ case "$1" in
             elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 service wazuh-manager stop
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
-            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
-                ${DIR}/ossec-control stop > /dev/null 2>&1
+            elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/prerm
@@ -18,7 +18,7 @@ case "$1" in
       elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
           service wazuh-manager stop > /dev/null 2>&1
       else
-          ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+          ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
 
       # Purging files
@@ -70,8 +70,8 @@ case "$1" in
     ;;
 
     failed-upgrade)
-      if [ -f ${DIR}/bin/ossec-control ]; then
-	       ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+      if [ -f ${DIR}/bin/wazuh-control ]; then
+	       ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
     ;;
 

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -117,6 +117,5 @@ ${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh
 rm -rf ${DIR}/packages_files
 
 if ${upgrade} && ${restart}; then
-    ${DIR}/bin/ossec-control restart
+    ${DIR}/bin/wazuh-control restart
 fi
-

--- a/macos/package_files/4.2.0/preinstall.sh
+++ b/macos/package_files/4.2.0/preinstall.sh
@@ -15,7 +15,7 @@ if [ ! -d ${DIR} ]; then
     launchctl setenv WAZUH_PKG_UPGRADE false
 else
     launchctl setenv WAZUH_PKG_UPGRADE true
-    if ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
+    if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
         launchctl setenv WAZUH_RESTART true
     else
         launchctl setenv WAZUH_RESTART false
@@ -80,8 +80,8 @@ if [[ ${new_uid} != ${new_gid} ]]
 fi
 
 # Stops the agent before upgrading it
-if [ -f ${DIR}/bin/ossec-control ]; then
-    ${DIR}/bin/ossec-control stop
+if [ -f ${DIR}/bin/wazuh-control ]; then
+    ${DIR}/bin/wazuh-control stop
 fi
 
 # Creating the group
@@ -150,15 +150,15 @@ fi
 
 StartService ()
 {
-        ${DIRECTORY}/bin/ossec-control start
+        ${DIRECTORY}/bin/wazuh-control start
 }
 StopService ()
 {
-        ${DIRECTORY}/bin/ossec-control stop
+        ${DIRECTORY}/bin/wazuh-control stop
 }
 RestartService ()
 {
-        ${DIRECTORY}/bin/ossec-control restart
+        ${DIRECTORY}/bin/wazuh-control restart
 }
 RunService "$1"
 EOF
@@ -204,12 +204,12 @@ if [ "X${DIRECTORY}" = "X" ]; then
 fi
 
 capture_sigterm() {
-    ${DIRECTORY}/bin/ossec-control stop
+    ${DIRECTORY}/bin/wazuh-control stop
     exit $?
 }
 
-if ! ${DIRECTORY}/bin/ossec-control start; then
-    ${DIRECTORY}/bin/ossec-control stop
+if ! ${DIRECTORY}/bin/wazuh-control start; then
+    ${DIRECTORY}/bin/wazuh-control stop
 fi
 
 while : ; do

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -198,8 +198,8 @@ if [ $1 = 2 ]; then
   elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     service wazuh-agent stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
-  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+  elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
@@ -353,7 +353,7 @@ if [ $1 = 0 ]; then
   elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
     service wazuh-agent stop > /dev/null 2>&1
   else # Anything else
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
   fi
 
   # Check for systemd
@@ -429,7 +429,7 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
     service wazuh-agent restart > /dev/null 2>&1
   else
-    %{_localstatedir}/bin/ossec-control restart > /dev/null 2>&1
+    %{_localstatedir}/bin/wazuh-control restart > /dev/null 2>&1
   fi
 fi
 
@@ -704,6 +704,6 @@ rm -fr %{buildroot}
 - Fixed compile errors on macOS.
 - Fixed option -V for Integrator.
 - Exclude symbolic links to directories when sending FIM diffs (by Stephan Joerrens).
-- Fixed daemon list for service reloading at ossec-control.
+- Fixed daemon list for service reloading at wazuh-control.
 - Fixed socket waiting issue on Windows agents.
 - Fixed PCI_DSS definitions grouping issue at Rootcheck controls.

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -562,7 +562,6 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/ossec-reportd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-syscheckd
 %attr(750, root, ossec) %{_localstatedir}/bin/update_ruleset
-%attr(750, root, root) %{_localstatedir}/bin/util.sh
 %attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-apid
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-clusterd
@@ -581,9 +580,7 @@ rm -fr %{buildroot}
 %dir %attr(770, ossec, ossec) %{_localstatedir}/etc/lists/amazon
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/amazon/*
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys.cdb
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel.cdb
 %dir %attr(770, root, ossec) %{_localstatedir}/etc/shared
 %dir %attr(770, ossec, ossec) %{_localstatedir}/etc/shared/default
 %attr(660, ossec, ossec) %{_localstatedir}/etc/shared/agent-template.conf

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -555,9 +555,9 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/ossec-integratord
 %attr(750, root, root) %{_localstatedir}/bin/ossec-logcollector
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/ossec-maild
 %attr(750, root, root) %{_localstatedir}/bin/ossec-monitord
+%attr(750, root, root) %{_localstatedir}/bin/wazuh-regex
 %attr(750, root, root) %{_localstatedir}/bin/ossec-remoted
 %attr(750, root, root) %{_localstatedir}/bin/ossec-reportd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-syscheckd

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -191,8 +191,8 @@ if [ $1 = 2 ]; then
   elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     service wazuh-manager stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
-  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+  elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
@@ -421,7 +421,7 @@ if [ $1 = 0 ]; then
   elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
     service wazuh-manager stop > /dev/null 2>&1
   else # Anything else
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
   fi
 
   # Check for systemd
@@ -505,7 +505,7 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   elif command -v service > /dev/null 2>&1 ; then
     service wazuh-manager restart > /dev/null 2>&1
   else
-    %{_localstatedir}/bin/ossec-control restart > /dev/null 2>&1
+    %{_localstatedir}/bin/wazuh-control restart > /dev/null 2>&1
   fi
 fi
 
@@ -548,24 +548,19 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/ossec-agentlessd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-analysisd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-authd
-%attr(750, root, root) %{_localstatedir}/bin/ossec-control
+%attr(750, root, root) %{_localstatedir}/bin/wazuh-control
 %attr(750, root, root) %{_localstatedir}/bin/ossec-csyslogd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-dbd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-execd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-integratord
 %attr(750, root, root) %{_localstatedir}/bin/ossec-logcollector
-%attr(750, root, root) %{_localstatedir}/bin/ossec-logtest
+%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/ossec-maild
-%attr(750, root, root) %{_localstatedir}/bin/ossec-makelists
 %attr(750, root, root) %{_localstatedir}/bin/ossec-monitord
-%attr(750, root, root) %{_localstatedir}/bin/ossec-regex
 %attr(750, root, root) %{_localstatedir}/bin/ossec-remoted
 %attr(750, root, root) %{_localstatedir}/bin/ossec-reportd
 %attr(750, root, root) %{_localstatedir}/bin/ossec-syscheckd
-%attr(750, root, root) %{_localstatedir}/bin/rootcheck_control
-%attr(750, root, root) %{_localstatedir}/bin/syscheck_control
-%attr(750, root, root) %{_localstatedir}/bin/syscheck_update
 %attr(750, root, ossec) %{_localstatedir}/bin/update_ruleset
 %attr(750, root, root) %{_localstatedir}/bin/util.sh
 %attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
 # preremove script for wazuh-agent
 
-/var/ossec/bin/ossec-control stop
+OSSEC_INIT="/etc/ossec-init.conf"
+control_binary="wazuh-control"
+
+set_control_binary() {
+  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
+  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
+  major=`echo $number_version | cut -d . -f 1`
+  minor=`echo $number_version | cut -d . -f 2`
+
+  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+    control_binary="ossec-control"
+  fi
+}
+
+set_control_binary
+
+/var/ossec/bin/${control_binary} stop

--- a/solaris/solaris10/solaris10_patch.sh
+++ b/solaris/solaris10/solaris10_patch.sh
@@ -34,7 +34,7 @@ sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/wazuh/wazuh.sh > ./src/init/wa
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/dist-detect.sh > ./src/init/dist-detect.sh.new && mv ./src/init/dist-detect.sh.new ./src/init/dist-detect.sh && chmod +x ./src/init/dist-detect.sh
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/shared.sh > ./src/init/shared.sh.new && mv ./src/init/shared.sh.new ./src/init/shared.sh && chmod +x ./src/init/shared.sh
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/ossec-local.sh > ./src/init/ossec-local.sh.new && mv ./src/init/ossec-local.sh.new ./src/init/ossec-local.sh && chmod +x ./src/init/ossec-local.sh
-sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/ossec-client.sh > ./src/init/ossec-client.sh.new && mv ./src/init/ossec-client.sh.new ./src/init/ossec-client.sh && chmod +x ./src/init/ossec-client.sh
+sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/wazuh-client.sh > ./src/init/wazuh-client.sh.new && mv ./src/init/wazuh-client.sh.new ./src/init/wazuh-client.sh && chmod +x ./src/init/wazuh-client.sh
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/osx105-addusers.sh > ./src/init/osx105-addusers.sh.new && mv ./src/init/osx105-addusers.sh.new ./src/init/osx105-addusers.sh && chmod +x ./src/init/osx105-addusers.sh
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/fw-check.sh > ./src/init/fw-check.sh.new && mv ./src/init/fw-check.sh.new ./src/init/fw-check.sh && chmod +x ./src/init/fw-check.sh
 sed "s:#!/bin/sh:#!/usr/xpg4/bin/sh:g" ./src/init/adduser.sh > ./src/init/adduser.sh.new && mv ./src/init/adduser.sh.new ./src/init/adduser.sh && chmod +x ./src/init/adduser.sh

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -1,9 +1,25 @@
 #/bin/sh
 
+OSSEC_INIT="/etc/ossec-init.conf"
+control_binary="wazuh-control"
+
+set_control_binary() {
+  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
+  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
+  major=`echo $number_version | cut -d . -f 1`
+  minor=`echo $number_version | cut -d . -f 2`
+
+  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+    control_binary="ossec-control"
+  fi
+}
+
+set_control_binary
+
 ## Stop and remove application
-/var/ossec/bin/ossec-control stop 2> /dev/null
+/var/ossec/bin/${control_binary} 2> /dev/null
 rm -rf /var/ossec/
-rm -f /etc/ossec-init.conf
+rm -f ${OSSEC_INIT}
 
 
 ## stop and unload dispatcher
@@ -11,7 +27,7 @@ rm -f /etc/ossec-init.conf
 
 # remove launchdaemons
 rm -f /etc/init.d/wazuh-agent
-rm -f /etc/ossec-init.conf
+rm -f ${OSSEC_INIT}
 
 rm -rf /etc/rc2.d/S97wazuh-agent
 rm -rf /etc/rc3.d/S97wazuh-agent

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -27,8 +27,6 @@ rm -f ${OSSEC_INIT}
 
 # remove launchdaemons
 rm -f /etc/init.d/wazuh-agent
-rm -f ${OSSEC_INIT}
-
 rm -rf /etc/rc2.d/S97wazuh-agent
 rm -rf /etc/rc3.d/S97wazuh-agent
 

--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -311,7 +311,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/bin/ossec-control": {
+    "/var/ossec/bin/wazuh-control": {
         "class": "static",
         "group": "root",
         "mode": "0750",

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -22,9 +22,7 @@ sudo rm -r /var/ossec*
 sudo rm ${OSSEC_INIT}
 
 # remove launchdaemons
-sudo rm -f ${OSSEC_INIT}/wazuh-agent
-
-sudo rm -f ${OSSEC_INIT}
+sudo rm -f /etc/init.d/wazuh-agent
 
 ## Remove User and Groups
 sudo userdel ossec

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -1,16 +1,30 @@
 #/bin/sh
 
+OSSEC_INIT="/etc/ossec-init.conf"
+control_binary="wazuh-control"
+
+set_control_binary() {
+  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
+  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
+  major=`echo $number_version | cut -d . -f 1`
+  minor=`echo $number_version | cut -d . -f 2`
+
+  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+    control_binary="ossec-control"
+  fi
+}
+
+set_control_binary
+
 ## Stop and remove application
-sudo /var/ossec/bin/ossec-control stop
+sudo /var/ossec/bin/${control_binary} stop
 sudo rm -r /var/ossec*
-sudo rm /etc/ossec-init.conf
+sudo rm ${OSSEC_INIT}
 
 # remove launchdaemons
-sudo rm -f /etc/init.d/wazuh-agent
+sudo rm -f ${OSSEC_INIT}/wazuh-agent
 
-
-sudo rm -f /etc/ossec-init.conf
-
+sudo rm -f ${OSSEC_INIT}
 
 ## Remove User and Groups
 sudo userdel ossec


### PR DESCRIPTION
|Related issue|
|---|
|#547|

## Description

Hello team,

This PR makes the following changes in `4.2.0` SPECS:

**Renamed**
- `ossec-control` -> `wazuh-control`
- `ossec-regex` -> `wazuh-regex`
- `ossec-logtest` -> `wazuh-logtest`

**Removed**
- `rootcheck_control` 
- `syscheck_control` 
- `syscheck_update`
- `ossec-makelists`

## Tests

- Manager RPM: https://devel.ci.wazuh.info/job/Packages_builder/5832/
- Agent RPM: https://devel.ci.wazuh.info/job/Packages_builder/5835/
- Manager DEB: https://devel.ci.wazuh.info/job/Packages_builder/5833/
- Agent DEB: https://devel.ci.wazuh.info/job/Packages_builder/5834/
- Agent macOS: https://ci.wazuh.info/job/Packages_builder_macos/278/
- Agent Solaris 10: https://ci.wazuh.info/job/Packages_builder_solaris/7163/
- Agent Solaris 11: https://ci.wazuh.info/job/Packages_builder_solaris/7179/

Best regards.