### PR TITLE
Updating packages generation scripts with the the new ruleset folder location

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -121,7 +121,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/windows
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sunos/5/11
 
-	cp -r etc/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r ruleset/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
 
 	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -138,7 +138,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/windows
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sunos/5/11
 
-	cp -r etc/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r ruleset/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
 
 	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -122,7 +122,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/16/04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/windows
 
-	cp -r etc/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r ruleset/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
 
 	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -139,7 +139,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/16/04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/windows
 
-	cp -r etc/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
+	cp -r ruleset/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
 
 	cp etc/templates/config/generic/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/generic

--- a/macos/package_files/4.2.0/build.sh
+++ b/macos/package_files/4.2.0/build.sh
@@ -62,8 +62,8 @@ function build() {
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/generic
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/{15,16,17,18}
 
-    cp -r ${SOURCES_PATH}/etc/sca/darwin ${INSTALLATION_SCRIPTS_DIR}/sca
-    cp -r ${SOURCES_PATH}/etc/sca/generic ${INSTALLATION_SCRIPTS_DIR}/sca
+    cp -r ${SOURCES_PATH}/ruleset/sca/darwin ${INSTALLATION_SCRIPTS_DIR}/sca
+    cp -r ${SOURCES_PATH}/ruleset/sca/generic ${INSTALLATION_SCRIPTS_DIR}/sca
     cp ${SOURCES_PATH}/etc/templates/config/generic/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/generic/
     cp ${SOURCES_PATH}/etc/templates/config/darwin/15/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/15/
     cp ${SOURCES_PATH}/etc/templates/config/darwin/16/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/16/

--- a/macos/package_files/5.0.0/build.sh
+++ b/macos/package_files/5.0.0/build.sh
@@ -62,8 +62,8 @@ function build() {
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/generic
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/{15,16,17,18}
 
-    cp -r ${SOURCES_PATH}/etc/sca/darwin ${INSTALLATION_SCRIPTS_DIR}/sca
-    cp -r ${SOURCES_PATH}/etc/sca/generic ${INSTALLATION_SCRIPTS_DIR}/sca
+    cp -r ${SOURCES_PATH}/ruleset/sca/darwin ${INSTALLATION_SCRIPTS_DIR}/sca
+    cp -r ${SOURCES_PATH}/ruleset/sca/generic ${INSTALLATION_SCRIPTS_DIR}/sca
     cp ${SOURCES_PATH}/etc/templates/config/generic/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/generic/
     cp ${SOURCES_PATH}/etc/templates/config/darwin/15/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/15/
     cp ${SOURCES_PATH}/etc/templates/config/darwin/16/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/16/

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -103,7 +103,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
 
-cp -r etc/sca/{applications,generic,centos,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{applications,generic,centos,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -114,7 +114,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
 
-cp -r etc/sca/{applications,generic,centos,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{applications,generic,centos,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/{sca.files,sca.manager.files} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -103,7 +103,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
 
-cp -r etc/sca/{applications,generic,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{applications,generic,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -112,7 +112,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
 
-cp -r etc/sca/{applications,generic,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{applications,generic,darwin,debian,rhel,sles,sunos,windows} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/{sca.files,sca.manager.files} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 


### PR DESCRIPTION
|Related issue|
|---|
|566|


## Description

This PR updates the `.specs` files to generate packages with the new location of the following ruleset components:
- **SCA**

Closes #566 
## Tests

The following tests were performed manually, the rest of the operative systems supported are being tested in the Jenkins pipelines of the PR [6907](https://github.com/wazuh/wazuh/pull/6907) in the `wazuh/wazuh` repository 

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
- [x] Package installation
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
- Tests for Linux deb
  - [x] Build the package for x86_64
