### PR TITLE
Remove ruleset version file from specs

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -664,7 +664,6 @@ rm -fr %{buildroot}
 %attr(0440, root, ossec) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%attr(640, root, ossec) %{_localstatedir}/ruleset/VERSION
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/decoders
 %attr(640, root, ossec) %{_localstatedir}/ruleset/decoders/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/rules

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -657,7 +657,6 @@ rm -fr %{buildroot}
 %attr(0440, root, ossec) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%attr(640, root, ossec) %{_localstatedir}/ruleset/VERSION
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/decoders
 %attr(640, root, ossec) %{_localstatedir}/ruleset/decoders/*
 %dir %attr(750, root, ossec) %{_localstatedir}/ruleset/rules


### PR DESCRIPTION
|Related issue|
|---|
|#565|

## Description
This PR updates the manager 4.2.0 and 5.0.0 SPEC files to contemplate the removal of the ruleset version file


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  
  
Closes #565 
