### PR TITLE
Remove obsolete update_ruleset from 4.2 and 5.0 spec files

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -566,7 +566,6 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/rootcheck_control
 %attr(750, root, root) %{_localstatedir}/bin/syscheck_control
 %attr(750, root, root) %{_localstatedir}/bin/syscheck_update
-%attr(750, root, ossec) %{_localstatedir}/bin/update_ruleset
 %attr(750, root, root) %{_localstatedir}/bin/util.sh
 %attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-apid

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -559,7 +559,6 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/rootcheck_control
 %attr(750, root, root) %{_localstatedir}/bin/syscheck_control
 %attr(750, root, root) %{_localstatedir}/bin/syscheck_update
-%attr(750, root, ossec) %{_localstatedir}/bin/update_ruleset
 %attr(750, root, root) %{_localstatedir}/bin/util.sh
 %attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-apid


### PR DESCRIPTION
|Related issue|
|---|
|#574|

## Description
This PR eliminates update_ruleset from the spec files of 4.2 and 5.0 because is now obsolete.
