### PR TITLE
Fix Solaris 10 Sparc SSL issues

### DIFF
--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -176,7 +176,7 @@ compute_version_revision()
 
 clone(){
     cd ${CURRENT_PATH}
-    git clone $REPOSITORY ${SOURCE} || return 1
+    GIT_SSL_NO_VERIFY=true git clone $REPOSITORY ${SOURCE} || return 1
     cd $SOURCE
     git checkout $wazuh_branch
     cp ${CURRENT_PATH}/solaris10_patch.sh ${CURRENT_PATH}/wazuh

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -140,7 +140,7 @@ installation(){
     gmake clean
     check_version
     if [ "$deps_version" = "true" ]; then
-        gmake deps
+        gmake deps RESOURCES_URL=http://packages.wazuh.com
     fi
     arch="$(uname -p)"
     # Build the binaries

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -179,7 +179,6 @@ clone(){
     GIT_SSL_NO_VERIFY=true git clone $REPOSITORY ${SOURCE} || return 1
     cd $SOURCE
     git checkout $wazuh_branch
-    cp ${CURRENT_PATH}/solaris10_patch.sh ${CURRENT_PATH}/wazuh
     compute_version_revision
 
     return 0
@@ -259,7 +258,6 @@ build(){
 
     groupadd ossec
     useradd -g ossec ossec
-    chmod +x $SOURCE/solaris10_patch.sh
     installation
     package
 }

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -20,6 +20,7 @@ SOURCE=${CURRENT_PATH}/repository
 CONFIG="$SOURCE/etc/preloaded-vars.conf"
 target_dir="${CURRENT_PATH}/output"
 control_binary=""
+short_version=""
 
 trap ctrl_c INT
 
@@ -129,6 +130,7 @@ check_version(){
     elif [ "$major" -gt 3 ]; then
         deps_version="true"
     fi
+    short_version="${major}.${minor}"
 }
 
 installation(){
@@ -140,7 +142,7 @@ installation(){
     gmake clean
     check_version
     if [ "$deps_version" = "true" ]; then
-        gmake deps RESOURCES_URL=http://packages.wazuh.com
+        gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/${short_version}
     fi
     arch="$(uname -p)"
     # Build the binaries


### PR DESCRIPTION
|Related issue|
|---|
| Closes #581 |

## Description

Hello team,

We have applied little fixes to get Solaris 10 package generation fully working.
We have removed all `solaris10_patch.sh` file references.
Added `RESOURCES_URL` parameter in deps compilation.

## Logs example
```
...
11:39:57  /export/home/jeijpn/solaris/wazuh-agent/install/checkinstall
11:39:57  /export/home/jeijpn/solaris/wazuh-agent/install/postinstall
11:39:57  /export/home/jeijpn/solaris/wazuh-agent/install/postremove
11:39:57  /export/home/jeijpn/solaris/wazuh-agent/install/preinstall
11:39:57  /export/home/jeijpn/solaris/wazuh-agent/install/preremove
11:39:57  ## Validating control scripts.
11:39:57  ## Packaging complete.
11:39:57  Transferring <wazuh-agent> package instance
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Solaris
