### PR TITLE
Fix SSL error (date) and preremove script

### DIFF
--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -142,7 +142,7 @@ installation(){
     gmake clean
     check_version
     if [ "$deps_version" = "true" ]; then
-        gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/${short_version}
+        gmake deps
     fi
     arch="$(uname -p)"
     # Build the binaries
@@ -178,7 +178,7 @@ compute_version_revision()
 
 clone(){
     cd ${CURRENT_PATH}
-    GIT_SSL_NO_VERIFY=true git clone $REPOSITORY ${SOURCE} || return 1
+    git clone $REPOSITORY ${SOURCE} || return 1
     cd $SOURCE
     git checkout $wazuh_branch
     compute_version_revision

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -4,9 +4,10 @@
 OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
+. /etc/ossec-init.conf
+
 set_control_binary() {
-  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
+  number_version=`echo "${VERSION}" | cut -d v -f 2`
   major=`echo $number_version | cut -d . -f 1`
   minor=`echo $number_version | cut -d . -f 2`
 

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -4,7 +4,7 @@
 OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
-. /etc/ossec-init.conf
+. ${OSSEC_INIT}
 
 set_control_binary() {
   number_version=`echo "${VERSION}" | cut -d v -f 2`


### PR DESCRIPTION
|Related issue|
|---|
| Closes #583 |

## Description

Hello team,

We have added a fix on Solaris 10 preremove script that left some files inside the installation path.


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Solaris
- [x] Package installation
- [x] Package upgrade
- [x] Package remove

- Tests for Solaris
  - [x] Test the package on Solaris 10

Regards!