### PR TITLE
Remove legacy .template.db in upgrades

### DIFF
--- a/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
@@ -71,6 +71,7 @@ case "$1" in
     if [ -f ${DIR}/var/db/global.db ]; then
         mv ${DIR}/var/db/global.db ${DIR}/queue/db/
         rm -f ${DIR}/var/db/global.db* || true
+        rm -f ${DIR}/var/db/.template.db || true
     fi
 
     if [ -f ${DIR}/queue/db/global.db ]; then

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -71,6 +71,7 @@ case "$1" in
     if [ -f ${DIR}/var/db/global.db ]; then
         mv ${DIR}/var/db/global.db ${DIR}/queue/db/
         rm -f ${DIR}/var/db/global.db* || true
+        rm -f ${DIR}/var/db/.template.db || true
     fi
 
     if [ -f ${DIR}/queue/db/global.db ]; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -71,6 +71,7 @@ case "$1" in
     if [ -f ${DIR}/var/db/global.db ]; then
         mv ${DIR}/var/db/global.db ${DIR}/queue/db/
         rm -f ${DIR}/var/db/global.db* || true
+        rm -f ${DIR}/var/db/.template.db || true
     fi
 
     if [ -f ${DIR}/queue/db/global.db ]; then

--- a/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
@@ -218,6 +218,7 @@ rm -f %{_localstatedir}/var/db/agents/* || true
 if [ -f %{_localstatedir}/var/db/global.db ]; then
   mv %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
   rm -f %{_localstatedir}/var/db/global.db* || true
+  rm -f %{_localstatedir}/var/db/.template.db || true
 fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -218,6 +218,7 @@ rm -f %{_localstatedir}/var/db/agents/* || true
 if [ -f %{_localstatedir}/var/db/global.db ]; then
   mv %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
   rm -f %{_localstatedir}/var/db/global.db* || true
+  rm -f %{_localstatedir}/var/db/.template.db || true
 fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -218,6 +218,7 @@ rm -f %{_localstatedir}/var/db/agents/* || true
 if [ -f %{_localstatedir}/var/db/global.db ]; then
   mv %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
   rm -f %{_localstatedir}/var/db/global.db* || true
+  rm -f %{_localstatedir}/var/db/.template.db || true
 fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then


### PR DESCRIPTION
Hi team,
This PR removes the file `/var/ossec/var/db/.template.db ` from SPECS manager files of Wazuh >= 4.1.0.
This file 
Tests:
- Generated amd/rpm packages with custom revision:
  -  https://devel.ci.wazuh.info/job/Packages_builder/5917/
  -  https://devel.ci.wazuh.info/job/Packages_builder/5919/
  -  https://devel.ci.wazuh.info/job/Packages_builder/5920/
  -  https://devel.ci.wazuh.info/job/Packages_builder/5921/
- Test_upgrade_tier with those packages: 
  - https://devel.ci.wazuh.info/job/Test_upgrade_tier/1456/
  
  Reggards.
