### PR TITLE
Fix: ossec group privilege for wazuh-logtest

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -562,7 +562,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-execd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
-%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest
+%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-maild
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-monitord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-regex


### PR DESCRIPTION
|Related issue|
|---|
| closes #542 |

## Description

Hello team,

This PR aims to fix  wazuh-logtest group privilege from `root` to `ossec` in RPM SPECS for 4.2.0

## Tests

- Build the package in any supported platform
- [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64

Regards.