### PR TITLE
Fix solaris11: state and pid files for wazuh daemons renaming

### DIFF
--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -1289,7 +1289,7 @@
         "type": "file",
         "user": "ossec"
     },
-    "/var/ossec/var/run/ossec-agentd.state": {
+    "/var/ossec/var/run/wazuh-agentd.state": {
         "class": "static",
         "group": "ossec",
         "mode": "0644",
@@ -1297,7 +1297,7 @@
         "type": "file",
         "user": "ossec"
     },
-    "/var/ossec/var/run/ossec-agentd-*.pid": {
+    "/var/ossec/var/run/wazuh-agentd-*.pid": {
         "class": "dynamic",
         "group": "ossec",
         "mode": "0640",
@@ -1305,7 +1305,7 @@
         "type": "file",
         "user": "ossec"
     },
-    "/var/ossec/var/run/ossec-execd-*.pid": {
+    "/var/ossec/var/run/wazuh-execd-*.pid": {
         "class": "dynamic",
         "group": "ossec",
         "mode": "0640",
@@ -1313,7 +1313,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/var/run/ossec-logcollector-*.pid": {
+    "/var/ossec/var/run/wazuh-logcollector-*.pid": {
         "class": "dynamic",
         "group": "ossec",
         "mode": "0640",
@@ -1321,7 +1321,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/var/run/ossec-syscheckd-*.pid": {
+    "/var/ossec/var/run/wazuh-syscheckd-*.pid": {
         "class": "dynamic",
         "group": "ossec",
         "mode": "0640",


### PR DESCRIPTION
|Related issue|
|---|
| #562  |

## Description

Hi team,

This PR aims to close #562 reopening by fixing `pid` and `state` files changed by the renaming of binaries.

## Logs example

NA
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Solaris
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

Regards,
Nico