### PR TITLE
Fixed HPUX checksum generation

### DIFF
--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -139,7 +139,7 @@ create_package() {
 
   if [ "${compute_checksums}" = "yes" ]; then
     cd ${target_dir}
-    pkg_checksum="$(openssl dgst -sha512 ${pkg_name} | cut -d'=' -f "2" | cut -b 2-)"
+    pkg_checksum="$(openssl dgst -sha512 ${pkg_name} | cut -d' ' -f "2")"
     echo "${pkg_checksum}  ${pkg_name}" > ${checksum_dir}/${pkg_name}.sha512
   fi
 }

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -139,7 +139,7 @@ create_package() {
 
   if [ "${compute_checksums}" = "yes" ]; then
     cd ${target_dir}
-    pkg_checksum="$(openssl dgst -sha512 ${pkg_name})"
+    pkg_checksum="$(openssl dgst -sha512 ${pkg_name} | cut -d'=' -f "2" | cut -b 2-)"
     echo "${pkg_checksum}  ${pkg_name}" > ${checksum_dir}/${pkg_name}.sha512
   fi
 }


### PR DESCRIPTION
|Related issue|
|---|
|#589|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #589 by fixing the checksum's file generation by parsing the output of the `openssl` command and unify it with the rest of the checksums' files generated by the scripts.
https://ci.wazuh.info/job/Packages_builder_special/146/console

## Logs example

```shellsession
# ./generate_wazuh_packages.sh -b v4.1.0-rc1 -c checksum
....
# cat wazuh-agent-4.1.0-1-hpux-11v3-ia64.tar.sha512
b554bfdd6294c5cf38c04987e7d8063d2577d6b317317f9cae975e295ba358205e70880accba245b921bf43880110094e34ad4dddad490ef8254812da8d9dbac  wazuh-agent-4.1.0-1-hpux-11v3-ia64.tar
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] HP-UX