### PR TITLE
Backup api.yaml configuration file to restore it when upgrading

### DIFF
--- a/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/postinst
@@ -154,6 +154,12 @@ case "$1" in
         rm -rf ${WAZUH_TMP_DIR}/rbac.db
     fi
 
+    # Restore API configuration file
+    if [ -f ${WAZUH_TMP_DIR}/api.yaml ]; then
+        cp -fp ${WAZUH_TMP_DIR}/api.yaml ${DIR}/api/configuration/api.yaml
+        rm -rf ${WAZUH_TMP_DIR}/api.yaml
+    fi
+
     # More files
     touch ${DIR}/etc/client.keys
 

--- a/debs/SPECS/4.1.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.1.0/wazuh-manager/debian/preinst
@@ -64,9 +64,14 @@ case "$1" in
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
-        # RBAC database
-        if [ "$1" = "upgrade" ] && [ -f ${DIR}/api/configuration/security/rbac.db ]; then
-            cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+        # RBAC database and API configuration file
+        if [ "$1" = "upgrade" ]; then
+            if [ -f ${DIR}/api/configuration/security/rbac.db ]; then
+                cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+            fi
+            if [ -f ${DIR}/api/configuration/api.yaml ]; then
+                cp -fp ${DIR}/api/configuration/api.yaml ${WAZUH_TMP_DIR}/api.yaml
+            fi
         fi
 
         # Delete old service

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -154,6 +154,12 @@ case "$1" in
         rm -rf ${WAZUH_TMP_DIR}/rbac.db
     fi
 
+    # Restore API configuration file
+    if [ -f ${WAZUH_TMP_DIR}/api.yaml ]; then
+        cp -fp ${WAZUH_TMP_DIR}/api.yaml ${DIR}/api/configuration/api.yaml
+        rm -rf ${WAZUH_TMP_DIR}/api.yaml
+    fi
+
     # More files
     touch ${DIR}/etc/client.keys
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
@@ -64,9 +64,14 @@ case "$1" in
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
-        # RBAC database
-        if [ "$1" = "upgrade" ] && [ -f ${DIR}/api/configuration/security/rbac.db ]; then
-            cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+        # RBAC database and API configuration file
+        if [ "$1" = "upgrade" ]; then
+            if [ -f ${DIR}/api/configuration/security/rbac.db ]; then
+                cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+            fi
+            if [ -f ${DIR}/api/configuration/api.yaml ]; then
+                cp -fp ${DIR}/api/configuration/api.yaml ${WAZUH_TMP_DIR}/api.yaml
+            fi
         fi
 
         # Delete old service

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -153,6 +153,12 @@ case "$1" in
         rm -rf ${WAZUH_TMP_DIR}/rbac.db
     fi
 
+    # Restore API configuration file
+    if [ -f ${WAZUH_TMP_DIR}/api.yaml ]; then
+        cp -fp ${WAZUH_TMP_DIR}/api.yaml ${DIR}/api/configuration/api.yaml
+        rm -rf ${WAZUH_TMP_DIR}/api.yaml
+    fi
+
     # More files
     touch ${DIR}/etc/client.keys
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
@@ -64,9 +64,14 @@ case "$1" in
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
-        # RBAC database
-        if [ "$1" = "upgrade" ] && [ -f ${DIR}/api/configuration/security/rbac.db ]; then
-            cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+        # RBAC database and API configuration file
+        if [ "$1" = "upgrade" ]; then
+            if [ -f ${DIR}/api/configuration/security/rbac.db ]; then
+                cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
+            fi
+            if [ -f ${DIR}/api/configuration/api.yaml ]; then
+                cp -fp ${DIR}/api/configuration/api.yaml ${WAZUH_TMP_DIR}/api.yaml
+            fi
         fi
 
         # Delete old service


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/591|

## Description
Hi team,
This PR adds the preservation of the `api.yaml` file after upgrading to the debs SPECS from 4.1.0. Before this PR the `api.yaml `file was overwritten by the upgrade.

## Tests
- Built custom package with custom branch with fix: https://ci.wazuh.info/view/Packages/job/Packages_builder/30350
- Installed Wazuh manager 4.0.3.
- Edit `/var/ossec/api/configuration/api.yaml` and upgrade to custom built package.
- File `/var/ossec/api/configuration/api.yaml` is not overwritten.

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux https://ci.wazuh.info/view/Packages/job/Packages_builder/30350/console
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [X] Build the package for x86_64 https://ci.wazuh.info/view/Packages/job/Packages_builder/30350/console
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [X] Package install/remove/install
  - [X] Package install/purge/install
  - [ ] Check file permissions after installing the package

