### PR TITLE
Add wazuh-logcollector.state to solaris SPECS

### DIFF
--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -1321,6 +1321,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/var/run/wazuh-logcollector.state": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0644",
+        "prot": "-rw-r--r--",
+        "type": "file",
+        "user": "ossec"
+    },
     "/var/ossec/var/run/wazuh-syscheckd-*.pid": {
         "class": "dynamic",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -1313,6 +1313,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/var/run/wazuh-logcollector.state": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0644",
+        "prot": "-rw-r--r--",
+        "type": "file",
+        "user": "ossec"
+    },
     "/var/ossec/var/run/ossec-syscheckd-*.pid": {
         "class": "dynamic",
         "group": "ossec",


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#6159|

## Description

Hi team!

This PR aims to add `wazuh-logcollector.state` into Solaris SPECS
## Checks
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [X] Windows
  - [X] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [X] Package upgrade
- [X] Package downgrade
- [X] Package remove
- [X] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [X] Check file permissions on Solaris 11 template

Regards,
Nico