### PR TITLE
Replacing the tag WAZUH_HOME with WAZUH_HOME_TMP

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -21,7 +21,6 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 
 %prep
 %setup -q
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/4.2
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir} DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
@@ -54,7 +53,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
@@ -202,7 +200,6 @@ rm -fr %{buildroot}
 
 %files
 %{_init_scripts}/*
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
@@ -218,7 +215,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -55,7 +55,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -21,7 +21,6 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 
 %prep
 %setup -q
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/5.0
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir} DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
@@ -54,7 +53,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
@@ -202,7 +200,6 @@ rm -fr %{buildroot}
 
 %files
 %{_init_scripts}/*
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
@@ -218,7 +215,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -55,7 +55,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -32,10 +32,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -133,10 +129,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -180,9 +180,6 @@ override_dh_install:
 	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_auto_clean:
 	$(MAKE) -C src clean
 

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,11 +60,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -177,7 +177,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -37,10 +37,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -232,10 +228,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -180,9 +180,6 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14/04
 	cp etc/templates/config/ubuntu/16/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/16/04
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,11 +66,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -32,10 +32,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -133,10 +129,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,11 +62,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -173,7 +173,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -176,9 +176,6 @@ override_dh_install:
 	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_auto_clean:
 	$(MAKE) -C src clean
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -37,10 +37,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -231,10 +227,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,11 +68,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -176,9 +176,6 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/12/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12/04
 	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14/04
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -135,7 +135,7 @@ create_package() {
   rm ${install_path}/wodles/oscap/content/*.xml
   wazuh_version=`echo "${wazuh_version}" | cut -d v -f 2`
   pkg_name="wazuh-agent-${wazuh_version}-${wazuh_revision}-hpux-11v3-ia64.tar"
-  tar cvpf ${target_dir}/${pkg_name} ${install_path} /etc/ossec-init.conf /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
+  tar cvpf ${target_dir}/${pkg_name} ${install_path} /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
 
   if [ "${compute_checksums}" = "yes" ]; then
     cd ${target_dir}
@@ -170,7 +170,7 @@ clean() {
   fi
 
   rm -rf ${install_path}
-  rm /etc/ossec-init.conf
+
   find /sbin -name "*wazuh-agent*" -exec rm {} \;
   userdel ossec
   groupdel ossec

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -64,8 +64,6 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-chown root:${GROUP} /etc/ossec-init.conf
-
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 
 upgrade=$(launchctl getenv WAZUH_PKG_UPGRADE)

--- a/macos/package_files/4.2.0/preinstall.sh
+++ b/macos/package_files/4.2.0/preinstall.sh
@@ -143,10 +143,8 @@ chown root:wheel /Library/StartupItems/WAZUH
 sudo tee /Library/StartupItems/WAZUH/WAZUH <<-'EOF'
 #!/bin/sh
 . /etc/rc.common
-. /etc/ossec-init.conf
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+
+DIRECTORY="/Library/Ossec"
 
 StartService ()
 {
@@ -197,11 +195,7 @@ chmod u=rw-,go=r-- /Library/StartupItems/WAZUH/StartupParameters.plist
 sudo tee /Library/StartupItems/WAZUH/launcher.sh <<-'EOF'
 #!/bin/sh
 
-. /etc/ossec-init.conf
-
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+DIRECTORY="/Library/Ossec"
 
 capture_sigterm() {
     ${DIRECTORY}/bin/wazuh-control stop

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -64,8 +64,6 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-chown root:${GROUP} /etc/ossec-init.conf
-
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 
 upgrade=$(launchctl getenv WAZUH_PKG_UPGRADE)

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -143,10 +143,8 @@ chown root:wheel /Library/StartupItems/WAZUH
 sudo tee /Library/StartupItems/WAZUH/WAZUH <<-'EOF'
 #!/bin/sh
 . /etc/rc.common
-. /etc/ossec-init.conf
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+
+DIRECTORY="/Library/Ossec"
 
 StartService ()
 {
@@ -197,11 +195,7 @@ chmod u=rw-,go=r-- /Library/StartupItems/WAZUH/StartupParameters.plist
 sudo tee /Library/StartupItems/WAZUH/launcher.sh <<-'EOF'
 #!/bin/sh
 
-. /etc/ossec-init.conf
-
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+DIRECTORY="/Library/Ossec"
 
 capture_sigterm() {
     ${DIRECTORY}/bin/ossec-control stop

--- a/macos/specs/4.x/wazuh-agent-4.2.0.pkgproj
+++ b/macos/specs/4.x/wazuh-agent-4.2.0.pkgproj
@@ -40,41 +40,6 @@
 									<key>CHILDREN</key>
 									<array/>
 									<key>GID</key>
-									<integer>0</integer>
-									<key>PATH</key>
-									<string>/private/etc/ossec-init.conf</string>
-									<key>PATH_TYPE</key>
-									<integer>0</integer>
-									<key>PERMISSIONS</key>
-									<integer>416</integer>
-									<key>TYPE</key>
-									<integer>3</integer>
-									<key>UID</key>
-									<integer>0</integer>
-								</dict>
-							</array>
-							<key>EXPANDED</key>
-							<true/>
-							<key>GID</key>
-							<integer>0</integer>
-							<key>PATH</key>
-							<string>/private/etc</string>
-							<key>PATH_TYPE</key>
-							<integer>0</integer>
-							<key>PERMISSIONS</key>
-							<integer>493</integer>
-							<key>TYPE</key>
-							<integer>3</integer>
-							<key>UID</key>
-							<integer>0</integer>
-						</dict>
-						<dict>
-							<key>CHILDREN</key>
-							<array>
-								<dict>
-									<key>CHILDREN</key>
-									<array/>
-									<key>GID</key>
 									<integer>80</integer>
 									<key>PATH</key>
 									<string>Application Support</string>
@@ -328,22 +293,6 @@
 													<integer>0</integer>
 													<key>PERMISSIONS</key>
 													<integer>416</integer>
-													<key>TYPE</key>
-													<integer>3</integer>
-													<key>UID</key>
-													<integer>0</integer>
-												</dict>
-												<dict>
-													<key>CHILDREN</key>
-													<array/>
-													<key>GID</key>
-													<integer>0</integer>
-													<key>PATH</key>
-													<string>/Library/Ossec/etc/ossec-init.conf</string>
-													<key>PATH_TYPE</key>
-													<integer>0</integer>
-													<key>PERMISSIONS</key>
-													<integer>493</integer>
 													<key>TYPE</key>
 													<integer>3</integer>
 													<key>UID</key>

--- a/macos/specs/4.x/wazuh-agent-5.0.0.pkgproj
+++ b/macos/specs/4.x/wazuh-agent-5.0.0.pkgproj
@@ -40,41 +40,6 @@
 									<key>CHILDREN</key>
 									<array/>
 									<key>GID</key>
-									<integer>0</integer>
-									<key>PATH</key>
-									<string>/private/etc/ossec-init.conf</string>
-									<key>PATH_TYPE</key>
-									<integer>0</integer>
-									<key>PERMISSIONS</key>
-									<integer>416</integer>
-									<key>TYPE</key>
-									<integer>3</integer>
-									<key>UID</key>
-									<integer>0</integer>
-								</dict>
-							</array>
-							<key>EXPANDED</key>
-							<true/>
-							<key>GID</key>
-							<integer>0</integer>
-							<key>PATH</key>
-							<string>/private/etc</string>
-							<key>PATH_TYPE</key>
-							<integer>0</integer>
-							<key>PERMISSIONS</key>
-							<integer>493</integer>
-							<key>TYPE</key>
-							<integer>3</integer>
-							<key>UID</key>
-							<integer>0</integer>
-						</dict>
-						<dict>
-							<key>CHILDREN</key>
-							<array>
-								<dict>
-									<key>CHILDREN</key>
-									<array/>
-									<key>GID</key>
 									<integer>80</integer>
 									<key>PATH</key>
 									<string>Application Support</string>
@@ -328,22 +293,6 @@
 													<integer>0</integer>
 													<key>PERMISSIONS</key>
 													<integer>416</integer>
-													<key>TYPE</key>
-													<integer>3</integer>
-													<key>UID</key>
-													<integer>0</integer>
-												</dict>
-												<dict>
-													<key>CHILDREN</key>
-													<array/>
-													<key>GID</key>
-													<integer>0</integer>
-													<key>PATH</key>
-													<string>/Library/Ossec/etc/ossec-init.conf</string>
-													<key>PATH_TYPE</key>
-													<integer>0</integer>
-													<key>PERMISSIONS</key>
-													<integer>493</integer>
 													<key>TYPE</key>
 													<integer>3</integer>
 													<key>UID</key>

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -3,7 +3,6 @@
 ## Stop and remove application
 sudo /Library/Ossec/bin/ossec-control stop
 sudo /bin/rm -r /Library/Ossec*
-sudo /bin/rm /etc/ossec-init.conf
 
 ## stop and unload dispatcher
 #sudo /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -84,9 +84,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -157,7 +157,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -34,7 +34,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -83,7 +82,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
@@ -248,7 +246,6 @@ rm -rf %{_localstatedir}/packages_files
 
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
-
 
 # CentOS
 if [ -r "/etc/centos-release" ]; then
@@ -443,7 +440,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
 %defattr(-,root,root)
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
 %dir %attr(770,root,ossec) %{_localstatedir}/.ssh
@@ -459,7 +455,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/localtime
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -31,7 +31,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf manager centos %rhel %{_localstatedir} > etc/ossec-server.conf
-./gen_ossec.sh init manager %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -78,7 +77,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
@@ -246,8 +244,14 @@ if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/~api ]; then
     rm -rf %{_localstatedir}/~api
   fi
-  # Import the variables from ossec-init.conf file
-  . %{_sysconfdir}/ossec-init.conf
+
+  if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+    # Import the variables from ossec-init.conf file
+    . %{_sysconfdir}/ossec-init.conf
+  else
+    # Ask wazuh-control the version
+    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
+  fi
 
   # Get the major and minor version
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
@@ -532,7 +536,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
 %defattr(-,root,ossec)
-%attr(640, root, ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750, root, ossec) %{_localstatedir}
 %attr(750, root, ossec) %{_localstatedir}/agentless
 %dir %attr(750, root, ossec) %{_localstatedir}/active-response
@@ -582,7 +585,6 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, ossec) %{_localstatedir}/etc/internal_options*
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640, root, ossec) %{_localstatedir}/etc/localtime
 %dir %attr(770, root, ossec) %{_localstatedir}/etc/decoders
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -79,9 +79,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -156,7 +156,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -34,7 +34,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -83,7 +82,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
@@ -244,7 +242,6 @@ rm -rf %{_localstatedir}/packages_files
 
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
-
 
 # CentOS
 if [ -r "/etc/centos-release" ]; then
@@ -439,7 +436,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
 %defattr(-,root,root)
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
 %dir %attr(770,root,ossec) %{_localstatedir}/.ssh
@@ -455,7 +451,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/localtime
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -84,9 +84,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -153,7 +153,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -79,9 +79,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -156,7 +156,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -200,7 +200,6 @@ package(){
     echo "i postinstall=postinstall.sh" >> "wazuh-agent_$VERSION.proto"
     echo "i preremove=preremove.sh" >> "wazuh-agent_$VERSION.proto"
     echo "i postremove=postremove.sh" >> "wazuh-agent_$VERSION.proto"
-    echo "f none /etc/ossec-init.conf  0640 root ossec" >> "wazuh-agent_$VERSION.proto"
     echo "f none /etc/init.d/wazuh-agent  0755 root root" >> "wazuh-agent_$VERSION.proto"
     echo "s none /etc/rc2.d/S97wazuh-agent=/etc/init.d/wazuh-agent" >> "wazuh-agent_$VERSION.proto"
     echo "s none /etc/rc3.d/S97wazuh-agent=/etc/init.d/wazuh-agent" >> "wazuh-agent_$VERSION.proto"
@@ -233,9 +232,8 @@ clean(){
     fi
 
     rm -r ${install_path}*
-    rm -f /etc/ossec-init.conf
 
-     # remove launchdaemons
+    # remove launchdaemons
     rm -f /etc/init.d/wazuh-agent
     rm -f /etc/rc2.d/S97wazuh-agent
     rm -f /etc/rc3.d/S97wazuh-agent

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -3,22 +3,19 @@
 # Wazuh, Inc 2015-2020
 
 if [ ! -f /etc/ossec-init.conf ]; then
-	DIR="/var/ossec"
-	ls -la /var/ossec > /dev/null 2>&1
-    if [ -d  /var/ossec ]; then
-		#upgrade
-        type=upgrade
-
-	else
-		#clean installation
-        type=install
-    fi
-
+  DIR="/var/ossec"
+  ls -la /var/ossec > /dev/null 2>&1
+  if [ -d /var/ossec ]; then
+    #upgrade
+    type=upgrade
+  else
+    #clean installation
+    type=install
+  fi
 else
-	#upgrade
-	DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
-	type=upgrade
-
+  #upgrade
+  DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
+  type=upgrade
 fi
 
 USER="ossec"

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -4,7 +4,11 @@
 OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
-. ${OSSEC_INIT}
+if [ -f ${OSSEC_INIT} ]; then
+  . ${OSSEC_INIT}
+else
+  VERSION=`/var/ossec/bin/${control_binary} -v`
+fi
 
 set_control_binary() {
   number_version=`echo "${VERSION}" | cut -d v -f 2`

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -1,15 +1,9 @@
 #/bin/sh
 
-OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
 set_control_binary() {
-  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-
-  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+  if [ ! -f /var/ossec/bin/${control_binary} ]; then
     control_binary="ossec-control"
   fi
 }
@@ -17,10 +11,8 @@ set_control_binary() {
 set_control_binary
 
 ## Stop and remove application
-/var/ossec/bin/${control_binary} 2> /dev/null
+/var/ossec/bin/${control_binary} stop
 rm -rf /var/ossec/
-rm -f ${OSSEC_INIT}
-
 
 ## stop and unload dispatcher
 #/bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
@@ -29,7 +21,6 @@ rm -f ${OSSEC_INIT}
 rm -f /etc/init.d/wazuh-agent
 rm -rf /etc/rc2.d/S97wazuh-agent
 rm -rf /etc/rc3.d/S97wazuh-agent
-
 
 ## Remove User and Groups
 userdel ossec 2> /dev/null

--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -407,15 +407,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec-init.conf": {
-        "class": "static",
-        "group": "root",
-        "mode": "0777",
-        "prot": "lrwxrwxrwx",
-        "target": "/etc/ossec-init.conf",
-        "type": "link",
-        "user": "root"
-    },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -407,15 +407,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec-init.conf": {
-        "class": "static",
-        "group": "root",
-        "mode": "0777",
-        "prot": "lrwxrwxrwx",
-        "target": "/etc/ossec-init.conf",
-        "type": "link",
-        "user": "root"
-    },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -166,9 +166,6 @@ create_package() {
         sed "s:file $file.*:& preserve=install-only:"  wazuh-agent.p5m.1 > wazuh-agent.p5m.1.aux_sed
         mv wazuh-agent.p5m.1.aux_sed wazuh-agent.p5m.1
     done
-    # Fix the /etc/ossec-init.conf link
-    sed "s:target=etc/ossec-init.conf:target=/etc/ossec-init.conf:"  wazuh-agent.p5m.1 > wazuh-agent.p5m.1.aux
-    mv wazuh-agent.p5m.1.aux wazuh-agent.p5m.1
     # Add service files
     echo "file wazuh-agent path=etc/init.d/wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
     echo "file S97wazuh-agent path=etc/rc2.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1

--- a/solaris/solaris11/solaris_fix.py
+++ b/solaris/solaris11/solaris_fix.py
@@ -68,9 +68,6 @@ def set_p5m1(template_path, p5m1_file_path):
                         # write the line into the file
                         p5m1_fixed.write("".join([i + " " for i in line_components])+"\n")
 
-        p5m1_fixed.write("file etc/ossec-init.conf path=etc/ossec-init.conf owner=root group=root mode=0640"+"\n")
-        p5m1_fixed.write("link path=var/ossec/etc/ossec-init.conf target=etc/ossec-init.conf"+"\n")
-
 
 def main():
     parser = argparse.ArgumentParser()

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -1,15 +1,9 @@
 #/bin/sh
 
-OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
 set_control_binary() {
-  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-
-  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+  if [ ! -f /var/ossec/bin/${control_binary} ]; then
     control_binary="ossec-control"
   fi
 }
@@ -19,7 +13,6 @@ set_control_binary
 ## Stop and remove application
 sudo /var/ossec/bin/${control_binary} stop
 sudo rm -r /var/ossec*
-sudo rm ${OSSEC_INIT}
 
 # remove launchdaemons
 sudo rm -f /etc/init.d/wazuh-agent


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7082 |

## Description

This PR modifies the name of the tag used by the installers to ser the Wazuh installation directory in the services files.

## Tests

- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
  - [x] Solaris
  - [x] AIX
  - [x] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install