### PR TITLE
Changed OVA name

### DIFF
--- a/ova/wazuh_ovf_template
+++ b/ova/wazuh_ovf_template
@@ -14,7 +14,7 @@
       <Description>The VM Network network</Description>
     </Network>
   </NetworkSection>
-    <VirtualSystem ovf:id="vm_wazuh">
+    <VirtualSystem ovf:id="Wazuh v{WAZUH_VERSION} OVA">
     <Info>A virtual machine</Info>
     <ProductSection>
       <Info>Meta-information about the installed software</Info>


### PR DESCRIPTION
Hello team,

I have changed ova name from `vm_wazuh` to `Wazuh v4.0.4 OVA`. This change is motivated due to `vm_wazuh` does not very descriptive.

closes #604 