### PR TITLE
Removal of the ossec-init.conf file from the Wazuh installations - Packages changes implementation

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -53,7 +53,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+sed "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
 mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -53,7 +53,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -21,7 +21,6 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 
 %prep
 %setup -q
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/4.2
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir} DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
@@ -54,7 +53,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
@@ -202,7 +200,6 @@ rm -fr %{buildroot}
 
 %files
 %{_init_scripts}/*
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
@@ -218,7 +215,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -137,7 +137,7 @@ if [ $1 = 1 ]; then
   chown ossec:ossec %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
-  %{_localstatedir}/tmp/src/init/register_configure_agent.sh > /dev/null || :
+  %{_localstatedir}/tmp/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 
 fi
 chown root:ossec %{_localstatedir}/etc/ossec.conf

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -55,7 +55,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -55,7 +55,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0750 src/init/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 
 # Add configuration scripts

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -53,7 +53,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+sed "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
 mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -21,7 +21,6 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 
 %prep
 %setup -q
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/5.0
 gmake TARGET=agent USE_SELINUX=no PREFIX=%{_localstatedir} DISABLE_SHARED=yes DISABLE_SYSC=yes
 cd ..
@@ -54,7 +53,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
@@ -202,7 +200,6 @@ rm -fr %{buildroot}
 
 %files
 %{_init_scripts}/*
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
@@ -218,7 +215,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -53,7 +53,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -137,7 +137,7 @@ if [ $1 = 1 ]; then
   chown ossec:ossec %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
-  %{_localstatedir}/tmp/src/init/register_configure_agent.sh > /dev/null || :
+  %{_localstatedir}/tmp/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 
 fi
 chown root:ossec %{_localstatedir}/etc/ossec.conf

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -55,7 +55,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -55,7 +55,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0750 src/init/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 
 # Add configuration scripts

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -142,6 +142,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -32,10 +32,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -51,6 +47,11 @@ case "$1" in
         cp -pL /etc/localtime ${DIR}/etc/;
         chmod 640 ${DIR}/etc/localtime
         chown root:${GROUP} ${DIR}/etc/localtime
+    fi
+
+    # Remove deprecated ossec-init.conf if exists
+    if [ -f /etc/ossec-init.conf ] ; then
+        rm /etc/ossec-init.conf
     fi
 
     # Restore the local rules, client.keys and local_decoder
@@ -133,10 +134,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -144,7 +144,7 @@ case "$1" in
 
     #Delete obsolete files
     if [ -f /etc/ossec-init.conf ]; then
-        rm /etc/ossec-init.conf
+        rm -f /etc/ossec-init.conf
     fi
 
     # Delete installation scripts

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -49,11 +49,6 @@ case "$1" in
         chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
-    # Remove deprecated ossec-init.conf if exists
-    if [ -f /etc/ossec-init.conf ] ; then
-        rm /etc/ossec-init.conf
-    fi
-
     # Restore the local rules, client.keys and local_decoder
     if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
         cp ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -128,7 +128,7 @@ case "$1" in
 
     # Register and configure agent if Wazuh environment variables are defined
     if [ -z "$2" ] ; then
-        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
+        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
 
     # Restoring file permissions

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,8 +60,8 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
-	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
+
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -63,10 +63,10 @@ override_dh_install:
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
+
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -183,8 +183,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -184,9 +184,6 @@ override_dh_install:
 	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_auto_clean:
 	$(MAKE) -C src clean
 

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,11 +60,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -181,7 +183,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,10 +60,12 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	install -m 0644 src/systemd/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
@@ -179,7 +181,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	cp src/systemd/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf
 	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,11 +60,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -181,7 +181,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -243,7 +243,7 @@ case "$1" in
 
     #Delete obsolete files
     if [ -f /etc/ossec-init.conf ]; then
-        rm /etc/ossec-init.conf
+        rm -f /etc/ossec-init.conf
     fi
 
     # Delete installation scripts

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -37,10 +37,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -115,6 +111,11 @@ case "$1" in
         cp -p /etc/TIMEZONE ${DIR}/etc/;
         chmod 640 ${DIR}/etc/TIMEZONE
         chown root:${GROUP} ${DIR}/etc/localtime
+    fi
+
+    # Remove deprecated ossec-init.conf if exists
+    if [ -f /etc/ossec-init.conf ] ; then
+        rm /etc/ossec-init.conf
     fi
 
     # Restore client.keys configuration
@@ -232,10 +233,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -113,11 +113,6 @@ case "$1" in
         chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
-    # Remove deprecated ossec-init.conf if exists
-    if [ -f /etc/ossec-init.conf ] ; then
-        rm /etc/ossec-init.conf
-    fi
-
     # Restore client.keys configuration
     if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
         mv ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -241,6 +241,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,10 +66,12 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	install -m 0644 src/systemd/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -68,10 +68,10 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}/etc/init.d/
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
+
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
-	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,11 +66,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,8 +66,7 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
-	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -184,9 +184,6 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14/04
 	cp etc/templates/config/ubuntu/16/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/16/04
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,11 +66,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -142,6 +142,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -32,10 +32,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -51,6 +47,11 @@ case "$1" in
         cp -pL /etc/localtime ${DIR}/etc/;
         chmod 640 ${DIR}/etc/localtime
         chown root:${GROUP} ${DIR}/etc/localtime
+    fi
+
+    # Remove deprecated ossec-init.conf if exists
+    if [ -f /etc/ossec-init.conf ] ; then
+        rm /etc/ossec-init.conf
     fi
 
     # Restore the local rules, client.keys and local_decoder
@@ -133,10 +134,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -49,11 +49,6 @@ case "$1" in
         chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
-    # Remove deprecated ossec-init.conf if exists
-    if [ -f /etc/ossec-init.conf ] ; then
-        rm /etc/ossec-init.conf
-    fi
-
     # Restore the local rules, client.keys and local_decoder
     if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
         cp ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -128,7 +128,7 @@ case "$1" in
 
     # Register and configure agent if Wazuh environment variables are defined
     if [ -z "$2" ] ; then
-        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
+        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
 
     # Restoring file permissions

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -66,8 +66,7 @@ override_dh_install:
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -178,8 +177,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -180,9 +180,6 @@ override_dh_install:
 	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_auto_clean:
 	$(MAKE) -C src clean
 

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,11 +62,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -177,7 +179,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,8 +62,7 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
-	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,11 +62,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -177,7 +177,7 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,10 +62,12 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	install -m 0644 src/systemd/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
@@ -175,7 +177,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	cp src/systemd/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Copy ossec-init.conf
 	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -240,6 +240,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -112,11 +112,6 @@ case "$1" in
         chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
-    # Remove deprecated ossec-init.conf if exists
-    if [ -f /etc/ossec-init.conf ] ; then
-        rm /etc/ossec-init.conf
-    fi
-
     # Restore client.keys configuration
     if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
         mv ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -37,10 +37,6 @@ case "$1" in
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
-    if [ -f ${SCRIPTS_DIR}/ossec-init.conf ] ; then
-        cp ${SCRIPTS_DIR}/ossec-init.conf /etc/ossec-init.conf
-    fi
-
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
@@ -114,6 +110,11 @@ case "$1" in
         cp -p /etc/TIMEZONE ${DIR}/etc/;
         chmod 640 ${DIR}/etc/TIMEZONE
         chown root:${GROUP} ${DIR}/etc/localtime
+    fi
+
+    # Remove deprecated ossec-init.conf if exists
+    if [ -f /etc/ossec-init.conf ] ; then
+        rm /etc/ossec-init.conf
     fi
 
     # Restore client.keys configuration
@@ -231,10 +232,6 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
-
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,11 +68,11 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,8 +68,7 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
-	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,10 +68,12 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	cp src/init/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	install -m 0644 src/systemd/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
+	sed -i "s|WAZUH_HOME|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -180,9 +180,6 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/12/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/12/04
 	cp etc/templates/config/ubuntu/14/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/14/04
 
-	# Copy ossec-init.conf
-	cp /etc/ossec-init.conf ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)
-
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,11 +68,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -70,10 +70,10 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}/etc/init.d/
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
+
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
-	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -169,11 +169,8 @@ clean() {
     ${install_path}/bin/${control_binary} stop
   fi
 
-  if [ -f /etc/ossec-init.conf ]; then
-    rm /etc/ossec-init.conf
-  fi
-
   rm -rf ${install_path}
+
   find /sbin -name "*wazuh-agent*" -exec rm {} \;
   userdel ossec
   groupdel ossec

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -20,273 +20,273 @@ control_binary=""
 
 build_environment() {
 
-  # Resizing partitions for Site Ox boxes (used by Wazuh team)
-  if grep 'siteox.com' /etc/motd > /dev/null 2>&1; then
-    for partition in "/home" "/tmp"; do
-      partition_size=$(df -b | grep $partition | awk -F' ' '{print $5}')
-      if [[ ${partition_size} -lt "3145728" ]]; then
-        echo "Resizing $partition partition to 3GB"
-        volume=$(cat /etc/fstab | grep $partition | awk -F' ' '{print $1}')
-        lvextend -L 3000 $volume
-        fsadm -b 3072000 $partition > /dev/null 2>&1
-      fi
-    done
-  fi
+    # Resizing partitions for Site Ox boxes (used by Wazuh team)
+    if grep 'siteox.com' /etc/motd > /dev/null 2>&1; then
+        for partition in "/home" "/tmp"; do
+            partition_size=$(df -b | grep $partition | awk -F' ' '{print $5}')
+            if [[ ${partition_size} -lt "3145728" ]]; then
+                echo "Resizing $partition partition to 3GB"
+                volume=$(cat /etc/fstab | grep $partition | awk -F' ' '{print $1}')
+                lvextend -L 3000 $volume
+                fsadm -b 3072000 $partition > /dev/null 2>&1
+          fi
+      done
+    fi
 
-  echo "Installing dependencies."
-  depot=""
-  if [ -z "${depot_path}" ]
-  then
-      depot=$current_path/depothelper-2.10-hppa_32-11.31.depot
-  else
-      depot=$depot_path
-  fi
+    echo "Installing dependencies."
+    depot=""
+    if [ -z "${depot_path}" ]
+    then
+        depot=$current_path/depothelper-2.10-hppa_32-11.31.depot
+    else
+        depot=$depot_path
+    fi
 
-  #Install dependencies
-  swinstall -s $depot \*
-  /usr/local/bin/depothelper -f curl
-  /usr/local/bin/depothelper -f unzip
-  /usr/local/bin/depothelper -f gcc
-  /usr/local/bin/depothelper -f make
-  /usr/local/bin/depothelper -f bash
-  /usr/local/bin/depothelper -f gzip
-  /usr/local/bin/depothelper -f automake
-  /usr/local/bin/depothelper -f autoconf
-  /usr/local/bin/depothelper -f libtool
-  /usr/local/bin/depothelper -f coreutils
-  /usr/local/bin/depothelper -f gdb
-  /usr/local/bin/depothelper -f perl-5.10.1
-  /usr/local/bin/depothelper -f regex
-  cp /usr/bin/perl /tmp/perl
-  cp /usr/local/bin/perl5.10.1 /usr/bin/perl
+    #Install dependencies
+    swinstall -s $depot \*
+    /usr/local/bin/depothelper -f curl
+    /usr/local/bin/depothelper -f unzip
+    /usr/local/bin/depothelper -f gcc
+    /usr/local/bin/depothelper -f make
+    /usr/local/bin/depothelper -f bash
+    /usr/local/bin/depothelper -f gzip
+    /usr/local/bin/depothelper -f automake
+    /usr/local/bin/depothelper -f autoconf
+    /usr/local/bin/depothelper -f libtool
+    /usr/local/bin/depothelper -f coreutils
+    /usr/local/bin/depothelper -f gdb
+    /usr/local/bin/depothelper -f perl-5.10.1
+    /usr/local/bin/depothelper -f regex
+    cp /usr/bin/perl /tmp/perl
+    cp /usr/local/bin/perl5.10.1 /usr/bin/perl
 }
 
 config() {
-  echo USER_LANGUAGE="en" > ${configuration_file}
-  echo USER_NO_STOP="y" >> ${configuration_file}
-  echo USER_INSTALL_TYPE="agent" >> ${configuration_file}
-  echo USER_DIR=${install_path} >> ${configuration_file}
-  echo USER_DELETE_DIR="y" >> ${configuration_file}
-  echo USER_CLEANINSTALL="y" >> ${configuration_file}
-  echo USER_BINARYINSTALL="y" >> ${configuration_file}
-  echo USER_AGENT_SERVER_IP="MANAGER_IP" >> ${configuration_file}
-  echo USER_ENABLE_SYSCHECK="y" >> ${configuration_file}
-  echo USER_ENABLE_ROOTCHECK="y" >> ${configuration_file}
-  echo USER_ENABLE_OPENSCAP="y" >> ${configuration_file}
-  echo USER_ENABLE_ACTIVE_RESPONSE="y" >> ${configuration_file}
-  echo USER_CA_STORE="n" >> ${configuration_file}
+    echo USER_LANGUAGE="en" > ${configuration_file}
+    echo USER_NO_STOP="y" >> ${configuration_file}
+    echo USER_INSTALL_TYPE="agent" >> ${configuration_file}
+    echo USER_DIR=${install_path} >> ${configuration_file}
+    echo USER_DELETE_DIR="y" >> ${configuration_file}
+    echo USER_CLEANINSTALL="y" >> ${configuration_file}
+    echo USER_BINARYINSTALL="y" >> ${configuration_file}
+    echo USER_AGENT_SERVER_IP="MANAGER_IP" >> ${configuration_file}
+    echo USER_ENABLE_SYSCHECK="y" >> ${configuration_file}
+    echo USER_ENABLE_ROOTCHECK="y" >> ${configuration_file}
+    echo USER_ENABLE_OPENSCAP="y" >> ${configuration_file}
+    echo USER_ENABLE_ACTIVE_RESPONSE="y" >> ${configuration_file}
+    echo USER_CA_STORE="n" >> ${configuration_file}
 }
 
 compute_version_revision() {
-  wazuh_version=$(cat ${source_directory}/src/VERSION | cut -d "-" -f1 | cut -c 2-)
+    wazuh_version=$(cat ${source_directory}/src/VERSION | cut -d "-" -f1 | cut -c 2-)
 
-  echo ${wazuh_version} > /tmp/VERSION
-  echo ${wazuh_revision} > /tmp/REVISION
+    echo ${wazuh_version} > /tmp/VERSION
+    echo ${wazuh_revision} > /tmp/REVISION
 
-  return 0
+    return 0
 }
 
 download_source() {
-  echo " Downloading source"
-  /usr/local/bin/curl -k -L -O https://github.com/wazuh/wazuh/archive/${wazuh_branch}.zip
-  /usr/local/bin/unzip ${wazuh_branch}.zip
-  mv wazuh-* ${source_directory}
-  compute_version_revision
+    echo " Downloading source"
+    /usr/local/bin/curl -k -L -O https://github.com/wazuh/wazuh/archive/${wazuh_branch}.zip
+    /usr/local/bin/unzip ${wazuh_branch}.zip
+    mv wazuh-* ${source_directory}
+    compute_version_revision
 }
 
 check_version() {
-  wazuh_version=`cat ${source_directory}/src/VERSION`
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-  if [ "$major" -eq "3" ]; then
-    if [ "$minor" -ge "5" ]; then
-      deps_version="true"
-    fi
-  elif [ "$major" -gt "3" ]; then
-    deps_version="true"
-  fi
-}
-
-compile() {
-  echo "Compiling code"
-  # Compile and install wazuh
-  cd ${source_directory}/src
-  config
-  check_version
-  if [ "$deps_version" = "true" ]; then
-    gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/$major.$minor
-  fi
-
-  gmake TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes
-  bash ${source_directory}/install.sh
-  cd $current_path
-}
-
-create_package() {
-  echo "Creating package"
-
-  if [ ! -d ${target_dir} ]; then
-    mkdir -p ${target_dir}
-  fi
-
-  #Build package
-  VERSION=`cat /tmp/VERSION`
-  rm ${install_path}/wodles/oscap/content/*.xml
-  wazuh_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  pkg_name="wazuh-agent-${wazuh_version}-${wazuh_revision}-hpux-11v3-ia64.tar"
-  tar cvpf ${target_dir}/${pkg_name} ${install_path} /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
-
-  if [ "${compute_checksums}" = "yes" ]; then
-    cd ${target_dir}
-    pkg_checksum="$(openssl dgst -sha512 ${pkg_name} | cut -d' ' -f "2")"
-    echo "${pkg_checksum}  ${pkg_name}" > ${checksum_dir}/${pkg_name}.sha512
-  fi
-}
-
-set_control_binary() {
-  if [ -e ${source_directory}/src/VERSION ]; then
     wazuh_version=`cat ${source_directory}/src/VERSION`
     number_version=`echo "${wazuh_version}" | cut -d v -f 2`
     major=`echo $number_version | cut -d . -f 1`
     minor=`echo $number_version | cut -d . -f 2`
-
-    if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
-      control_binary="ossec-control"
-    else
-      control_binary="wazuh-control"
+    if [ "$major" -eq "3" ]; then
+        if [ "$minor" -ge "5" ]; then
+            deps_version="true"
+        fi
+    elif [ "$major" -gt "3" ]; then
+        deps_version="true"
     fi
-  fi
+}
+
+compile() {
+    echo "Compiling code"
+    # Compile and install wazuh
+    cd ${source_directory}/src
+    config
+    check_version
+    if [ "$deps_version" = "true" ]; then
+        gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/$major.$minor
+    fi
+
+    gmake TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes
+    bash ${source_directory}/install.sh
+    cd $current_path
+}
+
+create_package() {
+    echo "Creating package"
+
+    if [ ! -d ${target_dir} ]; then
+        mkdir -p ${target_dir}
+    fi
+
+    #Build package
+    VERSION=`cat /tmp/VERSION`
+    rm ${install_path}/wodles/oscap/content/*.xml
+    wazuh_version=`echo "${wazuh_version}" | cut -d v -f 2`
+    pkg_name="wazuh-agent-${wazuh_version}-${wazuh_revision}-hpux-11v3-ia64.tar"
+    tar cvpf ${target_dir}/${pkg_name} ${install_path} /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
+
+    if [ "${compute_checksums}" = "yes" ]; then
+        cd ${target_dir}
+        pkg_checksum="$(openssl dgst -sha512 ${pkg_name} | cut -d' ' -f "2")"
+        echo "${pkg_checksum}  ${pkg_name}" > ${checksum_dir}/${pkg_name}.sha512
+    fi
+}
+
+set_control_binary() {
+    if [ -e ${source_directory}/src/VERSION ]; then
+        wazuh_version=`cat ${source_directory}/src/VERSION`
+        number_version=`echo "${wazuh_version}" | cut -d v -f 2`
+        major=`echo $number_version | cut -d . -f 1`
+        minor=`echo $number_version | cut -d . -f 2`
+
+        if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+            control_binary="ossec-control"
+        else
+            control_binary="wazuh-control"
+        fi
+    fi
 }
 
 # Uninstall agent.
 
 clean() {
-  exit_code=$1
-  set_control_binary
+    exit_code=$1
+    set_control_binary
 
-  if [ ! -z $control_binary ]; then
-    ${install_path}/bin/${control_binary} stop
-  fi
+    if [ ! -z $control_binary ]; then
+        ${install_path}/bin/${control_binary} stop
+    fi
 
-  rm -rf ${install_path}
+    rm -rf ${install_path}
 
-  find /sbin -name "*wazuh-agent*" -exec rm {} \;
-  userdel ossec
-  groupdel ossec
+    find /sbin -name "*wazuh-agent*" -exec rm {} \;
+    userdel ossec
+    groupdel ossec
 
-  exit ${exit_code}
+    exit ${exit_code}
 }
 
 show_help() {
-  echo
-  echo "Usage: $0 [OPTIONS]"
-  echo
-  echo "    -e Install all the packages necessaries to build the TAR package"
-  echo "    -b <branch> Select Git branch. Example v3.5.0"
-  echo "    -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created."
-  echo "    -p <tar_home> Installation path for the package. By default: /var"
-  echo "    -c, --checksum Compute the SHA512 checksum of the TAR package."
-  echo "    -d <path_to_depot>, --depot Change the path to depothelper package (by default current path)."
-  echo "    -h Shows this help"
-  echo
-  exit $1
+    echo
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "    -e Install all the packages necessaries to build the TAR package"
+    echo "    -b <branch> Select Git branch. Example v3.5.0"
+    echo "    -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created."
+    echo "    -p <tar_home> Installation path for the package. By default: /var"
+    echo "    -c, --checksum Compute the SHA512 checksum of the TAR package."
+    echo "    -d <path_to_depot>, --depot Change the path to depothelper package (by default current path)."
+    echo "    -h Shows this help"
+    echo
+    exit $1
 }
 
 build_package() {
-  download_source
-  compile
-  create_package
-  clean 0
+    download_source
+    compile
+    create_package
+    clean 0
 }
 
 # Main function, processes user input
 main() {
-  # If the script is called without arguments
-  # show the help
-  if [[ -z $1 ]] ; then
-    show_help 0
-  fi
+    # If the script is called without arguments
+    # show the help
+    if [[ -z $1 ]] ; then
+        show_help 0
+    fi
 
-  build_env="no"
-  build_pkg="no"
+    build_env="no"
+    build_pkg="no"
 
-  while [ -n "$1" ]
-  do
-    case $1 in
-      "-b")
-        if [ -n "$2" ]
-        then
-          wazuh_branch="$2"
-          build_pkg="yes"
-          shift 2
-        else
-          show_help 1
-        fi
-      ;;
-      "-h")
-        show_help
-        exit 0
-      ;;
-      "-e")
-        build_environment
-        exit 0
-      ;;
-      "-p")
-        if [ -n "$2" ]
-        then
-          install_path="$2"
-          shift 2
-        else
-          show_help 1
-        fi
-      ;;
-      "-s")
-        if [ -n "$2" ]
-        then
-          target_dir="$2"
-          shift 2
-        else
-          show_help 1
-        fi
-      ;;
-      "-c" | "--checksum")
-          if [ -n "$2" ]; then
-            checksum_dir="$2"
-            compute_checksums="yes"
-            shift 2
-          else
-            compute_checksums="yes"
-            shift 1
-          fi
-      ;;
-      "-d")
-        if [ -n "$2" ]
-        then
-          depot_path="$2"
-          shift 2
-        else
-          show_help 1
-        fi
-      ;;
-      *)
-        show_help 1
-    esac
-  done
+    while [ -n "$1" ]
+    do
+        case $1 in
+            "-b")
+                if [ -n "$2" ]
+                    then
+                    wazuh_branch="$2"
+                    build_pkg="yes"
+                    shift 2
+                else
+                    show_help 1
+                fi
+            ;;
+            "-h")
+                show_help
+                exit 0
+            ;;
+            "-e")
+                build_environment
+                exit 0
+            ;;
+            "-p")
+                if [ -n "$2" ]
+                    then
+                    install_path="$2"
+                    shift 2
+                else
+                    show_help 1
+                fi
+            ;;
+            "-s")
+                if [ -n "$2" ]
+                    then
+                    target_dir="$2"
+                    shift 2
+                else
+                    show_help 1
+                fi
+            ;;
+            "-c" | "--checksum")
+                if [ -n "$2" ]; then
+                    checksum_dir="$2"
+                    compute_checksums="yes"
+                    shift 2
+                else
+                    compute_checksums="yes"
+                    shift 1
+                fi
+            ;;
+            "-d")
+                if [ -n "$2" ]
+                    then
+                    depot_path="$2"
+                    shift 2
+                else
+                    show_help 1
+                fi
+            ;;
+            *)
+                show_help 1
+        esac
+    done
 
-  if [[ "${build_env}" = "yes" ]]; then
-    build_environment || exit 1
-  fi
+    if [[ "${build_env}" = "yes" ]]; then
+        build_environment || exit 1
+    fi
 
-  if [ -z "${checksum_dir}" ]; then
-    checksum_dir="${target_dir}"
-  fi
+    if [ -z "${checksum_dir}" ]; then
+        checksum_dir="${target_dir}"
+    fi
 
-  if [[ "${build_pkg}" = "yes" ]]; then
-    build_package || clean 1
-  fi
+    if [[ "${build_pkg}" = "yes" ]]; then
+        build_package || clean 1
+    fi
 
-  return 0
+    return 0
 }
 
 main "$@"

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -135,7 +135,7 @@ create_package() {
   rm ${install_path}/wodles/oscap/content/*.xml
   wazuh_version=`echo "${wazuh_version}" | cut -d v -f 2`
   pkg_name="wazuh-agent-${wazuh_version}-${wazuh_revision}-hpux-11v3-ia64.tar"
-  tar cvpf ${target_dir}/${pkg_name} ${install_path} /etc/ossec-init.conf /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
+  tar cvpf ${target_dir}/${pkg_name} ${install_path} /sbin/init.d/wazuh-agent /sbin/rc2.d/S97wazuh-agent /sbin/rc3.d/S97wazuh-agent
 
   if [ "${compute_checksums}" = "yes" ]; then
     cd ${target_dir}
@@ -169,8 +169,11 @@ clean() {
     ${install_path}/bin/${control_binary} stop
   fi
 
+  if [ -f /etc/ossec-init.conf ]; then
+    rm /etc/ossec-init.conf
+  fi
+
   rm -rf ${install_path}
-  rm /etc/ossec-init.conf
   find /sbin -name "*wazuh-agent*" -exec rm {} \;
   userdel ossec
   groupdel ossec

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -111,7 +111,7 @@ fi
 ${INSTALLATION_SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
 
 # Install the service
-${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh
+${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh ${DIR}
 
 # Remove temporary directory
 rm -rf ${DIR}/packages_files

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -64,10 +64,6 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-if [ -f /etc/ossec-init.conf ]; then
-    rm /etc/ossec-init.conf
-fi
-
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 
 upgrade=$(launchctl getenv WAZUH_PKG_UPGRADE)

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -85,24 +85,24 @@ SCA_TMP_DIR="${SCA_BASE_DIR}/${SCA_DIR}"
 
 # Install the configuration files needed for this hosts
 if [ -r "${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}"
 elif [ -r "${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}"
 elif [ -r "${SCA_BASE_DIR}/${DIST_NAME}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}"
 else
-  SCA_TMP_DIR="${SCA_BASE_DIR}/generic"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/generic"
 fi
 
 SCA_TMP_FILE="${SCA_TMP_DIR}/sca.files"
 
 if [ -r ${SCA_TMP_FILE} ]; then
 
-  rm -f ${DIR}/ruleset/sca/* || true
+    rm -f ${DIR}/ruleset/sca/* || true
 
-  for sca_file in $(cat ${SCA_TMP_FILE}); do
-    mv ${SCA_BASE_DIR}/${sca_file} ${DIR}/ruleset/sca
-  done
+    for sca_file in $(cat ${SCA_TMP_FILE}); do
+        mv ${SCA_BASE_DIR}/${sca_file} ${DIR}/ruleset/sca
+    done
 fi
 
 # Register and configure agent if Wazuh environment variables are defined

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -108,7 +108,7 @@ if [ -r ${SCA_TMP_FILE} ]; then
 fi
 
 # Register and configure agent if Wazuh environment variables are defined
-${INSTALLATION_SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
+${INSTALLATION_SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
 
 # Install the service
 ${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh ${DIR}

--- a/macos/package_files/4.2.0/postinstall.sh
+++ b/macos/package_files/4.2.0/postinstall.sh
@@ -64,7 +64,9 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-chown root:${GROUP} /etc/ossec-init.conf
+if [ -f /etc/ossec-init.conf ]; then
+    rm /etc/ossec-init.conf
+fi
 
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 

--- a/macos/package_files/4.2.0/preinstall.sh
+++ b/macos/package_files/4.2.0/preinstall.sh
@@ -143,10 +143,8 @@ chown root:wheel /Library/StartupItems/WAZUH
 sudo tee /Library/StartupItems/WAZUH/WAZUH <<-'EOF'
 #!/bin/sh
 . /etc/rc.common
-. /etc/ossec-init.conf
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+
+DIRECTORY="/Library/Ossec"
 
 StartService ()
 {
@@ -197,11 +195,7 @@ chmod u=rw-,go=r-- /Library/StartupItems/WAZUH/StartupParameters.plist
 sudo tee /Library/StartupItems/WAZUH/launcher.sh <<-'EOF'
 #!/bin/sh
 
-. /etc/ossec-init.conf
-
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+DIRECTORY="/Library/Ossec"
 
 capture_sigterm() {
     ${DIRECTORY}/bin/wazuh-control stop

--- a/macos/package_files/4.2.0/preinstall.sh
+++ b/macos/package_files/4.2.0/preinstall.sh
@@ -34,33 +34,33 @@ if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
 fi
 
 if [[ ! -f "/usr/bin/dscl" ]]
-  then
-  echo "Error: I couldn't find dscl, dying here";
-  exit
+    then
+    echo "Error: I couldn't find dscl, dying here";
+    exit
 fi
 
 DSCL="/usr/bin/dscl";
 
 function check_errm
 {
-   if  [[ ${?} != "0" ]]
-      then
-      echo "${1}";
-      exit ${2};
-      fi
+    if  [[ ${?} != "0" ]]
+        then
+        echo "${1}";
+        exit ${2};
+        fi
 }
 
 # get unique id numbers (uid, gid) that are greater than 100
 unset -v i new_uid new_gid idvar;
 declare -i new_uid=0 new_gid=0 i=100 idvar=0;
 while [[ $idvar -eq 0 ]]; do
-   i=$[i+1]
-   if [[ -z "$(/usr/bin/dscl . -search /Users uid ${i})" ]] && [[ -z "$(/usr/bin/dscl . -search /Groups gid ${i})" ]];
-      then
-      new_uid=$i
-      new_gid=$i
-      idvar=1
-      #break
+    i=$[i+1]
+    if [[ -z "$(/usr/bin/dscl . -search /Users uid ${i})" ]] && [[ -z "$(/usr/bin/dscl . -search /Groups gid ${i})" ]];
+        then
+        new_uid=$i
+        new_gid=$i
+        idvar=1
+        #break
    fi
 done
 
@@ -86,33 +86,33 @@ fi
 
 # Creating the group
 if [[ $(dscl . -read /Groups/ossec) ]]
-   then
-   echo "ossec group already exists.";
+    then
+    echo "ossec group already exists.";
 else
-   sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
-   check_errm "Error creating group ossec" "67"
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
+    check_errm "Error creating group ossec" "67"
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
 fi
 
 # Creating the user
 if [[ $(dscl . -read /Users/ossec) ]]
-   then
-   echo "ossec user already exists.";
+    then
+    echo "ossec user already exists.";
 else
-   sudo ${DSCL} localhost -create /Local/Default/Users/ossec
-   check_errm "Error creating user ossec" "77"
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
-   sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Users/ossec
+    check_errm "Error creating user ossec" "77"
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
+sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
 fi
 
 #Hide the fixed users

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -108,7 +108,7 @@ if [ -r ${SCA_TMP_FILE} ]; then
 fi
 
 # Register and configure agent if Wazuh environment variables are defined
-${INSTALLATION_SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
+${INSTALLATION_SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
 
 # Install the service
 ${INSTALLATION_SCRIPTS_DIR}/src/init/darwin-init.sh

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -64,10 +64,6 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-if [ -f /etc/ossec-init.conf ]; then
-    rm /etc/ossec-init.conf
-fi
-
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 
 upgrade=$(launchctl getenv WAZUH_PKG_UPGRADE)

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -85,24 +85,24 @@ SCA_TMP_DIR="${SCA_BASE_DIR}/${SCA_DIR}"
 
 # Install the configuration files needed for this hosts
 if [ -r "${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/${DIST_SUBVER}"
 elif [ -r "${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}/${DIST_VER}"
 elif [ -r "${SCA_BASE_DIR}/${DIST_NAME}/sca.files" ]; then
-  SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/${DIST_NAME}"
 else
-  SCA_TMP_DIR="${SCA_BASE_DIR}/generic"
+    SCA_TMP_DIR="${SCA_BASE_DIR}/generic"
 fi
 
 SCA_TMP_FILE="${SCA_TMP_DIR}/sca.files"
 
 if [ -r ${SCA_TMP_FILE} ]; then
 
-  rm -f ${DIR}/ruleset/sca/* || true
+    rm -f ${DIR}/ruleset/sca/* || true
 
-  for sca_file in $(cat ${SCA_TMP_FILE}); do
-    mv ${SCA_BASE_DIR}/${sca_file} ${DIR}/ruleset/sca
-  done
+    for sca_file in $(cat ${SCA_TMP_FILE}); do
+        mv ${SCA_BASE_DIR}/${sca_file} ${DIR}/ruleset/sca
+    done
 fi
 
 # Register and configure agent if Wazuh environment variables are defined

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -64,7 +64,9 @@ chmod 770 ${DIR}/.ssh
 chmod -R 770 ${DIR}/var
 chown -R root:${GROUP} ${DIR}/var
 
-chown root:${GROUP} /etc/ossec-init.conf
+if [ -f /etc/ossec-init.conf ]; then
+    rm /etc/ossec-init.conf
+fi
 
 . ${INSTALLATION_SCRIPTS_DIR}/src/init/dist-detect.sh
 

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -143,10 +143,8 @@ chown root:wheel /Library/StartupItems/WAZUH
 sudo tee /Library/StartupItems/WAZUH/WAZUH <<-'EOF'
 #!/bin/sh
 . /etc/rc.common
-. /etc/ossec-init.conf
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+
+DIRECTORY="/Library/Ossec"
 
 StartService ()
 {
@@ -197,11 +195,7 @@ chmod u=rw-,go=r-- /Library/StartupItems/WAZUH/StartupParameters.plist
 sudo tee /Library/StartupItems/WAZUH/launcher.sh <<-'EOF'
 #!/bin/sh
 
-. /etc/ossec-init.conf
-
-if [ "X${DIRECTORY}" = "X" ]; then
-    DIRECTORY="/Library/Ossec"
-fi
+DIRECTORY="/Library/Ossec"
 
 capture_sigterm() {
     ${DIRECTORY}/bin/ossec-control stop

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -34,34 +34,34 @@ if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
 fi
 
 if [[ ! -f "/usr/bin/dscl" ]]
-  then
-  echo "Error: I couldn't find dscl, dying here";
-  exit
+    then
+    echo "Error: I couldn't find dscl, dying here";
+    exit
 fi
 
 DSCL="/usr/bin/dscl";
 
 function check_errm
 {
-   if  [[ ${?} != "0" ]]
-      then
-      echo "${1}";
-      exit ${2};
-      fi
+    if  [[ ${?} != "0" ]]
+        then
+        echo "${1}";
+        exit ${2};
+        fi
 }
 
 # get unique id numbers (uid, gid) that are greater than 100
 unset -v i new_uid new_gid idvar;
 declare -i new_uid=0 new_gid=0 i=100 idvar=0;
 while [[ $idvar -eq 0 ]]; do
-   i=$[i+1]
-   if [[ -z "$(/usr/bin/dscl . -search /Users uid ${i})" ]] && [[ -z "$(/usr/bin/dscl . -search /Groups gid ${i})" ]];
-      then
-      new_uid=$i
-      new_gid=$i
-      idvar=1
-      #break
-   fi
+    i=$[i+1]
+    if [[ -z "$(/usr/bin/dscl . -search /Users uid ${i})" ]] && [[ -z "$(/usr/bin/dscl . -search /Groups gid ${i})" ]];
+        then
+        new_uid=$i
+        new_gid=$i
+        idvar=1
+        #break
+    fi
 done
 
 echo "UID available for ossec user is:";
@@ -69,14 +69,14 @@ echo ${new_uid}
 
 # Verify that the uid and gid exist and match
 if [[ $new_uid -eq 0 ]] || [[ $new_gid -eq 0 ]];
-   then
-   echo "Getting unique id numbers (uid, gid) failed!";
-   exit 1;
+    then
+    echo "Getting unique id numbers (uid, gid) failed!";
+    exit 1;
 fi
 if [[ ${new_uid} != ${new_gid} ]]
-   then
-   echo "I failed to find matching free uid and gid!";
-   exit 5;
+    then
+    echo "I failed to find matching free uid and gid!";
+    exit 5;
 fi
 
 # Stops the agent before upgrading it
@@ -86,33 +86,33 @@ fi
 
 # Creating the group
 if [[ $(dscl . -read /Groups/ossec) ]]
-   then
-   echo "ossec group already exists.";
+    then
+    echo "ossec group already exists.";
 else
-   sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
-   check_errm "Error creating group ossec" "67"
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
-   sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
+    check_errm "Error creating group ossec" "67"
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
 fi
 
 # Creating the user
 if [[ $(dscl . -read /Users/ossec) ]]
-   then
-   echo "ossec user already exists.";
+    then
+    echo "ossec user already exists.";
 else
-   sudo ${DSCL} localhost -create /Local/Default/Users/ossec
-   check_errm "Error creating user ossec" "77"
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
-   sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
-   sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Users/ossec
+    check_errm "Error creating user ossec" "77"
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
 fi
 
 #Hide the fixed users

--- a/macos/specs/4.x/wazuh-agent-4.2.0.pkgproj
+++ b/macos/specs/4.x/wazuh-agent-4.2.0.pkgproj
@@ -40,41 +40,6 @@
 									<key>CHILDREN</key>
 									<array/>
 									<key>GID</key>
-									<integer>0</integer>
-									<key>PATH</key>
-									<string>/private/etc/ossec-init.conf</string>
-									<key>PATH_TYPE</key>
-									<integer>0</integer>
-									<key>PERMISSIONS</key>
-									<integer>416</integer>
-									<key>TYPE</key>
-									<integer>3</integer>
-									<key>UID</key>
-									<integer>0</integer>
-								</dict>
-							</array>
-							<key>EXPANDED</key>
-							<true/>
-							<key>GID</key>
-							<integer>0</integer>
-							<key>PATH</key>
-							<string>/private/etc</string>
-							<key>PATH_TYPE</key>
-							<integer>0</integer>
-							<key>PERMISSIONS</key>
-							<integer>493</integer>
-							<key>TYPE</key>
-							<integer>3</integer>
-							<key>UID</key>
-							<integer>0</integer>
-						</dict>
-						<dict>
-							<key>CHILDREN</key>
-							<array>
-								<dict>
-									<key>CHILDREN</key>
-									<array/>
-									<key>GID</key>
 									<integer>80</integer>
 									<key>PATH</key>
 									<string>Application Support</string>
@@ -328,22 +293,6 @@
 													<integer>0</integer>
 													<key>PERMISSIONS</key>
 													<integer>416</integer>
-													<key>TYPE</key>
-													<integer>3</integer>
-													<key>UID</key>
-													<integer>0</integer>
-												</dict>
-												<dict>
-													<key>CHILDREN</key>
-													<array/>
-													<key>GID</key>
-													<integer>0</integer>
-													<key>PATH</key>
-													<string>/Library/Ossec/etc/ossec-init.conf</string>
-													<key>PATH_TYPE</key>
-													<integer>0</integer>
-													<key>PERMISSIONS</key>
-													<integer>493</integer>
 													<key>TYPE</key>
 													<integer>3</integer>
 													<key>UID</key>

--- a/macos/specs/4.x/wazuh-agent-5.0.0.pkgproj
+++ b/macos/specs/4.x/wazuh-agent-5.0.0.pkgproj
@@ -40,41 +40,6 @@
 									<key>CHILDREN</key>
 									<array/>
 									<key>GID</key>
-									<integer>0</integer>
-									<key>PATH</key>
-									<string>/private/etc/ossec-init.conf</string>
-									<key>PATH_TYPE</key>
-									<integer>0</integer>
-									<key>PERMISSIONS</key>
-									<integer>416</integer>
-									<key>TYPE</key>
-									<integer>3</integer>
-									<key>UID</key>
-									<integer>0</integer>
-								</dict>
-							</array>
-							<key>EXPANDED</key>
-							<true/>
-							<key>GID</key>
-							<integer>0</integer>
-							<key>PATH</key>
-							<string>/private/etc</string>
-							<key>PATH_TYPE</key>
-							<integer>0</integer>
-							<key>PERMISSIONS</key>
-							<integer>493</integer>
-							<key>TYPE</key>
-							<integer>3</integer>
-							<key>UID</key>
-							<integer>0</integer>
-						</dict>
-						<dict>
-							<key>CHILDREN</key>
-							<array>
-								<dict>
-									<key>CHILDREN</key>
-									<array/>
-									<key>GID</key>
 									<integer>80</integer>
 									<key>PATH</key>
 									<string>Application Support</string>
@@ -328,22 +293,6 @@
 													<integer>0</integer>
 													<key>PERMISSIONS</key>
 													<integer>416</integer>
-													<key>TYPE</key>
-													<integer>3</integer>
-													<key>UID</key>
-													<integer>0</integer>
-												</dict>
-												<dict>
-													<key>CHILDREN</key>
-													<array/>
-													<key>GID</key>
-													<integer>0</integer>
-													<key>PATH</key>
-													<string>/Library/Ossec/etc/ossec-init.conf</string>
-													<key>PATH_TYPE</key>
-													<integer>0</integer>
-													<key>PERMISSIONS</key>
-													<integer>493</integer>
 													<key>TYPE</key>
 													<integer>3</integer>
 													<key>UID</key>

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -3,7 +3,10 @@
 ## Stop and remove application
 sudo /Library/Ossec/bin/ossec-control stop
 sudo /bin/rm -r /Library/Ossec*
-sudo /bin/rm /etc/ossec-init.conf
+
+if [ -f /etc/ossec-init.conf ]; then
+    sudo /bin/rm /etc/ossec-init.conf
+fi
 
 ## stop and unload dispatcher
 #sudo /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -37,7 +37,7 @@ sudo /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent-etc
 # In case it was installed via Puppet pkgdmg provider
 
 if [ -e /var/db/.puppet_pkgdmg_installed_wazuh-agent ]; then
-  sudo rm -f /var/db/.puppet_pkgdmg_installed_wazuh-agent
+    sudo rm -f /var/db/.puppet_pkgdmg_installed_wazuh-agent
 fi
 
 echo

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -4,10 +4,6 @@
 sudo /Library/Ossec/bin/ossec-control stop
 sudo /bin/rm -r /Library/Ossec*
 
-if [ -f /etc/ossec-init.conf ]; then
-    sudo /bin/rm /etc/ossec-init.conf
-fi
-
 ## stop and unload dispatcher
 #sudo /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -84,8 +84,10 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-install -m 0644 src/systemd/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
@@ -157,7 +159,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-cp -rp src/init/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -82,11 +82,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
-mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -159,8 +157,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
-mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -242,7 +242,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 
   # Register and configure agent if Wazuh environment variables are defined
-  %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh > /dev/null || :
+  %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
 # Delete the installation files used to configure the agent

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -249,11 +249,6 @@ rm -rf %{_localstatedir}/packages_files
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
-# Remove deprecated ossec-init.conf
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm %{_sysconfdir}/ossec-init.conf
-fi
-
 # CentOS
 if [ -r "/etc/centos-release" ]; then
   DIST_NAME="centos"

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -34,7 +34,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -83,7 +82,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
@@ -251,6 +249,10 @@ rm -rf %{_localstatedir}/packages_files
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
+# Remove deprecated ossec-init.conf
+if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+  rm %{_sysconfdir}/ossec-init.conf
+fi
 
 # CentOS
 if [ -r "/etc/centos-release" ]; then
@@ -445,7 +447,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
 %defattr(-,root,root)
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
 %dir %attr(770,root,ossec) %{_localstatedir}/.ssh
@@ -461,7 +462,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/localtime
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -82,9 +82,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -157,7 +159,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -84,9 +84,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -159,7 +159,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -79,9 +79,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -158,7 +158,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -252,7 +252,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
   fi
 
   # Get the major and minor version

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -159,7 +159,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 # Add SUSE initscript
 sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
-cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
+cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/generic

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -31,7 +31,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf manager centos %rhel %{_localstatedir} > etc/ossec-server.conf
-./gen_ossec.sh init manager %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -78,7 +77,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
@@ -248,8 +246,14 @@ if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/~api ]; then
     rm -rf %{_localstatedir}/~api
   fi
-  # Import the variables from ossec-init.conf file
-  . %{_sysconfdir}/ossec-init.conf
+
+  if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+    # Import the variables from ossec-init.conf file
+    . %{_sysconfdir}/ossec-init.conf
+  else
+    # Ask wazuh-control the version
+    VERSION=$(%{_localstatedir}/bin/wazuh-control)
+  fi
 
   # Get the major and minor version
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
@@ -416,6 +420,11 @@ if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&
   fi
 fi
 
+# Remove deprecated ossec-init.conf
+if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+  rm %{_sysconfdir}/ossec-init.conf
+fi
+
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/packages_files
 
@@ -534,7 +543,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
 %defattr(-,root,ossec)
-%attr(640, root, ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750, root, ossec) %{_localstatedir}
 %attr(750, root, ossec) %{_localstatedir}/agentless
 %dir %attr(750, root, ossec) %{_localstatedir}/active-response
@@ -584,7 +592,6 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, ossec) %{_localstatedir}/etc/internal_options*
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640, root, ossec) %{_localstatedir}/etc/localtime
 %dir %attr(770, root, ossec) %{_localstatedir}/etc/decoders
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -77,9 +77,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -156,7 +158,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -79,8 +79,10 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-install -m 0644 src/systemd/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
@@ -156,7 +158,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-cp -rp src/init/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/generic

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -252,7 +252,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
   fi
 
   # Get the major and minor version

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -77,11 +77,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
-mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
-mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -158,8 +156,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
-mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -420,11 +420,6 @@ if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&
   fi
 fi
 
-# Remove deprecated ossec-init.conf
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm %{_sysconfdir}/ossec-init.conf
-fi
-
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/packages_files
 

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -34,7 +34,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
-./gen_ossec.sh init agent %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -83,7 +82,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
@@ -247,6 +245,10 @@ rm -rf %{_localstatedir}/packages_files
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
+# Remove deprecated ossec-init.conf
+if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+  rm %{_sysconfdir}/ossec-init.conf
+fi
 
 # CentOS
 if [ -r "/etc/centos-release" ]; then
@@ -441,7 +443,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
 %defattr(-,root,root)
-%attr(640,root,ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750,root,ossec) %{_localstatedir}
 %attr(750,root,ossec) %{_localstatedir}/agentless
 %dir %attr(770,root,ossec) %{_localstatedir}/.ssh
@@ -457,7 +458,6 @@ rm -fr %{buildroot}
 %attr(640,root,ossec) %{_localstatedir}/etc/localtime
 %attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
 %attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -84,8 +84,10 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-install -m 0644 src/systemd/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
@@ -153,7 +155,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-cp -rp src/init/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -245,11 +245,6 @@ rm -rf %{_localstatedir}/packages_files
 # Remove unnecessary files from shared directory
 rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
-# Remove deprecated ossec-init.conf
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm %{_sysconfdir}/ossec-init.conf
-fi
-
 # CentOS
 if [ -r "/etc/centos-release" ]; then
   DIST_NAME="centos"

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -238,7 +238,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 
   # Register and configure agent if Wazuh environment variables are defined
-  %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh > /dev/null || :
+  %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
 # Delete the installation files used to configure the agent

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -82,11 +82,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
-mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
-mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -155,8 +153,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
-mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -82,9 +82,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -153,7 +155,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -84,9 +84,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -155,7 +155,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -79,8 +79,10 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-install -m 0755 src/init/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-install -m 0644 src/systemd/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
 rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
@@ -156,7 +158,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-cp -rp src/init/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
+sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/generic

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -77,11 +77,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
-mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
-mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -158,8 +156,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
-mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -77,9 +77,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -156,7 +158,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -252,7 +252,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
   fi
 
   # Get the major and minor version

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -79,9 +79,9 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -158,7 +158,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -31,7 +31,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %setup -q
 
 ./gen_ossec.sh conf manager centos %rhel %{_localstatedir} > etc/ossec-server.conf
-./gen_ossec.sh init manager %{_localstatedir} > ossec-init.conf
 
 %build
 pushd src
@@ -78,7 +77,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-install -m 0640 ossec-init.conf ${RPM_BUILD_ROOT}%{_sysconfdir}
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
 sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
@@ -248,8 +246,14 @@ if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/~api ]; then
     rm -rf %{_localstatedir}/~api
   fi
-  # Import the variables from ossec-init.conf file
-  . %{_sysconfdir}/ossec-init.conf
+
+  if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+    # Import the variables from ossec-init.conf file
+    . %{_sysconfdir}/ossec-init.conf
+  else
+    # Ask wazuh-control the version
+    VERSION=$(%{_localstatedir}/bin/wazuh-control)
+  fi
 
   # Get the major and minor version
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
@@ -416,6 +420,11 @@ if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&
   fi
 fi
 
+# Remove deprecated ossec-init.conf
+if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+  rm %{_sysconfdir}/ossec-init.conf
+fi
+
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/packages_files
 
@@ -534,7 +543,6 @@ rm -fr %{buildroot}
 %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
 %defattr(-,root,ossec)
-%attr(640, root, ossec) %verify(not md5 size mtime) %{_sysconfdir}/ossec-init.conf
 %dir %attr(750, root, ossec) %{_localstatedir}
 %attr(750, root, ossec) %{_localstatedir}/agentless
 %dir %attr(750, root, ossec) %{_localstatedir}/active-response
@@ -590,7 +598,6 @@ rm -fr %{buildroot}
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, ossec) %{_localstatedir}/etc/internal_options*
 %attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%{_localstatedir}/etc/ossec-init.conf
 %attr(640, root, ossec) %{_localstatedir}/etc/localtime
 %dir %attr(770, root, ossec) %{_localstatedir}/etc/decoders
 %attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -252,7 +252,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
   fi
 
   # Get the major and minor version

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -420,11 +420,6 @@ if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&
   fi
 fi
 
-# Remove deprecated ossec-init.conf
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm %{_sysconfdir}/ossec-init.conf
-fi
-
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/packages_files
 

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -40,9 +40,9 @@ set_control_binary() {
     minor=`echo $number_version | cut -d . -f 2`
 
     if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
-      control_binary="ossec-control"
+        control_binary="ossec-control"
     else
-      control_binary="wazuh-control"
+        control_binary="wazuh-control"
     fi
   fi
 }

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -233,11 +233,6 @@ clean(){
 
     rm -r ${install_path}*
 
-    # Remove deprecated ossec-init.conf
-    if [ -f /etc/ossec-init.conf ]; then
-        rm -f /etc/ossec-init.conf
-    fi
-
     # remove launchdaemons
     rm -f /etc/init.d/wazuh-agent
     rm -f /etc/rc2.d/S97wazuh-agent

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -200,7 +200,6 @@ package(){
     echo "i postinstall=postinstall.sh" >> "wazuh-agent_$VERSION.proto"
     echo "i preremove=preremove.sh" >> "wazuh-agent_$VERSION.proto"
     echo "i postremove=postremove.sh" >> "wazuh-agent_$VERSION.proto"
-    echo "f none /etc/ossec-init.conf  0640 root ossec" >> "wazuh-agent_$VERSION.proto"
     echo "f none /etc/init.d/wazuh-agent  0755 root root" >> "wazuh-agent_$VERSION.proto"
     echo "s none /etc/rc2.d/S97wazuh-agent=/etc/init.d/wazuh-agent" >> "wazuh-agent_$VERSION.proto"
     echo "s none /etc/rc3.d/S97wazuh-agent=/etc/init.d/wazuh-agent" >> "wazuh-agent_$VERSION.proto"
@@ -233,9 +232,13 @@ clean(){
     fi
 
     rm -r ${install_path}*
-    rm -f /etc/ossec-init.conf
 
-     # remove launchdaemons
+    # Remove deprecated ossec-init.conf
+    if [ -f /etc/ossec-init.conf ]; then
+        rm -f /etc/ossec-init.conf
+    fi
+
+    # remove launchdaemons
     rm -f /etc/init.d/wazuh-agent
     rm -f /etc/rc2.d/S97wazuh-agent
     rm -f /etc/rc3.d/S97wazuh-agent

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -3,22 +3,19 @@
 # Wazuh, Inc 2015-2020
 
 if [ ! -f /etc/ossec-init.conf ]; then
-	DIR="/var/ossec"
-	ls -la /var/ossec > /dev/null 2>&1
-    if [ -d  /var/ossec ]; then
-		#upgrade
-        type=upgrade
-
-	else
-		#clean installation
-        type=install
-    fi
-
+  DIR="/var/ossec"
+  ls -la /var/ossec > /dev/null 2>&1
+  if [ -d /var/ossec ]; then
+    #upgrade
+    type=upgrade
+  else
+    #clean installation
+    type=install
+  fi
 else
-	#upgrade
-	DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
-	type=upgrade
-
+  #upgrade
+  DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
+  type=upgrade
 fi
 
 USER="ossec"

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -3,19 +3,19 @@
 # Wazuh, Inc 2015-2020
 
 if [ ! -f /etc/ossec-init.conf ]; then
-  DIR="/var/ossec"
-  ls -la /var/ossec > /dev/null 2>&1
-  if [ -d /var/ossec ]; then
-    #upgrade
-    type=upgrade
-  else
-    #clean installation
-    type=install
-  fi
+    DIR="/var/ossec"
+    ls -la /var/ossec > /dev/null 2>&1
+    if [ -d /var/ossec ]; then
+        #upgrade
+        type=upgrade
+    else
+        #clean installation
+        type=install
+    fi
 else
-  #upgrade
-  DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
-  type=upgrade
+    #upgrade
+    DIR=`cat $INSTALLATION_FILE | grep DIRECTORY | cut -d'=' -f2 | cut -d'"' -f2`
+    type=upgrade
 fi
 
 USER="ossec"
@@ -25,54 +25,54 @@ OSMYSHELL="/sbin/nologin"
 
 # environment configuration
 if [ ! -d ${OSSEC_HIDS_TMP_DIR} ]; then
-  mkdir ${OSSEC_HIDS_TMP_DIR}
+    mkdir ${OSSEC_HIDS_TMP_DIR}
 fi
 
 if [ ! -f ${OSMYSHELL} ]; then
-  if [ -f "/bin/false" ]; then
-    OSMYSHELL="/bin/false"
-  fi
+    if [ -f "/bin/false" ]; then
+        OSMYSHELL="/bin/false"
+    fi
 fi
 
 getent group | grep "^ossec"
 if [ "$?" -eq 1 ]; then
-  groupadd ${GROUP}
+    groupadd ${GROUP}
 fi
 
 getent passwd | grep "^ossec"
 if [ "$?" -eq 1 ]; then
-  useradd -d ${DIR} -s ${OSMYSHELL} -g ${GROUP} ${USER} > /dev/null 2>&1
+    useradd -d ${DIR} -s ${OSMYSHELL} -g ${GROUP} ${USER} > /dev/null 2>&1
 fi
 
 case $type in
     upgrade)
 
-        if [ -d "$DIR" ]
-		then
-                if [ -f ${DIR}/etc/ossec.conf ]; then
-                cp  ${DIR}/etc/ossec.conf  ${DIR}/etc/ossec.conf.deborig
-                chmod 0600 ${DIR}/etc/ossec.conf.deborig
-                chown root:root ${DIR}/etc/ossec.conf.deborig
-                echo "====================================================================================="
-                echo "= Backup from your ossec.conf has been created at /var/ossec/etc/ossec.conf.deborig ="
-                echo "= Please verify your ossec.conf configuration at /var/ossec/etc/ossec.conf          ="
-                echo "====================================================================================="
-                fi
-        fi
-        # Delete old service
-        if [ -f /etc/init.d/wazuh-agent ]; then
-            rm /etc/init.d/wazuh-agent
-        fi
-        # back up the current user rules
-        if [ -f ${DIR}/etc/client.keys ]; then
-            cp ${DIR}/etc/client.keys ${OSSEC_HIDS_TMP_DIR}/client.keys
-        fi
-        if [ -f ${DIR}/etc/local_internal_options.conf ]; then
-            cp -p ${DIR}/etc/local_internal_options.conf ${OSSEC_HIDS_TMP_DIR}/local_internal_options.conf
-        fi
+    if [ -d "$DIR" ]
+		    then
         if [ -f ${DIR}/etc/ossec.conf ]; then
-            cp -p ${DIR}/etc/ossec.conf ${OSSEC_HIDS_TMP_DIR}/ossec.conf
+            cp  ${DIR}/etc/ossec.conf  ${DIR}/etc/ossec.conf.deborig
+            chmod 0600 ${DIR}/etc/ossec.conf.deborig
+            chown root:root ${DIR}/etc/ossec.conf.deborig
+            echo "====================================================================================="
+            echo "= Backup from your ossec.conf has been created at /var/ossec/etc/ossec.conf.deborig ="
+            echo "= Please verify your ossec.conf configuration at /var/ossec/etc/ossec.conf          ="
+            echo "====================================================================================="
         fi
+    fi
+    # Delete old service
+    if [ -f /etc/init.d/wazuh-agent ]; then
+        rm /etc/init.d/wazuh-agent
+    fi
+    # back up the current user rules
+    if [ -f ${DIR}/etc/client.keys ]; then
+        cp ${DIR}/etc/client.keys ${OSSEC_HIDS_TMP_DIR}/client.keys
+    fi
+    if [ -f ${DIR}/etc/local_internal_options.conf ]; then
+        cp -p ${DIR}/etc/local_internal_options.conf ${OSSEC_HIDS_TMP_DIR}/local_internal_options.conf
+    fi
+    if [ -f ${DIR}/etc/ossec.conf ]; then
+        cp -p ${DIR}/etc/ossec.conf ${OSSEC_HIDS_TMP_DIR}/ossec.conf
+    fi
 
     ;;
 

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -3,12 +3,8 @@
 
 control_binary="wazuh-control"
 
-set_control_binary() {
-  if [ ! -f /var/ossec/bin/${control_binary} ]; then
-    control_binary="ossec-control"
-  fi
-}
-
-set_control_binary
+if [ ! -f /var/ossec/bin/${control_binary} ]; then
+  control_binary="ossec-control"
+fi
 
 /var/ossec/bin/${control_binary} stop

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -1,21 +1,10 @@
 #!/bin/sh
 # preremove script for wazuh-agent
 
-OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
-if [ -f ${OSSEC_INIT} ]; then
-  . ${OSSEC_INIT}
-else
-  VERSION=`/var/ossec/bin/${control_binary} -v`
-fi
-
 set_control_binary() {
-  number_version=`echo "${VERSION}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-
-  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+  if [ ! -f /var/ossec/bin/${control_binary} ]; then
     control_binary="ossec-control"
   fi
 }

--- a/solaris/solaris10/preremove.sh
+++ b/solaris/solaris10/preremove.sh
@@ -4,7 +4,11 @@
 OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
-. ${OSSEC_INIT}
+if [ -f ${OSSEC_INIT} ]; then
+  . ${OSSEC_INIT}
+else
+  VERSION=`/var/ossec/bin/${control_binary} -v`
+fi
 
 set_control_binary() {
   number_version=`echo "${VERSION}" | cut -d v -f 2`

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -11,7 +11,7 @@ set_control_binary() {
 set_control_binary
 
 ## Stop and remove application
-/var/ossec/bin/${control_binary} 2> /dev/null
+/var/ossec/bin/${control_binary} stop
 rm -rf /var/ossec/
 
 ## stop and unload dispatcher

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -2,13 +2,9 @@
 
 control_binary="wazuh-control"
 
-set_control_binary() {
-  if [ ! -f /var/ossec/bin/${control_binary} ]; then
-    control_binary="ossec-control"
-  fi
-}
-
-set_control_binary
+if [ ! -f /var/ossec/bin/${control_binary} ]; then
+  control_binary="ossec-control"
+fi
 
 ## Stop and remove application
 /var/ossec/bin/${control_binary} stop

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -13,8 +13,6 @@ set_control_binary
 ## Stop and remove application
 /var/ossec/bin/${control_binary} 2> /dev/null
 rm -rf /var/ossec/
-rm -f /etc/ossec-init.conf
-
 
 ## stop and unload dispatcher
 #/bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
@@ -23,7 +21,6 @@ rm -f /etc/ossec-init.conf
 rm -f /etc/init.d/wazuh-agent
 rm -rf /etc/rc2.d/S97wazuh-agent
 rm -rf /etc/rc3.d/S97wazuh-agent
-
 
 ## Remove User and Groups
 userdel ossec 2> /dev/null

--- a/solaris/solaris10/uninstall.sh
+++ b/solaris/solaris10/uninstall.sh
@@ -1,15 +1,9 @@
 #/bin/sh
 
-OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
 set_control_binary() {
-  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-
-  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+  if [ ! -f /var/ossec/bin/${control_binary} ]; then
     control_binary="ossec-control"
   fi
 }
@@ -19,7 +13,7 @@ set_control_binary
 ## Stop and remove application
 /var/ossec/bin/${control_binary} 2> /dev/null
 rm -rf /var/ossec/
-rm -f ${OSSEC_INIT}
+rm -f /etc/ossec-init.conf
 
 
 ## stop and unload dispatcher

--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -407,15 +407,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec-init.conf": {
-        "class": "static",
-        "group": "root",
-        "mode": "0777",
-        "prot": "lrwxrwxrwx",
-        "target": "/etc/ossec-init.conf",
-        "type": "link",
-        "user": "root"
-    },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -407,15 +407,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec-init.conf": {
-        "class": "static",
-        "group": "root",
-        "mode": "0777",
-        "prot": "lrwxrwxrwx",
-        "target": "/etc/ossec-init.conf",
-        "type": "link",
-        "user": "root"
-    },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -166,9 +166,6 @@ create_package() {
         sed "s:file $file.*:& preserve=install-only:"  wazuh-agent.p5m.1 > wazuh-agent.p5m.1.aux_sed
         mv wazuh-agent.p5m.1.aux_sed wazuh-agent.p5m.1
     done
-    # Fix the /etc/ossec-init.conf link
-    sed "s:target=etc/ossec-init.conf:target=/etc/ossec-init.conf:"  wazuh-agent.p5m.1 > wazuh-agent.p5m.1.aux
-    mv wazuh-agent.p5m.1.aux wazuh-agent.p5m.1
     # Add service files
     echo "file wazuh-agent path=etc/init.d/wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
     echo "file S97wazuh-agent path=etc/rc2.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1

--- a/solaris/solaris11/solaris_fix.py
+++ b/solaris/solaris11/solaris_fix.py
@@ -68,9 +68,6 @@ def set_p5m1(template_path, p5m1_file_path):
                         # write the line into the file
                         p5m1_fixed.write("".join([i + " " for i in line_components])+"\n")
 
-        p5m1_fixed.write("file etc/ossec-init.conf path=etc/ossec-init.conf owner=root group=root mode=0640"+"\n")
-        p5m1_fixed.write("link path=var/ossec/etc/ossec-init.conf target=etc/ossec-init.conf"+"\n")
-
 
 def main():
     parser = argparse.ArgumentParser()

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -13,7 +13,6 @@ set_control_binary
 ## Stop and remove application
 sudo /var/ossec/bin/${control_binary} stop
 sudo rm -r /var/ossec*
-sudo rm /etc/ossec-init.conf
 
 # remove launchdaemons
 sudo rm -f /etc/init.d/wazuh-agent

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -1,15 +1,9 @@
 #/bin/sh
 
-OSSEC_INIT="/etc/ossec-init.conf"
 control_binary="wazuh-control"
 
 set_control_binary() {
-  wazuh_version=$(grep VERSION ${OSSEC_INIT} | sed 's/VERSION="v//g' | sed 's/"//g')
-  number_version=`echo "${wazuh_version}" | cut -d v -f 2`
-  major=`echo $number_version | cut -d . -f 1`
-  minor=`echo $number_version | cut -d . -f 2`
-
-  if [ "$major" -le "4" ] && [ "$minor" -le "1" ]; then
+  if [ ! -f /var/ossec/bin/${control_binary} ]; then
     control_binary="ossec-control"
   fi
 }
@@ -19,7 +13,7 @@ set_control_binary
 ## Stop and remove application
 sudo /var/ossec/bin/${control_binary} stop
 sudo rm -r /var/ossec*
-sudo rm ${OSSEC_INIT}
+sudo rm /etc/ossec-init.conf
 
 # remove launchdaemons
 sudo rm -f /etc/init.d/wazuh-agent

--- a/solaris/solaris11/uninstall.sh
+++ b/solaris/solaris11/uninstall.sh
@@ -2,13 +2,9 @@
 
 control_binary="wazuh-control"
 
-set_control_binary() {
-  if [ ! -f /var/ossec/bin/${control_binary} ]; then
-    control_binary="ossec-control"
-  fi
-}
-
-set_control_binary
+if [ ! -f /var/ossec/bin/${control_binary} ]; then
+  control_binary="ossec-control"
+fi
 
 ## Stop and remove application
 sudo /var/ossec/bin/${control_binary} stop


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/608 |

## Description

This PR implements all the necessary changes in the Wazuh packages to remove the `ossec-init.conf` from the Wazuh installations. For more details check the **description** section of the Epic https://github.com/wazuh/wazuh/issues/7054.

## Tests

- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
  - [x] Solaris
  - [x] AIX
  - [x] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [x] `%files` section is correctly updated if necessary
  - [x] Check the changes from IBM AIX 5 to 7
