### PR TITLE
Fixing wazuh-control parameters in the calls to get the Wazuh version

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -250,7 +250,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
   fi
 
   # Get the major and minor version

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -250,7 +250,7 @@ if [ $1 = 2 ]; then
     . %{_sysconfdir}/ossec-init.conf
   else
     # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control -v)
+    VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
   fi
 
   # Get the major and minor version


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7090 |

## Description

This pull request implements a fix in the calls to `wazuh-control` when is used by the installers to get the Wazuh version. Basically there was a missing parameter called `info` that must be specified before the `-v` switch.

## Tests

- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade

- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64