### PR TITLE
Removing the usage of the -i switch in the sed command for all the installers

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -53,7 +53,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -53,7 +53,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_init_scripts}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 
 # Copy the files into RPM_BUILD_ROOT directory
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-aix.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
+mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
 install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 

--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -60,11 +60,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -177,7 +179,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -66,11 +66,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -62,11 +62,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-agent
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	install -m 0644 src/init/templates/wazuh-agent.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall
@@ -173,7 +175,8 @@ override_dh_install:
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/etc/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-agent.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+	mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 override_dh_auto_clean:

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -68,11 +68,13 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/ossec-hids-debian.init
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/ossec-hids-debian.init > src/init/templates/ossec-hids-debian.init.tmp
+	mv src/init/templates/ossec-hids-debian.init.tmp src/init/templates/ossec-hids-debian.init
 	cp src/init/templates/ossec-hids-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/
-	sed -i "s|WAZUH_HOME_TMP|${INSTALLATION_DIR}|g" src/init/templates/wazuh-manager.service
+	sed "s/WAZUH_HOME_TMP/${INSTALLATION_DIR}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+	mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 	install -m 0644 src/init/templates/wazuh-manager.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 	# Generating permission restoration file for postinstall

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -82,9 +82,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -155,7 +157,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -77,9 +77,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -154,7 +156,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -82,9 +82,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-agent.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-agent.service > src/init/templates/wazuh-agent.service.tmp
+mv src/init/templates/wazuh-agent.service.tmp src/init/templates/wazuh-agent.service
 install -m 0644 src/init/templates/wazuh-agent.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -151,7 +153,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_sc
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/init/
 
 # Copy scap templates

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -77,9 +77,11 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-rh.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-rh.init > src/init/templates/ossec-hids-rh.init.tmp
+mv src/init/templates/ossec-hids-rh.init.tmp src/init/templates/ossec-hids-rh.init
 install -m 0755 src/init/templates/ossec-hids-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-agent
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/wazuh-manager.service
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/wazuh-manager.service > src/init/templates/wazuh-manager.service.tmp
+mv src/init/templates/wazuh-manager.service.tmp src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 
 # Clean the preinstalled configuration assesment files
@@ -154,7 +156,8 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 
 # Add SUSE initscript
-sed -i "s|WAZUH_HOME_TMP|%{_localstatedir}|g" src/init/templates/ossec-hids-suse.init
+sed "s/WAZUH_HOME_TMP/%{_localstatedir}/g" src/init/templates/ossec-hids-suse.init > src/init/templates/ossec-hids-suse.init.tmp
+mv src/init/templates/ossec-hids-suse.init.tmp src/init/templates/ossec-hids-suse.init
 cp -rp src/init/templates/ossec-hids-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7090 |

## Description

As part of the exploratory testing that we made for the epic https://github.com/wazuh/wazuh/issues/7054 where we are removing the `ossec-init.conf` file from the Wazuh installations, we identified that we were using the `-i` switch in the `sed` command in some packages. This switch is not part of the standard of the `sed` command, so it doesn't work in AIX for example.

This PR removed the usage of that switch in all the packages.

## Tests

- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
  - [x] Solaris
  - [x] AIX
  - [x] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [x] `%files` section is correctly updated if necessary
  - [x] Check the changes from IBM AIX 5 to 7