### PR TITLE
Make postinst functions of .deb packages remove /etc/ossec-init.conf

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -142,6 +142,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -241,6 +241,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -142,6 +142,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -240,6 +240,11 @@ case "$1" in
         fi
     fi
 
+    #Delete obsolete files
+    if [ -f /etc/ossec-init.conf ]; then
+        rm /etc/ossec-init.conf
+    fi
+
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/7090 |

## Description

This pull request implements a fix in **postinst** functions of **.deb** packages to remove **/etc/ossec-init.con** that wasn't being deleted after the upgrade.

## Tests

- Build the package in any supported platform
  - [x] Linux
- [x] .deb package installation
- [x] .deb package upgrade
