### PR TITLE
Add oscap wodle files to unreleased rpms

### DIFF
--- a/rpms/SPECS/4.1.0/wazuh-agent-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-agent-4.1.0.spec
@@ -573,6 +573,8 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
+++ b/rpms/SPECS/4.1.0/wazuh-manager-4.1.0.spec
@@ -772,6 +772,8 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -580,6 +580,8 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -769,6 +769,8 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -569,6 +569,8 @@ rm -fr %{buildroot}
 %attr(750,root,ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -777,6 +777,8 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
 %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, ossec) %{_localstatedir}/wodles/oscap
+%attr(750, root, ossec) %{_localstatedir}/wodles/oscap/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This pull request adds the oscap wodle files that are currently missing from the RPM. Enabling the oscap wodle without these files does not appear to be possible and all of the documentation I've found on [Wazuh oscap configuration](https://documentation.wazuh.com/4.0/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.html) appears to assume that these files are already in place. My guess is this was just an oversight rather than an intentional choice.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
