### PR TITLE
Fix version in DEB preinstall

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
@@ -36,8 +36,13 @@ case "$1" in
             if [ -d ${DIR}/~api ]; then
                 rm -rf ${DIR}/~api
             fi
-            # Import the variables from ossec-init.conf file
-            . /etc/ossec-init.conf
+
+            # Get old package version
+            if [ -f . /etc/ossec-init.conf ]; then
+                . /etc/ossec-init.conf
+            else
+                VERSION=$(${DIR}/bin/wazuh-control info -v)
+            fi
 
             # Get the major and minor version
             MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
@@ -36,8 +36,13 @@ case "$1" in
             if [ -d ${DIR}/~api ]; then
                 rm -rf ${DIR}/~api
             fi
-            # Import the variables from ossec-init.conf file
-            . /etc/ossec-init.conf
+
+            # Get old package version
+            if [ -f . /etc/ossec-init.conf ]; then
+                . /etc/ossec-init.conf
+            else
+                VERSION=$(${DIR}/bin/wazuh-control info -v)
+            fi
 
             # Get the major and minor version
             MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes a problem with the upggrades from 4.2.0 for DEB packages where the version of the old package was not obtained correctly.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package

