### PR TITLE
Use ossec control in preinstall  if necessary

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/preinst
@@ -28,6 +28,9 @@ case "$1" in
             elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
+            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
         fi
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
@@ -30,6 +30,9 @@ case "$1" in
             elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
+            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
 
             # Delete old API backups

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/preinst
@@ -28,6 +28,9 @@ case "$1" in
             elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
+            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
         fi
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
@@ -30,6 +30,9 @@ case "$1" in
             elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
                 ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
+            elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+                ${DIR}/bin/ossec-control stop > /dev/null 2>&1
+                touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
 
             # Delete old API backups

--- a/macos/package_files/4.2.0/preinstall.sh
+++ b/macos/package_files/4.2.0/preinstall.sh
@@ -17,6 +17,8 @@ else
     launchctl setenv WAZUH_PKG_UPGRADE true
     if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
         launchctl setenv WAZUH_RESTART true
+    elif ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
+        launchctl setenv WAZUH_RESTART true
     else
         launchctl setenv WAZUH_RESTART false
     fi
@@ -82,6 +84,8 @@ fi
 # Stops the agent before upgrading it
 if [ -f ${DIR}/bin/wazuh-control ]; then
     ${DIR}/bin/wazuh-control stop
+elif [ -f ${DIR}/bin/ossec-control ]; then
+    ${DIR}/bin/ossec-control stop
 fi
 
 # Creating the group

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -17,6 +17,8 @@ else
     launchctl setenv WAZUH_PKG_UPGRADE true
     if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
         launchctl setenv WAZUH_RESTART true
+    elif ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
+        launchctl setenv WAZUH_RESTART true
     else
         launchctl setenv WAZUH_RESTART false
     fi
@@ -82,6 +84,8 @@ fi
 # Stops the agent before upgrading it
 if [ -f ${DIR}/bin/wazuh-control ]; then
     ${DIR}/bin/wazuh-control stop
+elif [ -f ${DIR}/bin/ossec-control ]; then
+    ${DIR}/bin/ossec-control stop
 fi
 
 # Creating the group

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -204,6 +204,9 @@ if [ $1 = 2 ]; then
   elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
+  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
 

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -197,6 +197,9 @@ if [ $1 = 2 ]; then
   elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
+  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
 

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -204,6 +204,9 @@ if [ $1 = 2 ]; then
   elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
+  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
 

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -197,6 +197,9 @@ if [ $1 = 2 ]; then
   elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
+  elif %{_localstatedir}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
+    touch %{_localstatedir}/tmp/wazuh.restart
   fi
 fi
 


### PR DESCRIPTION
|Related issue|
|---|
|#636|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a problem where wazuh-control was used when upgrading from versions lower than 4.2.0 causing the services to not be stopped propperly.

Regards,
Daniel Folch

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
