### PR TITLE
Updated homebrew install command

### DIFF
--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -255,7 +255,7 @@ function install_deps() {
 function install_xcode() {
 
     # Install brew tool. Brew will install X-Code if it is not already installed in the host.
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
     exit 0
 }


### PR DESCRIPTION
|Related issue|
|---|
| #659 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--

-->
Closes #659

Updated the installation command to the one provided here: #https://github.com/Homebrew/install/blob/dee8df98bfb65588007c666034c6e1ad0733b1b6/install#L3


## Logs example

<!--
Paste here related logs

-->
Installed x-code using updated command

```
==> Downloading https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby-2.6.3_2.yosemite.bottle.tar.gz
#################################################################################################################################################################################################### 100.0%
==> Pouring portable-ruby-2.6.3_2.yosemite.bottle.tar.gz
==> Installation successful!

```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
- [X] macOS
- [X] Package installation

