### PR TITLE
Add GCC5 support to Manager build with Python 3.9

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -19,6 +19,18 @@ RUN apt-get update && apt-get build-dep python3.2 -y && \
 RUN sed -i 's:https:http:g' /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && apt-get install nodejs -y
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
+    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer --disable-bootstrap && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64:${LD_LIBRARY_PATH}"
+ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/SPECS/4.1.3/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.1.3/wazuh-manager/debian/rules
@@ -24,6 +24,8 @@ export INSTALLATION_DIR="/var/ossec"
 export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/manager_installation_scripts"
 export JOBS="5"
 export DEBUG_ENABLED="no"
+export PATH="${PATH}"
+export LD_LIBRARY_PATH=""
 
 %:
 	dh $@

--- a/debs/SPECS/4.1.3/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.1.3/wazuh-manager/debian/rules
@@ -186,11 +186,11 @@ override_dh_install:
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions
-	chmod 0750 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/bin/2to3-3.8
-	chmod 0750 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/bin/pydoc3.8
+	chmod 0750 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/bin/2to3-3.9
+	chmod 0750 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/bin/pydoc3.9
 	chmod 0750 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/bin/python3-config
-	chmod 0640 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/lib/pkgconfig/python-3.8-embed.pc
-	chmod 0640 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/lib/pkgconfig/python-3.8.pc
+	chmod 0640 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/lib/pkgconfig/python-3.9-embed.pc
+	chmod 0640 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/lib/pkgconfig/python-3.9.pc
 	chmod 0640 ${TARGET_DIR}$(INSTALLATION_DIR)/framework/python/lib/pkgconfig/python3.pc
 
 override_dh_auto_clean:

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -85,6 +85,8 @@ cd ${build_dir}/${build_target} && tar -czf ${package_full_name}.orig.tar.gz "${
 sed -i "s:RELEASE:${package_release}:g" ${sources_dir}/debian/changelog
 sed -i "s:export JOBS=.*:export JOBS=${jobs}:g" ${sources_dir}/debian/rules
 sed -i "s:export DEBUG_ENABLED=.*:export DEBUG_ENABLED=${debug}:g" ${sources_dir}/debian/rules
+sed -i "s#export PATH=.*#export PATH=/usr/local/gcc-5.5.0/bin:${PATH}#g" ${sources_dir}/debian/rules
+sed -i "s#export LD_LIBRARY_PATH=.*#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}#g" ${sources_dir}/debian/rules
 sed -i "s:export INSTALLATION_DIR=.*:export INSTALLATION_DIR=${dir_path}:g" ${sources_dir}/debian/rules
 sed -i "s:DIR=\"/var/ossec\":DIR=\"${dir_path}\":g" ${sources_dir}/debian/{preinst,postinst,prerm,postrm}
 if [ "${build_target}" == "api" ]; then

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -40,6 +40,18 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
+    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
+ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/7/aarch64/Dockerfile
+++ b/rpms/CentOS/7/aarch64/Dockerfile
@@ -24,6 +24,18 @@ RUN yum install -y gcc make wget git \
     redhat-rpm-config sqlite-devel gdb tar tcl-devel tix-devel tk-devel \
     valgrind-devel python-rpm-macros python34 nodejs
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
+    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer --disable-bootstrap && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
+ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+
 RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     tar -xzf openssl-1.1.1a.tar.gz && cd openssl* && \
     ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' && \

--- a/rpms/CentOS/7/ppc64le/Dockerfile
+++ b/rpms/CentOS/7/ppc64le/Dockerfile
@@ -21,6 +21,18 @@ RUN yum install -y \
     http://packages.wazuh.com/utils/nodejs/npm-5.6.0-1.8.9.4.2.el7.ppc64le.rpm \
     http://packages.wazuh.com/utils/nodejs/nodejs-debuginfo-8.9.4-2.el7.ppc64le.rpm
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
+    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
+ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/SPECS/4.1.3/wazuh-manager-4.1.3.spec
+++ b/rpms/SPECS/4.1.3/wazuh-manager-4.1.3.spec
@@ -621,7 +621,7 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/integrations/*
 %dir %attr(750, root, ossec) %{_localstatedir}/lib
 %attr(750, root, ossec) %{_localstatedir}/lib/libwazuhext.so
-%{_localstatedir}/lib/libpython3.8.so.1.0
+%{_localstatedir}/lib/libpython3.9.so.1.0
 %dir %attr(770, ossec, ossec) %{_localstatedir}/logs
 %attr(660, ossec, ossec)  %ghost %{_localstatedir}/logs/active-responses.log
 %attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/api.log


### PR DESCRIPTION
|Related issue|
|---|
| closes #669  |

## Description
Hi there,

We have added support to GCC5.5 on Debian and RPM containers:
- Added GCC5.5 compilation on x86_64/amd64/arm64/aarch64 only.
- Uploaded all containers to ECR.
- Package built and tested.
- Updated generation scripts in Debian.

**Warning** This modifications also affect to the agent build that have to be selected on building time
With this change the packages will built as follows:
- Manager rpm -> GCC5
- Manager deb -> GCC5
- Agent rpm -> GCC5
- Agent deb -> GCC4
- The rest of agents -> GCC4

## Tests

X86_64 RPM manager -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6261/
AMD64 Deb manager -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6262/

X86_64 RPM agent GCC5.5 -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6277/
X86_64 RPM agent GCC4 -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6280
AMD64 Deb agent GCC5.5 -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6278/
AMD64 Deb agent GCC4 -> https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/6279/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for aarch64
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for aarch64

Regards!