### PR TITLE
Add wazuh-logtest-legacy tool to RPM SPECS

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -591,7 +591,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-execd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
-%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest.legacy
+%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest-legacy
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-maild
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-monitord


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#7806|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR is to add `wazuh-logtest-legacy` to rpm SPECS.

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [X] ~Windows~
  - [X] ~macOS~
  - [X] ~Solaris~
  - [X] ~AIX~
  - [X] ~HP-UX~
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [X] ~Test the package from macOS Sierra to Mojave~
- Tests for Solaris
  - [X] ~Test the package on Solaris 10~
  - [X] ~Test the package on Solaris 11~
  - [X] ~Check file permissions on Solaris 11 template~
- Tests for IBM AIX
  - [X] ~`%files` section is correctly updated if necessary~
  - [X] ~Check the changes from IBM AIX 5 to 7~

Regards.