### PR TITLE
Removed  code from provision-opendistro.sh

### DIFF
--- a/ova/Libraries/provision-opendistro.sh
+++ b/ova/Libraries/provision-opendistro.sh
@@ -142,19 +142,6 @@ installElasticsearch() {
         fi
         rm /etc/elasticsearch/certs/client-certificates.readme /etc/elasticsearch/certs/elasticsearch_elasticsearch_config_snippet.yml search-guard-tlstool-1.7.zip -f
 
-
-        ##CANDIDATO A IR FUERA
-        # # Configure JVM options for Elasticsearch
-        jv=$(java -version 2>&1 | grep -o -m1 '1.8.0') || :
-        if [ "${jv}" = "1.8.0" ]; then
-            ln -s /usr/lib/jvm/java-1.8.0/lib/tools.jar /usr/share/elasticsearch/lib/
-            echo "root hard nproc 4096" >> /etc/security/limits.conf
-            echo "root soft nproc 4096" >> /etc/security/limits.conf
-            echo "elasticsearch hard nproc 4096" >> /etc/security/limits.conf
-            echo "elasticsearch soft nproc 4096" >> /etc/security/limits.conf
-            echo "bootstrap.system_call_filter: false" >> /etc/elasticsearch/elasticsearch.yml
-        fi
-
         # While Performance Analyzer problems are solved (https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/229)
         /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_performance_analyzer
 

--- a/ova/Libraries/provision-opendistro.sh
+++ b/ova/Libraries/provision-opendistro.sh
@@ -92,17 +92,6 @@ addWazuhrepo() {
     fi
 }
 
-addElasticRepo(){
-
-    logger "Adding the Elastic repository..."
-    if [ "$?" != 0 ]; then
-        logger "Error: Wazuh repository could not be added"
-        exit 1
-    else
-        logger "Done"
-    fi
-}
-
 ## Wazuh manager
 installWazuh() {
 
@@ -154,6 +143,7 @@ installElasticsearch() {
         rm /etc/elasticsearch/certs/client-certificates.readme /etc/elasticsearch/certs/elasticsearch_elasticsearch_config_snippet.yml search-guard-tlstool-1.7.zip -f
 
 
+        ##CANDIDATO A IR FUERA
         # # Configure JVM options for Elasticsearch
         jv=$(java -version 2>&1 | grep -o -m1 '1.8.0') || :
         if [ "${jv}" = "1.8.0" ]; then

--- a/ova/Libraries/provision-opendistro.sh
+++ b/ova/Libraries/provision-opendistro.sh
@@ -53,7 +53,6 @@ getHelp() {
    exit $1 # Exit script after printing help
 }
 
-
 ## Install the required packages for the installation
 installPrerequisites() {
 
@@ -201,7 +200,7 @@ installKibana() {
         chown -R kibana:kibana /usr/share/kibana/plugins
         mkdir /usr/share/kibana/data
         chown -R kibana:kibana /usr/share/kibana/data
-
+        #Install Wazuh  Kibana plugin
         if [ "${PACKAGES_REPOSITORY}" = "prod" ]; then
             if [ "${WAZUH_MAJOR}" -ge "4" ]; then
                 sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/${WAZUH_MAJOR}.x/ui/kibana/wazuh_kibana-${WAZUH_VERSION}_${ELK_VERSION}-${UI_REVISION}.zip

--- a/ova/Libraries/provision-opendistro.sh
+++ b/ova/Libraries/provision-opendistro.sh
@@ -200,7 +200,7 @@ installKibana() {
         chown -R kibana:kibana /usr/share/kibana/plugins
         mkdir /usr/share/kibana/data
         chown -R kibana:kibana /usr/share/kibana/data
-        #Install Wazuh  Kibana plugin
+        ## Install Wazuh  Kibana plugin
         if [ "${PACKAGES_REPOSITORY}" = "prod" ]; then
             if [ "${WAZUH_MAJOR}" -ge "4" ]; then
                 sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/${WAZUH_MAJOR}.x/ui/kibana/wazuh_kibana-${WAZUH_VERSION}_${ELK_VERSION}-${UI_REVISION}.zip

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -90,7 +90,6 @@ yum install openssl -y
 
 installPrerequisites
 addWazuhrepo
-addElasticRepo
 installWazuh
 installElasticsearch
 installFilebeat


### PR DESCRIPTION
|Related issue|
|---|
|#627|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Related #627 
<!--
Add a clear description of how the problem has been solved.
-->
Removed `addElasticRepo` function from `provision-opendistro.sh` library and the call from `provision.sh`

Also removed `Configure JVM options` in `installElasticsearch` from `provision-opendistro.sh` as those steps are not required on the Wazuh documentation installation guide.

## Logs example

After remove the listed code, I could run the script as follow: `sh provision.sh 4.1.2 1.12.0 7.10.0 dev 4.1.2 1 -d`

And got the following result:

```
Elasticsearch installation succeeded.
+ filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.0
+ '[' 0 '!=' 0 ']'
+ logger 'Filebeat installation succeeded.'
+ echo Filebeat installation succeeded.
Filebeat installation succeeded.
+ logger 'Initializing Kibana (this may take a while)'
+ echo Initializing Kibana '(this' may take a 'while)'
Initializing Kibana (this may take a while)
++ grep '200 OK'
++ curl -XGET https://localhost/status -I -uadmin:admin -k -s
+ [[ -n '' ]]
+ logger -ne '#'
+ echo -ne
+ sleep 10
++ curl -XGET https://localhost/status -I -uadmin:admin -k -s
++ grep '200 OK'
 ]][ -n HTTP/1.1 200 OK
+ logger '
Installation finished'
+ echo Installation finished
Installation finished
+ cleanInstall
+ rm -rf /etc/yum.repos.d/adoptopenjdk.repo
+ rm -rf /etc/yum.repos.d/wazuh.repo
+ yum clean all
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Cleaning repos: base extras updates
Cleaning up list of fastest mirrors
Other repos take up 3.2 M of disk space (use --verbose for details)
+ rm -rf /vagrant
+ systemctl stop kibana filebeat elasticsearch
+ systemctl enable wazuh-manager
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.

```
When running `systemctl status elasticshearch` it shows the next promt:

```
● elasticsearch.service - Elasticsearch
   Loaded: loaded (/usr/lib/systemd/system/elasticsearch.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2021-03-25 08:05:24 UTC; 57s ago
     Docs: https://www.elastic.co
 Main PID: 802 (java)
   CGroup: /system.slice/elasticsearch.service
           └─802 /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encodi...

```

And when doing `systemctl status wazuh-manager` it returns:

```
● wazuh-manager.service - Wazuh manager
   Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2021-03-25 08:05:28 UTC; 2min 53s ago
  Process: 803 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-control start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/wazuh-manager.service
           ├─1439 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─1545 /var/ossec/bin/ossec-authd
           ├─1701 /var/ossec/bin/wazuh-db
           ├─1866 /var/ossec/bin/ossec-execd
           ├─1967 /var/ossec/bin/ossec-analysisd
           ├─2130 /var/ossec/bin/ossec-syscheckd
           ├─2397 /var/ossec/bin/ossec-remoted
           ├─2636 /var/ossec/bin/ossec-logcollector
           ├─2831 /var/ossec/bin/ossec-monitord
           └─3110 /var/ossec/bin/wazuh-modulesd

```
After building succesfully the OVA on Jenkins using this branch, got the following results after the wazuh installation:

When checked the elastic installation on the OVA got the following result:

![image](https://user-images.githubusercontent.com/23319307/112611220-d691b080-8e1d-11eb-968c-46fcbe5d5e9c.png)

And when checked the status from the Wazuh manager installation got:

![image](https://user-images.githubusercontent.com/23319307/112611374-05a82200-8e1e-11eb-9754-7385beba7af2.png)

<!--
Paste here related logs
-->
