### PR TITLE
Added wazuh-logtest-legacy to 5.0 RPM SPECs

### DIFF
--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -590,6 +590,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-execd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
+%attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest-legacy
 %attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-maild
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-monitord


### PR DESCRIPTION
|Related issue|
|---|
| Closes #682  |

## Description

Added `wazuh-logtest-legacy` to 5.0 RPM manager SPEC.

Regards.

## Tests

- Build the package in any supported platform
  - [x] Linux

- Tests for Linux RPM
  - [x] Build the package for x86_64
