### PR TITLE
Fix errors in 4.2.0 upgrade

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -110,11 +110,13 @@ fi
 %post
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
-    mv %{_localstatedir}/logs/ossec/* %{_localstatedir}/logs/wazuh
+    rm -rf %{_localstatedir}/logs/wazuh
+    cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
   fi
 
   if [ -d %{_localstatedir}/queue/ossec ]; then
-    mv %{_localstatedir}/queue/ossec/* %{_localstatedir}/queue/sockets
+    rm -rf %{_localstatedir}/queue/sockets
+    cp -rp %{_localstatedir}/queue/ossec %{_localstatedir}/queue/sockets
   fi
 fi
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/preinst
@@ -40,7 +40,7 @@ case "$1" in
             fi
             
             if [ -d ${DIR}/queue/ossec ]; then
-                mv ${DIR}/queue/ossec ${DIR}/logs/sockets
+                mv ${DIR}/queue/ossec ${DIR}/queue/sockets
             fi
 
             # Delete old API backups

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -212,11 +212,13 @@ fi
 %post
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
-    mv %{_localstatedir}/logs/ossec/* %{_localstatedir}/logs/wazuh
+    rm -rf %{_localstatedir}/logs/wazuh
+    cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
   fi
 
   if [ -d %{_localstatedir}/queue/ossec ]; then
-    mv %{_localstatedir}/queue/ossec/* %{_localstatedir}/queue/sockets
+    rm -rf %{_localstatedir}/queue/sockets
+    cp -rp %{_localstatedir}/queue/ossec %{_localstatedir}/queue/sockets
   fi
 fi
 # If the package is being installed

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -286,11 +286,13 @@ fi
 
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
-    mv %{_localstatedir}/logs/ossec/* %{_localstatedir}/logs/wazuh
+    rm -rf %{_localstatedir}/logs/wazuh
+    cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
   fi
 
   if [ -d %{_localstatedir}/queue/ossec ]; then
-    mv %{_localstatedir}/queue/ossec/* %{_localstatedir}/queue/sockets
+    rm -rf %{_localstatedir}/queue/sockets
+    cp -rp %{_localstatedir}/queue/ossec %{_localstatedir}/queue/sockets
   fi
 fi
 


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes some errors when upgrading to 4.2.0.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

### ERROR
```
09:44:19  2021/03/31 07:43:36 wazuh-agentd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
09:44:19  
09:44:19  2021/03/31 07:43:36 wazuh-syscheckd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
09:44:19  
09:44:19  2021/03/31 07:43:36 wazuh-syscheckd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
09:44:19  
09:44:19  2021/03/31 07:43:36 wazuh-logcollector: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
09:44:19  
09:44:19  2021/03/31 07:43:36 wazuh-modulesd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
09:44:19  
09:44:19  2021/03/31 07:43:36 wazuh-execd: INFO: Started (pid: 1964).
09:44:19  
09:44:19  2021/03/31 07:43:37 wazuh-agentd: ERROR: (1103): Could not open file 'queue/sockets/.agent_info' due to [(2)-(No such file or directory)].
```

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
