### PR TITLE
Fix debs ossec.conf filebeat path 

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/postinst
@@ -34,11 +34,11 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/postinst
@@ -39,8 +39,8 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
         passlist="${DIR}/agentless/.passlist"
 
@@ -55,7 +55,7 @@ case "$1" in
             fi
         fi
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -34,11 +34,11 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -39,8 +39,8 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
         passlist="${DIR}/agentless/.passlist"
 
@@ -55,7 +55,7 @@ case "$1" in
             fi
         fi
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -34,11 +34,11 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -39,8 +39,8 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
 
         passlist="${DIR}/agentless/.passlist"
 
@@ -55,7 +55,7 @@ case "$1" in
             fi
         fi
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} > ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8140|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Hi team,

This PR fixes the absolute path _error_ found in `ossec.conf` on Debian systems. 
Having eliminated the `PREFIX` compilation variable, it is necessary to indicate the path in which you are working in the scripts used in `postinst`, in order to avoid the configuration block being hardcoded.

## Logs example

After the changes, now the saved absolute path is modified according to the installation path selected when creating the package:

```
...
<ossec_config>
  <localfile>
    <log_format>syslog</log_format>
    <location>/usr/share/wazuh/logs/active-responses.log</location>
  </localfile>
...
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Package install/remove/install


