### PR TITLE
8028 - execd as wazuh module.

### DIFF
--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -586,7 +586,6 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-control
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-csyslogd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-dbd
-%attr(750, root, root) %{_localstatedir}/bin/wazuh-execd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest-legacy

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -303,14 +303,6 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/bin/wazuh-execd": {
-        "class": "static",
-        "group": "root",
-        "mode": "0750",
-        "prot": "-rwxr-x---",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/bin/wazuh-logcollector": {
         "class": "static",
         "group": "root",
@@ -1671,14 +1663,6 @@
         "prot": "-rw-r-----",
         "type": "file",
         "user": "ossec"
-    },
-    "/var/ossec/var/run/wazuh-execd-*.pid": {
-        "class": "dynamic",
-        "group": "ossec",
-        "mode": "0640",
-        "prot": "-rw-r-----",
-        "type": "file",
-        "user": "root"
     },
     "/var/ossec/var/run/wazuh-logcollector-*.pid": {
         "class": "dynamic",

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -1648,18 +1648,6 @@
         "type": "file",
         "user": "ossec"
     },
-<<<<<<< HEAD
-    "/var/ossec/var/run/wazuh-logcollector-*.pid": {
-=======
-    "/var/ossec/var/run/wazuh-execd-*.pid": {
->>>>>>> dev-agent-process-unified
-        "class": "dynamic",
-        "group": "ossec",
-        "mode": "0640",
-        "prot": "-rw-r-----",
-        "type": "file",
-        "user": "root"
-    },
     "/var/ossec/var/run/wazuh-logcollector.state": {
         "class": "static",
         "group": "ossec",


### PR DESCRIPTION
|Related issue|
|---|
https://github.com/wazuh/wazuh-packages/issues/700
https://github.com/wazuh/wazuh/issues/8028

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Execd, active response:

This issue points to the unification of processes on the agent side, in which it aims to only have wazuh-agentd and wazuh-modulesd.

One of the biggest challenges here is to decompose the main of the old module, separating what is the initialization, from the main processing loop, as well as the rearrangement of the configuration reading.

For this type of modification, the main thing is to normalize the module, to maintain the structure and design of wazuh-modulesd, as it is used in the pre-existing modules.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
