### PR TITLE
 Change default user and group 

### DIFF
--- a/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
+++ b/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
@@ -82,13 +82,13 @@ exit 0
 
 %pre
 
-# Create ossec user and group
-if ! grep "^ossec:" /etc/group > /dev/null 2>&1; then
-  /usr/bin/mkgroup ossec
+# Create wazuh user and group
+if ! grep "^wazuh:" /etc/group > /dev/null 2>&1; then
+  /usr/bin/mkgroup wazuh
 fi
-if ! grep "^ossec" /etc/passwd > /dev/null 2>&1; then
-  /usr/sbin/useradd ossec
-  /usr/sbin/usermod -G ossec ossec
+if ! grep "^wazuh" /etc/passwd > /dev/null 2>&1; then
+  /usr/sbin/useradd wazuh
+  /usr/sbin/usermod -G wazuh wazuh
 fi
 
 # Remove existent config file and notify user for new installations
@@ -130,7 +130,7 @@ if [ $1 = 1 ]; then
   # Add default local_files to ossec.conf
   %{_localstatedir}/tmp/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 
-  # Restore Wazuh manager configuration
+  # Restore Wazuh agent configuration
   if [ -f %{_localstatedir}/etc/ossec.conf.rpmorig ]; then
     %{_localstatedir}/tmp/src/init/replace_manager_ip.sh %{_localstatedir}/etc/ossec.conf.rpmorig %{_localstatedir}/etc/ossec.conf
   fi
@@ -147,13 +147,13 @@ if [ $1 = 1 ]; then
 
   # Generate the active-responses.log file
   touch %{_localstatedir}/logs/active-responses.log
-  chown ossec:ossec %{_localstatedir}/logs/active-responses.log
+  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
   %{_localstatedir}/tmp/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 
 fi
-chown root:ossec %{_localstatedir}/etc/ossec.conf
+chown root:wazuh %{_localstatedir}/etc/ossec.conf
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc2.d/S97wazuh-agent
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc3.d/S97wazuh-agent
 
@@ -174,6 +174,24 @@ if grep '<address>.*</address>' %{_localstatedir}/etc/ossec.conf | grep -v 'MANA
   /etc/rc.d/init.d/wazuh-agent restart > /dev/null 2>&1 || :
 fi
 
+# Remove old ossec user and group if exists and change ownwership of files
+
+if grep "^ossec:" /etc/group > /dev/null 2>&1; then
+  find %{_localstatedir} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if grep "^ossec" /etc/passwd > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if grep "^ossecm" /etc/passwd > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if grep "^ossecr" /etc/passwd > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  rmgroup ossec
+fi
 
 %preun
 
@@ -192,13 +210,13 @@ fi
 
 %postun
 
-# Remove ossec user and group
+# Remove wazuh user and group
 if [ $1 = 0 ];then
-  if grep "^ossec" /etc/passwd > /dev/null 2>&1; then
-    userdel ossec
+  if grep "^wazuh" /etc/passwd > /dev/null 2>&1; then
+    userdel wazuh
   fi
-  if grep "^ossec:" /etc/group > /dev/null 2>&1; then
-    rmgroup ossec
+  if grep "^wazuh:" /etc/group > /dev/null 2>&1; then
+    rmgroup wazuh
   fi
 
   rm -rf %{_localstatedir}/ruleset
@@ -224,63 +242,62 @@ rm -fr %{buildroot}
 %files
 %{_init_scripts}/*
 
-%dir %attr(750,root,ossec) %{_localstatedir}
-%attr(750,root,ossec) %{_localstatedir}/agentless
-%dir %attr(770,root,ossec) %{_localstatedir}/.ssh
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response/bin
-%attr(750,root,ossec) %{_localstatedir}/active-response/bin/*
-%dir %attr(750,root,system) %{_localstatedir}/bin
-%attr(750,root,system) %{_localstatedir}/bin/*
-%dir %attr(750,root,ossec) %{_localstatedir}/backup
-%dir %attr(770,ossec,ossec) %{_localstatedir}/etc
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
-%dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
-%attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
-%dir %attr(750,root,system) %{_localstatedir}/lib
-%dir %attr(770,ossec,ossec) %{_localstatedir}/logs
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750,ossec,ossec) %{_localstatedir}/logs/wazuh
-%dir %attr(750,root,ossec) %{_localstatedir}/queue
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/sockets
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/diff
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim/db
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector/db
-%attr(640, root,ossec) %{_localstatedir}/queue/syscollector/norm_config.json
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/alerts
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/rids
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/logcollector
-%dir %attr(750, ossec, ossec) %{_localstatedir}/ruleset/sca
-%attr(640, root, ossec) %{_localstatedir}/ruleset/sca/*
-%dir %attr(1750,root,ossec) %{_localstatedir}/tmp
-%attr(750,root,system) %config(missingok) %{_localstatedir}/tmp/add_localfiles.sh
-%attr(750,root,system) %config(missingok) %{_localstatedir}/tmp/gen_ossec.sh
-%dir %attr(1750,root,ossec) %config(missingok) %{_localstatedir}/tmp/etc/templates
-%dir %attr(1750,root,ossec) %config(missingok) %{_localstatedir}/tmp/etc/templates/config
-%dir %attr(1750,root,ossec) %config(missingok) %{_localstatedir}/tmp/etc/templates/config/generic
-%attr(750,root,system) %config(missingok) %{_localstatedir}/tmp/etc/templates/config/generic/*.template
-%dir %attr(1750,root,ossec) %config(missingok) /var/ossec/tmp/etc/templates/config/generic/localfile-logs
-%attr(750,root,system) %config(missingok) /var/ossec/tmp/etc/templates/config/generic/localfile-logs/*.template
-%attr(750,root,system) %config(missingok) %{_localstatedir}/tmp/src/*
-%dir %attr(750,root,ossec) %{_localstatedir}/var
-%dir %attr(770,root,ossec) %{_localstatedir}/var/incoming
-%dir %attr(770,root,ossec) %{_localstatedir}/var/run
-%dir %attr(770,root,ossec) %{_localstatedir}/var/upgrade
-%dir %attr(770,root,ossec) %{_localstatedir}/var/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles/aws
-%attr(750,root,ossec) %{_localstatedir}/wodles/aws/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
-
+%dir %attr(750, root, wazuh) %{_localstatedir}
+%attr(750, root, wazuh) %{_localstatedir}/agentless
+%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root,system) %{_localstatedir}/bin
+%attr(750, root,system) %{_localstatedir}/bin/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
+%attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
+%dir %attr(750, root,system) %{_localstatedir}/lib
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
+%dir %attr(750, root, wazuh) %{_localstatedir}/queue
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector/db
+%attr(640, root, wazuh) %{_localstatedir}/queue/syscollector/norm_config.json
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/rids
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/ruleset/sca
+%attr(640, root, wazuh) %{_localstatedir}/ruleset/sca/*
+%dir %attr(1750, root, wazuh) %{_localstatedir}/tmp
+%attr(750, root,system) %config(missingok) %{_localstatedir}/tmp/add_localfiles.sh
+%attr(750, root,system) %config(missingok) %{_localstatedir}/tmp/gen_ossec.sh
+%dir %attr(1750, root, wazuh) %config(missingok) %{_localstatedir}/tmp/etc/templates
+%dir %attr(1750, root, wazuh) %config(missingok) %{_localstatedir}/tmp/etc/templates/config
+%dir %attr(1750, root, wazuh) %config(missingok) %{_localstatedir}/tmp/etc/templates/config/generic
+%attr(750, root,system) %config(missingok) %{_localstatedir}/tmp/etc/templates/config/generic/*.template
+%dir %attr(1750, root, wazuh) %config(missingok) /var/ossec/tmp/etc/templates/config/generic/localfile-logs
+%attr(750, root,system) %config(missingok) /var/ossec/tmp/etc/templates/config/generic/localfile-logs/*.template
+%attr(750, root,system) %config(missingok) %{_localstatedir}/tmp/src/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/var
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/incoming
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
+%attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
+%attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
 * Wed Apr 28 2021 support <info@wazuh.com> - 4.3.0

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -10,8 +10,8 @@ case "$1" in
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
     DIR="/var/ossec"
-    USER="ossec"
-    GROUP="ossec"
+    USER="wazuh"
+    GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
@@ -25,10 +25,10 @@ case "$1" in
         fi
     fi
 
-    if ! getent group | grep -q "^ossec" ; then
-        addgroup --system ossec > /dev/null 2>&1
+    if ! getent group | grep -q "^wazuh" ; then
+        addgroup --system wazuh > /dev/null 2>&1
     fi
-    if ! getent passwd | grep -q "^ossec" ; then
+    if ! getent passwd | grep -q "^wazuh" ; then
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
@@ -111,7 +111,7 @@ case "$1" in
     fi
 
     touch ${DIR}/logs/active-responses.log
-    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chown wazuh:wazuh ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
 
     # Check if SELinux is installed and enabled
@@ -160,6 +160,25 @@ case "$1" in
     # If the parent directory is empty, delete it
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
+    fi
+
+    # Remove old ossec user and group if exists and change ownwership of files
+
+    if ! getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if ! getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossec
+        fi
+        if ! getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecm
+        fi
+        if ! getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecr
+        fi
+        delgroup ossec 
     fi
 
     ;;

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -164,17 +164,17 @@ case "$1" in
 
     # Remove old ossec user and group if exists and change ownwership of files
 
-    if ! getent group | grep -q "^ossec" ; then
+    if getent group | grep -q "^ossec" ; then
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if ! getent passwd | grep -q "^ossec" ; then
+        if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossec
         fi
-        if ! getent passwd | grep -q "^ossecm" ; then
+        if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecm
         fi
-        if ! getent passwd | grep -q "^ossecr" ; then
+        if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecr
         fi

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
@@ -49,11 +49,11 @@ case "$1" in
 
         purge)
 
-        if getent passwd | grep -q "^ossec" ; then
-            deluser ossec > /dev/null 2>&1
+        if getent passwd | grep -q "^wazuh" ; then
+            deluser wazuh > /dev/null 2>&1
         fi
-        if getent group | grep -q "^ossec" ; then
-            delgroup ossec > /dev/null 2>&1
+        if getent group | grep -q "^wazuh" ; then
+            delgroup wazuh > /dev/null 2>&1
         fi
         rm -rf ${DIR}/*
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -8,10 +8,8 @@ case "$1" in
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
     DIR="/var/ossec"
-    USER="ossec"
-    USER_MAIL="ossecm"
-    USER_REM="ossecr"
-    GROUP="ossec"
+    USER="wazuh"
+    GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
     OSMYSHELL="/sbin/nologin"
@@ -24,17 +22,11 @@ case "$1" in
         fi
     fi
 
-    if ! getent group | grep -q "^ossec" ; then
-        addgroup --system ossec  > /dev/null 2>&1
+    if ! getent group | grep -q "^wazuh" ; then
+        addgroup --system wazuh  > /dev/null 2>&1
     fi
-    if ! getent passwd | grep -q "^ossec" ; then
+    if ! getent passwd | grep -q "^wazuh" ; then
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
-    fi
-    if ! getent passwd | grep -q "^ossecm" ; then
-        adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_MAIL} > /dev/null 2>&1
-    fi
-    if ! getent passwd | grep -q "^ossecr" ; then
-        adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
@@ -72,7 +64,7 @@ case "$1" in
 
     if [ -f ${DIR}/queue/db/global.db ]; then
         chmod 640 ${DIR}/queue/db/global.db*
-        chown ossec:ossec ${DIR}/queue/db/global.db*
+        chown ${USER}:${GROUP} ${DIR}/queue/db/global.db*
     fi
 
     # Delete uncompatible DBs versions
@@ -161,14 +153,14 @@ case "$1" in
 
     touch ${DIR}/logs/active-responses.log
     touch ${DIR}/logs/integrations.log
-    chown ossec:ossec ${DIR}/logs/active-responses.log
-    chown ossecm:ossec ${DIR}/logs/integrations.log
+    chown ${USER}:${GROUP} ${DIR}/logs/active-responses.log
+    chown ${USER}:${GROUP} ${DIR}/logs/integrations.log
     chmod 0660 ${DIR}/logs/active-responses.log
     chmod 0640 ${DIR}/logs/integrations.log
 
 
     if [ -f ${DIR}/etc/shared/ar.conf ]; then
-        chown root:ossec ${DIR}/etc/shared/ar.conf
+        chown root:wazuh ${DIR}/etc/shared/ar.conf
     fi
 
     # Check if SELinux is installed and enabled
@@ -261,6 +253,25 @@ case "$1" in
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 
+    # Remove old ossec user and group if exists and change ownwership of files
+
+    if ! getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if ! getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossec
+        fi
+        if ! getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecm
+        fi
+        if ! getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecr
+        fi
+        delgroup ossec 
+    fi
+    
     ;;
 
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 # postinst script for Wazuh
 # Wazuh, Inc 2015-2020
-set -e
+set -ex
 case "$1" in
     configure)
 
@@ -255,17 +255,17 @@ case "$1" in
 
     # Remove old ossec user and group if exists and change ownwership of files
 
-    if ! getent group | grep -q "^ossec" ; then
+    if getent group | grep -q "^ossec" ; then
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if ! getent passwd | grep -q "^ossec" ; then
+        if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossec
         fi
-        if ! getent passwd | grep -q "^ossecm" ; then
+        if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossecm
         fi
-        if ! getent passwd | grep -q "^ossecr" ; then
+        if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossecr
         fi

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
@@ -59,17 +59,11 @@ case "$1" in
     ;;
 
     purge)
-        if getent passwd | grep -q "^ossecr" ; then
-            deluser ossecr  > /dev/null 2>&1
+        if getent passwd | grep -q "^wazuh" ; then
+            deluser wazuh  > /dev/null 2>&1
         fi
-        if getent passwd | grep -q "^ossecm" ; then
-            deluser ossecm  > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossec" ; then
-            deluser ossec  > /dev/null 2>&1
-        fi
-        if getent group | grep -q "^ossec" ; then
-            delgroup ossec  > /dev/null 2>&1
+        if getent group | grep -q "^wazuh" ; then
+            delgroup wazuh  > /dev/null 2>&1
         fi
         rm -rf ${DIR}
     ;;

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -10,8 +10,8 @@ case "$1" in
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
     DIR="/var/ossec"
-    USER="ossec"
-    GROUP="ossec"
+    USER="wazuh"
+    GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
@@ -25,10 +25,10 @@ case "$1" in
         fi
     fi
 
-    if ! getent group | grep -q "^ossec" ; then
-        addgroup --system ossec > /dev/null 2>&1
+    if ! getent group | grep -q "^wazuh" ; then
+        addgroup --system wazuh > /dev/null 2>&1
     fi
-    if ! getent passwd | grep -q "^ossec" ; then
+    if ! getent passwd | grep -q "^wazuh" ; then
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
     fi
 
@@ -111,7 +111,7 @@ case "$1" in
     fi
 
     touch ${DIR}/logs/active-responses.log
-    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chown wazuh:wazuh ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
 
     # Check if SELinux is installed and enabled
@@ -160,6 +160,25 @@ case "$1" in
     # If the parent directory is empty, delete it
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
+    fi
+
+    # Remove old ossec user and group if exists and change ownwership of files
+
+    if ! getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if ! getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossec
+        fi
+        if ! getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecm
+        fi
+        if ! getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecr
+        fi
+        delgroup ossec 
     fi
 
     ;;

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -164,17 +164,17 @@ case "$1" in
 
     # Remove old ossec user and group if exists and change ownwership of files
 
-    if ! getent group | grep -q "^ossec" ; then
+    if getent group | grep -q "^ossec" ; then
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if ! getent passwd | grep -q "^ossec" ; then
+        if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossec
         fi
-        if ! getent passwd | grep -q "^ossecm" ; then
+        if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecm
         fi
-        if ! getent passwd | grep -q "^ossecr" ; then
+        if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecr
         fi

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postrm
@@ -49,11 +49,11 @@ case "$1" in
 
         purge)
 
-        if getent passwd | grep -q "^ossec" ; then
-            deluser ossec > /dev/null 2>&1
+        if getent passwd | grep -q "^wazuh" ; then
+            deluser wazuh > /dev/null 2>&1
         fi
-        if getent group | grep -q "^ossec" ; then
-            delgroup ossec > /dev/null 2>&1
+        if getent group | grep -q "^wazuh" ; then
+            delgroup wazuh > /dev/null 2>&1
         fi
         rm -rf ${DIR}/*
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -257,15 +257,15 @@ case "$1" in
 
     if ! getent group | grep -q "^ossec" ; then
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if ! getent passwd | grep -q "^ossec" ; then
+        if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossec
         fi
-        if ! getent passwd | grep -q "^ossecm" ; then
+        if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossecm
         fi
-        if ! getent passwd | grep -q "^ossecr" ; then
+        if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossecr
         fi

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -8,10 +8,8 @@ case "$1" in
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
     DIR="/var/ossec"
-    USER="ossec"
-    USER_MAIL="ossecm"
-    USER_REM="ossecr"
-    GROUP="ossec"
+    USER="wazuh"
+    GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
     OSMYSHELL="/sbin/nologin"
@@ -24,17 +22,11 @@ case "$1" in
         fi
     fi
 
-    if ! getent group | grep -q "^ossec" ; then
-        addgroup --system ossec  > /dev/null 2>&1
+    if ! getent group | grep -q "^wazuh" ; then
+        addgroup --system wazuh  > /dev/null 2>&1
     fi
-    if ! getent passwd | grep -q "^ossec" ; then
+    if ! getent passwd | grep -q "^wazuh" ; then
         adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
-    fi
-    if ! getent passwd | grep -q "^ossecm" ; then
-        adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_MAIL} > /dev/null 2>&1
-    fi
-    if ! getent passwd | grep -q "^ossecr" ; then
-        adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER_REM} > /dev/null 2>&1
     fi
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
@@ -72,7 +64,7 @@ case "$1" in
 
     if [ -f ${DIR}/queue/db/global.db ]; then
         chmod 640 ${DIR}/queue/db/global.db*
-        chown ossec:ossec ${DIR}/queue/db/global.db*
+        chown ${USER}:${GROUP} ${DIR}/queue/db/global.db*
     fi
 
     # Delete uncompatible DBs versions
@@ -161,14 +153,14 @@ case "$1" in
 
     touch ${DIR}/logs/active-responses.log
     touch ${DIR}/logs/integrations.log
-    chown ossec:ossec ${DIR}/logs/active-responses.log
-    chown ossecm:ossec ${DIR}/logs/integrations.log
+    chown ${USER}:${GROUP} ${DIR}/logs/active-responses.log
+    chown ${USER}:${GROUP} ${DIR}/logs/integrations.log
     chmod 0660 ${DIR}/logs/active-responses.log
     chmod 0640 ${DIR}/logs/integrations.log
 
 
     if [ -f ${DIR}/etc/shared/ar.conf ]; then
-        chown root:ossec ${DIR}/etc/shared/ar.conf
+        chown root:wazuh ${DIR}/etc/shared/ar.conf
     fi
 
     # Check if SELinux is installed and enabled
@@ -261,6 +253,25 @@ case "$1" in
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
 
+    # Remove old ossec user and group if exists and change ownwership of files
+
+    if ! getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if ! getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossec
+        fi
+        if ! getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecm
+        fi
+        if ! getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecr
+        fi
+        delgroup ossec 
+    fi
+    
     ;;
 
 

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postrm
@@ -59,17 +59,11 @@ case "$1" in
     ;;
 
     purge)
-        if getent passwd | grep -q "^ossecr" ; then
-            deluser ossecr  > /dev/null 2>&1
+        if getent passwd | grep -q "^wazuh" ; then
+            deluser wazuh  > /dev/null 2>&1
         fi
-        if getent passwd | grep -q "^ossecm" ; then
-            deluser ossecm  > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossec" ; then
-            deluser ossec  > /dev/null 2>&1
-        fi
-        if getent group | grep -q "^ossec" ; then
-            delgroup ossec  > /dev/null 2>&1
+        if getent group | grep -q "^wazuh" ; then
+            delgroup wazuh  > /dev/null 2>&1
         fi
         rm -rf ${DIR}
     ;;

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -163,8 +163,8 @@ clean() {
     rm -rf ${install_path}
 
     find /sbin -name "*wazuh-agent*" -exec rm {} \;
-    userdel ossec
-    groupdel ossec
+    userdel wazuh
+    groupdel wazuh
 
     exit ${exit_code}
 }

--- a/macos/package_files/4.3.0/preinstall.sh
+++ b/macos/package_files/4.3.0/preinstall.sh
@@ -74,19 +74,19 @@ while [[ $idvar -eq 0 ]]; do
    fi
 done
 
-echo "UID available for ossec user is:";
+echo "UID available for wazuh user is:";
 echo ${new_uid}
 
 # Verify that the uid and gid exist and match
 if [[ $new_uid -eq 0 ]] || [[ $new_gid -eq 0 ]];
-   then
-   echo "Getting unique id numbers (uid, gid) failed!";
-   exit 1;
+    then
+    echo "Getting unique id numbers (uid, gid) failed!";
+    exit 1;
 fi
 if [[ ${new_uid} != ${new_gid} ]]
-   then
-   echo "I failed to find matching free uid and gid!";
-   exit 5;
+    then
+    echo "I failed to find matching free uid and gid!";
+    exit 5;
 fi
 
 # Stops the agent before upgrading it
@@ -97,38 +97,38 @@ elif [ -f ${DIR}/bin/ossec-control ]; then
 fi
 
 # Creating the group
-if [[ $(dscl . -read /Groups/ossec) ]]
+if [[ $(dscl . -read /Groups/wazuh) ]]
     then
-    echo "ossec group already exists.";
+    echo "wazuh group already exists.";
 else
-    sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
-    check_errm "Error creating group ossec" "67"
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Groups/wazuh
+    check_errm "Error creating group wazuh" "67"
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RealName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RecordName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RecordType: dsRecTypeStandard:Groups
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh Password "*"
 fi
 
 # Creating the user
-if [[ $(dscl . -read /Users/ossec) ]]
+if [[ $(dscl . -read /Users/wazuh) ]]
     then
-    echo "ossec user already exists.";
+    echo "wazuh user already exists.";
 else
-    sudo ${DSCL} localhost -create /Local/Default/Users/ossec
-    check_errm "Error creating user ossec" "77"
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
-    sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
-sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Users/wazuh
+    check_errm "Error creating user wazuh" "77"
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh RecordName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh RealName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh UserShell /usr/bin/false
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh NFSHomeDirectory /var/wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh UniqueID ${new_uid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -append /Local/Default/Groups/wazuh GroupMembership wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh Password "*"
 fi
 
 #Hide the fixed users
-dscl . create /Users/ossec IsHidden 1
+dscl . create /Users/wazuh IsHidden 1
 
 sudo tee /Library/LaunchDaemons/com.wazuh.agent.plist <<-'EOF'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -71,10 +71,10 @@ while [[ $idvar -eq 0 ]]; do
         new_gid=$i
         idvar=1
         #break
-    fi
+   fi
 done
 
-echo "UID available for ossec user is:";
+echo "UID available for wazuh user is:";
 echo ${new_uid}
 
 # Verify that the uid and gid exist and match
@@ -97,38 +97,38 @@ elif [ -f ${DIR}/bin/ossec-control ]; then
 fi
 
 # Creating the group
-if [[ $(dscl . -read /Groups/ossec) ]]
+if [[ $(dscl . -read /Groups/wazuh) ]]
     then
-    echo "ossec group already exists.";
+    echo "wazuh group already exists.";
 else
-    sudo ${DSCL} localhost -create /Local/Default/Groups/ossec
-    check_errm "Error creating group ossec" "67"
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec PrimaryGroupID ${new_gid}
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RealName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec RecordType: dsRecTypeStandard:Groups
-    sudo ${DSCL} localhost -createprop /Local/Default/Groups/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Groups/wazuh
+    check_errm "Error creating group wazuh" "67"
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RealName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RecordName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh RecordType: dsRecTypeStandard:Groups
+    sudo ${DSCL} localhost -createprop /Local/Default/Groups/wazuh Password "*"
 fi
 
 # Creating the user
-if [[ $(dscl . -read /Users/ossec) ]]
+if [[ $(dscl . -read /Users/wazuh) ]]
     then
-    echo "ossec user already exists.";
+    echo "wazuh user already exists.";
 else
-    sudo ${DSCL} localhost -create /Local/Default/Users/ossec
-    check_errm "Error creating user ossec" "77"
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RecordName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec RealName ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UserShell /usr/bin/false
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec NFSHomeDirectory /var/ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec UniqueID ${new_uid}
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec PrimaryGroupID ${new_gid}
-    sudo ${DSCL} localhost -append /Local/Default/Groups/ossec GroupMembership ossec
-    sudo ${DSCL} localhost -createprop /Local/Default/Users/ossec Password "*"
+    sudo ${DSCL} localhost -create /Local/Default/Users/wazuh
+    check_errm "Error creating user wazuh" "77"
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh RecordName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh RealName wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh UserShell /usr/bin/false
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh NFSHomeDirectory /var/wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh UniqueID ${new_uid}
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh PrimaryGroupID ${new_gid}
+    sudo ${DSCL} localhost -append /Local/Default/Groups/wazuh GroupMembership wazuh
+    sudo ${DSCL} localhost -createprop /Local/Default/Users/wazuh Password "*"
 fi
 
 #Hide the fixed users
-dscl . create /Users/ossec IsHidden 1
+dscl . create /Users/wazuh IsHidden 1
 
 sudo tee /Library/LaunchDaemons/com.wazuh.agent.plist <<-'EOF'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -14,22 +14,8 @@ sudo /bin/rm -f /Library/LaunchDaemons/com.wazuh.agent.plist
 sudo /bin/rm -rf /Library/StartupItems/WAZUH
 
 ## Remove User and Groups
-sudo /usr/bin/dscl . -delete "/Users/ossec"
-sudo /usr/bin/dscl . -delete "/Groups/ossec"
-
-sudo /usr/bin/dscl . -list "/Users/ossecm" > /dev/null 2>&1
-
-if [ $? = 0 ]
-then
-    sudo /usr/bin/dscl . -delete "/Users/ossecm"
-fi
-
-sudo /usr/bin/dscl . -list "/Users/ossecr" > /dev/null 2>&1
-
-if [ $? = 0 ]
-then
-    sudo /usr/bin/dscl . -delete "/Users/ossecr"
-fi
+sudo /usr/bin/dscl . -delete "/Users/wazuh"
+sudo /usr/bin/dscl . -delete "/Groups/wazuh"
 
 sudo /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent
 sudo /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent-etc

--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -180,15 +180,15 @@ fi
 exit 0
 
 %pre
-# Create the ossec group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
-  groupadd -r ossec
-elif ! id -g ossec > /dev/null 2>&1; then
-  groupadd -r ossec
+# Create the wazuh group if it doesn't exists
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
+elif ! id -g wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
 fi
-# Create the ossec user if it doesn't exists
-if ! id -u ossec > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossec
+# Create the wazuh user if it doesn't exists
+if ! id -u wazuh > /dev/null 2>&1; then
+  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
 fi
 
 # Stop the services to upgrade the package
@@ -240,14 +240,14 @@ if [ $1 = 1 ]; then
   fi
 
   touch %{_localstatedir}/logs/active-responses.log
-  chown ossec:ossec %{_localstatedir}/logs/active-responses.log
+  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
-  # Generating osse.conf file
+  # Generating ossec.conf file
   %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  chown root:ossec %{_localstatedir}/etc/ossec.conf
+  chown root:wazuh %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
@@ -356,6 +356,25 @@ fi
 # Restore ossec.conf permissions after upgrading
 chmod 0660 %{_localstatedir}/etc/ossec.conf
 
+# Remove old ossec user and group if exists and change ownwership of files
+
+if id -g ossec > /dev/null 2>&1; then
+  find %{_localstatedir} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if id -u ossec > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if id -u ossecm > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if id -u ossecr > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  groupdel ossec
+fi
+
 %preun
 
 if [ $1 = 0 ]; then
@@ -406,22 +425,22 @@ fi
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:ossec %{_localstatedir}/etc/localtime
+ chown root:wazuh %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %postun
 
 # If the package is been uninstalled
 if [ $1 = 0 ];then
-  # Remove the ossec user if it exists
-  if id -u ossec > /dev/null 2>&1; then
-    userdel ossec >/dev/null 2>&1
+  # Remove the wazuh user if it exists
+  if id -u wazuh > /dev/null 2>&1; then
+    userdel wazuh >/dev/null 2>&1
   fi
-  # Remove the ossec group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
-  elif id -g ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
+  # Remove the wazuh group if it exists
+  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
+  elif id -g wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
   fi
 
   # Remove lingering folders and files
@@ -462,150 +481,150 @@ rm -fr %{buildroot}
 %files
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
-%defattr(-,root,root)
-%dir %attr(750,root,ossec) %{_localstatedir}
-%attr(750,root,ossec) %{_localstatedir}/agentless
-%dir %attr(770,root,ossec) %{_localstatedir}/.ssh
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response/bin
-%attr(750,root,ossec) %{_localstatedir}/active-response/bin/*
-%dir %attr(750,root,root) %{_localstatedir}/bin
-%attr(750,root,root) %{_localstatedir}/bin/*
-%dir %attr(750,root,ossec) %{_localstatedir}/backup
-%dir %attr(770,ossec,ossec) %{_localstatedir}/etc
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
-%attr(640,root,ossec) %{_localstatedir}/etc/localtime
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
-%dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
-%attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
-%dir %attr(750,root,ossec) %{_localstatedir}/lib
-%attr(750,root,ossec) %{_localstatedir}/lib/*
-%dir %attr(770,ossec,ossec) %{_localstatedir}/logs
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750,ossec,ossec) %{_localstatedir}/logs/wazuh
+%defattr(-, root, root)
+%dir %attr(750, root, wazuh) %{_localstatedir}
+%attr(750, root, wazuh) %{_localstatedir}/agentless
+%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root, root) %{_localstatedir}/bin
+%attr(750, root, root) %{_localstatedir}/bin/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh) %{_localstatedir}/etc/localtime
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
+%attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, wazuh) %{_localstatedir}/lib/*
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/centos/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/rhel/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/suse/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/src/*
-%dir %attr(750,root,ossec) %{_localstatedir}/queue
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/sockets
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/diff
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim/db
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector/db
-%attr(640, root,ossec) %{_localstatedir}/queue/syscollector/norm_config.json
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/alerts
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/rids
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/logcollector
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%attr(750, root, ossec) %{_localstatedir}/lib/libdbsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/librsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsyscollector.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsysinfo.so
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
-%dir %attr(1770,root,ossec) %{_localstatedir}/tmp
-%dir %attr(750,root,ossec) %{_localstatedir}/var
-%dir %attr(770,root,ossec) %{_localstatedir}/var/incoming
-%dir %attr(770,root,ossec) %{_localstatedir}/var/run
-%dir %attr(770,root,ossec) %{_localstatedir}/var/selinux
-%attr(640,root,ossec) %{_localstatedir}/var/selinux/*
-%dir %attr(770,root,ossec) %{_localstatedir}/var/upgrade
-%dir %attr(770,root,ossec) %{_localstatedir}/var/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles/aws
-%attr(750,root,ossec) %{_localstatedir}/wodles/aws/*
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles/docker
-%attr(750,root,ossec) %{_localstatedir}/wodles/docker/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/centos/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/rhel/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/suse/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/src/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/queue
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector/db
+%attr(640, root, wazuh) %{_localstatedir}/queue/syscollector/norm_config.json
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/rids
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/sca
+%attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
+%dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
+%dir %attr(750, root, wazuh) %{_localstatedir}/var
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/incoming
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/selinux
+%attr(640, root, wazuh) %{_localstatedir}/var/selinux/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
+%attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
+%attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
+%attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
@@ -177,12 +177,17 @@ exit 0
 
 %pre
 
-# Create the ossec group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
-  groupadd -r ossec
-elif ! id -g ossec > /dev/null 2>&1; then
-  groupadd -r ossec
+# Create the wazuh group if it doesn't exists
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
+elif ! id -g wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
 fi
+
+# Create the wazuh user if it doesn't exists
+if ! id -u wazuh > /dev/null 2>&1; then
+  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
+fi 
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
@@ -202,19 +207,6 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-# Create the ossec user if it doesn't exists
-if ! id -u ossec > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossec
-fi
-# Create the ossecr user if it doesn't exists
-if ! id -u ossecr > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossecr
-fi
-# Create the ossecm user if it doesn't exists
-if ! id -u ossecm > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossecm
-fi
-
 # Remove/relocate existing SQLite databases
 rm -f %{_localstatedir}/var/db/cluster.db* || true
 rm -f %{_localstatedir}/var/db/.profile.db* || true
@@ -228,7 +220,7 @@ fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then
   chmod 640 %{_localstatedir}/queue/db/global.db*
-  chown ossec:ossec %{_localstatedir}/queue/db/global.db*
+  chown wazuh:wazuh %{_localstatedir}/queue/db/global.db*
 fi
 
 # Remove Vuln-detector database
@@ -320,8 +312,8 @@ if [ $1 = 1 ]; then
 
   touch %{_localstatedir}/logs/active-responses.log
   touch %{_localstatedir}/logs/integrations.log
-  chown ossec:ossec %{_localstatedir}/logs/active-responses.log
-  chown ossecm:ossec %{_localstatedir}/logs/integrations.log
+  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
+  chown wazuh:wazuh %{_localstatedir}/logs/integrations.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
   chmod 0640 %{_localstatedir}/logs/integrations.log
 
@@ -422,7 +414,7 @@ fi
 
 # Fix sca permissions, group and owner
 chmod 640 %{_localstatedir}/ruleset/sca/*
-chown root:ossec %{_localstatedir}/ruleset/sca/*
+chown root:wazuh %{_localstatedir}/ruleset/sca/*
 # Delete the temporary directory
 rm -rf ${SCA_BASE_DIR}
 
@@ -439,6 +431,25 @@ rm -rf %{_localstatedir}/packages_files
 
 # Remove unnecessary files from default group
 rm -f %{_localstatedir}/etc/shared/default/*.rpmnew
+
+# Remove old ossec user and group if exists and change ownwership of files
+
+if id -g ossec > /dev/null 2>&1; then
+  find %{_localstatedir} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if id -u ossec > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if id -u ossecm > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if id -u ossecr > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  groupdel ossec
+fi
 
 %preun
 
@@ -482,23 +493,15 @@ fi
 
 # If the package is been uninstalled
 if [ $1 = 0 ];then
-  # Remove the ossecr user if it exists
-  if id -u ossecr > /dev/null 2>&1; then
-    userdel ossecr >/dev/null 2>&1
+  # Remove the wazuh user if it exists
+  if id -u wazuh > /dev/null 2>&1; then
+    userdel wazuh >/dev/null 2>&1
   fi
-  # Remove the ossecm user if it exists
-  if id -u ossecm > /dev/null 2>&1; then
-    userdel ossecm >/dev/null 2>&1
-  fi
-  # Remove the ossec user if it exists
-  if id -u ossec > /dev/null 2>&1; then
-    userdel ossec >/dev/null 2>&1
-  fi
-  # Remove the ossec group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
-  elif id -g ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
+  # Remove the wazuh group if it exists
+  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
+  elif id -g wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
   fi
 
   # Backup agents centralized configuration (etc/shared)
@@ -550,7 +553,7 @@ fi
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:ossec %{_localstatedir}/etc/localtime
+ chown root:wazuh %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %clean
@@ -559,29 +562,29 @@ rm -fr %{buildroot}
 %files
 %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
-%defattr(-,root,ossec)
-%dir %attr(750, root, ossec) %{_localstatedir}
-%attr(750, root, ossec) %{_localstatedir}/agentless
-%dir %attr(750, root, ossec) %{_localstatedir}/active-response
-%dir %attr(750, root, ossec) %{_localstatedir}/active-response/bin
-%attr(750, root, ossec) %{_localstatedir}/active-response/bin/*
-%dir %attr(750, root, ossec) %{_localstatedir}/api
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration
-%attr(660, root, ossec) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/security
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/ssl
-%dir %attr(750, root, ossec) %{_localstatedir}/api/scripts
-%attr(640, root, ossec) %{_localstatedir}/api/scripts/wazuh-apid.py
-%dir %attr(750, root, ossec) %{_localstatedir}/backup
-%dir %attr(750, ossec, ossec) %{_localstatedir}/backup/agents
-%dir %attr(750, ossec, ossec) %{_localstatedir}/backup/groups
-%dir %attr(750, root, ossec) %{_localstatedir}/backup/shared
-%dir %attr(750, root, ossec) %{_localstatedir}/bin
+%defattr(-, root, wazuh)
+%dir %attr(750, root, wazuh) %{_localstatedir}
+%attr(750, root, wazuh) %{_localstatedir}/agentless
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/api
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/security
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/ssl
+%dir %attr(750, root, wazuh) %{_localstatedir}/api/scripts
+%attr(640, root, wazuh) %{_localstatedir}/api/scripts/wazuh-apid.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/agents
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/groups
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup/shared
+%dir %attr(750, root, wazuh) %{_localstatedir}/bin
 %attr(750, root, root) %{_localstatedir}/bin/agent_control
-%attr(750, root, ossec) %{_localstatedir}/bin/agent_groups
-%attr(750, root, ossec) %{_localstatedir}/bin/agent_upgrade
+%attr(750, root, wazuh) %{_localstatedir}/bin/agent_groups
+%attr(750, root, wazuh) %{_localstatedir}/bin/agent_upgrade
 %attr(750, root, root) %{_localstatedir}/bin/clear_stats
-%attr(750, root, ossec) %{_localstatedir}/bin/cluster_control
+%attr(750, root, wazuh) %{_localstatedir}/bin/cluster_control
 %attr(750, root, root) %{_localstatedir}/bin/manage_agents
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-agentlessd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-analysisd
@@ -593,72 +596,72 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest-legacy
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-maild
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-monitord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-regex
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-remoted
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-reportd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-syscheckd
-%attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-apid
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-clusterd
+%attr(750, root, wazuh) %{_localstatedir}/bin/verify-agent-conf
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-apid
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc
-%attr(660, root, ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640, root, ossec) %{_localstatedir}/etc/internal_options*
-%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(640, root, ossec) %{_localstatedir}/etc/localtime
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/decoders
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/lists
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc/lists/amazon
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/amazon/*
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/shared
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc/shared/default
-%attr(660, ossec, ossec) %{_localstatedir}/etc/shared/agent-template.conf
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/shared/default/*
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/rootcheck
-%attr(660, root, ossec) %{_localstatedir}/etc/rootcheck/*.txt
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/rules
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/rules/local_rules.xml
-%dir %attr(750, root, ossec) %{_localstatedir}/framework
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/python
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/localtime
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/decoders
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/lists
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/lists/amazon
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/amazon/*
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/shared/default
+%attr(660, wazuh, wazuh) %{_localstatedir}/etc/shared/agent-template.conf
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/shared/default/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/rootcheck
+%attr(660, root, wazuh) %{_localstatedir}/etc/rootcheck/*.txt
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/rules
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/rules/local_rules.xml
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/python
 %{_localstatedir}/framework/python/*
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/scripts
-%attr(640, root, ossec) %{_localstatedir}/framework/scripts/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/*.py
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/*.json
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/dapi
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/integrations
-%attr(750, root, ossec) %{_localstatedir}/integrations/*
-%dir %attr(750, root, ossec) %{_localstatedir}/lib
-%attr(750, root, ossec) %{_localstatedir}/lib/libwazuhext.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libdbsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/librsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsyscollector.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsysinfo.so
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/scripts
+%attr(640, root, wazuh) %{_localstatedir}/framework/scripts/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.py
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.json
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/integrations
+%attr(750, root, wazuh) %{_localstatedir}/integrations/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhext.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
 %{_localstatedir}/lib/libpython3.9.so.1.0
-%dir %attr(770, ossec, ossec) %{_localstatedir}/logs
-%attr(660, ossec, ossec)  %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/api.log
-%attr(640, ossecm, ossec) %ghost %{_localstatedir}/logs/integrations.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/api
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/archives
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/alerts
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/cluster
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/firewall
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/wazuh
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
+%attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/api.log
+%attr(640, wazuh, wazuh) %ghost %{_localstatedir}/logs/integrations.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/api
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/archives
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/alerts
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/firewall
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh
@@ -676,133 +679,133 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%dir %attr(750, root, ossec) %{_localstatedir}/queue
-%attr(600, root, ossec) %ghost %{_localstatedir}/queue/agents-timestamp
-%dir %attr(770, root, ossec) %{_localstatedir}/queue/agent-groups
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/agentless
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/alerts
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/cluster
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/db
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/diff
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/fim
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/fim/db
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/syscollector
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/syscollector/db
-%attr(640, root,ossec) %{_localstatedir}/queue/syscollector/norm_config.json
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/fts
-%dir %attr(770, ossecr, ossec) %{_localstatedir}/queue/rids
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/tasks
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/sockets
-%dir %attr(660, root, ossec) %{_localstatedir}/queue/vulnerabilities
-%dir %attr(440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/logcollector
-%attr(0440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
-%attr(0440, root, ossec) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/decoders
-%attr(640, root, ossec) %{_localstatedir}/ruleset/decoders/*
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/rules
-%attr(640, root, ossec) %{_localstatedir}/ruleset/rules/*
-%dir %attr(770, root, ossec) %{_localstatedir}/.ssh
-%dir %attr(750, ossec, ossec) %{_localstatedir}/stats
-%dir %attr(1770, root, ossec) %{_localstatedir}/tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
-%dir %attr(750, root, ossec) %{_localstatedir}/var
-%dir %attr(770, root, ossec) %{_localstatedir}/var/db
-%dir %attr(770, root, ossec) %{_localstatedir}/var/db/agents
-%attr(660, root, ossec) %{_localstatedir}/var/db/mitre.db
-%dir %attr(770, root, ossec) %{_localstatedir}/var/download
-%dir %attr(770, ossec, ossec) %{_localstatedir}/var/multigroups
-%dir %attr(770, root, ossec) %{_localstatedir}/var/run
-%dir %attr(770, root, ossec) %{_localstatedir}/var/selinux
-%attr(640, root, ossec) %{_localstatedir}/var/selinux/*
-%dir %attr(770, root, ossec) %{_localstatedir}/var/upgrade
-%dir %attr(770, root, ossec) %{_localstatedir}/var/wodles
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/aws
-%attr(750, root, ossec) %{_localstatedir}/wodles/aws/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/azure
-%attr(750, root, ossec) %{_localstatedir}/wodles/azure/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/docker
-%attr(750, root, ossec) %{_localstatedir}/wodles/docker/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/queue
+%attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
+%dir %attr(770, root, wazuh) %{_localstatedir}/queue/agent-groups
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector/db
+%attr(640, root, wazuh) %{_localstatedir}/queue/syscollector/norm_config.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fts
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/rids
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/tasks
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
+%dir %attr(660, root, wazuh) %{_localstatedir}/queue/vulnerabilities
+%dir %attr(440, root, wazuh) %{_localstatedir}/queue/vulnerabilities/dictionaries
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%attr(0440, root, wazuh) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
+%attr(0440, root, wazuh) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/sca
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/decoders
+%attr(640, root, wazuh) %{_localstatedir}/ruleset/decoders/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/rules
+%attr(640, root, wazuh) %{_localstatedir}/ruleset/rules/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/stats
+%dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/var
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/db
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/db/agents
+%attr(660, root, wazuh) %{_localstatedir}/var/db/mitre.db
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/download
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/var/multigroups
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/selinux
+%attr(640, root, wazuh) %{_localstatedir}/var/selinux/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
+%attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
+%attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
+%attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -180,15 +180,15 @@ fi
 exit 0
 
 %pre
-# Create the ossec group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
-  groupadd -r ossec
-elif ! id -g ossec > /dev/null 2>&1; then
-  groupadd -r ossec
+# Create the wazuh group if it doesn't exists
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
+elif ! id -g wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
 fi
-# Create the ossec user if it doesn't exists
-if ! id -u ossec > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossec
+# Create the wazuh user if it doesn't exists
+if ! id -u wazuh > /dev/null 2>&1; then
+  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
 fi
 
 # Stop the services to upgrade the package
@@ -240,14 +240,14 @@ if [ $1 = 1 ]; then
   fi
 
   touch %{_localstatedir}/logs/active-responses.log
-  chown ossec:ossec %{_localstatedir}/logs/active-responses.log
+  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
-  # Generating osse.conf file
+  # Generating ossec.conf file
   %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  chown root:ossec %{_localstatedir}/etc/ossec.conf
+  chown root:wazuh %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
@@ -356,6 +356,25 @@ fi
 # Restore ossec.conf permissions after upgrading
 chmod 0660 %{_localstatedir}/etc/ossec.conf
 
+# Remove old ossec user and group if exists and change ownwership of files
+
+if id -g ossec > /dev/null 2>&1; then
+  find %{_localstatedir} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if id -u ossec > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if id -u ossecm > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if id -u ossecr > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  groupdel ossec
+fi
+
 %preun
 
 if [ $1 = 0 ]; then
@@ -406,22 +425,22 @@ fi
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:ossec %{_localstatedir}/etc/localtime
+ chown root:wazuh %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %postun
 
 # If the package is been uninstalled
 if [ $1 = 0 ];then
-  # Remove the ossec user if it exists
-  if id -u ossec > /dev/null 2>&1; then
-    userdel ossec >/dev/null 2>&1
+  # Remove the wazuh user if it exists
+  if id -u wazuh > /dev/null 2>&1; then
+    userdel wazuh >/dev/null 2>&1
   fi
-  # Remove the ossec group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
-  elif id -g ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
+  # Remove the wazuh group if it exists
+  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
+  elif id -g wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
   fi
 
   # Remove lingering folders and files
@@ -462,150 +481,150 @@ rm -fr %{buildroot}
 %files
 %{_initrddir}/wazuh-agent
 /usr/lib/systemd/system/wazuh-agent.service
-%defattr(-,root,root)
-%dir %attr(750,root,ossec) %{_localstatedir}
-%attr(750,root,ossec) %{_localstatedir}/agentless
-%dir %attr(770,root,ossec) %{_localstatedir}/.ssh
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response
-%dir %attr(750,root,ossec) %{_localstatedir}/active-response/bin
-%attr(750,root,ossec) %{_localstatedir}/active-response/bin/*
-%dir %attr(750,root,root) %{_localstatedir}/bin
-%attr(750,root,root) %{_localstatedir}/bin/*
-%dir %attr(750,root,ossec) %{_localstatedir}/backup
-%dir %attr(770,ossec,ossec) %{_localstatedir}/etc
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640,root,ossec) %{_localstatedir}/etc/internal_options*
-%attr(640,root,ossec) %{_localstatedir}/etc/localtime
-%attr(640,root,ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(660,root,ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%attr(640,root,ossec) %{_localstatedir}/etc/wpk_root.pem
-%dir %attr(770,root,ossec) %{_localstatedir}/etc/shared
-%attr(660,root,ossec) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
-%dir %attr(750,root,ossec) %{_localstatedir}/lib
-%attr(750,root,ossec) %{_localstatedir}/lib/*
-%dir %attr(770,ossec,ossec) %{_localstatedir}/logs
-%attr(660,ossec,ossec) %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660,root,ossec) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750,ossec,ossec) %{_localstatedir}/logs/wazuh
+%defattr(-, root, root)
+%dir %attr(750, root, wazuh) %{_localstatedir}
+%attr(750, root, wazuh) %{_localstatedir}/agentless
+%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root, root) %{_localstatedir}/bin
+%attr(750, root, root) %{_localstatedir}/bin/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh) %{_localstatedir}/etc/localtime
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
+%attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, wazuh) %{_localstatedir}/lib/*
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/centos/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/rhel/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/suse/*
-%attr(750,root,root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/src/*
-%dir %attr(750,root,ossec) %{_localstatedir}/queue
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/sockets
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/diff
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/fim/db
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/syscollector/db
-%attr(640, root,ossec) %{_localstatedir}/queue/syscollector/norm_config.json
-%dir %attr(770,ossec,ossec) %{_localstatedir}/queue/alerts
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/rids
-%dir %attr(750,ossec,ossec) %{_localstatedir}/queue/logcollector
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%attr(750, root, ossec) %{_localstatedir}/lib/libdbsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/librsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsyscollector.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsysinfo.so
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
-%dir %attr(1770,root,ossec) %{_localstatedir}/tmp
-%dir %attr(750,root,ossec) %{_localstatedir}/var
-%dir %attr(770,root,ossec) %{_localstatedir}/var/incoming
-%dir %attr(770,root,ossec) %{_localstatedir}/var/run
-%dir %attr(770,root,ossec) %{_localstatedir}/var/selinux
-%attr(640,root,ossec) %{_localstatedir}/var/selinux/*
-%dir %attr(770,root,ossec) %{_localstatedir}/var/upgrade
-%dir %attr(770,root,ossec) %{_localstatedir}/var/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles/aws
-%attr(750,root,ossec) %{_localstatedir}/wodles/aws/*
-%dir %attr(750,root,ossec) %{_localstatedir}/wodles/docker
-%attr(750,root,ossec) %{_localstatedir}/wodles/docker/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/generic/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/centos/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/rhel/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/sles/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/etc/templates/config/suse/*
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/agent_installation_scripts/src/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/queue
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector/db
+%attr(640, root, wazuh) %{_localstatedir}/queue/syscollector/norm_config.json
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/rids
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/sca
+%attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
+%dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
+%dir %attr(750, root, wazuh) %{_localstatedir}/var
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/incoming
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/selinux
+%attr(640, root, wazuh) %{_localstatedir}/var/selinux/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
+%attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
+%attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
+%attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -177,12 +177,17 @@ exit 0
 
 %pre
 
-# Create the ossec group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
-  groupadd -r ossec
-elif ! id -g ossec > /dev/null 2>&1; then
-  groupadd -r ossec
+# Create the wazuh group if it doesn't exists
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
+elif ! id -g wazuh > /dev/null 2>&1; then
+  groupadd -r wazuh
 fi
+
+# Create the wazuh user if it doesn't exists
+if ! id -u wazuh > /dev/null 2>&1; then
+  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
+fi 
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
@@ -202,19 +207,6 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-# Create the ossec user if it doesn't exists
-if ! id -u ossec > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossec
-fi
-# Create the ossecr user if it doesn't exists
-if ! id -u ossecr > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossecr
-fi
-# Create the ossecm user if it doesn't exists
-if ! id -u ossecm > /dev/null 2>&1; then
-  useradd -g ossec -G ossec -d %{_localstatedir} -r -s /sbin/nologin ossecm
-fi
-
 # Remove/relocate existing SQLite databases
 rm -f %{_localstatedir}/var/db/cluster.db* || true
 rm -f %{_localstatedir}/var/db/.profile.db* || true
@@ -228,7 +220,7 @@ fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then
   chmod 640 %{_localstatedir}/queue/db/global.db*
-  chown ossec:ossec %{_localstatedir}/queue/db/global.db*
+  chown wazuh:wazuh %{_localstatedir}/queue/db/global.db*
 fi
 
 # Remove Vuln-detector database
@@ -320,8 +312,8 @@ if [ $1 = 1 ]; then
 
   touch %{_localstatedir}/logs/active-responses.log
   touch %{_localstatedir}/logs/integrations.log
-  chown ossec:ossec %{_localstatedir}/logs/active-responses.log
-  chown ossecm:ossec %{_localstatedir}/logs/integrations.log
+  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
+  chown wazuh:wazuh %{_localstatedir}/logs/integrations.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
   chmod 0640 %{_localstatedir}/logs/integrations.log
 
@@ -422,7 +414,7 @@ fi
 
 # Fix sca permissions, group and owner
 chmod 640 %{_localstatedir}/ruleset/sca/*
-chown root:ossec %{_localstatedir}/ruleset/sca/*
+chown root:wazuh %{_localstatedir}/ruleset/sca/*
 # Delete the temporary directory
 rm -rf ${SCA_BASE_DIR}
 
@@ -439,6 +431,25 @@ rm -rf %{_localstatedir}/packages_files
 
 # Remove unnecessary files from default group
 rm -f %{_localstatedir}/etc/shared/default/*.rpmnew
+
+# Remove old ossec user and group if exists and change ownwership of files
+
+if id -g ossec > /dev/null 2>&1; then
+  find %{_localstatedir} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if id -u ossec > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if id -u ossecm > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if id -u ossecr > /dev/null 2>&1; then
+    find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  groupdel ossec
+fi
 
 %preun
 
@@ -482,23 +493,15 @@ fi
 
 # If the package is been uninstalled
 if [ $1 = 0 ];then
-  # Remove the ossecr user if it exists
-  if id -u ossecr > /dev/null 2>&1; then
-    userdel ossecr >/dev/null 2>&1
+  # Remove the wazuh user if it exists
+  if id -u wazuh > /dev/null 2>&1; then
+    userdel wazuh >/dev/null 2>&1
   fi
-  # Remove the ossecm user if it exists
-  if id -u ossecm > /dev/null 2>&1; then
-    userdel ossecm >/dev/null 2>&1
-  fi
-  # Remove the ossec user if it exists
-  if id -u ossec > /dev/null 2>&1; then
-    userdel ossec >/dev/null 2>&1
-  fi
-  # Remove the ossec group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
-  elif id -g ossec > /dev/null 2>&1; then
-    groupdel ossec >/dev/null 2>&1
+  # Remove the wazuh group if it exists
+  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
+  elif id -g wazuh > /dev/null 2>&1; then
+    groupdel wazuh >/dev/null 2>&1
   fi
 
   # Backup agents centralized configuration (etc/shared)
@@ -550,7 +553,7 @@ fi
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:ossec %{_localstatedir}/etc/localtime
+ chown root:wazuh %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %clean
@@ -559,29 +562,29 @@ rm -fr %{buildroot}
 %files
 %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
-%defattr(-,root,ossec)
-%dir %attr(750, root, ossec) %{_localstatedir}
-%attr(750, root, ossec) %{_localstatedir}/agentless
-%dir %attr(750, root, ossec) %{_localstatedir}/active-response
-%dir %attr(750, root, ossec) %{_localstatedir}/active-response/bin
-%attr(750, root, ossec) %{_localstatedir}/active-response/bin/*
-%dir %attr(750, root, ossec) %{_localstatedir}/api
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration
-%attr(660, root, ossec) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/security
-%dir %attr(770, root, ossec) %{_localstatedir}/api/configuration/ssl
-%dir %attr(750, root, ossec) %{_localstatedir}/api/scripts
-%attr(640, root, ossec) %{_localstatedir}/api/scripts/wazuh-apid.py
-%dir %attr(750, root, ossec) %{_localstatedir}/backup
-%dir %attr(750, ossec, ossec) %{_localstatedir}/backup/agents
-%dir %attr(750, ossec, ossec) %{_localstatedir}/backup/groups
-%dir %attr(750, root, ossec) %{_localstatedir}/backup/shared
-%dir %attr(750, root, ossec) %{_localstatedir}/bin
+%defattr(-, root, wazuh)
+%dir %attr(750, root, wazuh) %{_localstatedir}
+%attr(750, root, wazuh) %{_localstatedir}/agentless
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/api
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/security
+%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/ssl
+%dir %attr(750, root, wazuh) %{_localstatedir}/api/scripts
+%attr(640, root, wazuh) %{_localstatedir}/api/scripts/wazuh-apid.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/agents
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/groups
+%dir %attr(750, root, wazuh) %{_localstatedir}/backup/shared
+%dir %attr(750, root, wazuh) %{_localstatedir}/bin
 %attr(750, root, root) %{_localstatedir}/bin/agent_control
-%attr(750, root, ossec) %{_localstatedir}/bin/agent_groups
-%attr(750, root, ossec) %{_localstatedir}/bin/agent_upgrade
+%attr(750, root, wazuh) %{_localstatedir}/bin/agent_groups
+%attr(750, root, wazuh) %{_localstatedir}/bin/agent_upgrade
 %attr(750, root, root) %{_localstatedir}/bin/clear_stats
-%attr(750, root, ossec) %{_localstatedir}/bin/cluster_control
+%attr(750, root, wazuh) %{_localstatedir}/bin/cluster_control
 %attr(750, root, root) %{_localstatedir}/bin/manage_agents
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-agentlessd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-analysisd
@@ -593,72 +596,72 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-integratord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logcollector
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-logtest-legacy
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-logtest
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-logtest
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-maild
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-monitord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-regex
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-remoted
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-reportd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-syscheckd
-%attr(750, root, ossec) %{_localstatedir}/bin/verify-agent-conf
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-apid
-%attr(750, root, ossec) %{_localstatedir}/bin/wazuh-clusterd
+%attr(750, root, wazuh) %{_localstatedir}/bin/verify-agent-conf
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-apid
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc
-%attr(660, root, ossec) %config(noreplace) %{_localstatedir}/etc/ossec.conf
-%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640, root, ossec) %{_localstatedir}/etc/internal_options*
-%attr(640, root, ossec) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(640, root, ossec) %{_localstatedir}/etc/localtime
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/decoders
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/lists
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc/lists/amazon
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/amazon/*
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/shared
-%dir %attr(770, ossec, ossec) %{_localstatedir}/etc/shared/default
-%attr(660, ossec, ossec) %{_localstatedir}/etc/shared/agent-template.conf
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/shared/default/*
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/rootcheck
-%attr(660, root, ossec) %{_localstatedir}/etc/rootcheck/*.txt
-%dir %attr(770, root, ossec) %{_localstatedir}/etc/rules
-%attr(660, ossec, ossec) %config(noreplace) %{_localstatedir}/etc/rules/local_rules.xml
-%dir %attr(750, root, ossec) %{_localstatedir}/framework
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/python
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/localtime
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/decoders
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/decoders/local_decoder.xml
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/lists
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/lists/amazon
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/amazon/*
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/audit-keys
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/shared/default
+%attr(660, wazuh, wazuh) %{_localstatedir}/etc/shared/agent-template.conf
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/shared/default/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/rootcheck
+%attr(660, root, wazuh) %{_localstatedir}/etc/rootcheck/*.txt
+%dir %attr(770, root, wazuh) %{_localstatedir}/etc/rules
+%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/rules/local_rules.xml
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/python
 %{_localstatedir}/framework/python/*
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/scripts
-%attr(640, root, ossec) %{_localstatedir}/framework/scripts/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/*.py
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/*.json
-%dir %attr(750, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/dapi
-%attr(640, root, ossec) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
-%dir %attr(750, root, ossec) %{_localstatedir}/integrations
-%attr(750, root, ossec) %{_localstatedir}/integrations/*
-%dir %attr(750, root, ossec) %{_localstatedir}/lib
-%attr(750, root, ossec) %{_localstatedir}/lib/libwazuhext.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libdbsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/librsync.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsyscollector.so
-%attr(750, root, ossec) %{_localstatedir}/lib/libsysinfo.so
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/scripts
+%attr(640, root, wazuh) %{_localstatedir}/framework/scripts/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.py
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.json
+%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi
+%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
+%dir %attr(750, root, wazuh) %{_localstatedir}/integrations
+%attr(750, root, wazuh) %{_localstatedir}/integrations/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhext.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
 %{_localstatedir}/lib/libpython3.9.so.1.0
-%dir %attr(770, ossec, ossec) %{_localstatedir}/logs
-%attr(660, ossec, ossec)  %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/api.log
-%attr(640, ossecm, ossec) %ghost %{_localstatedir}/logs/integrations.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660, ossec, ossec) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/api
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/archives
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/alerts
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/cluster
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/firewall
-%dir %attr(750, ossec, ossec) %{_localstatedir}/logs/wazuh
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
+%attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/api.log
+%attr(640, wazuh, wazuh) %ghost %{_localstatedir}/logs/integrations.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/api
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/archives
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/alerts
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/firewall
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh
@@ -676,133 +679,133 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%dir %attr(750, root, ossec) %{_localstatedir}/queue
-%attr(600, root, ossec) %ghost %{_localstatedir}/queue/agents-timestamp
-%dir %attr(770, root, ossec) %{_localstatedir}/queue/agent-groups
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/agentless
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/alerts
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/cluster
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/db
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/diff
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/fim
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/fim/db
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/syscollector
-%dir %attr(750, ossec,ossec) %{_localstatedir}/queue/syscollector/db
-%attr(640, root,ossec) %{_localstatedir}/queue/syscollector/norm_config.json
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/fts
-%dir %attr(770, ossecr, ossec) %{_localstatedir}/queue/rids
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/tasks
-%dir %attr(770, ossec, ossec) %{_localstatedir}/queue/sockets
-%dir %attr(660, root, ossec) %{_localstatedir}/queue/vulnerabilities
-%dir %attr(440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries
-%dir %attr(750, ossec, ossec) %{_localstatedir}/queue/logcollector
-%attr(0440, root, ossec) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
-%attr(0440, root, ossec) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/sca
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/decoders
-%attr(640, root, ossec) %{_localstatedir}/ruleset/decoders/*
-%dir %attr(750, root, ossec) %{_localstatedir}/ruleset/rules
-%attr(640, root, ossec) %{_localstatedir}/ruleset/rules/*
-%dir %attr(770, root, ossec) %{_localstatedir}/.ssh
-%dir %attr(750, ossec, ossec) %{_localstatedir}/stats
-%dir %attr(1770, root, ossec) %{_localstatedir}/tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
-%dir %attr(750, ossec, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
-%attr(640, root, ossec) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
-%dir %attr(750, root, ossec) %{_localstatedir}/var
-%dir %attr(770, root, ossec) %{_localstatedir}/var/db
-%dir %attr(770, root, ossec) %{_localstatedir}/var/db/agents
-%attr(660, root, ossec) %{_localstatedir}/var/db/mitre.db
-%dir %attr(770, root, ossec) %{_localstatedir}/var/download
-%dir %attr(770, ossec, ossec) %{_localstatedir}/var/multigroups
-%dir %attr(770, root, ossec) %{_localstatedir}/var/run
-%dir %attr(770, root, ossec) %{_localstatedir}/var/selinux
-%attr(640, root, ossec) %{_localstatedir}/var/selinux/*
-%dir %attr(770, root, ossec) %{_localstatedir}/var/upgrade
-%dir %attr(770, root, ossec) %{_localstatedir}/var/wodles
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/aws
-%attr(750, root, ossec) %{_localstatedir}/wodles/aws/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/azure
-%attr(750, root, ossec) %{_localstatedir}/wodles/azure/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/docker
-%attr(750, root, ossec) %{_localstatedir}/wodles/docker/*
-%dir %attr(750, root, ossec) %{_localstatedir}/wodles/gcloud
-%attr(750, root, ossec) %{_localstatedir}/wodles/gcloud/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/queue
+%attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
+%dir %attr(770, root, wazuh) %{_localstatedir}/queue/agent-groups
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fim/db
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/syscollector/db
+%attr(640, root, wazuh) %{_localstatedir}/queue/syscollector/norm_config.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/fts
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/rids
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/tasks
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
+%dir %attr(660, root, wazuh) %{_localstatedir}/queue/vulnerabilities
+%dir %attr(440, root, wazuh) %{_localstatedir}/queue/vulnerabilities/dictionaries
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%attr(0440, root, wazuh) %{_localstatedir}/queue/vulnerabilities/dictionaries/cpe_helper.json
+%attr(0440, root, wazuh) %ghost %{_localstatedir}/queue/vulnerabilities/dictionaries/msu.json.gz
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/sca
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/decoders
+%attr(640, root, wazuh) %{_localstatedir}/ruleset/decoders/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/rules
+%attr(640, root, wazuh) %{_localstatedir}/ruleset/rules/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/stats
+%dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/sca.files
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*yml
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sunos/*
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/11/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/sca.files
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/12/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/14/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/16/04/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/var
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/db
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/db/agents
+%attr(660, root, wazuh) %{_localstatedir}/var/db/mitre.db
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/download
+%dir %attr(770, wazuh, wazuh) %{_localstatedir}/var/multigroups
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/selinux
+%attr(640, root, wazuh) %{_localstatedir}/var/selinux/*
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%dir %attr(770, root, wazuh) %{_localstatedir}/var/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
+%attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
+%attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
+%attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %if %{_debugenabled} == "yes"
 /usr/lib/debug/%{_localstatedir}/*

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -239,8 +239,8 @@ clean(){
     rm -f /etc/rc3.d/S97wazuh-agent
 
     ## Remove User and Groups
-    userdel ossec
-    groupdel ossec
+    userdel wazuh
+    groupdel wazuh
 }
 
 ctrl_c() {
@@ -256,8 +256,8 @@ build(){
     echo "| Building |"
     echo "------------"
 
-    groupadd ossec
-    useradd -g ossec ossec
+    groupadd wazuh
+    useradd -g wazuh wazuh
     installation
     package
 }

--- a/solaris/solaris11/SPECS/template_agent_v4.3.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.3.0.json
@@ -1,7 +1,7 @@
 {
     "/var/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -9,7 +9,7 @@
     },
     "/var/ossec/.ssh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -17,7 +17,7 @@
     },
     "/var/ossec/active-response": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -25,7 +25,7 @@
     },
     "/var/ossec/active-response/bin": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -33,7 +33,7 @@
     },
     "/var/ossec/active-response/bin/default-firewall-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -41,7 +41,7 @@
     },
     "/var/ossec/active-response/bin/disable-account": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -49,7 +49,7 @@
     },
     "/var/ossec/active-response/bin/firewall-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -57,7 +57,7 @@
     },
     "/var/ossec/active-response/bin/firewalld-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -65,7 +65,7 @@
     },
     "/var/ossec/active-response/bin/host-deny": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -73,7 +73,7 @@
     },
     "/var/ossec/active-response/bin/ip-customblock": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -81,7 +81,7 @@
     },
     "/var/ossec/active-response/bin/ipfw": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -89,7 +89,7 @@
     },
     "/var/ossec/active-response/bin/kaspersky.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -97,7 +97,7 @@
     },
     "/var/ossec/active-response/bin/kaspersky": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -105,7 +105,7 @@
     },
     "/var/ossec/active-response/bin/npf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -113,7 +113,7 @@
     },
     "/var/ossec/active-response/bin/wazuh-slack": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -121,7 +121,7 @@
     },
     "/var/ossec/active-response/bin/pf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -129,7 +129,7 @@
     },
     "/var/ossec/active-response/bin/restart-wazuh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -137,7 +137,7 @@
     },
     "/var/ossec/active-response/bin/restart.sh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -145,7 +145,7 @@
     },
     "/var/ossec/active-response/bin/route-null": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -153,7 +153,7 @@
     },
     "/var/ossec/agentless": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -161,7 +161,7 @@
     },
     "/var/ossec/agentless/main.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -169,7 +169,7 @@
     },
     "/var/ossec/agentless/register_host.sh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -177,7 +177,7 @@
     },
     "/var/ossec/agentless/ssh.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -185,7 +185,7 @@
     },
     "/var/ossec/agentless/ssh_asa-fwsmconfig_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -193,7 +193,7 @@
     },
     "/var/ossec/agentless/ssh_foundry_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -201,7 +201,7 @@
     },
     "/var/ossec/agentless/ssh_generic_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -209,7 +209,7 @@
     },
     "/var/ossec/agentless/ssh_integrity_check_bsd": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -217,7 +217,7 @@
     },
     "/var/ossec/agentless/ssh_integrity_check_linux": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -225,7 +225,7 @@
     },
     "/var/ossec/agentless/ssh_nopass.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -233,7 +233,7 @@
     },
     "/var/ossec/agentless/ssh_pixconfig_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -241,7 +241,7 @@
     },
     "/var/ossec/agentless/sshlogin.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -249,7 +249,7 @@
     },
     "/var/ossec/agentless/su.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -257,7 +257,7 @@
     },
     "/var/ossec/backup": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -345,15 +345,15 @@
     },
     "/var/ossec/etc": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/client.keys": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -361,7 +361,7 @@
     },
     "/var/ossec/etc/client.keys.rpmnew": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -369,7 +369,7 @@
     },
     "/var/ossec/etc/internal_options.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -377,7 +377,7 @@
     },
     "/var/ossec/etc/local_internal_options.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -385,7 +385,7 @@
     },
     "/var/ossec/etc/localtime": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -393,7 +393,7 @@
     },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -401,7 +401,7 @@
     },
     "/var/ossec/etc/ossec.conf.rpmnew": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -417,7 +417,7 @@
     },
     "/var/ossec/etc/shared": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -425,23 +425,23 @@
     },
     "/var/ossec/etc/shared/agent.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/ar.conf": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/start-script-lock": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0755",
         "prot": "drwxr-xr-x",
         "type": "directory",
@@ -449,7 +449,7 @@
     },
     "/var/ossec/var/start-script-lock/pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
@@ -457,183 +457,183 @@
     },
     "/var/ossec/etc/shared/cis_apache2224_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_debian_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_mysql5-6_community_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_mysql5-6_enterprise_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel6_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel7_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_sles11_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_sles12_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_domainL1_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_domainL2_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_memberL1_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_memberL2_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/merged.mg": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/rootkit_files.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/rootkit_trojans.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/system_audit_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/system_audit_ssh.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_applications_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_audit_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_malware_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/wpk_root.pem": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -641,7 +641,7 @@
     },
     "/var/ossec/lib": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -649,7 +649,7 @@
     },
     "/var/ossec/lib/libwazuhext.so": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -657,39 +657,39 @@
     },
     "/var/ossec/logs": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/active-responses.log": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec.log": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -697,7 +697,7 @@
     },
     "/var/ossec/logs/ossec.json": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -705,599 +705,599 @@
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1305,15 +1305,15 @@
     },
     "/var/ossec/queue/alerts": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/alerts/cfgaq": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1321,7 +1321,7 @@
     },
     "/var/ossec/queue/alerts/execq": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1329,11 +1329,11 @@
     },
     "/var/ossec/queue/diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/diff/local": {
         "class": "dynamic",
@@ -1377,39 +1377,39 @@
     },
     "/var/ossec/queue/fim": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/fim/db": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector/db": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector/norm_config.json": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1417,23 +1417,23 @@
     },
     "/var/ossec/queue/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/.*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/logcollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1441,7 +1441,7 @@
     },
     "/var/ossec/queue/ossec/syscheck": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1449,7 +1449,7 @@
     },
     "/var/ossec/queue/ossec/wmodules": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1457,15 +1457,15 @@
     },
     "/var/ossec/queue/ossec/queue": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/com": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1473,7 +1473,7 @@
     },
     "/var/ossec/queue/ossec/control": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1481,23 +1481,23 @@
     },
     "/var/ossec/queue/sockets": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/.*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/logcollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1505,7 +1505,7 @@
     },
     "/var/ossec/queue/sockets/syscheck": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1513,7 +1513,7 @@
     },
     "/var/ossec/queue/sockets/wmodules": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1521,15 +1521,15 @@
     },
     "/var/ossec/queue/sockets/queue": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/com": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1537,7 +1537,7 @@
     },
     "/var/ossec/queue/sockets/control": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1545,31 +1545,31 @@
     },
     "/var/ossec/queue/rids": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/logcollector": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/rids/*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/ruleset": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1577,7 +1577,7 @@
     },
     "/var/ossec/ruleset/sca": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1586,7 +1586,7 @@
 
     "/var/ossec/ruleset/sca/cis_solaris11.yml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rwxr-----",
         "type": "file",
@@ -1594,7 +1594,7 @@
     },
     "/var/ossec/tmp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "1770",
         "prot": "drwxrwx--T",
         "type": "directory",
@@ -1602,7 +1602,7 @@
     },
     "/var/ossec/var": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1610,7 +1610,7 @@
     },
     "/var/ossec/var/db": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1618,7 +1618,7 @@
     },
     "/var/ossec/var/db/agents": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1626,7 +1626,7 @@
     },
     "/var/ossec/var/db/agents/001-*.db": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1634,7 +1634,7 @@
     },
     "/var/ossec/var/incoming": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1642,7 +1642,7 @@
     },
     "/var/ossec/var/run": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1650,31 +1650,31 @@
     },
     "/var/ossec/var/run/.syscheck_run": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-agentd.state": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-agentd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-execd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1682,7 +1682,7 @@
     },
     "/var/ossec/var/run/wazuh-logcollector-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1690,15 +1690,15 @@
     },
     "/var/ossec/var/run/wazuh-logcollector.state": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-syscheckd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1706,7 +1706,7 @@
     },
     "/var/ossec/var/run/wazuh-modulesd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1714,7 +1714,7 @@
     },
     "/var/ossec/var/run/agent-auth-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1722,7 +1722,7 @@
     },
     "/var/ossec/var/selinux": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1730,7 +1730,7 @@
     },
     "/var/ossec/var/selinux/wazuh.pp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1738,7 +1738,7 @@
     },
     "/var/ossec/var/upgrade": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1746,7 +1746,7 @@
     },
     "/var/ossec/var/wodles": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1754,7 +1754,7 @@
     },
     "/var/ossec/var/wodles/syscollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
@@ -1762,7 +1762,7 @@
     },
     "/var/ossec/wodles": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1770,7 +1770,7 @@
     },
     "/var/ossec/wodles/aws": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1778,7 +1778,7 @@
     },
     "/var/ossec/wodles/aws/aws-s3": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1786,7 +1786,7 @@
     },
     "/var/ossec/wodles/docker": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1794,7 +1794,7 @@
     },
     "/var/ossec/wodles/docker/DockerListener": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1802,7 +1802,7 @@
     },
     "/var/ossec/wodles/gcloud": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1810,7 +1810,7 @@
     },
     "/var/ossec/wodles/gcloud/gcloud": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1818,7 +1818,7 @@
     },
     "/var/ossec/wodles/gcloud/gcloud.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1826,7 +1826,7 @@
     },
     "/var/ossec/wodles/gcloud/integration.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1834,7 +1834,7 @@
     },
     "/var/ossec/wodles/gcloud/tools.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1842,7 +1842,7 @@
     },
     "/var/ossec/wodles/oscap": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1850,7 +1850,7 @@
     },
     "/var/ossec/wodles/oscap/content": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1858,7 +1858,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-debian-8-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1866,7 +1866,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-debian-9-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1874,7 +1874,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-redhat-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1882,7 +1882,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-redhat-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1890,7 +1890,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-ubuntu-xenial-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1898,7 +1898,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-centos-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1906,7 +1906,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-centos-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1914,7 +1914,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-debian-8-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1922,7 +1922,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-fedora-24-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1930,7 +1930,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-rhel-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1938,7 +1938,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-rhel-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1946,7 +1946,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-ubuntu-1404-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1954,7 +1954,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-ubuntu-1604-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1962,7 +1962,7 @@
     },
     "/var/ossec/wodles/oscap/oscap.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1970,7 +1970,7 @@
     },
     "/var/ossec/wodles/oscap/template_oval.xsl": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1978,7 +1978,7 @@
     },
     "/var/ossec/wodles/oscap/template_xccdf.xsl": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -1,7 +1,7 @@
 {
     "/var/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -9,7 +9,7 @@
     },
     "/var/ossec/.ssh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -17,7 +17,7 @@
     },
     "/var/ossec/active-response": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -25,7 +25,7 @@
     },
     "/var/ossec/active-response/bin": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -33,7 +33,7 @@
     },
     "/var/ossec/active-response/bin/default-firewall-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -41,7 +41,7 @@
     },
     "/var/ossec/active-response/bin/disable-account": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -49,7 +49,7 @@
     },
     "/var/ossec/active-response/bin/firewall-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -57,7 +57,7 @@
     },
     "/var/ossec/active-response/bin/firewalld-drop": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -65,7 +65,7 @@
     },
     "/var/ossec/active-response/bin/host-deny": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -73,7 +73,7 @@
     },
     "/var/ossec/active-response/bin/ip-customblock": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -81,7 +81,7 @@
     },
     "/var/ossec/active-response/bin/ipfw": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -89,7 +89,7 @@
     },
     "/var/ossec/active-response/bin/kaspersky.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -97,7 +97,7 @@
     },
     "/var/ossec/active-response/bin/kaspersky": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -105,7 +105,7 @@
     },
     "/var/ossec/active-response/bin/npf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -113,7 +113,7 @@
     },
     "/var/ossec/active-response/bin/wazuh-slack": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -121,7 +121,7 @@
     },
     "/var/ossec/active-response/bin/pf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -129,7 +129,7 @@
     },
     "/var/ossec/active-response/bin/restart-wazuh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -137,7 +137,7 @@
     },
     "/var/ossec/active-response/bin/restart.sh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -145,7 +145,7 @@
     },
     "/var/ossec/active-response/bin/route-null": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -153,7 +153,7 @@
     },
     "/var/ossec/agentless": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -161,7 +161,7 @@
     },
     "/var/ossec/agentless/main.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -169,7 +169,7 @@
     },
     "/var/ossec/agentless/register_host.sh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -177,7 +177,7 @@
     },
     "/var/ossec/agentless/ssh.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -185,7 +185,7 @@
     },
     "/var/ossec/agentless/ssh_asa-fwsmconfig_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -193,7 +193,7 @@
     },
     "/var/ossec/agentless/ssh_foundry_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -201,7 +201,7 @@
     },
     "/var/ossec/agentless/ssh_generic_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -209,7 +209,7 @@
     },
     "/var/ossec/agentless/ssh_integrity_check_bsd": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -217,7 +217,7 @@
     },
     "/var/ossec/agentless/ssh_integrity_check_linux": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -225,7 +225,7 @@
     },
     "/var/ossec/agentless/ssh_nopass.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -233,7 +233,7 @@
     },
     "/var/ossec/agentless/ssh_pixconfig_diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -241,7 +241,7 @@
     },
     "/var/ossec/agentless/sshlogin.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -249,7 +249,7 @@
     },
     "/var/ossec/agentless/su.exp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -257,7 +257,7 @@
     },
     "/var/ossec/backup": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -345,15 +345,15 @@
     },
     "/var/ossec/etc": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/client.keys": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -361,7 +361,7 @@
     },
     "/var/ossec/etc/client.keys.rpmnew": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -369,7 +369,7 @@
     },
     "/var/ossec/etc/internal_options.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -377,7 +377,7 @@
     },
     "/var/ossec/etc/local_internal_options.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -385,7 +385,7 @@
     },
     "/var/ossec/etc/localtime": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -393,7 +393,7 @@
     },
     "/var/ossec/etc/ossec.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -401,7 +401,7 @@
     },
     "/var/ossec/etc/ossec.conf.rpmnew": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -417,7 +417,7 @@
     },
     "/var/ossec/etc/shared": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -425,23 +425,23 @@
     },
     "/var/ossec/etc/shared/agent.conf": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/ar.conf": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/start-script-lock": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0755",
         "prot": "drwxr-xr-x",
         "type": "directory",
@@ -449,7 +449,7 @@
     },
     "/var/ossec/var/start-script-lock/pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
@@ -457,183 +457,183 @@
     },
     "/var/ossec/etc/shared/cis_apache2224_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_debian_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_mysql5-6_community_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_mysql5-6_enterprise_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel6_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel7_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_rhel_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_sles11_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_sles12_linux_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_domainL1_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_domainL2_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_memberL1_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/cis_win2012r2_memberL2_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/merged.mg": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/rootkit_files.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/rootkit_trojans.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/system_audit_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/system_audit_ssh.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_applications_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_audit_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/shared/win_malware_rcl.txt": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/etc/wpk_root.pem": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -641,7 +641,7 @@
     },
     "/var/ossec/lib": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -649,7 +649,7 @@
     },
     "/var/ossec/lib/libwazuhext.so": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -657,39 +657,39 @@
     },
     "/var/ossec/logs": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/active-responses.log": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec.log": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -697,7 +697,7 @@
     },
     "/var/ossec/logs/ossec.json": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -705,599 +705,599 @@
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/wazuh/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jan/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Feb/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Mar/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Apr/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/May/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jun/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Jul/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Aug/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Sep/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Oct/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Nov/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].json.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
      "/var/ossec/logs/ossec/[0-9][0-9][0-9][0-9]/Dec/ossec-[0-9][0-9].log.gz": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1305,15 +1305,15 @@
     },
     "/var/ossec/queue/alerts": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/alerts/cfgaq": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1321,7 +1321,7 @@
     },
     "/var/ossec/queue/alerts/execq": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1329,11 +1329,11 @@
     },
     "/var/ossec/queue/diff": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/diff/local": {
         "class": "dynamic",
@@ -1377,39 +1377,39 @@
     },
     "/var/ossec/queue/fim": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/fim/db": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector/db": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/syscollector/norm_config.json": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1417,23 +1417,23 @@
     },
     "/var/ossec/queue/ossec": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/.*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/logcollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1441,7 +1441,7 @@
     },
     "/var/ossec/queue/ossec/syscheck": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1449,7 +1449,7 @@
     },
     "/var/ossec/queue/ossec/wmodules": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1457,15 +1457,15 @@
     },
     "/var/ossec/queue/ossec/queue": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/ossec/com": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1473,7 +1473,7 @@
     },
     "/var/ossec/queue/ossec/control": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1481,23 +1481,23 @@
     },
     "/var/ossec/queue/sockets": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/.*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/logcollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1505,7 +1505,7 @@
     },
     "/var/ossec/queue/sockets/syscheck": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1513,7 +1513,7 @@
     },
     "/var/ossec/queue/sockets/wmodules": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1521,15 +1521,15 @@
     },
     "/var/ossec/queue/sockets/queue": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/sockets/com": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1537,7 +1537,7 @@
     },
     "/var/ossec/queue/sockets/control": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1545,31 +1545,31 @@
     },
     "/var/ossec/queue/rids": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/logcollector": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/queue/rids/*": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/ruleset": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1577,7 +1577,7 @@
     },
     "/var/ossec/ruleset/sca": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1586,7 +1586,7 @@
 
     "/var/ossec/ruleset/sca/cis_solaris11.yml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rwxr-----",
         "type": "file",
@@ -1594,7 +1594,7 @@
     },
     "/var/ossec/tmp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "1770",
         "prot": "drwxrwx--T",
         "type": "directory",
@@ -1602,7 +1602,7 @@
     },
     "/var/ossec/var": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1610,7 +1610,7 @@
     },
     "/var/ossec/var/db": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1618,7 +1618,7 @@
     },
     "/var/ossec/var/db/agents": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1626,7 +1626,7 @@
     },
     "/var/ossec/var/db/agents/001-*.db": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0660",
         "prot": "-rw-rw----",
         "type": "file",
@@ -1634,7 +1634,7 @@
     },
     "/var/ossec/var/incoming": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1642,7 +1642,7 @@
     },
     "/var/ossec/var/run": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1650,31 +1650,31 @@
     },
     "/var/ossec/var/run/.syscheck_run": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-agentd.state": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-agentd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-execd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1682,7 +1682,7 @@
     },
     "/var/ossec/var/run/wazuh-logcollector-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1690,15 +1690,15 @@
     },
     "/var/ossec/var/run/wazuh-logcollector.state": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
-        "user": "ossec"
+        "user": "wazuh"
     },
     "/var/ossec/var/run/wazuh-syscheckd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1706,7 +1706,7 @@
     },
     "/var/ossec/var/run/wazuh-modulesd-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1714,7 +1714,7 @@
     },
     "/var/ossec/var/run/agent-auth-*.pid": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1722,7 +1722,7 @@
     },
     "/var/ossec/var/selinux": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1730,7 +1730,7 @@
     },
     "/var/ossec/var/selinux/wazuh.pp": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1738,7 +1738,7 @@
     },
     "/var/ossec/var/upgrade": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1746,7 +1746,7 @@
     },
     "/var/ossec/var/wodles": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0770",
         "prot": "drwxrwx---",
         "type": "directory",
@@ -1754,7 +1754,7 @@
     },
     "/var/ossec/var/wodles/syscollector": {
         "class": "dynamic",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0644",
         "prot": "-rw-r--r--",
         "type": "file",
@@ -1762,7 +1762,7 @@
     },
     "/var/ossec/wodles": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1770,7 +1770,7 @@
     },
     "/var/ossec/wodles/aws": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1778,7 +1778,7 @@
     },
     "/var/ossec/wodles/aws/aws-s3": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1786,7 +1786,7 @@
     },
     "/var/ossec/wodles/docker": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1794,7 +1794,7 @@
     },
     "/var/ossec/wodles/docker/DockerListener": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1802,7 +1802,7 @@
     },
     "/var/ossec/wodles/gcloud": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1810,7 +1810,7 @@
     },
     "/var/ossec/wodles/gcloud/gcloud": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1818,7 +1818,7 @@
     },
     "/var/ossec/wodles/gcloud/gcloud.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1826,7 +1826,7 @@
     },
     "/var/ossec/wodles/gcloud/integration.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1834,7 +1834,7 @@
     },
     "/var/ossec/wodles/gcloud/tools.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1842,7 +1842,7 @@
     },
     "/var/ossec/wodles/oscap": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1850,7 +1850,7 @@
     },
     "/var/ossec/wodles/oscap/content": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "drwxr-x---",
         "type": "directory",
@@ -1858,7 +1858,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-debian-8-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1866,7 +1866,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-debian-9-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1874,7 +1874,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-redhat-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1882,7 +1882,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-redhat-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1890,7 +1890,7 @@
     },
     "/var/ossec/wodles/oscap/content/cve-ubuntu-xenial-oval.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1898,7 +1898,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-centos-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1906,7 +1906,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-centos-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1914,7 +1914,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-debian-8-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1922,7 +1922,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-fedora-24-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1930,7 +1930,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-rhel-6-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1938,7 +1938,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-rhel-7-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1946,7 +1946,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-ubuntu-1404-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1954,7 +1954,7 @@
     },
     "/var/ossec/wodles/oscap/content/ssg-ubuntu-1604-ds.xml": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0640",
         "prot": "-rw-r-----",
         "type": "file",
@@ -1962,7 +1962,7 @@
     },
     "/var/ossec/wodles/oscap/oscap.py": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1970,7 +1970,7 @@
     },
     "/var/ossec/wodles/oscap/template_oval.xsl": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",
@@ -1978,7 +1978,7 @@
     },
     "/var/ossec/wodles/oscap/template_xccdf.xsl": {
         "class": "static",
-        "group": "ossec",
+        "group": "wazuh",
         "mode": "0750",
         "prot": "-rwxr-x---",
         "type": "file",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -172,7 +172,7 @@ create_package() {
     if [ "${major_version}" -ge "4" ]; then
         if [ "${minor_version}" -ge "2" ]; then
             mkdir   ${install_path}/logs/ossec
-            chown ossec:ossec ${install_path}/logs/ossec
+            chown wazuh:wazuh ${install_path}/logs/ossec
             chmod 0750 ${install_path}/logs/ossec
             sed "s|<INSTALL_PATH>|${install_path}|" ${current_path}/postinstall.sh > ${current_path}/postinstall.sh.new
             mv ${current_path}/postinstall.sh.new ${current_path}/postinstall.sh
@@ -185,9 +185,9 @@ create_package() {
     echo "file wazuh-agent path=etc/init.d/wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
     echo "file S97wazuh-agent path=etc/rc2.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
     echo "file S97wazuh-agent path=etc/rc3.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
-    # Add user and group ossec
-    echo "group groupname=ossec" >> wazuh-agent.p5m.1
-    echo "user username=ossec group=ossec" >> wazuh-agent.p5m.1
+    # Add user and group wazuh
+    echo "group groupname=wazuh" >> wazuh-agent.p5m.1
+    echo "user username=wazuh group=wazuh" >> wazuh-agent.p5m.1
     pkgmogrify -DARCH=`uname -p` wazuh-agent.p5m.1 wazuh-agent.mog | pkgfmt > wazuh-agent.p5m.2
     pkgsend -s http://localhost:9001 publish -d ${install_path} -d /etc/init.d -d /etc/rc2.d -d /etc/rc3.d -d ${current_path} wazuh-agent.p5m.2 > pack
     package=`cat pack | grep wazuh | cut -c 13-` # This extracts the name of the package generated in the previous step

--- a/solaris/solaris11/postinstall.sh
+++ b/solaris/solaris11/postinstall.sh
@@ -3,10 +3,31 @@
 # Wazuh, Inc 2015-2020
 
 if [ -d <INSTALL_PATH>/logs/ossec ]; then
-  mv <INSTALL_PATH>/logs/ossec/* <INSTALL_PATH>/logs/wazuh
+  rm -rf <INSTALL_PATH>/logs/wazuh
+  cp -rp <INSTALL_PATH>/logs/ossec <INSTALL_PATH>/logs/wazuh
 fi
 if [ -d <INSTALL_PATH>/queue/ossec ]; then
-  mv <INSTALL_PATH>/queue/ossec/* <INSTALL_PATH>/queue/sockets
+  rm -rf <INSTALL_PATH>/queue/sockets
+  cp -rp <INSTALL_PATH>/queue/ossec <INSTALL_PATH>/queue/sockets
+fi
+
+# Remove old ossec user and group if exists and change ownwership of files
+
+if grep "^ossec:" /etc/group > /dev/null 2>&1; then
+  find <INSTALL_PATH> -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  if grep "^ossec" /etc/passwd > /dev/null 2>&1; then
+    find <INSTALL_PATH> -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossec
+  fi
+  if grep "^ossecm" /etc/passwd > /dev/null 2>&1; then
+    find <INSTALL_PATH> -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecm
+  fi
+  if grep "^ossecr" /etc/passwd > /dev/null 2>&1; then
+    find <INSTALL_PATH> -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    userdel ossecr
+  fi
+  groupdel ossec
 fi
 
 rm -rf <INSTALL_PATH>/logs/ossec/

--- a/solaris/solaris11/solaris_fix.py
+++ b/solaris/solaris11/solaris_fix.py
@@ -30,7 +30,7 @@ def set_p5m1(template_path, p5m1_file_path):
     new_file = aux_file_name+".fixed"
 
     with open(new_file, "w") as p5m1_fixed:
-        p5m1_fixed.write("dir  path=var/ossec owner=root group=ossec mode=0750"+"\n")
+        p5m1_fixed.write("dir  path=var/ossec owner=root group=wazuh mode=0750"+"\n")
         for line in pm51:
             line_components = line.split(' ')
             # if the element is a directory or a file, set the necessary


### PR DESCRIPTION
|Related issue|
|---|
|Closes #651|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR modifies the user and group used by the wazuh binaries acording to the specifications of the issue #651.

## Upgrade Log
```
[root@centos7 vagrant]# ls -lah /var/ossec/            
total 4.0K
drwxr-x---. 19 root  ossec  242 Mar 16 15:34 .
drwxr-xr-x. 19 root  root   267 Mar 16 15:34 ..
drwxrwx---.  2 root  ossec    6 Nov 30 08:42 .ssh
drwxr-x---.  3 root  ossec   17 Mar 16 15:34 active-response
drwxr-x---.  2 root  ossec  286 Mar 16 15:34 agentless
drwxr-x---.  4 root  ossec   42 Mar 16 15:34 api
drwxr-x---.  5 root  ossec   48 Mar 16 15:34 backup
drwxr-x---.  2 root  ossec 4.0K Mar 16 15:34 bin
drwxrwx---.  7 ossec ossec  265 Mar 16 15:34 etc
drwxr-x---.  5 root  ossec   48 Mar 16 15:34 framework
drwxr-x---.  2 root  ossec   91 Mar 16 15:34 integrations
drwxr-x---.  2 root  ossec   55 Mar 16 15:34 lib
drwxrwx---.  8 ossec ossec  143 Mar 16 15:34 logs
drwxr-x---. 14 root  ossec  181 Mar 16 15:34 queue
drwxr-x---.  5 root  ossec   61 Mar 16 15:34 ruleset
drwxr-x---.  2 ossec ossec    6 Nov 30 08:41 stats
drwxrwx--T.  2 root  ossec    6 Mar 16 15:34 tmp
drwxr-x---.  9 root  ossec  106 Mar 16 15:34 var
drwxr-x---.  6 root  ossec   58 Mar 16 15:34 wodles
[root@centos7 vagrant]# yum install https://s3-us-west-1.amazonaws.com/packages-dev.wazuh.com/warehouse/test/4.2/rpm/var/wazuh-manager-4.2.0-rename.user.x86_64.rpm
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
wazuh-manager-4.2.0-rename.user.x86_64.rpm                                                                                                                                                                                                                         | 107 MB  00:00:28     
Examining /var/tmp/yum-root-QnqK2Z/wazuh-manager-4.2.0-rename.user.x86_64.rpm: wazuh-manager-4.2.0-rename.user.x86_64
. . . .                                                                                                                                                                                                                                    

Complete!
[root@centos7 vagrant]# ls -lah /var/ossec/
total 4.0K
drwxr-x---. 19 root  wazuh  242 Mar 16 15:42 .
drwxr-xr-x. 19 root  root   267 Mar 16 15:34 ..
drwxrwx---.  2 root  wazuh    6 Mar 16 15:15 .ssh
drwxr-x---.  3 root  wazuh   17 Mar 16 15:14 active-response
drwxr-x---.  2 root  wazuh  286 Mar 16 15:42 agentless
drwxr-x---.  4 root  wazuh   42 Mar 16 15:15 api
drwxr-x---.  5 root  wazuh   48 Mar 16 15:15 backup
drwxr-x---.  2 root  wazuh 4.0K Mar 16 15:42 bin
drwxrwx---.  7 wazuh wazuh  267 Mar 16 15:42 etc
drwxr-x---.  5 root  wazuh   48 Mar 16 15:15 framework
drwxr-x---.  2 root  wazuh   91 Mar 16 15:42 integrations
drwxr-x---.  2 root  wazuh  141 Mar 16 15:42 lib
drwxrwx---.  8 wazuh wazuh  143 Mar 16 15:42 logs
drwxr-x---. 16 root  wazuh  219 Mar 16 15:42 queue
drwxr-x---.  5 root  wazuh   46 Mar 16 15:42 ruleset
drwxr-x---.  2 wazuh wazuh    6 Mar 16 15:14 stats
drwxrwx--T.  2 root  wazuh    6 Mar 16 15:42 tmp
drwxr-x---.  9 root  wazuh  106 Mar 16 15:14 var
drwxr-x---.  6 root  wazuh   58 Mar 16 15:15 wodles
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] ~Windows~ (not applicable)
  - [x] macOS
  - [x] Solaris
- [x] Package installation
  - [x] Linux
  - [x] ~Windows~ (not applicable)
  - [x] macOS
  - [x] Solaris
- [x] Package upgrade
  - [x] Linux
  - [x] ~Windows~ (not applicable)
  - [x] macOS
  - [x] Solaris
- [x] Package downgrade
  - [x] Linux
  - [x] ~Windows~ (not applicable)
  - [x] macOS
  - [x] Solaris
- [x] Package remove
  - [x] Linux
  - [x] ~Windows~ (not applicable)
  - [x] macOS
  - [x] Solaris
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md