### PR TITLE
Fix opendistro-performance-analyzer plugin name in OVA

### DIFF
--- a/ova/Libraries/provision-opendistro.sh
+++ b/ova/Libraries/provision-opendistro.sh
@@ -166,7 +166,7 @@ installElasticsearch() {
         fi
 
         # While Performance Analyzer problems are solved (https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/229)
-        /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_performance_analyzer
+        /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
 
         # Start Elasticsearch
         startService "elasticsearch"


### PR DESCRIPTION
|Related issue|
|---|
|#718|

This PR closes #718.

We have corrected tha naming of the opendistro-performance-analyzer plugin in the OVA provision scripts.
