### PR TITLE
Fix WPK compilation and library copy

### DIFF
--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -OL http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     make -j$(nproc) && make install && echo "/usr/lib" > /etc/ld.so.conf.d/openssl-1.1.1a.conf && \
     ldconfig -v && cd / && rm -rf openssl-1.1.1a*
 
-RUN pip3 install cryptography==2.9.2 awscli
+RUN pip3 install cryptography==2.9.2 typing awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -208,7 +208,7 @@ clean() {
     rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*}
     rm -rf src/{headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd}
     rm -rf src/{os_dbdos_execd,os_integrator,os_maild,os_netos_regex,os_xml,os_zlib}
-    rm -rf src/{remoted,reportd,shared,syscheckd,tests,update,wazuh_db,wazuh_modules}
+    rm -rf src/{remoted,reportd,shared,syscheckd,tests,update,wazuh_db}
 
     if [[ "${BUILD_TARGET}" != "winagent" ]]; then
         rm -rf src/win32

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -203,9 +203,12 @@ main() {
 }
 
 clean() {
+    rm -rf ./{api,framework}
     rm -rf doc wodles/oscap/content/* gen_ossec.sh add_localfiles.sh Jenkinsfile*
-    rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*,headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd,os_dbdos_execd}
-    rm -rf src/{os_integrator,os_maild,os_netos_regex,os_xml,os_zlib,remoted,reportd,shared,syscheckd,tests,update,wazuh_db,wazuh_modules}
+    rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*}
+    rm -rf src/{headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd}
+    rm -rf src/{os_dbdos_execd,os_integrator,os_maild,os_netos_regex,os_xml,os_zlib}
+    rm -rf src/{remoted,reportd,shared,syscheckd,tests,update,wazuh_db,wazuh_modules}
 
     if [[ "${BUILD_TARGET}" != "winagent" ]]; then
         rm -rf src/win32


### PR DESCRIPTION
|Related issue|
|---|
| closes #717 |

## Description
Hi!

This PR solves an error related with the WPK package generation that doesn't copy the Syscollector compiled library required to a good performance of the Wazuh agent.
We have changed the `wazuh_modules` folder removal and added some removals of API and framework folders that aren't required.

## Tests
- Build the package in any supported platform
  - [x] Linux
- [x] Package upgrade

Regards.