### PR TITLE
725 Solaris sparc link error

### DIFF
--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -164,6 +164,10 @@ check_version(){
 }
 
 installation(){
+    export PATH=/usr/local/gcc-5.5.0/bin:/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
+    export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
+    export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
+
     cd ${CURRENT_PATH}
     cd $SOURCE/src
     gmake clean

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -85,12 +85,13 @@ build_environment(){
     unset CPLUS_INCLUDE_PATH
     unset LD_LIBRARY_PATH
 
+    export PATH=/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
+
     mkdir -p /usr/local
     ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib --disable-libsanitizer --disable-bootstrap --with-ld=/usr/ccs/bin/ld --without-gnu-ld --with-gnu-as --with-as=/opt/csw/bin/gas
-    gmake -j$(nproc) && gmake install
+    gmake && gmake install
     export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
     export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
-    export PATH=/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
 
     echo "export PATH=/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin" >> /etc/profile
     echo "export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0" >> /etc/profile
@@ -101,7 +102,7 @@ build_environment(){
     curl -sL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz | gtar xz
     cd cmake-3.18.3
     ./bootstrap
-    gmake -j$(nproc) && gmake install
+    gmake && gmake install
     cd .. && rm -rf cmake-3.18.3
     ln -sf /usr/local/bin/cmake /usr/bin/cmake
 
@@ -164,9 +165,6 @@ check_version(){
 
 installation(){
     cd ${CURRENT_PATH}
-    # Removing incompatible flags
-    mv $SOURCE/src/Makefile $SOURCE/src/Makefile.tmp
-    sed -n '/OSSEC_LDFLAGS+=-z relax=secadj/!p' $SOURCE/src/Makefile.tmp > $SOURCE/src/Makefile
     cd $SOURCE/src
     gmake clean
     check_version

--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -655,6 +655,38 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib/libdbsync.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/lib/librsync.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/lib/libsysinfo.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/lib/libsyscollector.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/logs": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -142,11 +142,6 @@ compile() {
     export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
     export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
 
-    if [ "${arch}" = "sparc" ]; then
-        mv $SOURCE/src/Makefile $SOURCE/src/Makefile.tmp
-        sed -n '/OSSEC_LDFLAGS+=-z relax=secadj/!p' $SOURCE/src/Makefile.tmp > $SOURCE/src/Makefile
-    fi
-
     cd ${current_path}
     VERSION=`cat $SOURCE/src/VERSION`
     number_version=`echo "$VERSION" | cut -d v -f 2`

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -138,7 +138,7 @@ check_version(){
 
 #Compile and install wazuh-agent
 compile() {
-    export PATH=/usr/local/gcc-5.5.0/bin:/usr/local/bin:$PATH
+    export PATH=/usr/local/gcc-5.5.0/bin:/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
     export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
     export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #725 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Linking error during solaris build in sparc architecture.

```
12:23:07      CC manage_agents
12:23:07  ld: fatal: bad section layout: .SUNW_ldynsym must precede and be adjacent to .dynsym
12:23:07  collect2: error: ld returned 1 exit status
12:23:07  gmake[1]: *** [wazuh-syscheckd] Error 1
12:23:07  gmake[1]: *** Waiting for unfinished jobs....
12:23:07  gmake: *** [agent] Error 2
```

Solaris 10 SPARC error:
```
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5848: warning: v8+ ABI violation: illegal use of %i or %l register as rs1 in "movrz" instruction
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5849: warning: v8+ ABI violation: illegal use of %i or %l register as rs1 in "movrz" instruction
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5850: warning: v8+ ABI violation: illegal use of %i or %l register as rs1 in "movrz" instruction
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5851: warning: v8+ ABI violation: illegal use of %i or %l register as rs1 in "movrz" instruction
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 4792: warning: stack alignment problem; second operand is not a multiple of 8
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5043: warning: stack alignment problem; second operand is not a multiple of 8
11:43:41  /usr/ccs/bin/as: "/var/tmp//ccdvfaxp.s", line 5511: warning: stack alignment problem; second operand is not a multiple of 8
11:43:41  ar: creating libssl.a
11:43:41  ar: creating test/libtestutil.a
11:43:41  ar: creating libcrypto.a
11:43:41  grep: can't open /etc/os-release
11:43:41  grep: can't open /etc/redhat-release
11:43:41  /bin/sh/bin/sh: cmake: not found
11:43:41  : cmake: not found
11:43:41  gmake[1]: *** [Makefile:1367: build_sysinfo] Error 1
11:43:41  gmake[1]: *** Waiting for unfinished jobs....
11:43:41  gmake[1]: *** [Makefile:1357: build_shared_modules] Error 1
11:43:41  gmake: *** [Makefile:731: agent] Error 2
11:43:41  find: stat() error /var/ossec: No such file or directory
11:43:41  ## Building pkgmap from package prototype file.
11:43:41  ERROR in wazuh-agent_v4.2.0.proto:
11:43:41      no object for </etc/init.d/wazuh-agent> found in root directory
11:43:41  pkgmk: ERROR: unable to build pkgmap from prototype file
11:43:41  ## Packaging was not successful.
11:43:41  pkgtrans: ERROR: unable to complete package transfer
11:43:41      - no packages were selected from </export/home/qfub/solaris>
11:43:41  mv: cannot access wazuh-agent_v4.2.0-sol10-sparc.pkg
11:43:41  /opt/csw/gnu/sha512sum: wazuh-agent_v4.2.0-sol10-sparc.pkg: No such file or directory
11:43:41  /export/home/qfub/solaris/generate_wazuh_packages.sh: line 260: /var/ossec/bin/wazuh-control: No such file or directory
11:43:41  /var/ossec*: No such file or directory
11:43:41  /export/home/qfub/solaris/generate_wazuh_packages.sh: line 260: /var/ossec/bin/wazuh-control: No such file or directory
11:43:41  /var/ossec*: No such file or directory
11:43:41  UX: userdel: ERROR: ossec does not exist.
11:43:41  UX: groupdel: ERROR: ossec does not exist.
```

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
