### PR TITLE
Fix solaris 11 postinstall service

### DIFF
--- a/solaris/solaris11/postinstall.sh
+++ b/solaris/solaris11/postinstall.sh
@@ -1,13 +1,22 @@
 #!/bin/sh
 # postinst script for wazuh-agent
 # Wazuh, Inc 2015-2020
+set -x
+install_path="<INSTALL_PATH>"
 
-if [ -d <INSTALL_PATH>/logs/ossec ]; then
-  mv <INSTALL_PATH>/logs/ossec/* <INSTALL_PATH>/logs/wazuh
+if [ -d ${install_path}/logs/ossec ]; then
+  if [ -z "$(ls -A ${install_path}/logs/ossec)" ]; then
+    rm -rf ${install_path}/logs/ossec
+  else
+    rm -rf ${install_path}/logs/wazuh
+    mv ${install_path}/logs/ossec ${install_path}/logs/wazuh
+  fi
+fi  
+if [ -d ${install_path}/queue/ossec ]; then
+  if [ -z "$(ls -A ${install_path}/queue/ossec)" ]; then
+    rm -rf ${install_path}/queue/ossec
+  else
+    rm -rf ${install_path}/queue/sockets
+    mv ${install_path}/queue/ossec/ ${install_path}/queue/sockets
+  fi
 fi
-if [ -d <INSTALL_PATH>/queue/ossec ]; then
-  mv <INSTALL_PATH>/queue/ossec/* <INSTALL_PATH>/queue/sockets
-fi
-
-rm -rf <INSTALL_PATH>/logs/ossec/
-rm -rf <INSTALL_PATH>/queue/ossec/


### PR DESCRIPTION
|Related issue|
|---|
|#742|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a problem with `/var/ossec/queue/ossec` and `/var/ossec/logs/ossec`  not being included in the Solaris 11 package and improves the postinstall script.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Solaris

- [x] Package installation
- [x] Package upgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Solaris
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template

