### PR TITLE
Rename Wazuh configuration files

### DIFF
--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -61,7 +61,7 @@ cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 
 # Add configuration scripts
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/
-cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/
+cp gen_wazuh.sh ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/
 cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/
 
 # Support files for dynamic creation of configuraiton file
@@ -125,7 +125,7 @@ if [ $1 = 1 ]; then
 
   # Generating ossec.conf file
   . %{_localstatedir}/tmp/src/init/dist-detect.sh
-  %{_localstatedir}/tmp/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  %{_localstatedir}/tmp/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/tmp/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf

--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -93,10 +93,10 @@ fi
 
 # Remove existent config file and notify user for new installations
 if [ $1 = 1 ]; then
-  if [ -f %{_localstatedir}/etc/ossec.conf ]; then
-    echo "A backup from your ossec.conf has been created at %{_localstatedir}/etc/ossec.conf.rpmorig"
-    echo "Please verify your ossec.conf configuration at %{_localstatedir}/etc/ossec.conf"
-    mv %{_localstatedir}/etc/ossec.conf %{_localstatedir}/etc/ossec.conf.rpmorig
+  if [ -f %{_localstatedir}/etc/agent.conf ]; then
+    echo "A backup from your agent.conf has been created at %{_localstatedir}/etc/agent.conf.rpmorig"
+    echo "Please verify your agent.conf configuration at %{_localstatedir}/etc/agent.conf"
+    mv %{_localstatedir}/etc/agent.conf %{_localstatedir}/etc/agent.conf.rpmorig
   fi
 fi
 
@@ -123,23 +123,23 @@ fi
 # New installations
 if [ $1 = 1 ]; then
 
-  # Generating ossec.conf file
+  # Generating agent.conf file
   . %{_localstatedir}/tmp/src/init/dist-detect.sh
-  %{_localstatedir}/tmp/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  %{_localstatedir}/tmp/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/agent.conf
 
-  # Add default local_files to ossec.conf
-  %{_localstatedir}/tmp/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
+  # Add default local_files to agent.conf
+  %{_localstatedir}/tmp/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/agent.conf
 
   # Restore Wazuh agent configuration
-  if [ -f %{_localstatedir}/etc/ossec.conf.rpmorig ]; then
-    %{_localstatedir}/tmp/src/init/replace_manager_ip.sh %{_localstatedir}/etc/ossec.conf.rpmorig %{_localstatedir}/etc/ossec.conf
+  if [ -f %{_localstatedir}/etc/agent.conf.rpmorig ]; then
+    %{_localstatedir}/tmp/src/init/replace_manager_ip.sh %{_localstatedir}/etc/agent.conf.rpmorig %{_localstatedir}/etc/agent.conf
   fi
 
   # Fix for AIX: netstat command
-  sed 's/netstat -tulpn/nestat -tu/' %{_localstatedir}/etc/ossec.conf > %{_localstatedir}/etc/ossec.conf.tmp
-  mv %{_localstatedir}/etc/ossec.conf.tmp %{_localstatedir}/etc/ossec.conf
-  sed 's/sort -k 4 -g/sort -n -k 4/' %{_localstatedir}/etc/ossec.conf > %{_localstatedir}/etc/ossec.conf.tmp
-  mv %{_localstatedir}/etc/ossec.conf.tmp %{_localstatedir}/etc/ossec.conf
+  sed 's/netstat -tulpn/nestat -tu/' %{_localstatedir}/etc/agent.conf > %{_localstatedir}/etc/agent.conf.tmp
+  mv %{_localstatedir}/etc/agent.conf.tmp %{_localstatedir}/etc/agent.conf
+  sed 's/sort -k 4 -g/sort -n -k 4/' %{_localstatedir}/etc/agent.conf > %{_localstatedir}/etc/agent.conf.tmp
+  mv %{_localstatedir}/etc/agent.conf.tmp %{_localstatedir}/etc/agent.conf
 
   # Generate the active-responses.log file
   touch %{_localstatedir}/logs/active-responses.log
@@ -149,7 +149,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/tmp/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 
 fi
-chown root:wazuh %{_localstatedir}/etc/ossec.conf
+chown root:wazuh %{_localstatedir}/etc/agent.conf
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc2.d/S97wazuh-agent
 ln -fs /etc/rc.d/init.d/wazuh-agent /etc/rc.d/rc3.d/S97wazuh-agent
 
@@ -157,16 +157,16 @@ rm -rf %{_localstatedir}/tmp/etc
 rm -rf %{_localstatedir}/tmp/src
 rm -f %{_localstatedir}/tmp/add_localfiles.sh
 
-chmod 0660 %{_localstatedir}/etc/ossec.conf
+chmod 0660 %{_localstatedir}/etc/agent.conf
 
 # Restart wazuh-agent when manager settings are in place
-if grep '<server-ip>.*</server-ip>' %{_localstatedir}/etc/ossec.conf | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
+if grep '<server-ip>.*</server-ip>' %{_localstatedir}/etc/agent.conf | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' > /dev/null 2>&1; then
   /etc/rc.d/init.d/wazuh-agent restart > /dev/null 2>&1 || :
 fi
-if grep '<server-hostname>.*</server-hostname>' %{_localstatedir}/etc/ossec.conf > /dev/null 2>&1; then
+if grep '<server-hostname>.*</server-hostname>' %{_localstatedir}/etc/agent.conf > /dev/null 2>&1; then
   /etc/rc.d/init.d/wazuh-agent restart > /dev/null 2>&1 || :
 fi
-if grep '<address>.*</address>' %{_localstatedir}/etc/ossec.conf | grep -v 'MANAGER_IP' > /dev/null 2>&1; then
+if grep '<address>.*</address>' %{_localstatedir}/etc/agent.conf | grep -v 'MANAGER_IP' > /dev/null 2>&1; then
   /etc/rc.d/init.d/wazuh-agent restart > /dev/null 2>&1 || :
 fi
 
@@ -251,7 +251,7 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/agent.conf
 %attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
 %attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -11,11 +11,24 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
+FROM debian:7
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Installing necessary packages
+RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y apt-utils && \
+    apt-get install -y --force-yes \
+    curl gcc make sudo wget expect gnupg perl-base=5.14.2-21+deb7u3 perl \
+    libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
+    cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
+    libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 6
-RUN apt-get update && apt-get build-dep python3.2 -y && \
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    apt-get update && apt-get build-dep python3.2 -y && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash -
-
 RUN sed -i 's:https:http:g' /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && apt-get install nodejs -y
 
@@ -38,6 +51,7 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
 
+ENV PATH="/usr/local/bin:${PATH}"
 # Add the script to build the Debian package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -11,19 +11,6 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
-FROM debian:7
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Installing necessary packages
-RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
-    echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y --force-yes \
-    curl gcc make sudo wget expect gnupg perl-base=5.14.2-21+deb7u3 perl \
-    libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \
-    cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
-    libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 6
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -13,11 +13,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 6
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    apt-get update && apt-get build-dep python3.2 -y && \
-    curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN sed -i 's:https:http:g' /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install nodejs -y
+RUN apt-get build-dep python3.2 -y && \
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
     tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/postinst
@@ -34,12 +34,12 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_wazuh.sh conf agent ${OS} ${VER} > ${DIR}/etc/agent.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/agent.conf
 
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
-        chmod 660 ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_wazuh.sh conf agent ${OS} ${VER} > ${DIR}/etc/agent.conf.new
+        chmod 660 ${DIR}/etc/agent.conf.new
     fi
 
     # For the etc dir
@@ -53,9 +53,9 @@ case "$1" in
     if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
         cp ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys
     fi
-    # Restore ossec.conf configuration
-    if [ -f ${WAZUH_TMP_DIR}/ossec.conf ]; then
-        mv ${WAZUH_TMP_DIR}/ossec.conf ${DIR}/etc/ossec.conf
+    # Restore agent.conf configuration
+    if [ -f ${WAZUH_TMP_DIR}/agent.conf ]; then
+        mv ${WAZUH_TMP_DIR}/agent.conf ${DIR}/etc/agent.conf
     fi
     # Restore internal options configuration
     if [ -f ${WAZUH_TMP_DIR}/local_internal_options.conf ]; then

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/preinst
@@ -42,7 +42,7 @@ case "$1" in
             fi
         fi
 
-        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/ossec.conf ] ; then
+        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/agent.conf ] ; then
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
@@ -57,8 +57,8 @@ case "$1" in
         if [ -f ${DIR}/etc/local_internal_options.conf ]; then
             cp -p ${DIR}/etc/local_internal_options.conf ${WAZUH_TMP_DIR}/local_internal_options.conf
         fi
-        if [ -f ${DIR}/etc/ossec.conf ]; then
-            cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
+        if [ -f ${DIR}/etc/agent.conf ]; then
+            cp -p ${DIR}/etc/agent.conf ${WAZUH_TMP_DIR}/agent.conf
         fi
 
         if [ -d ${DIR}/etc/shared ]; then

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/prerm
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/prerm
@@ -33,9 +33,9 @@ case "$1" in
       if [ -f ${DIR}/etc/local_internal_options.conf ]; then
         cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
       fi
-      # Save the ossec.conf
-      if [ -f ${DIR}/etc/ossec.conf ]; then
-        cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
+      # Save the agent.conf
+      if [ -f ${DIR}/etc/agent.conf ]; then
+        cp -p ${DIR}/etc/agent.conf ${DIR}/tmp/conffiles
       fi
       # Save the shared configuration files
       if [ -d ${DIR}/etc/shared ]; then

--- a/debs/SPECS/5.0.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-agent/debian/rules
@@ -90,7 +90,7 @@ override_dh_install:
 
 	# Copying install scripts to /usr/share
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
-	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp gen_wazuh.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postinst
@@ -31,8 +31,8 @@ case "$1" in
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
 
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
-        ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
+        ${SCRIPTS_DIR}/gen_wazuh.sh conf manager ${OS} ${VER} > ${DIR}/etc/manager.conf
+        ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/manager.conf
 
         passlist="${DIR}/agentless/.passlist"
 
@@ -47,8 +47,8 @@ case "$1" in
             fi
         fi
     else
-        ${SCRIPTS_DIR}/gen_ossec.sh conf manager ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
-        chmod 660 ${DIR}/etc/ossec.conf.new
+        ${SCRIPTS_DIR}/gen_wazuh.sh conf manager ${OS} ${VER} > ${DIR}/etc/manager.conf.new
+        chmod 660 ${DIR}/etc/manager.conf.new
     fi
 
     # Remove/relocate existing SQLite databases
@@ -117,9 +117,9 @@ case "$1" in
     if [ -d ${WAZUH_TMP_DIR}/lists ]; then
         cp -rp ${WAZUH_TMP_DIR}/lists  ${DIR}/etc/
     fi
-    # Restore ossec.conf configuration
-    if [ -f ${WAZUH_TMP_DIR}/ossec.conf ]; then
-        mv ${WAZUH_TMP_DIR}/ossec.conf ${DIR}/etc/ossec.conf
+    # Restore manager.conf configuration
+    if [ -f ${WAZUH_TMP_DIR}/manager.conf ]; then
+        mv ${WAZUH_TMP_DIR}/manager.conf ${DIR}/etc/manager.conf
     fi
     # Restore local_rules.xml configuration
     if [ -f ${WAZUH_TMP_DIR}/local_rules.xml ]; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/postrm
@@ -27,8 +27,8 @@ case "$1" in
         fi
 
         # Move files from ${DIR}/tmp to ${DIR}/etc
-        if [ -f ${DIR}/tmp/conffiles/shared/default/agent.conf ]; then
-            mv ${DIR}/tmp/conffiles/shared/default/agent.conf ${DIR}/etc/shared/default/agent.conf.save
+        if [ -f ${DIR}/tmp/conffiles/shared/default/shared.conf ]; then
+            mv ${DIR}/tmp/conffiles/shared/default/shared.conf ${DIR}/etc/shared/default/shared.conf.save
         fi
 
         # Move files from ${DIR}/tmp to ${DIR}/etc

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/preinst
@@ -76,7 +76,7 @@ case "$1" in
             fi
         fi
 
-        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/ossec.conf ] ; then
+        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/manager.conf ] ; then
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
@@ -115,8 +115,8 @@ case "$1" in
             cp -p ${DIR}/etc/decoders/local_decoder.xml ${WAZUH_TMP_DIR}/local_decoder.xml
         fi
 
-        if [ -f ${DIR}/etc/ossec.conf ]; then
-            cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
+        if [ -f ${DIR}/etc/manager.conf ]; then
+            cp -p ${DIR}/etc/manager.conf ${WAZUH_TMP_DIR}/manager.conf
         fi
 
         if [ -d ${DIR}/etc/shared ]; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/prerm
@@ -38,9 +38,9 @@ case "$1" in
       if [ -f ${DIR}/etc/local_internal_options.conf ]; then
         cp -p ${DIR}/etc/local_internal_options.conf ${DIR}/tmp/conffiles
       fi
-      # Save the ossec.conf
-      if [ -f ${DIR}/etc/ossec.conf ]; then
-        cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
+      # Save the manager.conf
+      if [ -f ${DIR}/etc/manager.conf ]; then
+        cp -p ${DIR}/etc/manager.conf ${DIR}/tmp/conffiles
       fi
       # Save the local decoders
       if [ -d ${DIR}/etc/decoders ]; then
@@ -58,10 +58,10 @@ case "$1" in
       if [ -d ${DIR}/etc/rules ]; then
         cp -pr ${DIR}/etc/rules ${DIR}/tmp/conffiles
       fi
-      # Save the agent.conf from the group default
+      # Save the shared.conf from the group default
       mkdir -p ${DIR}/tmp/conffiles/shared/default
-      if [ -f ${DIR}/etc/shared/default/agent.conf ]; then
-        cp -p ${DIR}/etc/shared/default/agent.conf ${DIR}/tmp/conffiles/shared/default
+      if [ -f ${DIR}/etc/shared/default/shared.conf ]; then
+        cp -p ${DIR}/etc/shared/default/shared.conf ${DIR}/tmp/conffiles/shared/default
       fi
       # Save the client.keys
       if [ -f ${DIR}/api/configuration/api.yaml ]; then

--- a/debs/SPECS/5.0.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/5.0.0/wazuh-manager/debian/rules
@@ -94,7 +94,7 @@ override_dh_install:
 	cp -r $(INSTALLATION_DIR)/. $(TARGET_DIR)$(INSTALLATION_DIR)/
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
-	cp gen_ossec.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
+	cp gen_wazuh.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 	cp add_localfiles.sh ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/
 
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/src

--- a/macos/package_files/5.0.0/build.sh
+++ b/macos/package_files/5.0.0/build.sh
@@ -48,7 +48,7 @@ function build() {
 
     # Add the auxiliar script used while installing the package
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/
-    cp ${SOURCES_PATH}/gen_ossec.sh ${INSTALLATION_SCRIPTS_DIR}/
+    cp ${SOURCES_PATH}/gen_wazuh.sh ${INSTALLATION_SCRIPTS_DIR}/
     cp ${SOURCES_PATH}/add_localfiles.sh ${INSTALLATION_SCRIPTS_DIR}/
 
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/src/init

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -73,8 +73,8 @@ launchctl unsetenv WAZUH_PKG_UPGRADE
 launchctl unsetenv WAZUH_RESTART
 
 if [ "${upgrade}" = "false" ]; then
-    ${INSTALLATION_SCRIPTS_DIR}/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${DIR} > ${DIR}/etc/ossec.conf
-    chown root:wazuh ${DIR}/etc/ossec.conf
+    ${INSTALLATION_SCRIPTS_DIR}/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${DIR} > ${DIR}/etc/ossec.conf
+    chown root:ossec ${DIR}/etc/ossec.conf
     chmod 0640 ${DIR}/etc/ossec.conf
 fi
 

--- a/macos/package_files/5.0.0/postinstall.sh
+++ b/macos/package_files/5.0.0/postinstall.sh
@@ -15,8 +15,8 @@ INSTALLATION_SCRIPTS_DIR="${DIR}/packages_files/agent_installation_scripts"
 SCA_BASE_DIR="${INSTALLATION_SCRIPTS_DIR}/sca"
 
 if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
-    rm -rf ${DIR}/etc/{ossec.conf,client.keys,local_internal_options.conf,shared}
-    cp -rf ${DIR}/config_files/{ossec.conf,client.keys,local_internal_options.conf,shared} ${DIR}/etc/
+    rm -rf ${DIR}/etc/{agent.conf,client.keys,local_internal_options.conf,shared}
+    cp -rf ${DIR}/config_files/{agent.conf,client.keys,local_internal_options.conf,shared} ${DIR}/etc/
     rm -rf ${DIR}/config_files/
 fi
 
@@ -54,8 +54,8 @@ chmod 640 ${DIR}/etc/localtime
 chmod 770 ${DIR}/etc/shared # ossec must be able to write to it
 chown -R root:${GROUP} ${DIR}/etc/shared
 find ${DIR}/etc/shared/ -type f -exec chmod 660 {} \;
-chown root:${GROUP} ${DIR}/etc/ossec.conf
-chmod 660 ${DIR}/etc/ossec.conf
+chown root:${GROUP} ${DIR}/etc/agent.conf
+chmod 660 ${DIR}/etc/agent.conf
 
 
 chmod 770 ${DIR}/.ssh
@@ -73,9 +73,9 @@ launchctl unsetenv WAZUH_PKG_UPGRADE
 launchctl unsetenv WAZUH_RESTART
 
 if [ "${upgrade}" = "false" ]; then
-    ${INSTALLATION_SCRIPTS_DIR}/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${DIR} > ${DIR}/etc/ossec.conf
-    chown root:ossec ${DIR}/etc/ossec.conf
-    chmod 0640 ${DIR}/etc/ossec.conf
+    ${INSTALLATION_SCRIPTS_DIR}/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${DIR} > ${DIR}/etc/agent.conf
+    chown root:wazuh ${DIR}/etc/agent.conf
+    chmod 0640 ${DIR}/etc/agent.conf
 fi
 
 SCA_DIR="${DIST_NAME}/${DIST_VER}"

--- a/macos/package_files/5.0.0/preinstall.sh
+++ b/macos/package_files/5.0.0/preinstall.sh
@@ -26,7 +26,7 @@ fi
 
 if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
     mkdir -p ${DIR}/config_files/
-    cp -r ${DIR}/etc/{ossec.conf,client.keys,local_internal_options.conf,shared} ${DIR}/config_files/
+    cp -r ${DIR}/etc/{agent.conf,client.keys,local_internal_options.conf,shared} ${DIR}/config_files/
 
     if [ -d ${DIR}/logs/ossec ]; then
         mv ${DIR}/logs/ossec ${DIR}/logs/wazuh

--- a/macos/specs/5.x/wazuh-agent-5.0.0.pkgproj
+++ b/macos/specs/5.x/wazuh-agent-5.0.0.pkgproj
@@ -336,7 +336,7 @@
 													<key>GID</key>
 													<integer>0</integer>
 													<key>PATH</key>
-													<string>/Library/Ossec/etc/ossec.conf</string>
+													<string>/Library/Ossec/etc/agent.conf</string>
 													<key>PATH_TYPE</key>
 													<integer>0</integer>
 													<key>PERMISSIONS</key>

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -33,7 +33,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %prep
 %setup -q
 
-./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
+./gen_wazuh.sh conf agent centos %rhel %{_localstatedir} > etc/agent.conf
 
 %build
 pushd src
@@ -146,7 +146,7 @@ cp etc/templates/config/debian/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 
 # Add configuration scripts
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/
-cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/
+cp gen_wazuh.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/
 cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/
 
 # Templates for initscript
@@ -245,12 +245,12 @@ if [ $1 = 1 ]; then
 
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
-  # Generating ossec.conf file
-  %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  chown root:wazuh %{_localstatedir}/etc/ossec.conf
+  # Generating agent.conf file
+  %{_localstatedir}/packages_files/agent_installation_scripts/gen_wazuh.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/agent.conf
+  chown root:ossec %{_localstatedir}/etc/agent.conf
 
-  # Add default local_files to ossec.conf
-  %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
+  # Add default local_files to agent.conf
+  %{_localstatedir}/packages_files/agent_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/agent.conf
 
   # Register and configure agent if Wazuh environment variables are defined
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
@@ -353,8 +353,8 @@ else
   fi
 fi
 
-# Restore ossec.conf permissions after upgrading
-chmod 0660 %{_localstatedir}/etc/ossec.conf
+# Restore agent.conf permissions after upgrading
+chmod 0660 %{_localstatedir}/etc/agent.conf
 
 # Remove old ossec user and group if exists and change ownwership of files
 

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -33,8 +33,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %prep
 %setup -q
 
-./gen_wazuh.sh conf agent centos %rhel %{_localstatedir} > etc/agent.conf
-
 %build
 pushd src
 # Rebuild for agent

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -494,7 +494,7 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh) %{_localstatedir}/etc/localtime
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/agent.conf
 %attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
 %attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -607,7 +607,8 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
-%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/manager.conf
+%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/agent.conf
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
@@ -621,7 +622,7 @@ rm -fr %{buildroot}
 %attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/lists/security-eventchannel
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/shared/default
-%attr(660, wazuh, wazuh) %{_localstatedir}/etc/shared/agent-template.conf
+%attr(660, wazuh, wazuh) %{_localstatedir}/etc/shared/shared-template.conf
 %attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/shared/default/*
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/rootcheck
 %attr(660, root, wazuh) %{_localstatedir}/etc/rootcheck/*.txt

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -30,8 +30,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %prep
 %setup -q
 
-./gen_wazuh.sh conf manager centos %rhel %{_localstatedir} > etc/manager.conf
-
 %build
 pushd src
 # Rebuild for server

--- a/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-manager-5.0.0.spec
@@ -30,7 +30,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %prep
 %setup -q
 
-./gen_ossec.sh conf manager centos %rhel %{_localstatedir} > etc/ossec-server.conf
+./gen_wazuh.sh conf manager centos %rhel %{_localstatedir} > etc/manager.conf
 
 %build
 pushd src
@@ -90,7 +90,7 @@ install -m 0440 src/wazuh_modules/vulnerability_detector/*.json ${RPM_BUILD_ROOT
 
 # Add configuration scripts
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/
-cp gen_ossec.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/
+cp gen_wazuh.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/
 cp add_localfiles.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/
 
 # Templates for initscript
@@ -307,8 +307,8 @@ if [ $1 = 1 ]; then
 
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh
 
-  # Generating ossec.conf file
-  %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  # Generating manager.conf file
+  %{_localstatedir}/packages_files/manager_installation_scripts/gen_wazuh.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/manager.conf
 
   touch %{_localstatedir}/logs/active-responses.log
   touch %{_localstatedir}/logs/integrations.log
@@ -317,8 +317,8 @@ if [ $1 = 1 ]; then
   chmod 0660 %{_localstatedir}/logs/active-responses.log
   chmod 0640 %{_localstatedir}/logs/integrations.log
 
-  # Add default local_files to ossec.conf
-  %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
+  # Add default local_files to manager.conf
+  %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/manager.conf
 fi
 
 # Generation auto-signed certificate if not exists
@@ -665,7 +665,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh
-%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh
+%attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/gen_wazuh.sh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/REVISION
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/VERSION

--- a/solaris/solaris10/postinstall.sh
+++ b/solaris/solaris10/postinstall.sh
@@ -5,14 +5,14 @@
 OSSEC_HIDS_TMP_DIR="/tmp/wazuh-agent"
 DIR="/var/ossec"
 
-# Restore the ossec.confs, client.keys and local_internal_options
+# Restore the agent.confs, client.keys and local_internal_options
 if [ -f ${OSSEC_HIDS_TMP_DIR}/client.keys ]; then
     cp ${OSSEC_HIDS_TMP_DIR}/client.keys ${DIR}/etc/client.keys
 fi
-# Restore ossec.conf configuration
-if [ -f ${OSSEC_HIDS_TMP_DIR}/ossec.conf ]; then
-    mv ${OSSEC_HIDS_TMP_DIR}/ossec.conf ${DIR}/etc/ossec.conf
-    chmod 640 ${DIR}/etc/ossec.conf
+# Restore agent.conf configuration
+if [ -f ${OSSEC_HIDS_TMP_DIR}/agent.conf ]; then
+    mv ${OSSEC_HIDS_TMP_DIR}/agent.conf ${DIR}/etc/agent.conf
+    chmod 640 ${DIR}/etc/agent.conf
 fi
 # Restore client.keys configuration
 if [ -f ${OSSEC_HIDS_TMP_DIR}/local_internal_options.conf ]; then

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -49,13 +49,13 @@ case $type in
 
     if [ -d "$DIR" ]
 		    then
-        if [ -f ${DIR}/etc/ossec.conf ]; then
-            cp  ${DIR}/etc/ossec.conf  ${DIR}/etc/ossec.conf.deborig
-            chmod 0600 ${DIR}/etc/ossec.conf.deborig
-            chown root:root ${DIR}/etc/ossec.conf.deborig
+        if [ -f ${DIR}/etc/agent.conf ]; then
+            cp  ${DIR}/etc/agent.conf  ${DIR}/etc/agent.conf.deborig
+            chmod 0600 ${DIR}/etc/agent.conf.deborig
+            chown root:root ${DIR}/etc/agent.conf.deborig
             echo "====================================================================================="
-            echo "= Backup from your ossec.conf has been created at /var/ossec/etc/ossec.conf.deborig ="
-            echo "= Please verify your ossec.conf configuration at /var/ossec/etc/ossec.conf          ="
+            echo "= Backup from your agent.conf has been created at /var/ossec/etc/agent.conf.deborig ="
+            echo "= Please verify your agent.conf configuration at /var/ossec/etc/agent.conf          ="
             echo "====================================================================================="
         fi
     fi
@@ -70,8 +70,8 @@ case $type in
     if [ -f ${DIR}/etc/local_internal_options.conf ]; then
         cp -p ${DIR}/etc/local_internal_options.conf ${OSSEC_HIDS_TMP_DIR}/local_internal_options.conf
     fi
-    if [ -f ${DIR}/etc/ossec.conf ]; then
-        cp -p ${DIR}/etc/ossec.conf ${OSSEC_HIDS_TMP_DIR}/ossec.conf
+    if [ -f ${DIR}/etc/agent.conf ]; then
+        cp -p ${DIR}/etc/agent.conf ${OSSEC_HIDS_TMP_DIR}/agent.conf
     fi
 
     ;;

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -391,7 +391,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec.conf": {
+    "/var/ossec/etc/agent.conf": {
         "class": "static",
         "group": "wazuh",
         "mode": "0660",
@@ -399,7 +399,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec.conf.rpmnew": {
+    "/var/ossec/etc/agent.conf.rpmnew": {
         "class": "dynamic",
         "group": "wazuh",
         "mode": "0660",
@@ -407,7 +407,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/etc/ossec.conf.new": {
+    "/var/ossec/etc/agent.conf.new": {
         "class": "dynamic",
         "group": "root",
         "mode": "0660",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -164,7 +164,7 @@ create_package() {
     python solaris_fix.py -t SPECS/template_agent_${VERSION}.json -p wazuh-agent.p5m.1 # Fix p5m.1 file
     mv wazuh-agent.p5m.1.aux.fixed wazuh-agent.p5m.1
     # Add the preserve=install-only tag to the configuration files
-    for file in etc/ossec.conf etc/local_internal_options.conf etc/client.keys; do
+    for file in etc/agent.conf etc/local_internal_options.conf etc/client.keys; do
         sed "s:file $file.*:& preserve=install-only:"  wazuh-agent.p5m.1 > wazuh-agent.p5m.1.aux_sed
         mv wazuh-agent.p5m.1.aux_sed wazuh-agent.p5m.1
     done


### PR DESCRIPTION
|Related issue|
|---|
|Closes #658|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR changes the ossec.conf files to agent.conf and manager.conf following the guidelines given in #658.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] macOS
  - [x] Solaris
  - [ ] AIX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7