### PR TITLE
Dev footprint reduction

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -23,7 +23,7 @@ Wazuh is an open source security monitoring solution for threat detection, integ
 %setup -q
 deps_version=`cat src/Makefile | grep "DEPS_VERSION =" | cut -d " " -f 3`
 cd src && gmake clean && gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
-gmake TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes
+gmake TARGET=agent USE_SELINUX=no
 cd ..
 
 %install
@@ -44,7 +44,7 @@ echo 'USER_UPDATE="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_AGENT_SERVER_IP="MANAGER_IP"' >> ./etc/preloaded-vars.conf
 echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
-DISABLE_SHARED="yes" DISABLE_SYSC="yes" ./install.sh
+./install.sh
 
 # Remove unnecessary files or directories
 rm -rf %{_localstatedir}/selinux

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -77,9 +77,9 @@ build_environment() {
   if grep 'www.siteox.com' /etc/motd > /dev/null 2>&1; then
     for partition in "/home" "/opt"; do
       partition_size=$(df -m | grep $partition | awk -F' ' '{print $2}' | cut -d'.' -f1)
-      if [[ ${partition_size} -lt "3000" ]]; then
-        echo "Resizing $partition partition to 3GB"
-        chfs -a size=3G $partition > /dev/null 2>&1
+      if [[ ${partition_size} -lt "3584" ]]; then
+        echo "Resizing $partition partition to 3.5GB"
+        chfs -a size=3584M $partition > /dev/null 2>&1
       fi
     done
   fi

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -109,7 +109,7 @@ compile() {
     config
     check_version
     gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
-    gmake TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes
+    gmake TARGET=agent USE_SELINUX=no
     bash ${source_directory}/install.sh
     cd $current_path
 }

--- a/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-agent-4.2.0.spec
@@ -330,6 +330,7 @@ if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DI
   if command -v getenforce > /dev/null 2>&1; then
     if [ $(getenforce) !=  "Disabled" ]; then
       chcon -t textrel_shlib_t  %{_localstatedir}/lib/libwazuhext.so
+      chcon -t textrel_shlib_t  %{_localstatedir}/lib/libwazuhshared.so
     fi
   fi
 else

--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -657,6 +657,7 @@ rm -fr %{buildroot}
 %attr(750, root, ossec) %{_localstatedir}/integrations/*
 %dir %attr(750, root, ossec) %{_localstatedir}/lib
 %attr(750, root, ossec) %{_localstatedir}/lib/libwazuhext.so
+%attr(750, root, ossec) %{_localstatedir}/lib/libwazuhshared.so
 %attr(750, root, ossec) %{_localstatedir}/lib/libdbsync.so
 %attr(750, root, ossec) %{_localstatedir}/lib/librsync.so
 %attr(750, root, ossec) %{_localstatedir}/lib/libsyscollector.so

--- a/solaris/solaris10/generate_wazuh_packages.sh
+++ b/solaris/solaris10/generate_wazuh_packages.sh
@@ -178,9 +178,9 @@ installation(){
     arch="$(uname -p)"
     # Build the binaries
     if [ "$arch" = "sparc" ]; then
-        gmake -j $THREADS TARGET=agent USE_SELINUX=no USE_BIG_ENDIAN=yes DISABLE_SHARED=yes || return 1
+        gmake -j $THREADS TARGET=agent USE_SELINUX=no USE_BIG_ENDIAN=yes || return 1
     else
-        gmake -j $THREADS TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes || return 1
+        gmake -j $THREADS TARGET=agent USE_SELINUX=no || return 1
     fi
 
     cd $SOURCE

--- a/solaris/solaris11/SPECS/template_agent_v4.2.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.2.0.json
@@ -655,6 +655,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib/libwazuhshared.so": {
+        "class": "static",
+        "group": "ossec",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/lib/libdbsync.so": {
         "class": "static",
         "group": "ossec",

--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -158,9 +158,9 @@ compile() {
     arch="$(uname -p)"
     # Build the binaries
     if [ "$arch" = "sparc" ]; then
-        gmake -j $THREADS TARGET=agent USE_SELINUX=no USE_BIG_ENDIAN=yes DISABLE_SHARED=yes || exit 1
+        gmake -j $THREADS TARGET=agent USE_SELINUX=no USE_BIG_ENDIAN=yes || exit 1
     else
-        gmake -j $THREADS TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes || exit 1
+        gmake -j $THREADS TARGET=agent USE_SELINUX=no || exit 1
     fi
 
     $SOURCE/install.sh || exit 1


### PR DESCRIPTION
|Related issue|
|---|
|[#8525](https://github.com/wazuh/wazuh/issues/8525)|
## Description
This pr has the purpose of improving the size of the packages for 4.2, which was strongly impacted by the incorporated changes.
With these changes (4.2.0):
```
AIX -> 7 MB
DEB -> 6.6 MB
HPUX -> 18.9 MB
RPM -> 6.9 MB
RPM rhel 5 -> 6.7 MB
Windows -> 4.4 MB
Solaris 10-> 13.9 MB
Solaris 11-> 5.7MB
macOS-> 4.9 MB
```
Previous this change (4.2.0):
```
Modified: 2021-04-30 07:16:18	Size: 47.83 MB	Object: pre-release/aix/wazuh-agent-4.2.0-1.aix.ppc.rpm	
Modified: 2021-04-29 18:00:54	Size: 9.29 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.2.0-1_amd64.deb	
Modified: 2021-04-29 18:38:55	Size: 3.78 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.2.0-1_arm64.deb	
Modified: 2021-04-29 19:02:32	Size: 3.75 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.2.0-1_armhf.deb	
Modified: 2021-04-29 18:38:57	Size: 9.42 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.2.0-1_i386.deb	
Modified: 2021-04-29 18:18:06	Size: 109.91 MB	Object: pre-release/apt/pool/main/w/wazuh-manager/wazuh-manager_4.2.0-1_amd64.deb	
Modified: 2021-04-29 19:02:50	Size: 73.4 MB	Object: pre-release/apt/pool/main/w/wazuh-manager/wazuh-manager_4.2.0-1_arm64.deb	
Modified: 2021-05-03 10:28:19	Size: 171.96 MB	Object: pre-release/hp-ux/wazuh-agent-4.2.0-1-hpux-11v3-ia64.tar	
Modified: 2021-04-29 18:04:05	Size: 7.74 MB	Object: pre-release/macos/wazuh-agent-4.2.0-1.pkg	
Modified: 2021-04-29 18:03:16	Size: 99.18 MB	Object: pre-release/solaris/i386/10/wazuh-agent_v4.2.0-sol10-i386.pkg	
Modified: 2021-05-03 13:51:20	Size: 43.97 MB	Object: pre-release/solaris/i386/11/wazuh-agent_v4.2.0-sol11-i386.p5p	
File pre-release/solaris/sparc/10/wazuh-agent_v4.2.0-sol10-sparc.pkg doesn't exist.
File pre-release/solaris/sparc/11/wazuh-agent_v4.2.0-sol11-sparc.p5p doesn't exist.
Modified: 2021-04-30 14:29:05	Size: 4.47 MB	Object: pre-release/windows/wazuh-agent-4.2.0-1.msi	
Modified: 2021-04-29 17:55:00	Size: 0.56 KB	Object: pre-release/wpk/linux/x86_64/versions	
Modified: 2021-04-29 17:54:48	Size: 17.09 MB	Object: pre-release/wpk/linux/x86_64/wazuh_agent_v4.2.0_linux_x86_64.wpk	
Modified: 2021-04-30 15:32:36	Size: 0.56 KB	Object: pre-release/wpk/windows/versions	
Modified: 2021-04-30 15:32:29	Size: 4.18 MB	Object: pre-release/wpk/windows/wazuh_agent_v4.2.0_windows.wpk	
Modified: 2021-04-07 06:50:04	Size: 220.12 MB	Object: pre-release/yum/elasticsearch-oss-7.10.2-x86_64.rpm	
Modified: 2021-04-29 18:57:35	Size: 9.63 MB	Object: pre-release/yum/wazuh-agent-4.2.0-1.aarch64.rpm	
Modified: 2021-04-29 18:57:36	Size: 8.85 MB	Object: pre-release/yum/wazuh-agent-4.2.0-1.armv7hl.rpm	
Modified: 2021-04-29 18:35:09	Size: 9.74 MB	Object: pre-release/yum/wazuh-agent-4.2.0-1.i386.rpm	
Modified: 2021-04-29 18:11:51	Size: 9.98 MB	Object: pre-release/yum/wazuh-agent-4.2.0-1.x86_64.rpm	
Modified: 2021-04-29 18:57:36	Size: 129.97 MB	Object: pre-release/yum/wazuh-manager-4.2.0-1.aarch64.rpm	
Modified: 2021-04-29 18:11:52	Size: 110.59 MB	Object: pre-release/yum/wazuh-manager-4.2.0-1.x86_64.rpm	
Modified: 2021-04-29 18:50:06	Size: 9.61 MB	Object: pre-release/yum5/i386/wazuh-agent-4.2.0-1.el5.i386.rpm	
Modified: 2021-04-29 18:14:06	Size: 9.75 MB	Object: pre-release/yum5/x86_64/wazuh-agent-4.2.0-1.el5.x86_64.rpm	
```
Similar expected(4.1.5):
```
Modified: 2021-04-22 10:34:27	Size: 13.95 MB	Object: pre-release/aix/wazuh-agent-4.1.5-1.aix.ppc.rpm	
Modified: 2021-04-22 10:26:00	Size: 5.07 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.1.5-1_amd64.deb	
Modified: 2021-04-22 13:40:33	Size: 2.7 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.1.5-1_arm64.deb	
Modified: 2021-04-22 13:40:34	Size: 2.79 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.1.5-1_armhf.deb	
Modified: 2021-04-22 13:40:35	Size: 5.03 MB	Object: pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.1.5-1_i386.deb	
Modified: 2021-04-22 13:49:32	Size: 106.07 MB	Object: pre-release/apt/pool/main/w/wazuh-manager/wazuh-manager_4.1.5-1_amd64.deb	
Modified: 2021-04-22 13:49:43	Size: 72.51 MB	Object: pre-release/apt/pool/main/w/wazuh-manager/wazuh-manager_4.1.5-1_arm64.deb	
Modified: 2021-04-22 12:47:10	Size: 52.66 MB	Object: pre-release/hp-ux/wazuh-agent-4.1.5-1-hpux-11v3-ia64.tar	
Modified: 2021-04-22 10:45:57	Size: 3.99 MB	Object: pre-release/macos/wazuh-agent-4.1.5-1.pkg	
Modified: 2021-04-22 10:25:06	Size: 29.04 MB	Object: pre-release/solaris/i386/10/wazuh-agent_v4.1.5-sol10-i386.pkg	
Modified: 2021-04-22 10:25:05	Size: 14.27 MB	Object: pre-release/solaris/i386/11/wazuh-agent_v4.1.5-sol11-i386.p5p	
Modified: 2021-04-22 11:14:37	Size: 30.37 MB	Object: pre-release/solaris/sparc/10/wazuh-agent_v4.1.5-sol10-sparc.pkg	
Modified: 2021-04-22 11:12:39	Size: 14.44 MB	Object: pre-release/solaris/sparc/11/wazuh-agent_v4.1.5-sol11-sparc.p5p	
File pre-release/vm/wazuh-4.1.5_1.13.3.ova doesn't exist.
Modified: 2021-04-22 10:25:35	Size: 3.36 MB	Object: pre-release/windows/wazuh-agent-4.1.5-1.msi	
Modified: 2021-04-29 17:55:00	Size: 0.56 KB	Object: pre-release/wpk/linux/x86_64/versions	
Modified: 2021-04-22 10:20:21	Size: 8.17 MB	Object: pre-release/wpk/linux/x86_64/wazuh_agent_v4.1.5_linux_x86_64.wpk	
Modified: 2021-04-30 15:32:36	Size: 0.56 KB	Object: pre-release/wpk/windows/versions	
Modified: 2021-04-22 10:50:00	Size: 3.06 MB	Object: pre-release/wpk/windows/wazuh_agent_v4.1.5_windows.wpk	
Modified: 2021-04-22 14:01:58	Size: 5.2 MB	Object: pre-release/yum/wazuh-agent-4.1.5-1.aarch64.rpm	
Modified: 2021-04-22 14:01:59	Size: 4.99 MB	Object: pre-release/yum/wazuh-agent-4.1.5-1.armv7hl.rpm	
Modified: 2021-04-22 13:36:52	Size: 5.29 MB	Object: pre-release/yum/wazuh-agent-4.1.5-1.i386.rpm	
Modified: 2021-04-22 10:37:14	Size: 5.41 MB	Object: pre-release/yum/wazuh-agent-4.1.5-1.x86_64.rpm	
Modified: 2021-04-22 14:01:59	Size: 125.93 MB	Object: pre-release/yum/wazuh-manager-4.1.5-1.aarch64.rpm	
Modified: 2021-04-22 14:02:14	Size: 106.4 MB	Object: pre-release/yum/wazuh-manager-4.1.5-1.x86_64.rpm	
Modified: 2021-04-22 14:11:53	Size: 5.22 MB	Object: pre-release/yum5/i386/wazuh-agent-4.1.5-1.el5.i386.rpm	
Modified: 2021-04-22 10:40:06	Size: 5.25 MB	Object: pre-release/yum5/x86_64/wazuh-agent-4.1.5-1.el5.x86_64.rpm	
```


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
  - [x] Solaris
  - [x] AIX
  - [x] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
