### PR TITLE
Update 4.1 build Debian Dockerfile

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -12,12 +12,8 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
-# Add Debian's source repository and, Install NodeJS 6
-RUN apt-get update && apt-get build-dep python3.2 -y && \
-    curl -sL https://deb.nodesource.com/setup_6.x | bash -
-
-RUN sed -i 's:https:http:g' /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install nodejs -y
+# Add Debian's source repository
+RUN apt-get update && apt-get build-dep python3.2 -y 
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
     tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
@@ -37,3 +33,4 @@ RUN chmod +x /usr/local/bin/build_package
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/build_package"]
+


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/780|


## Description

Nodejs installation was no longer required on 4.1. Nevertheless, it is still present on our 4.1 Debian Dockerfile. This pull request removes it because it has started to cause an error due to invalid keys.

## Logs example

![image](https://user-images.githubusercontent.com/15269938/119343014-2530bf00-bc96-11eb-8712-96fdd764d94c.png)

