### PR TITLE
Fix DEB packages wrong python permissions

### DIFF
--- a/debs/SPECS/4.2.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-agent/debian/rules
@@ -146,4 +146,4 @@ override_dh_auto_clean:
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym
 
-.PHONY: override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure
+.PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure

--- a/debs/SPECS/4.2.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.2.0/wazuh-manager/debian/rules
@@ -202,4 +202,4 @@ override_dh_auto_clean:
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
 
-.PHONY: override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure
+.PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure override_dh_fixperms


### PR DESCRIPTION
|Related issue|
|---|
|Closes #789|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an issue with the permissions set for the python files in Debian packages.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package

