### PR TITLE
Set AIX changelog in chronological order

### DIFF
--- a/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
+++ b/aix/SPECS/4.2.0/wazuh-agent-4.2.0-aix.spec
@@ -282,6 +282,8 @@ rm -fr %{buildroot}
 %changelog
 * Mon Apr 26 2021 support <info@wazuh.com> - 4.2.0
 - More info: https://documentation.wazuh.com/current/release-notes/
+* Sat Apr 24 2021 support <info@wazuh.com> - 3.13.3
+- More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Apr 22 2021 support <info@wazuh.com> - 4.1.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Mar 29 2021 support <info@wazuh.com> - 4.1.4
@@ -301,8 +303,6 @@ rm -fr %{buildroot}
 * Sat Oct 31 2020 support <info@wazuh.com> - 4.0.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Oct 19 2020 support <info@wazuh.com> - 4.0.0
-- More info: https://documentation.wazuh.com/current/release-notes/
-* Sat Apr 24 2021 support <info@wazuh.com> - 3.13.3
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Fri Aug 21 2020 support <info@wazuh.com> - 3.13.2
 - More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION
This PR fixes a problem with the order of the versions in AIX 4.2.0 SPEC.