### PR TITLE
Update Windows compiler dockerfile to update minGW (5.0-dev branch) 

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Installing necessary packages
 RUN apt-get update && \


### PR DESCRIPTION
|Related issue|
|---|
| closes #802 |

## Description
Hello team,

We have updated the docker of Windows package builder to use latest minGW version 9.3.0.

Regards.

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Windows
