### PR TITLE
Add ossec-init to 4.3 RPM SPECS

### DIFF
--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -480,6 +480,7 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,root)
 %{_initrddir}/wazuh-agent
+%attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-agent.service
 %dir %attr(750, root, wazuh) %{_localstatedir}
 %attr(750, root, wazuh) %{_localstatedir}/agentless

--- a/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
@@ -558,7 +558,7 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,wazuh)
 %{_initrddir}/wazuh-manager
-%attr(640, root, ossec) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
+%attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-manager.service
 %dir %attr(750, root, wazuh) %{_localstatedir}
 %attr(750, root, wazuh) %{_localstatedir}/agentless


### PR DESCRIPTION
This PR adds ossec-init to 4.3 rpm SPECS.