### PR TITLE
Fixed wazuh-api obsolete harcode

### DIFF
--- a/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
+++ b/rpms/SPECS/4.2.0/wazuh-manager-4.2.0.spec
@@ -14,7 +14,7 @@ Requires(post):   /sbin/chkconfig
 Requires(preun):  /sbin/chkconfig /sbin/service
 Requires(postun): /sbin/service /usr/sbin/groupdel /usr/sbin/userdel
 Conflicts:   ossec-hids ossec-hids-agent wazuh-agent wazuh-local
-Obsoletes: wazuh-api <= 3.13.2
+Obsoletes: wazuh-api < 4.0.0
 AutoReqProv: no
 
 Requires: coreutils


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh-packages/issues/816. The `wazuh-api` version to be obsoleted is fixed. 