### PR TITLE
Add azure wodle to rpm, aix and solaris spec files

### DIFF
--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -293,6 +293,8 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
 %attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 

--- a/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
+++ b/rpms/SPECS/5.0.0/wazuh-agent-5.0.0.spec
@@ -589,6 +589,8 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
 %attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
 %attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud

--- a/solaris/solaris11/SPECS/template_agent_v5.0.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v5.0.0.json
@@ -1784,6 +1784,22 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/azure": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure-logs": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/docker": {
         "class": "static",
         "group": "wazuh",


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9181|

## Description

This PR add azure wodle to rpm, aix and solaris spec files


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Solaris
  - [x] AIX

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Solaris
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7



