### PR TITLE
Change location of .agent_info and .wait files to /var/run/ in aix spec

### DIFF
--- a/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
+++ b/aix/SPECS/5.0.0/wazuh-agent-5.0.0-aix.spec
@@ -196,8 +196,8 @@ if [ $1 = 0 ]; then
 
   /etc/rc.d/init.d/wazuh-agent stop > /dev/null 2>&1 || :
   rm -f %{_localstatedir}/queue/sockets/*
-  rm -f %{_localstatedir}/queue/sockets/.agent_info || :
-  rm -f %{_localstatedir}/queue/sockets/.wait || :
+  rm -f %{_localstatedir}/var/run/.agent_info || :
+  rm -f %{_localstatedir}/var/run/.wait || :
   rm -f %{_localstatedir}/queue/diff/*
   rm -f %{_localstatedir}/queue/alerts/*
   rm -f %{_localstatedir}/queue/rids/*


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8304|

## Description

This PR change the location of .agent_info and .wait files from queue/sockets to var/run directory in aix spec


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] AIX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package remove
- [ ] Package install/remove/install

- Tests for IBM AIX
  - [ ] Check the changes from IBM AIX 5 to 7
