### PR TITLE
Fix netstat typo

### DIFF
--- a/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
+++ b/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
@@ -137,7 +137,7 @@ if [ $1 = 1 ]; then
   fi
 
   # Fix for AIX: netstat command
-  sed 's/netstat -tulpn/nestat -tu/' %{_localstatedir}/etc/ossec.conf > %{_localstatedir}/etc/ossec.conf.tmp
+  sed 's/netstat -tulpn/netstat -tu/' %{_localstatedir}/etc/ossec.conf > %{_localstatedir}/etc/ossec.conf.tmp
   mv %{_localstatedir}/etc/ossec.conf.tmp %{_localstatedir}/etc/ossec.conf
   sed 's/sort -k 4 -g/sort -n -k 4/' %{_localstatedir}/etc/ossec.conf > %{_localstatedir}/etc/ossec.conf.tmp
   mv %{_localstatedir}/etc/ossec.conf.tmp %{_localstatedir}/etc/ossec.conf


### PR DESCRIPTION
|Related issue|
|---|
|Closes #824 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


This PR fixes a typo with the netstat command in ossec.conf