### PR TITLE
Wazuhapp update build script kibana 7.11

### DIFF
--- a/wazuhapp/Docker/build.sh
+++ b/wazuhapp/Docker/build.sh
@@ -87,9 +87,9 @@ install_dependencies () {
     cd ${kibana_dir}
     change_node_version $kibana_node_version
     npm install -g "yarn@${kibana_yarn_version}"
-    sed -i 's/node scripts\/build_ts_refs/node scripts\/build_ts_refs --allow-root/' ${kibana_dir}/package.json
-    sed -i 's/node scripts\/register_git_hook/node scripts\/register_git_hook --allow-root/' ${kibana_dir}/package.json
-    yarn kbn bootstrap --skip-kibana-plugins --oss --allow-root
+    #sed -i 's/node scripts\/build_ts_refs/node scripts\/build_ts_refs --allow-root/' ${kibana_dir}/package.json
+    #sed -i 's/node scripts\/register_git_hook/node scripts\/register_git_hook --allow-root/' ${kibana_dir}/package.json
+    yarn kbn bootstrap --skip-kibana-plugins --oss #--allow-root
 }
 
 
@@ -114,7 +114,7 @@ build_package(){
 
     # Build the package
     yarn
-    KIBANA_VERSION=${kibana_version} yarn build --allow-root
+    KIBANA_VERSION=${kibana_version} yarn build #--allow-root
 
     find ${build_dir} -name "*.zip" -exec mv {} ${destination_dir}/${wazuh_app_pkg_name} \;
 

--- a/wazuhapp/Docker/build.sh
+++ b/wazuhapp/Docker/build.sh
@@ -26,6 +26,7 @@ wazuh_version=""
 kibana_version=""
 kibana_yarn_version=""
 kibana_node_version=""
+aux_kibana_version=""
 
 
 change_node_version () {
@@ -55,8 +56,13 @@ prepare_env() {
                     print(pkg["version"])')
     kibana_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                      print(pkg["kibana"]["version"])')
+    aux_kibana_version=$kibana_version
 
-    kibana_package_json_url="${kibana_app_raw_repo_url}/v${kibana_version}/package.json"
+    if [ "${wazuh_version}" \< "4.2.2" ] && [ "${kibana_version}" \> "7.10.2" ]; then
+        aux_kibana_version="7.10.2"
+    fi
+
+    kibana_package_json_url="${kibana_app_raw_repo_url}/v${aux_kibana_version}/package.json"
 
     echo "Downloading package.json from elastic/kibana repository"
     if ! curl $kibana_package_json_url -o "/tmp/package.json" ; then
@@ -72,8 +78,8 @@ prepare_env() {
 }
 
 
-download_kibana_sources() {
-    if ! git clone $kibana_app_repo_url --branch "v${kibana_version}" --depth=1 kibana_source; then
+download_kibana_sources() {    
+    if ! git clone $kibana_app_repo_url --branch "v${aux_kibana_version}" --depth=1 kibana_source; then
         echo "Error downloading Kibana source code from elastic/kibana GitHub repository."
         exit 1
     fi
@@ -87,8 +93,10 @@ install_dependencies () {
     cd ${kibana_dir}
     change_node_version $kibana_node_version
     npm install -g "yarn@${kibana_yarn_version}"
-    #sed -i 's/node scripts\/build_ts_refs/node scripts\/build_ts_refs --allow-root/' ${kibana_dir}/package.json
-    #sed -i 's/node scripts\/register_git_hook/node scripts\/register_git_hook --allow-root/' ${kibana_dir}/package.json
+    if [ "${aux_kibana_version}" \< "7.11.0" ]; then
+        sed -i 's/node scripts\/build_ts_refs/node scripts\/build_ts_refs --allow-root/' ${kibana_dir}/package.json
+        sed -i 's/node scripts\/register_git_hook/node scripts\/register_git_hook --allow-root/' ${kibana_dir}/package.json
+    fi
     yarn kbn bootstrap --skip-kibana-plugins --oss #--allow-root
 }
 
@@ -114,7 +122,11 @@ build_package(){
 
     # Build the package
     yarn
-    KIBANA_VERSION=${kibana_version} yarn build #--allow-root
+    if [ "${aux_kibana_version}" \< "7.11.0"  ]; then
+        KIBANA_VERSION=${kibana_version} yarn build --allow-root
+    else
+        KIBANA_VERSION=${kibana_version} yarn build
+    fi
 
     find ${build_dir} -name "*.zip" -exec mv {} ${destination_dir}/${wazuh_app_pkg_name} \;
 


### PR DESCRIPTION
## Description

Hi team, this PR resolves:

- Use Kibana 7.10.2 when Wazuh is lower than 4.2.2 even when Kibana is 7.11 o higher
- Seed `--allow-root` only for Kibana 7.10.2


## Logs example

<details>
  <summary>Test `v4.1.5-7.11.2` should use Kibana `7.10.2`</summary> 
  
  ```bash
  ./generate_wazuh_app.sh -b v4.2.1-7.11.2 -r 1                                                                                                        [1]
Sending build context to Docker daemon  7.168kB
Step 1/6 : FROM centos:8
 ---> 300e315adb2f
Step 2/6 : RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centostesting &&     curl -sL https://rpm.nodesource.com/setup_10.x | bash - &&     yum install nodejs git gcc gcc-c++ make sudo zip python3 -y &&     alternatives --set python /usr/bin/python3 &&     npm install -g n
 ---> Using cache
 ---> ee6279a1e23b
Step 3/6 : ADD build.sh /
 ---> 95253395df81
Step 4/6 : RUN chmod +x /build.sh
 ---> Running in f8f9ec1dbb3d
Removing intermediate container f8f9ec1dbb3d
 ---> 71e980a2e771
Step 5/6 : RUN mkdir /wazuh_app /source
 ---> Running in 87329b8f9c38
Removing intermediate container 87329b8f9c38
 ---> 321ea93170a8
Step 6/6 : ENTRYPOINT ["/build.sh"]
 ---> Running in 3bfbbcaa63c7
Removing intermediate container 3bfbbcaa63c7
 ---> 73d87b9f0130
Successfully built 73d87b9f0130
Successfully tagged wazuh-kibana-app-builder:latest
+ wazuh_branch=v4.2.1-7.11.2
+ checksum=no
+ app_revision=1
+ kibana_dir=/tmp/source
+ source_dir=/tmp/source/plugins/wazuh
+ build_dir=/tmp/source/plugins/wazuh/build
+ destination_dir=/wazuh_app
+ checksum_dir=/var/local/checksum
+ wazuh_app_clone_repo_url=https://github.com/wazuh/wazuh-kibana-app.git
+ wazuh_app_raw_repo_url=https://raw.githubusercontent.com/wazuh/wazuh-kibana-app
+ kibana_app_repo_url=https://github.com/elastic/kibana.git
+ kibana_app_raw_repo_url=https://raw.githubusercontent.com/elastic/kibana
+ wazuh_app_package_json_url=https://raw.githubusercontent.com/wazuh/wazuh-kibana-app/v4.2.1-7.11.2/package.json
+ wazuh_version=
+ kibana_version=
+ kibana_yarn_version=
+ kibana_node_version=
+ aux_kibana_version=
+ prepare_env
+ echo 'Downloading package.json from wazuh-kibana app repository'
Downloading package.json from wazuh-kibana app repository
+ curl https://raw.githubusercontent.com/wazuh/wazuh-kibana-app/v4.2.1-7.11.2/package.json -o /tmp/package.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2100  100  2100    0     0   3129      0 --:--:-- --:--:-- --:--:--  3125
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                    print(pkg["version"])'
+ wazuh_version=4.2.1
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                     print(pkg["kibana"]["version"])'
+ kibana_version=7.11.2
+ aux_kibana_version=7.11.2
+ '[' 4.2.1 '<' 4.2.2 ']'
+ '[' 7.11.2 '>' 7.10.2 ']'
+ aux_kibana_version=7.10.2
+ kibana_package_json_url=https://raw.githubusercontent.com/elastic/kibana/v7.10.2/package.json
+ echo 'Downloading package.json from elastic/kibana repository'
Downloading package.json from elastic/kibana repository
+ curl https://raw.githubusercontent.com/elastic/kibana/v7.10.2/package.json -o /tmp/package.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16156  100 16156    0     0  23482      0 --:--:-- --:--:-- --:--:-- 23448
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                          print(pkg["engines"]["node"])'
+ kibana_node_version=10.23.1
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                          print(pkg["engines"]["yarn"])'
+ kibana_yarn_version='^1.21.1'
+ download_kibana_sources
+ git clone https://github.com/elastic/kibana.git --branch v7.10.2 --depth=1 kibana_source
Cloning into 'kibana_source'...
remote: Enumerating objects: 40710, done.
remote: Counting objects: 100% (40710/40710), done.
remote: Compressing objects: 100% (33482/33482), done.
remote: Total 40710 (delta 10357), reused 23741 (delta 5801), pack-reused 0
Receiving objects: 100% (40710/40710), 424.97 MiB | 2.20 MiB/s, done.
Resolving deltas: 100% (10357/10357), done.
Note: switching to 'a0b793698735eb1d0ab1038f8e5d7a951524e929'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Updating files: 100% (33470/33470), done.
+ mkdir -p kibana_source/plugins
+ mv kibana_source /tmp/source
+ install_dependencies
+ cd /tmp/source
+ change_node_version 10.23.1
++ node -v
+ installed_node_version=v10.24.0
+ node_version=10.23.1
+ n 10.23.1
  installing : node-v10.23.1
       mkdir : /usr/local/n/versions/node/10.23.1
       fetch : https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-x64.tar.xz
   installed : v10.23.1 (with npm 6.14.10)

Note: the node command changed location and the old location may be remembered in your current shell.
         old : /usr/bin/node
         new : /usr/local/bin/node
To reset the command location hash either start a new shell, or execute PATH="$PATH"
+ [[ v10.24.0 != \v\1\0\.\2\3\.\1 ]]
+ mv /usr/local/bin/node /usr/bin
+ mv /usr/local/bin/npm /usr/bin
+ mv /usr/local/bin/npx /usr/bin
++ node -v
+ echo 'Using v10.23.1 node version'
Using v10.23.1 node version
+ npm install -g 'yarn@^1.21.1'

> yarn@1.22.11 preinstall /usr/lib/node_modules/yarn
> :; (node ./preinstall.js > /dev/null 2>&1 || true)

/usr/bin/yarn -> /usr/lib/node_modules/yarn/bin/yarn.js
/usr/bin/yarnpkg -> /usr/lib/node_modules/yarn/bin/yarn.js
+ yarn@1.22.11
added 1 package in 2.451s
+ '[' 7.10.2 '<' 7.11.0 ']'
+ sed -i 's/node scripts\/build_ts_refs/node scripts\/build_ts_refs --allow-root/' /tmp/source/package.json
+ sed -i 's/node scripts\/register_git_hook/node scripts\/register_git_hook --allow-root/' /tmp/source/package.json
+ yarn kbn bootstrap --skip-kibana-plugins --oss
yarn run v1.22.11
$ node scripts/kbn bootstrap --skip-kibana-plugins --oss
 info [kibana] running yarn

$ node ./preinstall_check
[1/5] Validating package.json...
[2/5] Resolving packages...
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "schema-utils@1.0.0" is incompatible with requested version "schema-utils@^0.3.0"
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@^3.3.3333"
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@^3.2.2"
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@^3.0.3"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "typescript@4.0.2" is incompatible with requested version "typescript@^3.4.5"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
[3/5] Fetching packages...
info fsevents@1.2.12: The platform "linux" is incompatible with this module.
info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
warning " > @elastic/eui@29.3.2" has incorrect peer dependency "typescript@^3.7.2".
warning " > @testing-library/react-hooks@3.4.1" has unmet peer dependency "react-test-renderer@>=16.9.0".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > @kbn/storybook > @storybook/addon-essentials@6.0.16" has unmet peer dependency "react-is@^16.8.0".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > x-pack > @cypress/webpack-preprocessor@5.4.6" has unmet peer dependency "@babel/preset-env@^7.0.0".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > x-pack > @elastic/apm-rum-react@1.2.5" has incorrect peer dependency "react-router-dom@^4.0.0".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > x-pack > react-shortcuts@2.0.1" has incorrect peer dependency "react@^0.14.8 || ^15".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > x-pack > react-shortcuts@2.0.1" has incorrect peer dependency "react-dom@^0.14.8 || ^15".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > @kbn/storybook > @storybook/addon-essentials > @storybook/addon-docs@6.0.16" has unmet peer dependency "react-is@^16.8.0".
warning "workspace-aggregator-a2e7ab71-3937-4bbf-8d07-85f566866bd2 > @kbn/storybook > @storybook/addon-essentials > @storybook/addon-docs > @mdx-js/react@1.6.16" has incorrect peer dependency "react@^16.13.1".
[5/5] Building fresh packages...

 succ yarn.lock analysis completed without any issues
 info [@kbn/config-schema] running [kbn:bootstrap] script
 info [@kbn/utility-types] running [kbn:bootstrap] script
 succ [@kbn/utility-types] bootstrap complete
 succ [@kbn/config-schema] bootstrap complete
 info [@kbn/std] running [kbn:bootstrap] script
 info [@kbn/utils] running [kbn:bootstrap] script
 succ [@kbn/utils] bootstrap complete
 succ [@kbn/std] bootstrap complete
 info [@kbn/apm-config-loader] running [kbn:bootstrap] script
 info [@kbn/dev-utils] running [kbn:bootstrap] script
 info [@kbn/logging] running [kbn:bootstrap] script
 succ [@kbn/logging] bootstrap complete
 succ [@kbn/apm-config-loader] bootstrap complete
 succ [@kbn/dev-utils] bootstrap complete
 info [@kbn/ace] running [kbn:bootstrap] script
 info [@kbn/analytics] running [kbn:bootstrap] script
 info [@kbn/config] running [kbn:bootstrap] script
 info [@kbn/es-archiver] running [kbn:bootstrap] script
 succ [@kbn/analytics] bootstrap complete
 info [@kbn/es] running [kbn:bootstrap] script
 succ [@kbn/ace] bootstrap complete
 info [@kbn/i18n] running [kbn:bootstrap] script
 succ [@kbn/config] bootstrap complete
 info [@kbn/monaco] running [kbn:bootstrap] script
 succ [@kbn/es] bootstrap complete
 info [@kbn/plugin-generator] running [kbn:bootstrap] script
 succ [@kbn/es-archiver] bootstrap complete
 info [@kbn/release-notes] running [kbn:bootstrap] script
 succ [@kbn/i18n] bootstrap complete
 info [@kbn/storybook] running [kbn:bootstrap] script
 succ [@kbn/plugin-generator] bootstrap complete
 info [@kbn/telemetry-tools] running [kbn:bootstrap] script
 succ [@kbn/storybook] bootstrap complete
 info [@kbn/test] running [kbn:bootstrap] script
 succ [@kbn/release-notes] bootstrap complete
 succ [@kbn/telemetry-tools] bootstrap complete
 succ [@kbn/monaco] bootstrap complete
 succ [@kbn/test] bootstrap complete
 info [@kbn/interpreter] running [kbn:bootstrap] script
 info [@kbn/ui-shared-deps] running [kbn:bootstrap] script
 succ [@kbn/interpreter] bootstrap complete
 succ [@kbn/ui-shared-deps] bootstrap complete
 info [@kbn/optimizer] running [kbn:bootstrap] script
 succ [@kbn/optimizer] bootstrap complete
 info [@kbn/plugin-helpers] running [kbn:bootstrap] script
 succ [@kbn/plugin-helpers] bootstrap complete
 info [kibana] running [kbn:bootstrap] script
 succ [kibana] bootstrap complete
Done in 542.38s.
+ download_wazuh_app_sources
+ git clone https://github.com/wazuh/wazuh-kibana-app.git --branch v4.2.1-7.11.2 --depth=1 /tmp/source/plugins/wazuh
Cloning into '/tmp/source/plugins/wazuh'...
remote: Enumerating objects: 1416, done.
remote: Counting objects: 100% (1416/1416), done.
remote: Compressing objects: 100% (1230/1230), done.
remote: Total 1416 (delta 296), reused 615 (delta 123), pack-reused 0
Receiving objects: 100% (1416/1416), 3.34 MiB | 1.83 MiB/s, done.
Resolving deltas: 100% (296/296), done.
Note: switching to '7788c751dd7a4809bca9c1fc78fe893ee8884dc8'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

+ build_package
+ cd /tmp/source/plugins/wazuh
+ '[' -z 1 ']'
+ wazuh_app_pkg_name=wazuh_kibana-4.2.1_7.11.2-1.zip
+ yarn
yarn install v1.22.11
info No lockfile found.
[1/4] Resolving packages...
warning pdfmake > pdfkit > fontkit > babel-runtime > core-js@2.6.12: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > angular-material@1.1.18" has unmet peer dependency "angular@1.4 - 1.7.0 || ^1.7.2".
warning " > angular-material@1.1.18" has unmet peer dependency "angular-aria@1.4 - 1.7.0 || ^1.7.2".
warning " > angular-material@1.1.18" has unmet peer dependency "angular-messages@1.4 - 1.7.0 || ^1.7.2".
warning " > pug-loader@2.4.0" has unmet peer dependency "pug@^2.0.0".
warning " > react-codemirror@1.0.0" has unmet peer dependency "react@>=15.5 <16".
warning " > react-codemirror@1.0.0" has unmet peer dependency "react-dom@>=15.5 <16".
warning " > react-cookie@4.1.1" has unmet peer dependency "react@>= 16.3.0".
warning " > tslint@5.20.1" has unmet peer dependency "typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev".
warning "tslint > tsutils@2.29.0" has unmet peer dependency "typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev".
warning " > typescript-eslint-parser@18.0.0" has unmet peer dependency "typescript@*".
[4/4] Building fresh packages...
success Saved lockfile.
Done in 35.61s.
+ '[' 7.10.2 '<' 7.11.0 ']'
+ KIBANA_VERSION=7.11.2
+ yarn build --allow-root
yarn run v1.22.11
$ node scripts/generate-build-version
kibana.json file has been saved with latest version number
$ yarn plugin-helpers build --kibana-version=$KIBANA_VERSION --allow-root
$ node ../../scripts/plugin_helpers build --kibana-version=7.11.2 --allow-root
 info Loaded config file from [/tmp/source/plugins/wazuh/.kibana-plugin-helpers.json]
 info deleting the build and target directories
 info running @kbn/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
 │ warn worker stderr npx browserslist@latest --update-db
 │ succ 1 bundles compiled successfully after 231.1 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [wazuh-7.11.2.zip]
Done in 252.76s.
+ find /tmp/source/plugins/wazuh/build -name '*.zip' -exec mv '{}' /wazuh_app/wazuh_kibana-4.2.1_7.11.2-1.zip ';'
+ '[' no = yes ']'
+ exit 0
  ```
  
</details>

<details>
  <summary>Test `v4.2.2-7.12.1` should use Kibana `7.12.1`</summary> 
  
  ```bash
./generate_wazuh_app.sh -b v4.2.2-7.12.1-rc1 -r 1                                                                                                       
Sending build context to Docker daemon  7.168kB
Step 1/6 : FROM centos:8
 ---> 300e315adb2f
Step 2/6 : RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centostesting &&     curl -sL https://rpm.nodesource.com/setup_10.x | bash - &&     yum install nodejs git gcc gcc-c++ make sudo zip python3 -y &&     alternatives --set python /usr/bin/python3 &&     npm install -g n
 ---> Using cache
 ---> ee6279a1e23b
Step 3/6 : ADD build.sh /
 ---> Using cache
 ---> 95253395df81
Step 4/6 : RUN chmod +x /build.sh
 ---> Using cache
 ---> 71e980a2e771
Step 5/6 : RUN mkdir /wazuh_app /source
 ---> Using cache
 ---> 321ea93170a8
Step 6/6 : ENTRYPOINT ["/build.sh"]
 ---> Using cache
 ---> 73d87b9f0130
Successfully built 73d87b9f0130
Successfully tagged wazuh-kibana-app-builder:latest
+ wazuh_branch=v4.2.2-7.12.1-rc1
+ checksum=no
+ app_revision=1
+ kibana_dir=/tmp/source
+ source_dir=/tmp/source/plugins/wazuh
+ build_dir=/tmp/source/plugins/wazuh/build
+ destination_dir=/wazuh_app
+ checksum_dir=/var/local/checksum
+ wazuh_app_clone_repo_url=https://github.com/wazuh/wazuh-kibana-app.git
+ wazuh_app_raw_repo_url=https://raw.githubusercontent.com/wazuh/wazuh-kibana-app
+ kibana_app_repo_url=https://github.com/elastic/kibana.git
+ kibana_app_raw_repo_url=https://raw.githubusercontent.com/elastic/kibana
+ wazuh_app_package_json_url=https://raw.githubusercontent.com/wazuh/wazuh-kibana-app/v4.2.2-7.12.1-rc1/package.json
+ wazuh_version=
+ kibana_version=
+ kibana_yarn_version=
+ kibana_node_version=
+ aux_kibana_version=
+ prepare_env
+ echo 'Downloading package.json from wazuh-kibana app repository'
Downloading package.json from wazuh-kibana app repository
+ curl https://raw.githubusercontent.com/wazuh/wazuh-kibana-app/v4.2.2-7.12.1-rc1/package.json -o /tmp/package.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2100  100  2100    0     0   2149      0 --:--:-- --:--:-- --:--:--  2147
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                    print(pkg["version"])'
+ wazuh_version=4.2.2
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                     print(pkg["kibana"]["version"])'
+ kibana_version=7.12.1
+ aux_kibana_version=7.12.1
+ '[' 4.2.2 '<' 4.2.2 ']'
+ kibana_package_json_url=https://raw.githubusercontent.com/elastic/kibana/v7.12.1/package.json
+ echo 'Downloading package.json from elastic/kibana repository'
Downloading package.json from elastic/kibana repository
+ curl https://raw.githubusercontent.com/elastic/kibana/v7.12.1/package.json -o /tmp/package.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 29051  100 29051    0     0  19857      0  0:00:01  0:00:01 --:--:-- 19857
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                          print(pkg["engines"]["node"])'
+ kibana_node_version=14.16.1
++ python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                          print(pkg["engines"]["yarn"])'
+ kibana_yarn_version='^1.21.1'
+ download_kibana_sources
+ git clone https://github.com/elastic/kibana.git --branch v7.12.1 --depth=1 kibana_source
Cloning into 'kibana_source'...
remote: Enumerating objects: 46720, done.
remote: Counting objects: 100% (46720/46720), done.
remote: Compressing objects: 100% (36900/36900), done.
remote: Total 46720 (delta 11558), reused 29170 (delta 8348), pack-reused 0
Receiving objects: 100% (46720/46720), 482.05 MiB | 1.74 MiB/s, done.
Resolving deltas: 100% (11558/11558), done.
Note: switching to 'abb04c5543d2201630c9669fe3680864506d924e'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Updating files: 100% (39002/39002), done.
+ mkdir -p kibana_source/plugins
+ mv kibana_source /tmp/source
+ install_dependencies
+ cd /tmp/source
+ change_node_version 14.16.1
++ node -v
+ installed_node_version=v10.24.0
+ node_version=14.16.1
+ n 14.16.1
  installing : node-v14.16.1
       mkdir : /usr/local/n/versions/node/14.16.1
       fetch : https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-x64.tar.xz
   installed : v14.16.1 (with npm 6.14.12)

Note: the node command changed location and the old location may be remembered in your current shell.
         old : /usr/bin/node
         new : /usr/local/bin/node
To reset the command location hash either start a new shell, or execute PATH="$PATH"
+ [[ v10.24.0 != \v\1\4\.\1\6\.\1 ]]
+ mv /usr/local/bin/node /usr/bin
+ mv /usr/local/bin/npm /usr/bin
+ mv /usr/local/bin/npx /usr/bin
++ node -v
+ echo 'Using v14.16.1 node version'
Using v14.16.1 node version
+ npm install -g 'yarn@^1.21.1'

> yarn@1.22.11 preinstall /usr/lib/node_modules/yarn
> :; (node ./preinstall.js > /dev/null 2>&1 || true)

/usr/bin/yarn -> /usr/lib/node_modules/yarn/bin/yarn.js
/usr/bin/yarnpkg -> /usr/lib/node_modules/yarn/bin/yarn.js
+ yarn@1.22.11
added 1 package in 2.682s
+ '[' 7.12.1 '<' 7.11.0 ']'
+ yarn kbn bootstrap --skip-kibana-plugins --oss
yarn run v1.22.11
$ node scripts/kbn bootstrap --skip-kibana-plugins --oss
 info [bazel_tools] installing Bazel tools
 succ [bazel_tools] all bazel tools are correctly installed
 info [kibana] running yarn

$ node ./preinstall_check
[1/5] Validating package.json...
[2/5] Resolving packages...
warning Resolution field "prismjs@1.23.0" is incompatible with requested version "prismjs@~1.22.0"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "@types/node@14.14.14" is incompatible with requested version "@types/node@^12.0.2"
warning Resolution field "@types/node@14.14.14" is incompatible with requested version "@types/node@8.10.54"
warning Resolution field "typescript@4.1.3" is incompatible with requested version "typescript@~3.7.2"
warning Resolution field "typescript@4.1.3" is incompatible with requested version "typescript@^3.5.3"
warning Resolution field "typescript@4.1.3" is incompatible with requested version "typescript@^3.2.2"
warning Resolution field "schema-utils@1.0.0" is incompatible with requested version "schema-utils@^0.3.0"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
warning Resolution field "typescript@4.1.3" is incompatible with requested version "typescript@^3.3.3333"
warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
[3/5] Fetching packages...
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
warning " > @elastic/apm-rum-react@1.2.5" has incorrect peer dependency "react-router-dom@^4.0.0".
warning " > @elastic/charts@25.0.5" has incorrect peer dependency "moment@^2.29.1".
warning " > @elastic/charts@25.0.5" has incorrect peer dependency "moment-timezone@^0.5.32".
warning "@octokit/rest > @octokit/plugin-request-log@1.0.2" has unmet peer dependency "@octokit/core@>=3".
warning "@storybook/addon-docs > @mdx-js/react@1.6.16" has incorrect peer dependency "react@^16.13.1".
warning " > react-monaco-editor@0.41.2" has incorrect peer dependency "@types/react@^17.x".
warning " > react-monaco-editor@0.41.2" has incorrect peer dependency "react@^17.x".
warning " > react-shortcuts@2.0.1" has incorrect peer dependency "react@^0.14.8 || ^15".
warning " > react-shortcuts@2.0.1" has incorrect peer dependency "react-dom@^0.14.8 || ^15".
[5/5] Building fresh packages...

 succ yarn.lock analysis completed without any issues
 info [bazel] Extracting Bazel installation...
 info [bazel] Starting local Bazel server and connecting to it...
 info [bazel] INFO: Invocation ID: a66f20fe-5aa8-4d22-82ea-335425e73dc9
 info [bazel] INFO: Analyzed target //packages:build (1 packages loaded, 1 target configured).
 info [bazel] INFO: Found 1 target...
 info [bazel] INFO: Elapsed time: 7.809s, Critical Path: 0.94s
 info [bazel] INFO: 1 process: 1 internal.
 info [bazel] 
 info [@kbn/apm-utils] running [kbn:bootstrap] script
 info [@kbn/config-schema] running [kbn:bootstrap] script
 info [@kbn/tinymath] running [kbn:bootstrap] script
 info [@kbn/utility-types] running [kbn:bootstrap] script
 succ [@kbn/tinymath] bootstrap complete
 succ [@kbn/apm-utils] bootstrap complete
 succ [@kbn/utility-types] bootstrap complete
 succ [@kbn/config-schema] bootstrap complete
 info [@kbn/babel-code-parser] running [kbn:bootstrap] script
 info [@kbn/std] running [kbn:bootstrap] script
 info [@kbn/utils] running [kbn:bootstrap] script
 succ [@kbn/babel-code-parser] bootstrap complete
 succ [@kbn/utils] bootstrap complete
 succ [@kbn/std] bootstrap complete
 info [@kbn/apm-config-loader] running [kbn:bootstrap] script
 info [@kbn/dev-utils] running [kbn:bootstrap] script
 info [@kbn/legacy-logging] running [kbn:bootstrap] script
 info [@kbn/logging] running [kbn:bootstrap] script
 succ [@kbn/logging] bootstrap complete
 succ [@kbn/apm-config-loader] bootstrap complete
 succ [@kbn/legacy-logging] bootstrap complete
 succ [@kbn/dev-utils] bootstrap complete
 info [@kbn/ace] running [kbn:bootstrap] script
 info [@kbn/analytics] running [kbn:bootstrap] script
 info [@kbn/config] running [kbn:bootstrap] script
 info [@kbn/es] running [kbn:bootstrap] script
 succ [@kbn/analytics] bootstrap complete
 info [@kbn/i18n] running [kbn:bootstrap] script
 succ [@kbn/es] bootstrap complete
 info [@kbn/plugin-generator] running [kbn:bootstrap] script
 succ [@kbn/ace] bootstrap complete
 info [@kbn/release-notes] running [kbn:bootstrap] script
 succ [@kbn/config] bootstrap complete
 info [@kbn/storybook] running [kbn:bootstrap] script
 succ [@kbn/release-notes] bootstrap complete
 info [@kbn/telemetry-tools] running [kbn:bootstrap] script
 succ [@kbn/i18n] bootstrap complete
 succ [@kbn/plugin-generator] bootstrap complete
 succ [@kbn/storybook] bootstrap complete
 succ [@kbn/telemetry-tools] bootstrap complete
 info [@kbn/interpreter] running [kbn:bootstrap] script
 info [@kbn/monaco] running [kbn:bootstrap] script
 succ [@kbn/interpreter] bootstrap complete
 succ [@kbn/monaco] bootstrap complete
 info [@kbn/ui-shared-deps] running [kbn:bootstrap] script
 succ [@kbn/ui-shared-deps] bootstrap complete
 info [@kbn/optimizer] running [kbn:bootstrap] script
 succ [@kbn/optimizer] bootstrap complete
 info [@kbn/plugin-helpers] running [kbn:bootstrap] script
 info [@kbn/test] running [kbn:bootstrap] script
 succ [@kbn/plugin-helpers] bootstrap complete
 succ [@kbn/test] bootstrap complete
 info [@kbn/es-archiver] running [kbn:bootstrap] script
 succ [@kbn/es-archiver] bootstrap complete
 info [kibana] running [kbn:bootstrap] script
 succ [kibana] bootstrap complete
Done in 1394.48s.
+ download_wazuh_app_sources
+ git clone https://github.com/wazuh/wazuh-kibana-app.git --branch v4.2.2-7.12.1-rc1 --depth=1 /tmp/source/plugins/wazuh
Cloning into '/tmp/source/plugins/wazuh'...
remote: Enumerating objects: 1455, done.
remote: Counting objects: 100% (1455/1455), done.
remote: Compressing objects: 100% (1237/1237), done.
remote: Total 1455 (delta 318), reused 665 (delta 155), pack-reused 0
Receiving objects: 100% (1455/1455), 3.37 MiB | 1.96 MiB/s, done.
Resolving deltas: 100% (318/318), done.
Note: switching to 'c4f1f6a128325874c45b9aa0da8b61cd002d7749'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

+ build_package
+ cd /tmp/source/plugins/wazuh
+ '[' -z 1 ']'
+ wazuh_app_pkg_name=wazuh_kibana-4.2.2_7.12.1-1.zip
+ yarn
yarn install v1.22.11
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > angular-material@1.1.18" has unmet peer dependency "angular@1.4 - 1.7.0 || ^1.7.2".
warning " > angular-material@1.1.18" has unmet peer dependency "angular-aria@1.4 - 1.7.0 || ^1.7.2".
warning " > angular-material@1.1.18" has unmet peer dependency "angular-messages@1.4 - 1.7.0 || ^1.7.2".
warning " > pug-loader@2.4.0" has unmet peer dependency "pug@^2.0.0".
warning " > react-codemirror@1.0.0" has unmet peer dependency "react@>=15.5 <16".
warning " > react-codemirror@1.0.0" has unmet peer dependency "react-dom@>=15.5 <16".
warning " > react-cookie@4.1.1" has unmet peer dependency "react@>= 16.3.0".
warning " > tslint@5.20.1" has unmet peer dependency "typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev".
warning "tslint > tsutils@2.29.0" has unmet peer dependency "typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev".
warning " > typescript-eslint-parser@18.0.0" has unmet peer dependency "typescript@*".
[4/4] Building fresh packages...
success Saved lockfile.
Done in 43.49s.
+ '[' 7.12.1 '<' 7.11.0 ']'
+ KIBANA_VERSION=7.12.1
+ yarn build
yarn run v1.22.11
$ node scripts/generate-build-version
kibana.json file has been saved with latest version number
$ yarn plugin-helpers build --kibana-version=$KIBANA_VERSION
$ node ../../scripts/plugin_helpers build --kibana-version=7.12.1
 info Loaded config file from [/tmp/source/plugins/wazuh/.kibana-plugin-helpers.json]
 info deleting the build and target directories
 info running @kbn/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ succ 1 bundles compiled successfully after 306.8 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [wazuh-7.12.1.zip]
Done in 334.29s.
+ find /tmp/source/plugins/wazuh/build -name '*.zip' -exec mv '{}' /wazuh_app/wazuh_kibana-4.2.2_7.12.1-1.zip ';'
+ '[' no = yes ']'
+ exit 0
  
  ```
  
</details>