### PR TITLE
 Remove applications SCA dir from RP; agent specs

### DIFF
--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -545,8 +545,6 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR removes the applications SCA directory from the Wazuh agent SPEC files section. This caused the following error when building the package:
```
RPM build errors:
    Directory not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.3.0-0.commit55f9741.x86_64/var/ossec/tmp/sca-4.3.0-0.commit55f9741-tmp/applications
    File not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.3.0-0.commit55f9741.x86_64/var/ossec/tmp/sca-4.3.0-0.commit55f9741-tmp/applications/*

```

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary

