### PR TITLE
Fix error with Find in CentOS 5 package building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.3.0]
 
 - Update SPECS [#689](https://github.com/wazuh/wazuh-packages/pull/689)
+- Fix `find` error in CentOS 5 building [#888](https://github.com/wazuh/wazuh-packages/pull/888)
 
 ## [v4.2.2]
 

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -67,7 +67,7 @@ cp -R wazuh-* ${build_dir}/${package_name}
 # Including spec file
 if [ "${use_local_specs}" = "no" ]; then
     curl -sL https://github.com/wazuh/wazuh-packages/tarball/${wazuh_packages_branch} | tar zx
-    specs_path=$(find . -type d -name "SPECS" -path "*rpms*")
+    specs_path=$(find ./wazuh* -type d -name "SPECS" -path "*rpms*")
 else
     specs_path="/specs"
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#887|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds a fix for an error that appeared with find when building CentOS 5 packages.
## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary

