### PR TITLE
Remove execute permissions before build the splunk package

### DIFF
--- a/splunkapp/Docker/build.sh
+++ b/splunkapp/Docker/build.sh
@@ -22,12 +22,17 @@ download_sources() {
     splunk_version=$(cat ${package_conf} | grep version -m 3 | cut -d ' ' -f 3 | head -n 3 | tail -1)
 }
 
+remove_execute_permissions() {
+    chmod -R -x+X * ./SplunkAppForWazuh/appserver
+}
 
 build_package() {
 
     download_sources
 
     cd ${build_dir}
+
+    remove_execute_permissions
 
     if [ -z ${revision} ]; then
         wazuh_splunk_pkg_name="wazuh_splunk-${wazuh_version}_${splunk_version}.tar.gz"


### PR DESCRIPTION
## Description
Hi team, this resolves:

- After publishing a new package generated by Jenkins we got this error from the `splunk-appinspect` analysis that  SplunkBase uses to determine if an app is compatible with the Splunk Cloud.
![image](https://user-images.githubusercontent.com/26828184/136402683-a61d019f-8735-430b-8108-6a42c18054a3.png)

Even running splunk-appinspect` locally.
![image](https://user-images.githubusercontent.com/26828184/136402593-9e42d3b0-acef-4a24-b8ff-dda99f19476f.png)

## Tests
Before the fix 
![image](https://user-images.githubusercontent.com/26828184/136402916-b087c88d-fb07-42af-9d5c-732f69609c62.png)


<!-- Minimum checks required -->
- [x] Build the package 
- [x] Run `splunk-inspect` 

