### PR TITLE
Re-enable disk allocation in elasticsearch templates

### DIFF
--- a/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch.yml
+++ b/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch.yml
@@ -20,7 +20,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch

--- a/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_all_in_one.yml
+++ b/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_all_in_one.yml
@@ -20,7 +20,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch

--- a/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_cluster_initial_node.yml
+++ b/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_cluster_initial_node.yml
@@ -35,7 +35,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch

--- a/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_cluster_subsequent_nodes.yml
+++ b/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_cluster_subsequent_nodes.yml
@@ -35,7 +35,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch

--- a/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_unattended.yml
+++ b/unattended_scripts/open-distro/elasticsearch/7.x/elasticsearch_unattended.yml
@@ -31,7 +31,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch

--- a/unattended_scripts/open-distro/unattended-installation/distributed/templates/elasticsearch_unattended.yml
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/templates/elasticsearch_unattended.yml
@@ -19,7 +19,6 @@ opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
-cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
 
 path.data: /var/lib/elasticsearch


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/883|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
I have removed the line
```
cluster.routing.allocation.disk.threshold_enabled: false
```
on the elasticsearch templates for the unattended scripts. This will make it go to default settings when it is installed, which are to enable the disk allocation decider. Disabling the disk allocation decider can bring problems to the installation.

## Logs example

<!--
Paste here related logs
-->

## Tests
Tested on a Debian 9 and a CentOS 7 machine and elasticsearch runs flawlessly.

