### PR TITLE
Fixed wazuh-passwords-tool.sh so it doesn't remove the password in kibana.yml [4.2]

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -262,6 +262,12 @@ changePassword() {
             echo "${conf}" > /etc/filebeat/filebeat.yml  
             restartService "filebeat"
         fi 
+
+        if [[ -n "${haskibana}" ]] && [[ -n "${kibpass}" ]]; then
+            conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
+            echo "${conf}" > /etc/kibana/kibana.yml 
+            restartService "kibana"
+        fi         
     fi
 
     if [ "$NUSER" == "kibanaserver" ] || [ -n "$CHANGEALL" ]; then

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -275,7 +275,7 @@ changePassword() {
             restartService "filebeat"
         fi 
 
-        if [ -n "${haskibana}" && -n "${kibpass}"]; then
+        if [[ -n "${haskibana}" ]] && [[ -n "${kibpass}" ]]; then
             conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
             echo "${conf}" > /etc/kibana/kibana.yml 
             restartService "kibana"

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -237,7 +237,7 @@ changePassword() {
 
         if [ "${NUSER}" == "wazuh" ]; then
             wazuhpass=${PASSWORD}
-        elif [ "${USERS[i]}" == "kibanaserver" ]; then
+        elif [ "${NUSER}" == "kibanaserver" ]; then
             kibpass=${PASSWORD}
         fi        
 
@@ -253,33 +253,36 @@ changePassword() {
             hasfilebeat=$(apt list --installed  2>/dev/null | grep filebeat)
         fi 
 
-        if [ "${SYS_TYPE}" == "yum" ]; then
-            haskibana=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch-kibana)
-        elif [ "${SYS_TYPE}" == "zypper" ]; then
-            haskibana=$(zypper packages --installed | grep opendistroforelasticsearch-kibana | grep i+)
-        elif [ "${SYS_TYPE}" == "apt-get" ]; then
-            haskibana=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch-kibana)
-        fi     
-
         wazuhold=$(grep "password:" /etc/filebeat/filebeat.yml )
         ra="  password: "
         wazuhold="${wazuhold//$ra}"
-
-        wazuhkibold=$(grep "password:" /etc/kibana/kibana.yml )
-        rk="elasticsearch.password: "
-        wazuhkibold="${wazuhkibold//$rk}"        
 
         if [ -n "${hasfilebeat}" ]; then
             conf="$(awk '{sub("  password: '${wazuhold}'", "  password: '${wazuhpass}'")}1' /etc/filebeat/filebeat.yml)"
             echo "${conf}" > /etc/filebeat/filebeat.yml  
             restartService "filebeat"
         fi 
+    fi
 
-        if [[ -n "${haskibana}" ]] && [[ -n "${kibpass}" ]]; then
-            conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
-            echo "${conf}" > /etc/kibana/kibana.yml 
-            restartService "kibana"
-        fi         
+    if [ "$NUSER" == "kibanaserver" ] || [ -n "$CHANGEALL" ]; then
+
+	    if [ "${SYS_TYPE}" == "yum" ]; then
+		    haskibana=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch-kibana)
+	    elif [ "${SYS_TYPE}" == "zypper" ]; then
+		    haskibana=$(zypper packages --installed | grep opendistroforelasticsearch-kibana | grep i+)
+	    elif [ "${SYS_TYPE}" == "apt-get" ]; then
+		    haskibana=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch-kibana)
+	    fi
+
+	    wazuhkibold=$(grep "password:" /etc/kibana/kibana.yml )
+	    rk="elasticsearch.password: "
+	    wazuhkibold="${wazuhkibold//$rk}"
+
+	    if [ -n "${haskibana}" ] && [ -n "${kibpass}" ]; then
+		    conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
+		    echo "${conf}" > /etc/kibana/kibana.yml 
+		    restartService "kibana"
+	    fi         
     fi
 
 }

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -262,12 +262,27 @@ changePassword() {
             echo "${conf}" > /etc/filebeat/filebeat.yml  
             restartService "filebeat"
         fi 
+    fi
 
-        if [[ -n "${haskibana}" ]] && [[ -n "${kibpass}" ]]; then
-            conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
-            echo "${conf}" > /etc/kibana/kibana.yml 
-            restartService "kibana"
-        fi         
+    if [ "$NUSER" == "kibanaserver" ] || [ -n "$CHANGEALL" ]; then
+
+	    if [ "${SYS_TYPE}" == "yum" ]; then
+		    haskibana=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch-kibana)
+	    elif [ "${SYS_TYPE}" == "zypper" ]; then
+		    haskibana=$(zypper packages --installed | grep opendistroforelasticsearch-kibana | grep i+)
+	    elif [ "${SYS_TYPE}" == "apt-get" ]; then
+		    haskibana=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch-kibana)
+	    fi
+
+	    wazuhkibold=$(grep "password:" /etc/kibana/kibana.yml )
+	    rk="elasticsearch.password: "
+	    wazuhkibold="${wazuhkibold//$rk}"
+
+	    if [ -n "${haskibana}" ] && [ -n "${kibpass}" ]; then
+		    conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
+		    echo "${conf}" > /etc/kibana/kibana.yml 
+		    restartService "kibana"
+	    fi         
     fi
 
     if [ "$NUSER" == "kibanaserver" ] || [ -n "$CHANGEALL" ]; then

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -283,7 +283,7 @@ changePassword() {
 		    echo "${conf}" > /etc/kibana/kibana.yml 
 		    restartService "kibana"
 	    fi         
-    fi
+   fi
 
 }
 

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -275,7 +275,7 @@ changePassword() {
             restartService "filebeat"
         fi 
 
-        if [ -n "${haskibana}" ]; then
+        if [ -n "${haskibana}" && -n "${kibpass}"]; then
             conf="$(awk '{sub("elasticsearch.password: '${wazuhkibold}'", "elasticsearch.password: '${kibpass}'")}1' /etc/kibana/kibana.yml)"
             echo "${conf}" > /etc/kibana/kibana.yml 
             restartService "kibana"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/920|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
I have changed wazuh-passwords-tool.sh so that it only changes the kibana.yml elasticsearch password if the user or one of the users changed is kibanaserver 

## Logs example

<!--
Paste here related logs
-->
![kibana_passwords](https://user-images.githubusercontent.com/61122643/137524514-1b0ec871-0a62-4d54-9e5f-07d254ec7985.png)
>



## Tests


<!-- Minimum checks required -->
Checked on CentOS 7 and Ubuntu 18