### PR TITLE
Add new functionality to wazuh-passwords-tool.sh

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -220,7 +220,7 @@ generateHash() {
 
 changePassword() {
     
-    if [[ -n "${CHANGEALL}" ]] && [[ -z "${PASSWORD}" ]]; then
+    if [ -n "${CHANGEALL}" ] && [ -z "${PASSWORD}" ]; then
         for i in "${!PASSWORDS[@]}"
         do
            awk -v new=${HASHES[i]} 'prev=="'${USERS[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
@@ -232,7 +232,7 @@ changePassword() {
             fi  
 
         done
-    elif [[ -n "${CHANGEALL}" ]] && [[ -n "${PASSWORD}" ]]; then
+    elif [ -n "${CHANGEALL}" ] && [ -n "${PASSWORD}" ]; then
         for i in "${!USERS[@]}"
         do 
             awk -v new=$HASH 'prev=="'${USERS[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
@@ -321,7 +321,7 @@ runSecurityAdmin() {
         echo "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi    
 
-    if [[ -n "${CHANGEALL}" ]] && [[ -z "${PASSWORD}" ]]; then
+    if [ -n "${CHANGEALL}" ] && [ -z "${PASSWORD}" ]; then
         
         for i in "${!USERS[@]}"
         do
@@ -412,11 +412,11 @@ main() {
             generatePassword
         fi
 
-	if [ -n "${CHANGEALL} " ]; then
+	if [ -n "${CHANGEALL}" ]; then
             readUsers
 	fi                    
 
-	if [[ -n "${CHANGEALL}" ]] && [[ -z "${PASSWORD}" ]]; then
+	if [ -n "${CHANGEALL}" ] && [ -z "${PASSWORD}" ]; then
 		generatePassword
 	fi
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/920|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

I have changed the script so you can use '-a' and '-p' parameters together and the script changes all users passwords to the password given

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
Tested on CentOS 7 and Ubuntu 18