### PR TITLE
Added function to get passwords from file in wazuh-passwords-tool.sh

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -188,7 +188,7 @@ User:
 		    supported=true
 		fi
 	    done
-	    if [ ! $supported ]; then
+	    if [ $supported = false ]; then
 	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
 	    fi
         done


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/920|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
I have added a new parameter, '-f' with which you can give a file in this format:
```
User: 
    name: Wazuh
    password: SecretPassword

User: 
    name: elasticsearch
    password: SecretPassword2
```
and the passwords of users Wazuh and elasticsearch will be changed to SecretPassword and SecretPassword2 respectively. If you  also use the argument '-a' all users will be changed to random passwords except the ones in the file, which will get the given passwords.

....

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests

Tested on Ubuntu18, CentOS7 and CentOS8