### PR TITLE
Added function to get passwords from file in wazuh-passwords-tool.sh[4.2]

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -142,6 +142,7 @@ readUsers() {
 ## Reads all the users and passwords in the given passwords file
 
 readFileUsers() {
+<<<<<<< HEAD
 
     FILECORRECT=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*\w+\s*)+\Z' $FILE)
     if [ $FILECORRECT -ne 1 ]; then
@@ -156,6 +157,8 @@ User:
 	exit 1
     fi	
 
+=======
+>>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
     SFILEUSERS=$(grep name: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
     SFILEPASSWORDS=$(grep password: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
 
@@ -168,6 +171,7 @@ User:
     fi
 
     if [ -n "${CHANGEALL}" ]; then
+<<<<<<< HEAD
         for j in "${!FILEUSERS[@]}"; do
 	    supported=false
 	    for i in "${!USERS[@]}"; do
@@ -179,23 +183,39 @@ User:
 	    if [ $supported = false ]; then
 	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
 	    fi
+=======
+        for i in "${!USERS[@]}"; do
+	    for j in "${!FILEUSERS[@]}"; do
+	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
+		    PASSWORDS[i]=${FILEPASSWORDS[j]}
+		fi
+	    done
+>>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
         done
     else
 	FINALUSERS=()
 	FINALPASSWORDS=()
 
 	for j in "${!FILEUSERS[@]}"; do
+<<<<<<< HEAD
 	    supported=false
+=======
+>>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
 	    for i in "${!USERS[@]}"; do
 	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
 		    FINALUSERS+=(${FILEUSERS[j]})
 		    FINALPASSWORDS+=(${FILEPASSWORDS[j]})
+<<<<<<< HEAD
 		    supported=true
 		fi
 	    done
             if [ $supported = false ]; then
 	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
 	    fi
+=======
+		fi
+	    done
+>>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
         done
 
 	USERS=()

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -142,6 +142,20 @@ readUsers() {
 ## Reads all the users and passwords in the given passwords file
 
 readFileUsers() {
+
+    FILECORRECT=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*\w+\s*)+\Z' $FILE)
+    if [ $FILECORRECT -ne 1 ]; then
+	echo "Error: the password file doesn't have a correct format.
+It must have this format:
+User:
+   name: wazuh
+   password: wazuhpasword
+User:
+   name: kibanaserver
+   password: kibanaserverpassword"
+	exit 1
+    fi	
+
     SFILEUSERS=$(grep name: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
     SFILEPASSWORDS=$(grep password: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
 
@@ -154,24 +168,34 @@ readFileUsers() {
     fi
 
     if [ -n "${CHANGEALL}" ]; then
-        for i in "${!USERS[@]}"; do
-	    for j in "${!FILEUSERS[@]}"; do
+        for j in "${!FILEUSERS[@]}"; do
+	    supported=false
+	    for i in "${!USERS[@]}"; do
 	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
 		    PASSWORDS[i]=${FILEPASSWORDS[j]}
+		    supported=true
 		fi
 	    done
+	    if [ $supported = false ]; then
+	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
+	    fi
         done
     else
 	FINALUSERS=()
 	FINALPASSWORDS=()
 
 	for j in "${!FILEUSERS[@]}"; do
+	    supported=false
 	    for i in "${!USERS[@]}"; do
 	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
 		    FINALUSERS+=(${FILEUSERS[j]})
 		    FINALPASSWORDS+=(${FILEPASSWORDS[j]})
+		    supported=true
 		fi
 	    done
+            if [ $supported = false ]; then
+	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
+	    fi
         done
 
 	USERS=()

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -169,39 +169,39 @@ User:
 
     if [ -n "${CHANGEALL}" ]; then
         for j in "${!FILEUSERS[@]}"; do
-	    supported=false
-	    for i in "${!USERS[@]}"; do
-	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
-		    PASSWORDS[i]=${FILEPASSWORDS[j]}
-		    supported=true
-		fi
-	    done
-	    if [ $supported = false ]; then
-	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
-	    fi
-       done
-    else
-	    FINALUSERS=()
-	    FINALPASSWORDS=()
-
-    	for j in "${!FILEUSERS[@]}"; do
-           supported=false
-	        for i in "${!USERS[@]}"; do
-	            if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
-		            FINALUSERS+=(${FILEUSERS[j]})
-		            FINALPASSWORDS+=(${FILEPASSWORDS[j]})
-		            supported=true
-		        fi
-	        done
+            supported=false
+            for i in "${!USERS[@]}"; do
+                if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
+                    PASSWORDS[i]=${FILEPASSWORDS[j]}
+                    supported=true
+                fi
+            done
             if [ $supported = false ]; then
-	            echo "Error: The given user ${FILEUSERS[j]} does not exist"
-		    fi
+                echo "Error: The given user ${FILEUSERS[j]} does not exist"
+            fi
+        done
+    else
+        FINALUSERS=()
+        FINALPASSWORDS=()
+
+        for j in "${!FILEUSERS[@]}"; do
+            supported=false
+            for i in "${!USERS[@]}"; do
+                if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
+                    FINALUSERS+=(${FILEUSERS[j]})
+                    FINALPASSWORDS+=(${FILEPASSWORDS[j]})
+                    supported=true
+                fi
+            done
+            if [ $supported = false ]; then
+                echo "Error: The given user ${FILEUSERS[j]} does not exist"
+            fi
         done
 
-	    USERS=()
-	    USERS=(${FINALUSERS[@]})
-	    PASSWORDS=(${FINALPASSWORDS[@]})
-    	CHANGEALL=1
+        USERS=()
+        USERS=(${FINALUSERS[@]})
+        PASSWORDS=(${FINALPASSWORDS[@]})
+        CHANGEALL=1
     fi
 
 }

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -142,7 +142,6 @@ readUsers() {
 ## Reads all the users and passwords in the given passwords file
 
 readFileUsers() {
-<<<<<<< HEAD
 
     FILECORRECT=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*\w+\s*)+\Z' $FILE)
     if [ $FILECORRECT -ne 1 ]; then
@@ -157,8 +156,6 @@ User:
 	exit 1
     fi	
 
-=======
->>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
     SFILEUSERS=$(grep name: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
     SFILEPASSWORDS=$(grep password: ${FILE} | awk '{ print substr( $2, 1, length($2) ) }')
 
@@ -171,7 +168,6 @@ User:
     fi
 
     if [ -n "${CHANGEALL}" ]; then
-<<<<<<< HEAD
         for j in "${!FILEUSERS[@]}"; do
 	    supported=false
 	    for i in "${!USERS[@]}"; do
@@ -183,45 +179,29 @@ User:
 	    if [ $supported = false ]; then
 	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
 	    fi
-=======
-        for i in "${!USERS[@]}"; do
-	    for j in "${!FILEUSERS[@]}"; do
-	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
-		    PASSWORDS[i]=${FILEPASSWORDS[j]}
-		fi
-	    done
->>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
-        done
+       done
     else
-	FINALUSERS=()
-	FINALPASSWORDS=()
+	    FINALUSERS=()
+	    FINALPASSWORDS=()
 
-	for j in "${!FILEUSERS[@]}"; do
-<<<<<<< HEAD
-	    supported=false
-=======
->>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
-	    for i in "${!USERS[@]}"; do
-	        if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
-		    FINALUSERS+=(${FILEUSERS[j]})
-		    FINALPASSWORDS+=(${FILEPASSWORDS[j]})
-<<<<<<< HEAD
-		    supported=true
-		fi
-	    done
+    	for j in "${!FILEUSERS[@]}"; do
+           supported=false
+	        for i in "${!USERS[@]}"; do
+	            if [[ ${USERS[i]} == ${FILEUSERS[j]} ]]; then
+		            FINALUSERS+=(${FILEUSERS[j]})
+		            FINALPASSWORDS+=(${FILEPASSWORDS[j]})
+		            supported=true
+		        fi
+	        done
             if [ $supported = false ]; then
-	        echo "Error: The given user ${FILEUSERS[j]} does not exist"
-	    fi
-=======
-		fi
-	    done
->>>>>>> cc0ad005 (Corrected array copy for password file comprobation)
+	            echo "Error: The given user ${FILEUSERS[j]} does not exist"
+		    fi
         done
 
-	USERS=()
-	USERS=(${FINALUSERS[@]})
-	PASSWORDS=(${FINALPASSWORDS[@]})
-	CHANGEALL=1
+	    USERS=()
+	    USERS=(${FINALUSERS[@]})
+	    PASSWORDS=(${FINALPASSWORDS[@]})
+    	CHANGEALL=1
     fi
 
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/920|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
I have added a new parameter, '-f' with which you can give a file in this format:
```
User: 
    name: wazuh
    password: SecretPassword

User: 
    name: elasticsearch
    password: SecretPassword2
```
and the passwords of users Wazuh and elasticsearch will be changed to SecretPassword and SecretPassword2 respectively. If you  also use the argument '-a' all users will be changed to random passwords except the ones in the file, which will get the given passwords.

....

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests

Tested on Ubuntu18, CentOS7 and CentOS8