### PR TITLE
Add ossec group to Solaris Packages

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -217,6 +217,7 @@ create_package() {
     echo "file S97wazuh-agent path=etc/rc3.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
     # Add user and group wazuh
     echo "group groupname=wazuh" >> wazuh-agent.p5m.1
+    echo "group groupname=ossec" >> wazuh-agent.p5m.1
     echo "user username=wazuh group=wazuh" >> wazuh-agent.p5m.1
     echo "user username=ossec group=ossec" >> wazuh-agent.p5m.1
     pkgmogrify -DARCH=`uname -p` wazuh-agent.p5m.1 wazuh-agent.mog | pkgfmt > wazuh-agent.p5m.2


### PR DESCRIPTION
|Related issue|
|---|
|Closes  #948|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes an error when installing 4.3.0 packages in Solaris 11
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
