### PR TITLE
Removed echo corresponding to a download link in unattended installer [stable]

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -270,7 +270,6 @@ installElasticsearch() {
         ## Create certificates
         eval "mkdir /etc/elasticsearch/certs ${debug}"
         eval "cd /etc/elasticsearch/certs ${debug}"
-        echo "${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300"
         eval "curl -so ~/wazuh-cert-tool.sh ${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300 ${debug}"
 
         echo "# Elasticsearch nodes" >> ~/instances.yml


### PR DESCRIPTION
|Related issue|
|---|
| #886 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
I removed the line 
```
 echo "${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300" 
```
in the opendistro all in one unattended installation script that printed the download link corresponding to the next line: 
```
eval "curl -so ~/wazuh-cert-tool.sh ${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300 ${debug}"
```
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->


```
[vagrant@centos7 wazuh-packages]$ sudo bash unattended_scripts/open-distro/unattended-installation/unattended-installation.sh 
Starting the installation...
Installing all necessary utilities for the installation...
Done
Adding the Wazuh repository...
Done
Installing the Wazuh manager...
Done
Wazuh-manager started
Installing Open Distro for Elasticsearch...
Done
Configuring Elasticsearch...
Configuration file found. Creating certificates...
Creating the Elasticsearch certificates...
Creating Wazuh server certificates...
Creating Kibana certificate...
Certificates creation finished. They can be found in ~/certs.
Certificates created
Elasticsearch started
Initializing Elasticsearch...
Done
Installing Filebeat...
Filebeat started
Done
Installing Open Distro for Kibana...
Kibana started
Done
Generating random passwords
Done
Creating backup...
Backup created
Generating hashes
Hashes generated
Filebeat started
Kibana started
Loading changes...
Done

The password for wazuh is kyl0DnwTJBNZJf2uOGX3D0dV8Jkhce--

The password for admin is dCdlCepCI00gAuctAiJ7orlpELK942g6

The password for kibanaserver is nxnojqIWINR4dxBpOXr41dl-QUN9V2hs

The password for kibanaro is ErjXt073INklf_NekkXbg_sa8SqpeL-3

The password for logstash is DuKK0GantHhNYw2qcM49A1Et47Gu5Nib

The password for readall is zPMnOin9jgWhAC4LKxmZaOVNrItZgQmm

The password for snapshotrestore is f1MiWTcsP_6n1QBJZvHDA3LM6LMNA5jr

The password for wazuh_admin is teUXIQXXGjF7HshypMycBV6Gl9-8ug1P

The password for wazuh_user is g_befrtQGF3hWvUJRKRrpQiJCpdMJkup

Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services.

Checking the installation...
Elasticsearch installation succeeded.
Filebeat installation succeeded.
Initializing Kibana (this may take a while)
.
Installation finished

You can access the web interface https://<kibana_ip>. The credentials are wazuh:kyl0DnwTJBNZJf2uOGX3D0dV8Jkhce--
[vagrant@centos7 wazuh-packages]$ 

```
