### PR TITLE
Removed repeated argument in getHelp method in unattended script [4.2]

### DIFF
--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
@@ -95,7 +95,6 @@ getHelp() {
    echo -e "\t-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)"
    echo -e "\t-n     | --node-name Name of the node"
    echo -e "\t-c     | --create-certificates Generates the certificates for all the indicated nodes"
-   echo -e "\t-k     | --install-kibana Install Kibana"
    echo -e "\t-p     | --elastic-password Elastic user password"
    echo -e "\t-d     | --debug Shows the complete installation output"
    echo -e "\t-i     | --ignore-health-check Ignores the health-check"

--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -88,7 +88,6 @@ getHelp() {
    echo -e "\t-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)"
    echo -e "\t-n     | --node-name Name of the node"
    echo -e "\t-c     | --create-certificates Generates the certificates for all the indicated nodes"
-   echo -e "\t-k     | --install-kibana Install Kibana"
    echo -e "\t-d     | --debug Shows the complete installation output"
    echo -e "\t-i     | --ignore-health-check Ignores the health-check"
    echo -e "\t-h     | --help Shows help"


### PR DESCRIPTION
|Related issue|
|---|
| #947 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
I have removed the repeated argument in method getHelp() of the elasticsearch distributed installer of the unattended scripts.
```
echo -e "\t-k     | --install-kibana Install Kibana"
```
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->
```
[vagrant@centos7 wazuh-packages]$ sudo bash unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh -h

Usage: unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh arguments
	-e     | --install-elasticsearch Installs Open Distro for Elasticsearch (cannot be used together with option -k)
	-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)
	-n     | --node-name Name of the node
	-c     | --create-certificates Generates the certificates for all the indicated nodes
	-p     | --elastic-password Elastic user password
	-d     | --debug Shows the complete installation output
	-i     | --ignore-health-check Ignores the health-check
	-h     | --help Shows help
[vagrant@centos7 wazuh-packages]$ 
```
```
[vagrant@centos7 wazuh-packages]$ sudo bash unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh -h

Usage: unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh arguments
	-e     | --install-elasticsearch Installs Open Distro for Elasticsearch (cannot be used together with option -k)
	-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)
	-n     | --node-name Name of the node
	-c     | --create-certificates Generates the certificates for all the indicated nodes
	-d     | --debug Shows the complete installation output
	-i     | --ignore-health-check Ignores the health-check
	-h     | --help Shows help
```