### PR TITLE
Removed usage of echo to populate instances.yml, changed for template and sed [stable]

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -272,11 +272,11 @@ installElasticsearch() {
         eval "cd /etc/elasticsearch/certs ${debug}"
         echo "${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300"
         eval "curl -so ~/wazuh-cert-tool.sh ${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300 ${debug}"
-       	eval "curl -so ~/instances.yml ${resources}/open-distro/tools/certificate-utility/instances.yml"
-	eval "grep -A 4 'Elasticsearch nodes' ~/instances.yml | sed  's/<node-name>/elasticsearch/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
-	eval "grep -A 4 'Wazuh server nodes' ~/instances.yml | sed  's/<node-name>/filebeat/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
-	eval "grep -A 4 'Kibana node' ~/instances.yml | sed  's/<node-name>/kibana/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
-	eval "mv -f ~/instances_tmp.yml ~/instances.yml"
+        eval "curl -so ~/instances.yml ${resources}/open-distro/tools/certificate-utility/instances.yml"
+        eval "grep -A 4 'Elasticsearch nodes' ~/instances.yml | sed  's/<node-name>/elasticsearch/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+        eval "grep -A 4 'Wazuh server nodes' ~/instances.yml | sed  's/<node-name>/filebeat/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+        eval "grep -A 4 'Kibana node' ~/instances.yml | sed  's/<node-name>/kibana/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+        eval "mv -f ~/instances_tmp.yml ~/instances.yml"
 
         export JAVA_HOME=/usr/share/elasticsearch/jdk/
         bash ~/wazuh-cert-tool.sh

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -272,24 +272,11 @@ installElasticsearch() {
         eval "cd /etc/elasticsearch/certs ${debug}"
         echo "${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300"
         eval "curl -so ~/wazuh-cert-tool.sh ${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300 ${debug}"
-
-        echo "# Elasticsearch nodes" >> ~/instances.yml
-        echo "elasticsearch-nodes:" >> ~/instances.yml
-        echo "- name: elasticsearch" >> ~/instances.yml
-        echo "    ip:" >> ~/instances.yml
-        echo "    - 127.0.0.1" >> ~/instances.yml
-
-        echo "# Wazuh server nodes" >> ~/instances.yml
-        echo "wazuh-servers:" >> ~/instances.yml
-        echo "- name: filebeat" >> ~/instances.yml
-        echo "    ip:" >> ~/instances.yml
-        echo "    - 127.0.0.1" >> ~/instances.yml
-
-        echo "# Kibana node"  >> ~/instances.yml
-        echo "kibana:"  >> ~/instances.yml
-        echo "- name: kibana" >> ~/instances.yml
-        echo "    ip:" >> ~/instances.yml
-        echo "    - 127.0.0.1" >> ~/instances.yml
+       	eval "curl -so ~/instances.yml ${resources}/open-distro/tools/certificate-utility/instances.yml"
+	eval "grep -A 4 'Elasticsearch nodes' ~/instances.yml | sed  's/<node-name>/elasticsearch/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+	eval "grep -A 4 'Wazuh server nodes' ~/instances.yml | sed  's/<node-name>/filebeat/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+	eval "grep -A 4 'Kibana node' ~/instances.yml | sed  's/<node-name>/kibana/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
+	eval "mv -f ~/instances_tmp.yml ~/instances.yml"
 
         export JAVA_HOME=/usr/share/elasticsearch/jdk/
         bash ~/wazuh-cert-tool.sh


### PR DESCRIPTION
|Related issue|
|---|
| #898 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

I have removed the lines that created and populated the file instances.yml in the method installElasticsearch(). Instead, a template is downloaded and its values are changed using grep and sed, in a similar way as other files are downloaded and changed in the script.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

Tested on CentOS 7 and Debian 9
The file instances.yml as left after the installation:
```
[vagrant@centos7 ~]$ sudo cat /root/instances.yml
# Elasticsearch nodes
elasticsearch-nodes:
  - name: elasticsearch
    ip:
      - 127.0.0.1
# Wazuh server nodes
wazuh-servers:
  - name: filebeat
    ip:
      - 127.0.0.1      
# Kibana node
kibana:
  - name: kibana
    ip:
      - 127.0.0.1        
[vagrant@centos7 ~]$ 

```
