### PR TITLE
Configuring wazuh cluster in the unattended installation [stable]

### DIFF
--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/templates/wazuh_config.yml
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/templates/wazuh_config.yml
@@ -1,0 +1,15 @@
+## Multi-node Wazuh cluster configuration
+
+cluster.name: <wazuh-cluster>
+
+node.type: <master|worker>
+
+master.address: <wazuh-master-address>
+
+bind.address: 0.0.0.0
+
+port: 1516
+
+hidden: no
+
+disabled: no

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
@@ -86,8 +86,7 @@ getHelp() {
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-p    | --elastic-password Elastic user password"
    echo -e "\t-d    | --debug Shows the complete installation output"
-   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a \
-wazuh_config.yml configuration file to automatically configure the wazuh cluster"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
@@ -115,7 +115,10 @@ checkConfig() {
         echo "No certificates file found."
         exit 1;
     fi
-
+    if [ -n "${clusterkey}" ] && [ ! -f ~/wazuh_config.yml ]; then
+        echo "No configuration file found for the wazuh cluster."
+        exit 1;
+    fi
 }
 
 ## Install the required packages for the installation

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
@@ -86,6 +86,8 @@ getHelp() {
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-p    | --elastic-password Elastic user password"
    echo -e "\t-d    | --debug Shows the complete installation output"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a \
+wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 
@@ -239,9 +241,34 @@ installWazuh() {
     else
         logger "Done"
     fi
-    startService "wazuh-manager"
 
 }
+   
+configureWazuh() {
+    cn=$(awk '/cluster.name:/ {print $2}' ~/wazuh_config.yml)
+    nt=$(awk '/node.type:/ {print $2}' ~/wazuh_config.yml)
+    ma=$(awk '/master.address:/ {print $2}' ~/wazuh_config.yml)
+    ba=$(awk '/bind.address:/ {print $2}' ~/wazuh_config.yml)
+    port=$(awk '/port:/ {print $2}' ~/wazuh_config.yml)
+    hidden=$(awk '/hidden:/ {print $2}' ~/wazuh_config.yml)
+    disabled=$(awk '/disabled:/ {print $2}' ~/wazuh_config.yml)
+    lstart=$(grep -n "<cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+    lend=$(grep -n "</cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+
+    eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>${cn}<\/name>/" \
+	-e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${iname}<\/node_name>/" \
+	-e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${nt}<\/node_type>/" \
+	-e "${lstart},${lend}s/<key>.*<\/key>/<key>${clusterkey}<\/key>/" \
+	-e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
+	-e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${ba}<\/bind_addr>/" \
+	-e "${lstart},${lend}s/<node>.*<\/node>/<node>${ma}<\/node>/" \
+	-e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
+	-e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
+	/var/ossec/etc/ossec.conf'
+
+    startService "wazuh-manager"
+}
+
 
 ## Filebeat
 installFilebeat() {
@@ -384,6 +411,11 @@ main() {
                 d=1
                 shift 1
                 ;;
+            "-k"|"--key")
+                clusterkey=$2
+                shift
+                shift
+                ;;
             "-h"|"--help")
                 getHelp
                 ;;
@@ -422,6 +454,9 @@ main() {
         addElasticrepo
         addWazuhrepo
         installWazuh
+        if [ -n "${clusterkey}" ]; then
+            configureWazuh
+        fi
         installFilebeat iname
         configureFilebeat iname password
     else

--- a/unattended_scripts/open-distro/unattended-installation/distributed/templates/wazuh_config.yml
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/templates/wazuh_config.yml
@@ -1,0 +1,15 @@
+## Multi-node Wazuh cluster configuration
+
+cluster.name: <wazuh-cluster>
+
+node.type: <master|worker>
+
+master.address: <wazuh-master-address>
+
+bind.address: 0.0.0.0
+
+port: 1516
+
+hidden: no
+
+disabled: no

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -104,11 +104,9 @@ checkConfig() {
         echo "No certificates file found."
         exit 1;
     fi
-    if [ -n "${clusterkey}" ]; then
-        if [ ! -f ~/wazuh_config.yml ]; then
-            echo "No configuration file found for the wazuh cluster."
-            exit 1;
-        fi
+    if [ -n "${clusterkey}" ] && [ ! -f ~/wazuh_config.yml ]; then
+        echo "No configuration file found for the wazuh cluster."
+        exit 1;
     fi
 }
 

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -87,6 +87,8 @@ getHelp() {
    echo -e "\t-i    | --ignore-healthcheck Ignores the healthcheck"
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-d    | --debug Shows the complete installation output"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a \
+wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 }
@@ -102,7 +104,7 @@ checkConfig() {
         echo "No certificates file found."
         exit 1;
     fi
-    if [ -n "${key}" ]: then
+    if [ -n "${clusterkey}" ]; then
 	if [ ! -f ~/wazuh_config.yml ]; then
  	    echo "No configuration file found for the wazuh cluster."
 	    exit 1;
@@ -175,34 +177,31 @@ installWazuh() {
     else
         logger "Done"
     fi
+}
 
-    ## Configure cluster if wazuh_config.yml is here
-    if [ -n $key ]; then
-	cn=$(awk '/cluster.name:/ {print $2}' ~/wazuh_config.yml)
-	nt=$(awk '/node.type:/ {print $2}' ~/wazuh_config.yml)
-	ma=$(awk '/master.address:/ {print $2}' ~/wazuh_config.yml)
-	ba=$(awk '/bind.address:/ {print $2}' ~/wazuh_config.yml)
-	port=$(awk '/port:/ {print $2}' ~/wazuh_config.yml)
-	hidden=$(awk '/hidden:/ {print $2}' ~/wazuh_config.yml)
-	disabled=$(awk '/disabled:/ {print $2}' ~/wazuh_config.yml)
-	lstart=$(grep -n "<cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
-        lend=$(grep -n "</cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+configureWazuh() {
+    cn=$(awk '/cluster.name:/ {print $2}' ~/wazuh_config.yml)
+    nt=$(awk '/node.type:/ {print $2}' ~/wazuh_config.yml)
+    ma=$(awk '/master.address:/ {print $2}' ~/wazuh_config.yml)
+    ba=$(awk '/bind.address:/ {print $2}' ~/wazuh_config.yml)
+    port=$(awk '/port:/ {print $2}' ~/wazuh_config.yml)
+    hidden=$(awk '/hidden:/ {print $2}' ~/wazuh_config.yml)
+    disabled=$(awk '/disabled:/ {print $2}' ~/wazuh_config.yml)
+    lstart=$(grep -n "<cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+    lend=$(grep -n "</cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
 
-        eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>${cn}<\/name>/" \
-		-e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${iname}<\/node_name>/" \
-		-e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${nt}<\/node_type>/" \
-		-e "${lstart},${lend}s/<key>.*<\/key>/<key>${key}<\/key>/" \
-		-e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
-		-e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${ba}<\/bind_addr>/" \
-		-e "${lstart},${lend}s/<node>.*<\/node>/<node>${ma}<\/node>/" \
-		-e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
-		-e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
-		/var/ossec/etc/ossec.conf'
-    fi	
-
+    eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>${cn}<\/name>/" \
+	-e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${iname}<\/node_name>/" \
+	-e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${nt}<\/node_type>/" \
+	-e "${lstart},${lend}s/<key>.*<\/key>/<key>${clusterkey}<\/key>/" \
+	-e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
+	-e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${ba}<\/bind_addr>/" \
+	-e "${lstart},${lend}s/<node>.*<\/node>/<node>${ma}<\/node>/" \
+	-e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
+	-e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
+	/var/ossec/etc/ossec.conf'
 
     startService "wazuh-manager"
-
 }
 
 ## Filebeat
@@ -346,6 +345,9 @@ main() {
         installPrerequisites
         addWazuhrepo
         installWazuh
+	if [ -n "${clusterkey}" ]; then 
+	    configureWazuh 
+	fi
         installFilebeat iname
         configureFilebeat
     else

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -105,10 +105,10 @@ checkConfig() {
         exit 1;
     fi
     if [ -n "${clusterkey}" ]; then
-	if [ ! -f ~/wazuh_config.yml ]; then
- 	    echo "No configuration file found for the wazuh cluster."
-	    exit 1;
-	fi
+        if [ ! -f ~/wazuh_config.yml ]; then
+            echo "No configuration file found for the wazuh cluster."
+            exit 1;
+        fi
     fi
 }
 
@@ -309,11 +309,11 @@ main() {
             "-h"|"--help")
                 getHelp
                 ;;
-	    "-k"|"--key")
-		clusterkey=$2
-		shift
-		shift
-		;;
+            "-k"|"--key")
+                clusterkey=$2
+                shift
+                shift
+                ;;
             *)
                 getHelp
             esac
@@ -345,9 +345,9 @@ main() {
         installPrerequisites
         addWazuhrepo
         installWazuh
-	if [ -n "${clusterkey}" ]; then 
-	    configureWazuh 
-	fi
+        if [ -n "${clusterkey}" ]; then 
+            configureWazuh 
+        fi
         installFilebeat iname
         configureFilebeat
     else

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -306,13 +306,13 @@ main() {
                 debugEnabled=1
                 shift 1
                 ;;
-            "-h"|"--help")
-                getHelp
-                ;;
             "-k"|"--key")
                 clusterkey=$2
                 shift
                 shift
+                ;;
+            "-h"|"--help")
+                getHelp
                 ;;
             *)
                 getHelp

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -87,8 +87,7 @@ getHelp() {
    echo -e "\t-i    | --ignore-healthcheck Ignores the healthcheck"
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-d    | --debug Shows the complete installation output"
-   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a \
-wazuh_config.yml configuration file to automatically configure the wazuh cluster"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 }


### PR DESCRIPTION
|Related issue|
|---|
| #866 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds the option to configure the wazuh cluster on install using a similar config file to the one used for the unattended distributed installation of elasticsearch. The template is given in the templates folder and includes all parameters to set on `ossec.conf` when the installation is finished except the key. 

The key must be passed as an argument with `-k/--key` and the usage of this argument is what tells the script it should be looking for `wazuh_config.yml` and configuring the cluster. If the argument is passed but no `wazuh_config.yml` is not found, the script will exit.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
Tests:
- OpenDistro Installation:
  - [x] CentOS 7 
  - [x] Debian 10
- Elasticsearch Installation:
  - [x] CentOS 7
  - [x] Debian 10