### PR TITLE
Configuring wazuh cluster in the unattended installation [4.2]

### DIFF
--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/templates/wazuh_config.yml
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/templates/wazuh_config.yml
@@ -1,0 +1,15 @@
+## Multi-node Wazuh cluster configuration
+
+cluster.name: <wazuh-cluster>
+
+node.type: <master|worker>
+
+master.address: <wazuh-master-address>
+
+bind.address: 0.0.0.0
+
+port: 1516
+
+hidden: no
+
+disabled: no

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
@@ -114,11 +114,9 @@ checkConfig() {
         echo "No certificates file found."
         exit 1;
     fi
-    if [ -n "${clusterkey}" ]; then
-        if [ ! -f ~/wazuh_config.yml ]; then
-            echo "No configuration file found for the wazuh cluster."
-            exit 1;
-        fi
+    if [ -n "${clusterkey}" ] &&  [ ! -f ~/wazuh_config.yml ]; then
+        echo "No configuration file found for the wazuh cluster."
+        exit 1;
     fi
 
 }

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh
@@ -86,6 +86,7 @@ getHelp() {
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-p    | --elastic-password Elastic user password"
    echo -e "\t-d    | --debug Shows the complete installation output"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 
@@ -112,6 +113,12 @@ checkConfig() {
     else
         echo "No certificates file found."
         exit 1;
+    fi
+    if [ -n "${clusterkey}" ]; then
+        if [ ! -f ~/wazuh_config.yml ]; then
+            echo "No configuration file found for the wazuh cluster."
+            exit 1;
+        fi
     fi
 
 }
@@ -239,8 +246,32 @@ installWazuh() {
     else
         logger "Done"
     fi
-    startService "wazuh-manager"
 
+}
+
+configureWazuh() {
+    cn=$(awk '/cluster.name:/ {print $2}' ~/wazuh_config.yml)
+    nt=$(awk '/node.type:/ {print $2}' ~/wazuh_config.yml)
+    ma=$(awk '/master.address:/ {print $2}' ~/wazuh_config.yml)
+    ba=$(awk '/bind.address:/ {print $2}' ~/wazuh_config.yml)
+    port=$(awk '/port:/ {print $2}' ~/wazuh_config.yml)
+    hidden=$(awk '/hidden:/ {print $2}' ~/wazuh_config.yml)
+    disabled=$(awk '/disabled:/ {print $2}' ~/wazuh_config.yml)
+    lstart=$(grep -n "<cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+    lend=$(grep -n "</cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+
+    eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>${cn}<\/name>/" \
+	-e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${iname}<\/node_name>/" \
+	-e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${nt}<\/node_type>/" \
+	-e "${lstart},${lend}s/<key>.*<\/key>/<key>${clusterkey}<\/key>/" \
+	-e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
+	-e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${ba}<\/bind_addr>/" \
+	-e "${lstart},${lend}s/<node>.*<\/node>/<node>${ma}<\/node>/" \
+	-e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
+	-e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
+	/var/ossec/etc/ossec.conf'
+
+    startService "wazuh-manager"
 }
 
 ## Filebeat
@@ -384,6 +415,11 @@ main() {
                 d=1
                 shift 1
                 ;;
+            "-k"|"--key")
+                clusterkey=$2
+                shift
+                shift
+                ;;
             "-h"|"--help")
                 getHelp
                 ;;
@@ -422,6 +458,9 @@ main() {
         addElasticrepo
         addWazuhrepo
         installWazuh
+        if [ -n "${clusterkey}" ]; then
+            configureWazuh
+        fi
         installFilebeat iname
         configureFilebeat iname password
     else

--- a/unattended_scripts/open-distro/unattended-installation/distributed/templates/wazuh_config.yml
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/templates/wazuh_config.yml
@@ -1,0 +1,15 @@
+## Multi-node Wazuh cluster configuration
+
+cluster.name: <wazuh-cluster>
+
+node.type: <master|worker>
+
+master.address: <wazuh-master-address>
+
+bind.address: 0.0.0.0
+
+port: 1516
+
+hidden: no
+
+disabled: no

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -87,6 +87,7 @@ getHelp() {
    echo -e "\t-i    | --ignore-healthcheck Ignores the healthcheck"
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-d    | --debug Shows the complete installation output"
+   echo -e "\t-k | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 }
@@ -100,6 +101,10 @@ checkConfig() {
         eval "tar --overwrite -C ~/ -xf ~/certs.tar config.yml ${debug}"
     else
         echo "No certificates file found."
+        exit 1;
+    fi
+    if [ -n "${clusterkey}" ] && [ ! -f ~/wazuh_config.yml ]; then
+        echo "No configuration file found for the wazuh cluster."
         exit 1;
     fi
 
@@ -170,8 +175,32 @@ installWazuh() {
     else
         logger "Done"
     fi
-    startService "wazuh-manager"
 
+}
+
+configureWazuh() {
+    cn=$(awk '/cluster.name:/ {print $2}' ~/wazuh_config.yml)
+    nt=$(awk '/node.type:/ {print $2}' ~/wazuh_config.yml)
+    ma=$(awk '/master.address:/ {print $2}' ~/wazuh_config.yml)
+    ba=$(awk '/bind.address:/ {print $2}' ~/wazuh_config.yml)
+    port=$(awk '/port:/ {print $2}' ~/wazuh_config.yml)
+    hidden=$(awk '/hidden:/ {print $2}' ~/wazuh_config.yml)
+    disabled=$(awk '/disabled:/ {print $2}' ~/wazuh_config.yml)
+    lstart=$(grep -n "<cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+    lend=$(grep -n "</cluster>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+
+    eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>${cn}<\/name>/" \
+	-e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${iname}<\/node_name>/" \
+	-e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${nt}<\/node_type>/" \
+	-e "${lstart},${lend}s/<key>.*<\/key>/<key>${clusterkey}<\/key>/" \
+	-e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
+	-e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${ba}<\/bind_addr>/" \
+	-e "${lstart},${lend}s/<node>.*<\/node>/<node>${ma}<\/node>/" \
+	-e "${lstart},${lend}s/<hidden>.*<\/hidden>/<hidden>${hidden}<\/hidden>/" \
+	-e "${lstart},${lend}s/<disabled>.*<\/disabled>/<disabled>${disabled}<\/disabled>/" \
+	/var/ossec/etc/ossec.conf'
+
+    startService "wazuh-manager"
 }
 
 ## Filebeat
@@ -276,6 +305,11 @@ main() {
                 debugEnabled=1
                 shift 1
                 ;;
+            "-k"|"--key")
+                clusterkey=$2
+                shift
+                shift
+                ;;
             "-h"|"--help")
                 getHelp
                 ;;
@@ -310,7 +344,10 @@ main() {
         installPrerequisites
         addWazuhrepo
         installWazuh
-        installFilebeat iname
+        if [ -n "${clusterkey}" ]; then 
+            configureWazuh 
+        fi
+        finstallFilebeat iname
         configureFilebeat
     else
         getHelp

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -87,7 +87,7 @@ getHelp() {
    echo -e "\t-i    | --ignore-healthcheck Ignores the healthcheck"
    echo -e "\t-n    | --node-name Name of the node"
    echo -e "\t-d    | --debug Shows the complete installation output"
-   echo -e "\t-k | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
+   echo -e "\t-k    | --key <wazuh-cluster-key> Use this option as well as a wazuh_config.yml configuration file to automatically configure the wazuh cluster"
    echo -e "\t-h    | --help Shows help"
    exit 1 # Exit script after printing help
 }
@@ -347,7 +347,7 @@ main() {
         if [ -n "${clusterkey}" ]; then 
             configureWazuh 
         fi
-        finstallFilebeat iname
+        installFilebeat iname
         configureFilebeat
     else
         getHelp


### PR DESCRIPTION
|Related issue|
|---|
|#866 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds the option to configure the wazuh cluster on install using a similar config file to the one used for the unattended distributed installation of elasticsearch. The template is given in the templates folder and includes all parameters to set on ossec.conf when the installation is finished except the key. The key must be passed as an argument with -k/--key and the usage of this argument is what tells the script it should be looking for wazuh_config.yml and configuring the cluster. If the argument is passed but no wazuh_config.yml is not found, the script will exit.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
Tests:
- OpenDistro Installation:
  - [x] CentOS 7 
  - [x] Debian 10
- Elasticsearch Installation:
  - [x] CentOS 7
  - [x] Debian 10