### PR TITLE
Fix missing tar as dependency in unattended-installation.sh

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -180,13 +180,13 @@ installPrerequisites() {
     logger "Installing all necessary utilities for the installation..."
 
     if [ ${sys_type} == "yum" ]; then
-        eval "yum install curl unzip wget libcap -y ${debug}"
+        eval "yum install curl unzip wget libcap tar -y ${debug}"
     elif [ ${sys_type} == "zypper" ]; then
-        eval "zypper -n install curl unzip wget ${debug}"         
+        eval "zypper -n install curl unzip wget tar ${debug}"
         eval "zypper -n install libcap-progs ${debug} || zypper -n install libcap2 ${debug}"
     elif [ ${sys_type} == "apt-get" ]; then
         eval "apt-get update -q $debug"
-        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin -y ${debug}"        
+        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin tar -y ${debug}"
     fi
 
     if [  "$?" != 0  ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-kibana-app/issues/2664|


## Description
If you run the unattended-installation.sh script on a minimal CentOS8 system, it finished without a noticeable error, but the Filebeat modules for Wazuh are not extracted since it needs tar. Problem is described in the issue above. Added tar as a required package. 


## Tests

- Run the installation script on following platforms:
 - [x] CentOS8

**Did not tested in on a zypper or apt based OS!**