### PR TITLE
Fixed wazuh-passwords-tool.sh for opensuse tumbleweed [stable]

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -114,7 +114,7 @@ checkInstalled() {
     if [ "${SYS_TYPE}" == "yum" ]; then
         elasticinstalled=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch)
     elif [ "${SYS_TYPE}" == "zypper" ]; then
-        elasticinstalled=$(zypper packages --installed | grep opendistroforelasticsearch | grep i+ | grep noarch)
+        elasticinstalled=$(zypper packages --installed-only | grep opendistroforelasticsearch | grep i+)
     elif [ "${SYS_TYPE}" == "apt-get" ]; then
         elasticinstalled=$(apt list --installed  2>/dev/null | grep 'opendistroforelasticsearch*')
     fi 
@@ -338,7 +338,7 @@ changePassword() {
         if [ "${SYS_TYPE}" == "yum" ]; then
             hasfilebeat=$(yum list installed 2>/dev/null | grep filebeat)
         elif [ "${SYS_TYPE}" == "zypper" ]; then
-            hasfilebeat=$(zypper packages --installed | grep filebeat | grep i+ | grep noarch)
+            hasfilebeat=$(zypper packages --installed-only | grep filebeat | grep i+)
         elif [ "${SYS_TYPE}" == "apt-get" ]; then
             hasfilebeat=$(apt list --installed  2>/dev/null | grep filebeat)
         fi 
@@ -358,7 +358,7 @@ changePassword() {
 	    if [ "${SYS_TYPE}" == "yum" ]; then
 		    haskibana=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch-kibana)
 	    elif [ "${SYS_TYPE}" == "zypper" ]; then
-		    haskibana=$(zypper packages --installed | grep opendistroforelasticsearch-kibana | grep i+)
+		    haskibana=$(zypper packages --installed-only | grep opendistroforelasticsearch-kibana | grep i+)
 	    elif [ "${SYS_TYPE}" == "apt-get" ]; then
 		    haskibana=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch-kibana)
 	    fi

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -435,7 +435,7 @@ checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         wazuhinstalled=$(yum list installed 2>/dev/null | grep wazuh-manager)
     elif [ "${sys_type}" == "zypper" ]; then
-        wazuhinstalled=$(zypper packages --installed | grep wazuh-manager | grep i+)
+        wazuhinstalled=$(zypper packages --installed-only | grep wazuh-manager | grep i+)
     elif [ "${sys_type}" == "apt-get" ]; then
         wazuhinstalled=$(apt list --installed  2>/dev/null | grep wazuh-manager)
     fi    
@@ -451,7 +451,7 @@ checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         elasticinstalled=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch)
     elif [ "${sys_type}" == "zypper" ]; then
-        elasticinstalled=$(zypper packages --installed | grep opendistroforelasticsearch | grep i+ | grep noarch)
+        elasticinstalled=$(zypper packages --installed-only | grep opendistroforelasticsearch | grep i+)
     elif [ "${sys_type}" == "apt-get" ]; then
         elasticinstalled=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch)
     fi 
@@ -467,7 +467,7 @@ checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         filebeatinstalled=$(yum list installed 2>/dev/null | grep filebeat)
     elif [ "${sys_type}" == "zypper" ]; then
-        filebeatinstalled=$(zypper packages --installed | grep filebeat | grep i+ | grep noarch)
+        filebeatinstalled=$(zypper packages --installed-only | grep filebeat | grep i+)
     elif [ "${sys_type}" == "apt-get" ]; then
         filebeatinstalled=$(apt list --installed  2>/dev/null | grep filebeat)
     fi 
@@ -483,7 +483,7 @@ checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         kibanainstalled=$(yum list installed 2>/dev/null | grep opendistroforelasticsearch-kibana)
     elif [ "${sys_type}" == "zypper" ]; then
-        kibanainstalled=$(zypper packages --installed | grep opendistroforelasticsearch-kibana | grep i+)
+        kibanainstalled=$(zypper packages --installed-only | grep opendistroforelasticsearch-kibana | grep i+)
     elif [ "${sys_type}" == "apt-get" ]; then
         kibanainstalled=$(apt list --installed  2>/dev/null | grep opendistroforelasticsearch-kibana)
     fi 


### PR DESCRIPTION
|Related issue|
|---|
| #916 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description
The command used in wazuh-password-tool.sh to see if OpenDistro was installed in an OpenSUSE tumbleweed used an inexistent flag:
```
zypper packages --installed
```
I changed it for 
```
zypper packages --installed-only
```
I also removed `grep noarch` in command:
```
elasticinstalled=$(zypper packages --installed | grep opendistroforelasticsearch | grep i+ | grep noarch)
```
for opendistro and filebeat as both of them are installed as x86_64 packages
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->
Log before:
![image](https://user-images.githubusercontent.com/61122643/141496841-ded50259-0a13-494a-968d-4bdc351b3343.png)
Log after:
```
opensuse:/usr/share/kibana # bash wazuh-passwords-tool.sh -a
11/12/2021 16:56:48 INFO: Generating random passwords
11/12/2021 16:56:48 INFO: Done
11/12/2021 16:56:48 INFO: Creating backup...
11/12/2021 16:56:49 ERROR: The backup could not be created
opensuse:/usr/share/kibana # zypper info opendistroforelasticsearch
Loading repository data...
Reading installed packages...


Information for package opendistroforelasticsearch:
---------------------------------------------------
Repository     : EL-20211031 - Wazuh
Name           : opendistroforelasticsearch
Version        : 1.13.2-1
Arch           : x86_64
Vendor         : Amazon
Installed Size : 0 B
Installed      : Yes
Status         : up-to-date
Source package : opendistroforelasticsearch-1.13.2-1.
Summary        : OpenDistro for Elasticsearch.  Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
Description    : 

opensuse:/usr/share/kibana # 

```
(The error comes from the installation, in 4.2 it isn't working for OpenSUSE)


## Tests
Tested on OpenSuse Tumbleweed