### PR TITLE
Bump ELK version to 7.14.2

### DIFF
--- a/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
@@ -10,7 +10,7 @@
 
 WAZUH_VER="4.2.5"
 WAZUH_REV="1"
-ELK_VER="7.12.1"
+ELK_VER="7.14.2"
 WAZUH_KIB_PLUG_REV="1"
 
 ## Check if system is based on yum or apt-get or zypper

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
@@ -11,7 +11,7 @@
 WAZUH_MAJOR="4.2"
 WAZUH_VER="4.2.5"
 WAZUH_REV="1"
-ELK_VER="7.12.1"
+ELK_VER="7.14.2"
 WAZUH_KIB_PLUG_REV="1"
 
 ## Check if system is based on yum or apt-get

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -363,7 +363,7 @@ installFilebeat() {
     else
         filebeatinstalled="1"
         eval "curl -so /etc/filebeat/filebeat.yml ${resources}/open-distro/filebeat/7.x/filebeat_unattended.yml --max-time 300  ${debug}"
-        eval "curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.0/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300 ${debug}"
+        eval "curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.2/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300 ${debug}"
         eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
         eval "curl -s '${repobaseurl}'/filebeat/wazuh-filebeat-0.1.tar.gz --max-time 300 | tar -xvz -C /usr/share/filebeat/module ${debug}"
         eval "mkdir /etc/filebeat/certs ${debug}"


### PR DESCRIPTION
This PR updates the Elasticsearch version in the unattended scripts to 7.14.2.