### PR TITLE
Fixed the logger for the unattended installer [stable]

### DIFF
--- a/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
@@ -302,6 +302,7 @@ installElasticsearch() {
             echo -ne $char
             sleep 10
         done
+        echo ""
         logger $'\nGenerating passwords...'
         passwords=$(/usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto -b)
         password=$(echo $passwords | awk 'NF{print $NF; exit}')
@@ -309,6 +310,7 @@ installElasticsearch() {
             echo -ne $char
             sleep 10
         done
+        echo ""
 
         logger "Done"
     fi
@@ -442,8 +444,10 @@ checkInstallation() {
         echo -ne $char
         sleep 10
     done
+    echo ""
     logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-    logger "$passwords"
+    passwords=$(sed $'s/Changed/\\\nChanged/g' <<< $passwords)
+    echo "$passwords"
     logger $'\nInstallation finished'
     disableRepos
     logger $'\nYou can access the web interface https://<kibana_ip>. The credentials are elastic:'$password''    

--- a/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
@@ -446,8 +446,7 @@ checkInstallation() {
     done
     echo ""
     logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-    passwords=$(sed $'s/Changed/\\\n\\\nChanged/g' <<< $passwords)
-    echo "$passwords"
+    echo -e "$passwords"
     logger $'\nInstallation finished'
     disableRepos
     logger $'\nYou can access the web interface https://<kibana_ip>. The credentials are elastic:'$password''    

--- a/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/all-in-one-installation.sh
@@ -446,7 +446,7 @@ checkInstallation() {
     done
     echo ""
     logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-    passwords=$(sed $'s/Changed/\\\nChanged/g' <<< $passwords)
+    passwords=$(sed $'s/Changed/\\\n\\\nChanged/g' <<< $passwords)
     echo "$passwords"
     logger $'\nInstallation finished'
     disableRepos

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
@@ -410,6 +410,7 @@ initializeElastic() {
             echo -ne $char
             sleep 10
         done
+        echo ""
         logger $'\nGenerating passwords...'
         passwords=$(/usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto -b)
         password=$(echo $passwords | awk 'NF{print $NF; exit}')
@@ -418,10 +419,12 @@ initializeElastic() {
             echo -ne $char
             sleep 10
         done
+        echo ""
 
         logger "Done"
         logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-        logger "$passwords"
+        passwords=$(sed $'s/Changed/\\\nChanged/g' <<< $passwords)
+        echo "$passwords"
     fi
     logger $'\nElasticsearch installation finished'
     disableRepos
@@ -524,6 +527,7 @@ initializeKibana() {
         echo -ne $char
         sleep 10
     done
+    echo ""
     sleep 10
     wip=$(grep -A 2 ${iname} ~/config.yml | tail -1)
     rw1="- "

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
@@ -423,8 +423,7 @@ initializeElastic() {
 
         logger "Done"
         logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-        passwords=$(sed $'s/Changed/\\\n\\\nChanged/g' <<< $passwords)
-        echo "$passwords"
+        echo -e "$passwords"
     fi
     logger $'\nElasticsearch installation finished'
     disableRepos

--- a/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh
@@ -423,7 +423,7 @@ initializeElastic() {
 
         logger "Done"
         logger $'\nDuring the installation of Elasticsearch the passwords for its user were generated. Please take note of them:'
-        passwords=$(sed $'s/Changed/\\\nChanged/g' <<< $passwords)
+        passwords=$(sed $'s/Changed/\\\n\\\nChanged/g' <<< $passwords)
         echo "$passwords"
     fi
     logger $'\nElasticsearch installation finished'

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -392,21 +392,21 @@ runSecurityAdmin() {
     logger "Done"
 
     if [[ -n "${NUSER}" ]] && [[ -n ${AUTOPASS} ]]; then
-        logger "The password for user '${NUSER}' is '${PASSWORD}'"
-        logger "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        echo "The password for user '${NUSER}' is '${PASSWORD}'"
+        logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi
 
     if [[ -n "${NUSER}" ]] && [[ -z ${AUTOPASS} ]]; then
-        logger "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi    
 
     if [ -n "${CHANGEALL}" ]; then
         
         for i in "${!USERS[@]}"
         do
-            logger "The password for ${USERS[i]} is ${PASSWORDS[i]}"
+            echo "The password for ${USERS[i]} is ${PASSWORDS[i]}"
         done
-        logger "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi 
 
 }

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -392,7 +392,7 @@ runSecurityAdmin() {
     logger "Done"
 
     if [[ -n "${NUSER}" ]] && [[ -n ${AUTOPASS} ]]; then
-        echo "The password for user '${NUSER}' is '${PASSWORD}'"
+        echo -e "The password for user '${NUSER}' is '${PASSWORD}'\n"
         logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi
 
@@ -404,7 +404,7 @@ runSecurityAdmin() {
         
         for i in "${!USERS[@]}"
         do
-            echo "The password for ${USERS[i]} is ${PASSWORDS[i]}"
+            echo -e "The password for ${USERS[i]} is ${PASSWORDS[i]}\n"
         done
         logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
     fi 

--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -437,6 +437,7 @@ initializeElastic() {
         echo -ne ${char}
         sleep 10
     done
+    echo ""
 
     if [ -n "${single}" ]; then
         eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
@@ -544,6 +545,7 @@ initializeKibana() {
         echo -ne ${char}
         sleep 10
     done
+    echo ""
     wip=$(grep -A 1 "Wazuh-master-configuration" ~/config.yml | tail -1)
     rm="- "
     wip="${wip//$rm}"

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -337,6 +337,7 @@ installElasticsearch() {
             echo -ne ${char}
             sleep 10
         done    
+        echo ""
 
         eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
         eval "./securityadmin.sh -cd ../securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
@@ -607,6 +608,7 @@ checkInstallation() {
         echo -ne $char
         sleep 10
     done
+    echo ""
     setWazuhUserRBACPermissions
     logger $'\nInstallation finished'
     logger $'\nYou can access the web interface https://<kibana_ip>. The credentials are wazuh:'${wazuhpass}''


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description
I have fixed the points in the unattended installer where the logger didn't work as expected. 
Firstly, in the initialization, the installer wrote some points as it waited for events. The next logger line appeared appended to the points. I added a new line with an `echo ""`. 
Secondly, in both installers, all messages for the changed passwords appeared in the same line or with the logger header. They are now printed on a different block, separated by a line, and without the logger header

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

Log before: 
```
11/15/2021 13:55:14 INFO: Starting the installation...
11/15/2021 13:55:14 INFO: Installing all necessary utilities for the installation...
11/15/2021 13:55:15 INFO: Done
11/15/2021 13:55:15 INFO: Adding the Elasticsearch repository...
11/15/2021 13:55:16 INFO: Done
11/15/2021 13:55:16 INFO: Adding the Wazuh repository...
11/15/2021 13:55:17 INFO: Done
11/15/2021 13:55:17 INFO: Installing the Wazuh manager...
11/15/2021 13:56:02 INFO: Done
11/15/2021 13:56:17 INFO: Wazuh-manager started
11/15/2021 13:56:17 INFO: Installing Elasticsearch...
11/15/2021 13:56:32 INFO: Done
11/15/2021 13:56:32 INFO: Configuring Elasticsearch...
11/15/2021 13:56:34 INFO: Certificates created
11/15/2021 13:56:49 INFO: Elasticsearch started
11/15/2021 13:56:49 INFO: Initializing Elasticsearch...(this may take a while)
.11/15/2021 13:56:59 INFO: Generating passwords...
11/15/2021 13:57:03 INFO: Done
11/15/2021 13:57:03 INFO: Installing Filebeat...
11/15/2021 13:57:09 INFO: Filebeat started
11/15/2021 13:57:09 INFO: Done
11/15/2021 13:57:09 INFO: Installing Kibana...
11/15/2021 13:58:53 INFO: Kibana started
11/15/2021 13:58:53 INFO: Done
11/15/2021 13:58:53 INFO: Checking the installation...
11/15/2021 13:58:53 INFO: Elasticsearch installation succeeded.
11/15/2021 13:58:53 INFO: Filebeat installation succeeded.
11/15/2021 13:58:53 INFO: Initializing Kibana (this may take a while)
..11/15/2021 13:59:14 INFO: During the installation of Elasticsearch, the passwords for its user were generated. Please take note of them:
11/15/2021 13:59:14 INFO: Changed password for user apm_system PASSWORD apm_system = ZJX9xS080WINs6fpekXn Changed password for user kibana_system PASSWORD kibana_system = 5h5z091iQ7JPLxU2KWkt Changed password for user kibana PASSWORD kibana = 5h5z091iQ7JPLxU2KWkt Changed password for user logstash_system PASSWORD logstash_system = wgmmmsqL5KDFDqZJ9fGd Changed password for user beats_system PASSWORD beats_system = b4FSVtPCBKTID7TdqCS8 Changed password for user remote_monitoring_user PASSWORD remote_monitoring_user = axyjSH1SFwX7sAjqOIMk Changed password for user elastic PASSWORD elastic = aNaRBbeSDUQBMnMa6XWZ
11/15/2021 13:59:14 INFO: Installation finished
11/15/2021 13:59:14 INFO: You can access the web interface https://<kibana_ip>. The credentials are elastic:aNaRBbeSDUQBMnMa6XWZ
```
Log after changes: 
```
[root@centos7 ~]# bash all-in-one-installation.sh 
11/16/2021 13:25:36 INFO: Starting the installation...
11/16/2021 13:25:36 INFO: Installing all necessary utilities for the installation...
11/16/2021 13:26:35 INFO: Done
11/16/2021 13:26:35 INFO: Adding the Elasticsearch repository...
11/16/2021 13:26:35 INFO: Done
11/16/2021 13:26:35 INFO: Adding the Wazuh repository...
11/16/2021 13:26:36 INFO: Done
11/16/2021 13:26:36 INFO: Installing the Wazuh manager...
11/16/2021 13:33:27 INFO: Done
11/16/2021 13:33:47 INFO: Wazuh-manager started
11/16/2021 13:33:47 INFO: Installing Elasticsearch...
11/16/2021 13:44:35 INFO: Done
11/16/2021 13:44:35 INFO: Configuring Elasticsearch...
11/16/2021 13:44:39 INFO: Certificates created
11/16/2021 13:44:59 INFO: Elasticsearch started
11/16/2021 13:44:59 INFO: Initializing Elasticsearch...(this may take a while)
.
11/16/2021 13:45:09 INFO: Generating passwords...

11/16/2021 13:45:15 INFO: Done
11/16/2021 13:45:15 INFO: Installing Filebeat...
11/16/2021 13:46:47 INFO: Filebeat started
11/16/2021 13:46:47 INFO: Done
11/16/2021 13:46:47 INFO: Installing Kibana...
11/16/2021 14:01:50 INFO: Kibana started
11/16/2021 14:01:50 INFO: Done
11/16/2021 14:01:50 INFO: Checking the installation...
11/16/2021 14:01:50 INFO: Elasticsearch installation succeeded.
11/16/2021 14:01:50 INFO: Filebeat installation succeeded.
11/16/2021 14:01:50 INFO: Initializing Kibana (this may take a while)
..
11/16/2021 14:02:12 INFO: During the installation of Elasticsearch the passwords for its user were generated. Please take note of them:

Changed password for user apm_system 
PASSWORD apm_system = ZLOdRmB067RjNNL1io9k 

Changed password for user kibana_system 
PASSWORD kibana_system = PDJxw8wTWkn1qimFbnmE 

Changed password for user kibana 
PASSWORD kibana = PDJxw8wTWkn1qimFbnmE 

Changed password for user logstash_system 
PASSWORD logstash_system = y3cLo7HE1gLEitarfYaJ 

Changed password for user beats_system 
PASSWORD beats_system = iUZBW0w3A8JFEAffNwqz 

Changed password for user remote_monitoring_user 
PASSWORD remote_monitoring_user = xv1UE6rvEq7jp99h6NBA 

Changed password for user elastic 
PASSWORD elastic = OYwwzLiYmJGdCr96QdE6

11/16/2021 14:02:12 INFO: Installation finished
11/16/2021 14:02:12 INFO: You can access the web interface https://<kibana_ip>. The credentials are elastic:OYwwzLiYmJGdCr96QdE6
[root@centos7 ~]# 