### PR TITLE
Fix wazuh user error in Debian packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fix `find` error in CentOS 5 building [#888](https://github.com/wazuh/wazuh-packages/pull/888)
 - Add new SCA files to Solaris 11 [#944](https://github.com/wazuh/wazuh-packages/pull/944)
 - Improved support for ppc64le on CentOS and Debian [#915](https://github.com/wazuh/wazuh-packages/pull/975)
+- Fix error with wazuh user in Debian packages [#1005](https://github.com/wazuh/wazuh-packages/pull/1005)
 
 ## [v4.2.2]
 

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -176,17 +176,17 @@ case "$1" in
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
         if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossec
+            deluser ossec > /dev/null 2>&1
         fi
         if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecm
+            deluser ossecm > /dev/null 2>&1
         fi
         if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecr
+            deluser ossecr > /dev/null 2>&1
         fi
-        delgroup ossec 
+        delgroup ossec > /dev/null 2>&1
     fi
 
     ;;

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -2,7 +2,7 @@
 # postinst script for wazuh-agent
 # Wazuh, Inc 2015-2020
 
-set -e
+set -ex
 
 case "$1" in
     configure)

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -2,7 +2,7 @@
 # postinst script for wazuh-agent
 # Wazuh, Inc 2015-2020
 
-set -ex
+set -e
 
 case "$1" in
     configure)

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -136,7 +136,25 @@ case "$1" in
             systemctl daemon-reload > /dev/null 2>&1
         fi
     fi
+    # Remove old ossec user and group if exists and change ownwership of files
 
+    if getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossec > /dev/null 2>&1
+        fi
+        if getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecm > /dev/null 2>&1
+        fi
+        if getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+            deluser ossecr > /dev/null 2>&1
+        fi
+        delgroup ossec > /dev/null 2>&1
+    fi
+    
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
@@ -168,25 +186,6 @@ case "$1" in
     # If the parent directory is empty, delete it
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
-    fi
-
-    # Remove old ossec user and group if exists and change ownwership of files
-
-    if getent group | grep -q "^ossec" ; then
-        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if getent passwd | grep -q "^ossec" ; then
-            find ${DIR} -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossec > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossecm" ; then
-            find ${DIR} -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecm > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossecr" ; then
-            find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecr > /dev/null 2>&1
-        fi
-        delgroup ossec > /dev/null 2>&1
     fi
 
     ;;

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 # postinst script for Wazuh
 # Wazuh, Inc 2015-2020
-set -e
+set -ex
 case "$1" in
     configure)
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 # postinst script for Wazuh
 # Wazuh, Inc 2015-2020
-set -ex
+set -e
 case "$1" in
     configure)
 
@@ -220,6 +220,7 @@ case "$1" in
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
+    cp ${SCRIPTS_DIR}/restore-permissions.sh ${DIR}/restore-permissions.sh
 
     # Remove old service file /etc/systemd/system/wazuh-manager.service if present
     if [ -f /etc/systemd/system/wazuh-manager.service ]; then
@@ -227,6 +228,25 @@ case "$1" in
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             systemctl daemon-reload > /dev/null 2>&1
         fi
+    fi
+
+    # Remove old ossec user and group if exists and change ownwership of files
+
+    if getent group | grep -q "^ossec" ; then
+        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        if getent passwd | grep -q "^ossec" ; then
+            find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossec > /dev/null 2>&1
+        fi
+        if getent passwd | grep -q "^ossecm" ; then
+            find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecm > /dev/null 2>&1
+        fi
+        if getent passwd | grep -q "^ossecr" ; then
+            find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            deluser ossecr > /dev/null 2>&1
+        fi
+        delgroup ossec > /dev/null 2>&1
     fi
 
     if [ ! -z "$2" ]; then
@@ -261,26 +281,7 @@ case "$1" in
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
-
-    # Remove old ossec user and group if exists and change ownwership of files
-
-    if getent group | grep -q "^ossec" ; then
-        find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
-        if getent passwd | grep -q "^ossec" ; then
-            find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossec > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossecm" ; then
-            find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossecm > /dev/null 2>&1
-        fi
-        if getent passwd | grep -q "^ossecr" ; then
-            find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossecr > /dev/null 2>&1
-        fi
-        delgroup ossec > /dev/null 2>&1
-    fi
-    
+   
     ;;
 
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -268,17 +268,17 @@ case "$1" in
         find ${DIR} -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
         if getent passwd | grep -q "^ossec" ; then
             find ${DIR} -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossec
+            deluser ossec > /dev/null 2>&1
         fi
         if getent passwd | grep -q "^ossecm" ; then
             find ${DIR} -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossecm
+            deluser ossecm > /dev/null 2>&1
         fi
         if getent passwd | grep -q "^ossecr" ; then
             find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
-            deluser ossecr
+            deluser ossecr > /dev/null 2>&1
         fi
-        delgroup ossec 
+        delgroup ossec > /dev/null 2>&1
     fi
     
     ;;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #909 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes an error with the change to the new Wazuh user in Debian packages.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
