### PR TITLE
Fixed installlation of 4.2.5 agent and manager on CentOS 8 Stream [stable]

### DIFF
--- a/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
@@ -234,7 +234,11 @@ if [ $1 = 1 ]; then
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
   # Generating osse.conf file
-  %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  if [ -n ${DIST_SUBVER} ]; then
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  else
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  fi
   chown root:ossec %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf

--- a/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
@@ -32,7 +32,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 
 %prep
 %setup -q
-
+set -x
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
 
 %build
@@ -57,6 +57,7 @@ popd
 
 %install
 # Clean BUILDROOT
+set -x
 rm -fr %{buildroot}
 
 echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
@@ -164,6 +165,7 @@ exit 0
 
 %pre
 
+set -x
 # Create the ossec group if it doesn't exists
 if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
   groupadd -r ossec
@@ -194,6 +196,7 @@ fi
 
 %post
 
+set -x
 echo "VERSION=\"$(%{_localstatedir}/bin/wazuh-control info -v)\"" > /etc/ossec-init.conf
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
@@ -344,7 +347,7 @@ fi
 chmod 0660 %{_localstatedir}/etc/ossec.conf
 
 %preun
-
+set -x
 if [ $1 = 0 ]; then
 
   # Stop the services before uninstall the package
@@ -397,7 +400,7 @@ fi
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %postun
-
+set -x
 # If the package is been uninstalled
 if [ $1 = 0 ];then
   # Remove the ossec user if it exists
@@ -424,6 +427,7 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
+set -x
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1
@@ -455,6 +459,7 @@ if [ -f %{_sysconfdir}/ossec-init.conf ]; then
 fi
 
 %clean
+set -x
 rm -fr %{buildroot}
 
 %files

--- a/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
@@ -32,7 +32,6 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 
 %prep
 %setup -q
-set -x
 ./gen_ossec.sh conf agent centos %rhel %{_localstatedir} > etc/ossec-agent.conf
 
 %build
@@ -57,7 +56,6 @@ popd
 
 %install
 # Clean BUILDROOT
-set -x
 rm -fr %{buildroot}
 
 echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
@@ -165,7 +163,6 @@ exit 0
 
 %pre
 
-set -x
 # Create the ossec group if it doesn't exists
 if command -v getent > /dev/null 2>&1 && ! getent group ossec > /dev/null 2>&1; then
   groupadd -r ossec
@@ -196,7 +193,6 @@ fi
 
 %post
 
-set -x
 echo "VERSION=\"$(%{_localstatedir}/bin/wazuh-control info -v)\"" > /etc/ossec-init.conf
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
@@ -351,7 +347,7 @@ fi
 chmod 0660 %{_localstatedir}/etc/ossec.conf
 
 %preun
-set -x
+
 if [ $1 = 0 ]; then
 
   # Stop the services before uninstall the package
@@ -404,7 +400,7 @@ fi
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %postun
-set -x
+
 # If the package is been uninstalled
 if [ $1 = 0 ];then
   # Remove the ossec user if it exists
@@ -431,7 +427,6 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
-set -x
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1
@@ -463,7 +458,6 @@ if [ -f %{_sysconfdir}/ossec-init.conf ]; then
 fi
 
 %clean
-set -x
 rm -fr %{buildroot}
 
 %files

--- a/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
@@ -233,11 +233,11 @@ if [ $1 = 1 ]; then
 
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
-  # Generating osse.conf file
-  if [ -n ${DIST_SUBVER} ]; then
-    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  else
+# Generating osse.conf file
+  if [ -z "${DIST_SUBVER}" ]; then
     %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  else
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
   fi
   chown root:ossec %{_localstatedir}/etc/ossec.conf
 

--- a/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-agent-4.2.5.spec
@@ -229,7 +229,7 @@ if [ $1 = 1 ]; then
 
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
-# Generating osse.conf file
+# Generating ossec.conf file
   if [ -z "${DIST_SUBVER}" ]; then
     %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
   else

--- a/rpms/SPECS/4.2.5/wazuh-manager-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-manager-4.2.5.spec
@@ -320,7 +320,11 @@ if [ $1 = 1 ]; then
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh
 
   # Generating ossec.conf file
-  %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  if [ -z "${DIST_SUBVER}" ]; then
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  else
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  fi
 
   touch %{_localstatedir}/logs/active-responses.log
   touch %{_localstatedir}/logs/integrations.log

--- a/rpms/SPECS/4.2.5/wazuh-manager-4.2.5.spec
+++ b/rpms/SPECS/4.2.5/wazuh-manager-4.2.5.spec
@@ -321,9 +321,9 @@ if [ $1 = 1 ]; then
 
   # Generating ossec.conf file
   if [ -z "${DIST_SUBVER}" ]; then
-    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+    %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
   else
-    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+    %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
   fi
 
   touch %{_localstatedir}/logs/active-responses.log


### PR DESCRIPTION
|Related issue|
|---|
| #1004 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When installing a package of 4.2.5 on CentOS 8 Stream, an error was displayed for a file not found. I localized that error as coming from [wazuh/gen_ossec.sh](https://github.com/wazuh/wazuh/blob/master/gen_ossec.sh), [wazuh/src/init/inst-functions.sh](https://github.com/wazuh/wazuh/blob/master/src/init/inst-functions.sh) and finally, [wazuh/src/init/template-select.sh
](https://github.com/wazuh/wazuh/blob/master/src/init/template-select.sh). A couple of templates where not found because the distribution subversion was not defined from the call to gen_ossec.sh. I added a condition so that if `DIST_SUBVER` is not defined, the call is:
```
%{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
```
instead of:
```
%{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
```
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

Installation before:
```
Last metadata expiration check: 5:27:58 ago on Tue 16 Nov 2021 12:15:15 PM AST.
wazuh-agent-4.2.5-1.x86_64.rpm                                                                                                1.1 MB/s | 6.4 MB     00:05
Dependencies resolved.
==============================================================================================================================================================
 Package                                Architecture                      Version                               Repository                               Size
==============================================================================================================================================================
Installing:
 wazuh-agent                            x86_64                            4.2.5-1                               @commandline                            6.4 M

Transaction Summary
==============================================================================================================================================================
Install  1 Package

Total size: 6.4 M
Installed size: 18 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                      1/1
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                                                                                      1/1
  Installing       : wazuh-agent-4.2.5-1.x86_64                                                                                            1/1
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                                                                                       1/1
sed: can't read ERROR_PARAM: No such file or directory
sed: can't read ERROR_PARAM: No such file or directory
sed: can't read ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory

  Verifying        : wazuh-agent-4.2.5-1.x86_64                                                                                                           1/1
Installed products updated.

Installed:
  wazuh-agent-4.2.5-1.x86_64
```
Installation after:
```
[vagrant@centos vagrant]$ sudo yum install wazuh-agent-4.2.5-1.x86_64.rpm 
Last metadata expiration check: 1:14:15 ago on Tue 23 Nov 2021 10:01:20 AM UTC.
Dependencies resolved.
=========================================================================
 Package           Architecture Version         Repository          Size
=========================================================================
Installing:
 wazuh-agent       x86_64       4.2.5-1         @commandline       6.4 M

Transaction Summary
=========================================================================
Install  1 Package

Total size: 6.4 M
Installed size: 18 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                 1/1 
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                      1/1 
  Installing       : wazuh-agent-4.2.5-1.x86_64                      1/1 
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                      1/1 
  Verifying        : wazuh-agent-4.2.5-1.x86_64                      1/1 

Installed:
  wazuh-agent-4.2.5-1.x86_64                                             

Complete!
[vagrant@centos vagrant]$ 
```


## Tests


<!-- Minimum checks required -->
- Tested creation of package in CentOS 7 and installation on CentOS 8 Stream