### PR TITLE
Fixed installlation of 4.3.0 agent and manager on CentOS 8 Stream [master]

### DIFF
--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -241,7 +241,11 @@ if [ $1 = 1 ]; then
   . %{_localstatedir}/packages_files/agent_installation_scripts/src/init/dist-detect.sh
 
   # Generating ossec.conf file
-  %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  if [ -z "${DIST_SUBVER}" ]; then
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  else
+    %{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  fi
   chown root:wazuh %{_localstatedir}/etc/ossec.conf
 
   # Add default local_files to ossec.conf

--- a/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
@@ -305,7 +305,11 @@ if [ $1 = 1 ]; then
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh
 
   # Generating ossec.conf file
-  %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  if [ -z "${DIST_SUBVER}" ]; then
+    %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  else
+    %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
+  fi  
 
   touch %{_localstatedir}/logs/active-responses.log
   touch %{_localstatedir}/logs/integrations.log


### PR DESCRIPTION
|Related issue|
|---|
| closes #1004 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When installing a wazuh-agent package of 4.2.5 on CentOS 8 Stream, an error was displayed for a file not found. I localized that error as coming from [wazuh/gen_ossec.sh](https://github.com/wazuh/wazuh/blob/master/gen_ossec.sh), [wazuh/src/init/inst-functions.sh](https://github.com/wazuh/wazuh/blob/master/src/init/inst-functions.sh) and finally, [wazuh/src/init/template-select.sh
](https://github.com/wazuh/wazuh/blob/master/src/init/template-select.sh). A couple of templates where not found because the distribution subversion was not defined from the call to gen_ossec.sh. I added a condition so that if `DIST_SUBVER` is not defined, the call is:
```
%{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
```
instead of:
```
%{_localstatedir}/packages_files/agent_installation_scripts/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
```
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

Installation before:
```
Last metadata expiration check: 5:27:58 ago on Tue 16 Nov 2021 12:15:15 PM AST.
wazuh-agent-4.2.5-1.x86_64.rpm                                                                                                1.1 MB/s | 6.4 MB     00:05
Dependencies resolved.
==============================================================================================================================================================
 Package                                Architecture                      Version                               Repository                               Size
==============================================================================================================================================================
Installing:
 wazuh-agent                            x86_64                            4.2.5-1                               @commandline                            6.4 M

Transaction Summary
==============================================================================================================================================================
Install  1 Package

Total size: 6.4 M
Installed size: 18 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                      1/1
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                                                                                      1/1
  Installing       : wazuh-agent-4.2.5-1.x86_64                                                                                            1/1
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                                                                                       1/1
sed: can't read ERROR_PARAM: No such file or directory
sed: can't read ERROR_PARAM: No such file or directory
sed: can't read ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory
cat: ERROR_PARAM: No such file or directory

  Verifying        : wazuh-agent-4.2.5-1.x86_64                                                                                                           1/1
Installed products updated.

Installed:
  wazuh-agent-4.2.5-1.x86_64
```
Installation after:
```
[vagrant@centos vagrant]$ sudo yum install wazuh-agent-4.2.5-1.x86_64.rpm 
Last metadata expiration check: 1:14:15 ago on Tue 23 Nov 2021 10:01:20 AM UTC.
Dependencies resolved.
=========================================================================
 Package           Architecture Version         Repository          Size
=========================================================================
Installing:
 wazuh-agent       x86_64       4.2.5-1         @commandline       6.4 M

Transaction Summary
=========================================================================
Install  1 Package

Total size: 6.4 M
Installed size: 18 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                 1/1 
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                      1/1 
  Installing       : wazuh-agent-4.2.5-1.x86_64                      1/1 
  Running scriptlet: wazuh-agent-4.2.5-1.x86_64                      1/1 
  Verifying        : wazuh-agent-4.2.5-1.x86_64                      1/1 

Installed:
  wazuh-agent-4.2.5-1.x86_64                                             

Complete!
[vagrant@centos vagrant]$ 
```
Testing explained in the issue