### PR TITLE
Removed cd usages in unattended installer and fixed uninstaller [4.2]

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -284,7 +284,6 @@ installElasticsearch() {
 
         ## Create certificates
         eval "mkdir /etc/elasticsearch/certs ${debug}"
-        eval "cd /etc/elasticsearch/certs ${debug}"
         eval "curl -so ~/wazuh-cert-tool.sh ${resources}/open-distro/tools/certificate-utility/wazuh-cert-tool.sh --max-time 300 ${debug}"
 	eval "curl -so ~/instances.yml ${resources}/open-distro/tools/certificate-utility/instances.yml"
 	eval "grep -A 4 'Elasticsearch nodes' ~/instances.yml | sed  's/<node-name>/elasticsearch/; s/node-IP/127.0.0.1/' >> ~/instances_tmp.yml"
@@ -326,8 +325,7 @@ installElasticsearch() {
         done    
         echo ""
 
-        eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
-        eval "./securityadmin.sh -cd ../securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
+        eval "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
         logger "Done"
         
     fi
@@ -385,7 +383,6 @@ installKibana() {
         eval "cp  /unattended_scripts/open-distro/kibana/7.x/kibana_unattended.yml /etc/kibana/kibana.yml"
         eval "mkdir /usr/share/kibana/data ${debug}"
         eval "chown -R kibana:kibana /usr/share/kibana/ ${debug}"
-        eval "cd /usr/share/kibana ${debug}"
         eval "sudo -u kibana /usr/share/kibana/bin/kibana-plugin install '${repobaseurl}'/ui/kibana/wazuh_kibana-${WAZUH_VER}_${ELK_VER}-${WAZUH_KIB_PLUG_REV}.zip ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "Wazuh Kibana plugin could not be installed."
@@ -485,7 +482,7 @@ checkInstalled() {
         fi  
     fi  
 
-    if [ -z "${wazuhinstalled}" ] || [ -z "${elasticinstalled}" ] || [ -z "${filebeatinstalled}" ] || [ -z "${kibanainstalled}" ] && [ -n "${uninstall}" ]; then 
+    if [ -z "${wazuhinstalled}" ] && [ -z "${elasticinstalled}" ] && [ -z "${filebeatinstalled}" ] && [ -z "${kibanainstalled}" ] && [ -n "${uninstall}" ]; then 
         logger -e "No Wazuh components were found on the system."
         exit 1;        
     fi


### PR DESCRIPTION
|Related issue|
|---|
| #974, #839 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
When using the debugger option on the unattended installer all commands using `cd` didn't work, as `cd` doesn't work with pipelines. I removed all of them, making sure all paths were complete and not depending on the working directory.
I also changed the condition that made the uninstaller fail. It only worked when all components were installed. Now it only needs one component to function and it uninstalls all components there are.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->
```
11/24/2021 10:08:25 INFO: Starting the installation...
11/24/2021 10:08:25 INFO: Installing all necessary utilities for the installation...
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.gadix.com
 * extras: repo.ifca.es
 * updates: repo.ifca.es
Package curl-7.29.0-59.el7_9.1.x86_64 already installed and latest version
Package unzip-6.0-22.el7_9.x86_64 already installed and latest version
Package wget-1.14-18.el7_6.1.x86_64 already installed and latest version
Package libcap-2.22-11.el7.x86_64 already installed and latest version
Nothing to do
11/24/2021 10:08:26 INFO: Done
11/24/2021 10:08:26 INFO: Adding the Wazuh repository...
[wazuh]
gpgcheck=1
gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-$releasever - Wazuh
baseurl=https://packages.wazuh.com/4.x/yum/
protect=1
11/24/2021 10:08:26 INFO: Done
11/24/2021 10:08:26 INFO: Installing the Wazuh manager...
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.gadix.com
 * extras: repo.ifca.es
 * updates: repo.ifca.es
Resolving Dependencies
There are unfinished transactions remaining. You might consider running yum-complete-transaction, or "yum-complete-transaction --cleanup-only" and "yum history redo last", first to finish them. If those don't work you'll have to try removing/installing packages by hand (maybe package-cleanup can help).
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.2.5-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch            Version            Repository      Size
================================================================================
Installing:
 wazuh-manager          x86_64          4.2.5-1            wazuh          111 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 111 M
Installed size: 427 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.2.5-1.x86_64                                 1/1 
  Verifying  : wazuh-manager-4.2.5-1.x86_64                                 1/1 

Installed:
  wazuh-manager.x86_64 0:4.2.5-1                                                

Complete!
11/24/2021 10:10:02 INFO: Done
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
11/24/2021 10:10:23 INFO: Wazuh-manager started
11/24/2021 10:10:23 INFO: Installing Open Distro for Elasticsearch...
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.gadix.com
 * extras: repo.ifca.es
 * updates: repo.ifca.es
Resolving Dependencies
There are unfinished transactions remaining. You might consider running yum-complete-transaction, or "yum-complete-transaction --cleanup-only" and "yum history redo last", first to finish them. If those don't work you'll have to try removing/installing packages by hand (maybe package-cleanup can help).
--> Running transaction check
---> Package opendistroforelasticsearch.x86_64 0:1.13.2-1 will be installed
--> Processing Dependency: elasticsearch-oss = 7.10.2 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-sql < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-security < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-reports-scheduler < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-performance-analyzer < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-knn < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-job-scheduler < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-index-management < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-asynchronous-search < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-anomaly-detection < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-alerting < 1.13.3.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-sql >= 1.13.2.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-security >= 1.13.1.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-reports-scheduler >= 1.13.0.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-performance-analyzer >= 1.13.0.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-knn >= 1.13.0.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-job-scheduler >= 1.13.0.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-index-management >= 1.13.2.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-asynchronous-search >= 1.13.0.1 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-anomaly-detection >= 1.13.0.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Processing Dependency: opendistro-alerting >= 1.13.1.0 for package: opendistroforelasticsearch-1.13.2-1.x86_64
--> Running transaction check
---> Package elasticsearch-oss.x86_64 0:7.10.2-1 will be installed
---> Package opendistro-alerting.noarch 0:1.13.1.0-1 will be installed
---> Package opendistro-anomaly-detection.noarch 0:1.13.0.0-1 will be installed
---> Package opendistro-asynchronous-search.noarch 0:1.13.0.1-1 will be installed
---> Package opendistro-index-management.noarch 0:1.13.2.0-1 will be installed
---> Package opendistro-job-scheduler.noarch 0:1.13.0.0-1 will be installed
---> Package opendistro-knn.noarch 0:1.13.0.0-1 will be installed
--> Processing Dependency: opendistro-knnlib = 1.13.0.0 for package: opendistro-knn-1.13.0.0-1.noarch
---> Package opendistro-performance-analyzer.noarch 0:1.13.0.0-1 will be installed
---> Package opendistro-reports-scheduler.noarch 0:1.13.0.0-1 will be installed
---> Package opendistro-security.noarch 0:1.13.1.0-1 will be installed
---> Package opendistro-sql.noarch 0:1.13.2.0-1 will be installed
--> Running transaction check
---> Package opendistro-knnlib.x86_64 0:1.13.0.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                             Arch       Version         Repository
                                                                           Size
================================================================================
Installing:
 opendistroforelasticsearch          x86_64     1.13.2-1        wazuh     3.2 k
Installing for dependencies:
 elasticsearch-oss                   x86_64     7.10.2-1        wazuh     220 M
 opendistro-alerting                 noarch     1.13.1.0-1      wazuh      13 M
 opendistro-anomaly-detection        noarch     1.13.0.0-1      wazuh     8.7 M
 opendistro-asynchronous-search      noarch     1.13.0.1-1      wazuh     166 k
 opendistro-index-management         noarch     1.13.2.0-1      wazuh     6.9 M
 opendistro-job-scheduler            noarch     1.13.0.0-1      wazuh     955 k
 opendistro-knn                      noarch     1.13.0.0-1      wazuh     2.7 M
 opendistro-knnlib                   x86_64     1.13.0.0-1      wazuh     545 k
 opendistro-performance-analyzer     noarch     1.13.0.0-1      wazuh      62 M
 opendistro-reports-scheduler        noarch     1.13.0.0-1      wazuh     5.2 M
 opendistro-security                 noarch     1.13.1.0-1      wazuh      38 M
 opendistro-sql                      noarch     1.13.2.0-1      wazuh      15 M

Transaction Summary
================================================================================
Install  1 Package (+12 Dependent packages)

Total download size: 373 M
Installed size: 571 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              2.8 MB/s | 373 MB  02:14     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Creating elasticsearch group... OK
Creating elasticsearch user... OK
  Installing : elasticsearch-oss-7.10.2-1.x86_64                           1/13 
### NOT starting on installation, please execute the following statements to configure elasticsearch service to start automatically using systemd
 sudo systemctl daemon-reload
 sudo systemctl enable elasticsearch.service
### You can start elasticsearch service by executing
 sudo systemctl start elasticsearch.service
  Installing : opendistro-index-management-1.13.2.0-1.noarch               2/13 
  Installing : opendistro-alerting-1.13.1.0-1.noarch                       3/13 
  Installing : opendistro-performance-analyzer-1.13.0.0-1.noarch           4/13 
# Enabling opendistro performance analyzer to start and stop along with elasticsearch.service
  Installing : opendistro-sql-1.13.2.0-1.noarch                            5/13 
  Installing : opendistro-asynchronous-search-1.13.0.1-1.noarch            6/13 
  Installing : opendistro-anomaly-detection-1.13.0.0-1.noarch              7/13 
  Installing : opendistro-security-1.13.1.0-1.noarch                       8/13 
OpenDistro for Elasticsearch Security Demo Installer
 ** Warning: Do not use on production or public reachable systems **
Basedir: /usr/share/elasticsearch
This script maybe require your root password for 'sudo' privileges
Elasticsearch install type: rpm/deb on CentOS Linux release 7.9.2009 (Core)
Elasticsearch config dir: /etc/elasticsearch
Elasticsearch config file: /etc/elasticsearch/elasticsearch.yml
Elasticsearch bin dir: /usr/share/elasticsearch/bin
Elasticsearch plugins dir: /usr/share/elasticsearch/plugins
Elasticsearch lib dir: /usr/share/elasticsearch/lib
Detected Elasticsearch Version: x-content-7.10.2
Detected Open Distro Security Version: 1.13.1.0

### Success
### Execute this script now on all your nodes and then start all nodes
### Open Distro Security will be automatically initialized.
### If you like to change the runtime configuration 
### change the files in ../securityconfig and execute: 
sudo "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh" -cd "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig" -icl -key "/etc/elasticsearch/kirk-key.pem" -cert "/etc/elasticsearch/kirk.pem" -cacert "/etc/elasticsearch/root-ca.pem" -nhnv
### or run ./securityadmin_demo.sh
### To use the Security Plugin ConfigurationGUI
### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/admin.
### (Ignore the SSL certificate warning because we installed self-signed demo certificates)
  Installing : opendistro-reports-scheduler-1.13.0.0-1.noarch              9/13 
  Installing : opendistro-job-scheduler-1.13.0.0-1.noarch                 10/13 
  Installing : opendistro-knnlib-1.13.0.0-1.x86_64                        11/13 
  Installing : opendistro-knn-1.13.0.0-1.noarch                           12/13 
  Installing : opendistroforelasticsearch-1.13.2-1.x86_64                 13/13 
Created elasticsearch keystore in /etc/elasticsearch/elasticsearch.keystore
  Verifying  : opendistro-index-management-1.13.2.0-1.noarch               1/13 
  Verifying  : opendistro-knn-1.13.0.0-1.noarch                            2/13 
  Verifying  : opendistro-knnlib-1.13.0.0-1.x86_64                         3/13 
  Verifying  : opendistro-alerting-1.13.1.0-1.noarch                       4/13 
  Verifying  : opendistro-performance-analyzer-1.13.0.0-1.noarch           5/13 
  Verifying  : opendistro-sql-1.13.2.0-1.noarch                            6/13 
  Verifying  : elasticsearch-oss-7.10.2-1.x86_64                           7/13 
  Verifying  : opendistroforelasticsearch-1.13.2-1.x86_64                  8/13 
  Verifying  : opendistro-asynchronous-search-1.13.0.1-1.noarch            9/13 
  Verifying  : opendistro-anomaly-detection-1.13.0.0-1.noarch             10/13 
  Verifying  : opendistro-security-1.13.1.0-1.noarch                      11/13 
  Verifying  : opendistro-reports-scheduler-1.13.0.0-1.noarch             12/13 
  Verifying  : opendistro-job-scheduler-1.13.0.0-1.noarch                 13/13 

Installed:
  opendistroforelasticsearch.x86_64 0:1.13.2-1                                  

Dependency Installed:
  elasticsearch-oss.x86_64 0:7.10.2-1                                           
  opendistro-alerting.noarch 0:1.13.1.0-1                                       
  opendistro-anomaly-detection.noarch 0:1.13.0.0-1                              
  opendistro-asynchronous-search.noarch 0:1.13.0.1-1                            
  opendistro-index-management.noarch 0:1.13.2.0-1                               
  opendistro-job-scheduler.noarch 0:1.13.0.0-1                                  
  opendistro-knn.noarch 0:1.13.0.0-1                                            
  opendistro-knnlib.x86_64 0:1.13.0.0-1                                         
  opendistro-performance-analyzer.noarch 0:1.13.0.0-1                           
  opendistro-reports-scheduler.noarch 0:1.13.0.0-1                              
  opendistro-security.noarch 0:1.13.1.0-1                                       
  opendistro-sql.noarch 0:1.13.2.0-1                                            

Complete!
11/24/2021 10:12:50 INFO: Done
11/24/2021 10:12:50 INFO: Configuring Elasticsearch...
11/24/2021 10:12:53 INFO: Configuration file found. Creating certificates...
11/24/2021 10:12:53 INFO: Creating the Elasticsearch certificates...
11/24/2021 10:12:53 INFO: Creating Wazuh server certificates...
11/24/2021 10:12:54 INFO: Creating Kibana certificate...
11/24/2021 10:12:54 INFO: Certificates creation finished. They can be found in ~/certs.
11/24/2021 10:12:54 INFO: Certificates created
-> removing [opendistro-performance-analyzer]...
Created symlink from /etc/systemd/system/multi-user.target.wants/elasticsearch.service to /usr/lib/systemd/system/elasticsearch.service.
11/24/2021 10:13:10 INFO: Elasticsearch started
11/24/2021 10:13:10 INFO: Initializing Elasticsearch...

Open Distro Security Admin v7
Will connect to localhost:9300 ... done
Connected as CN=admin,OU=Docu,O=Wazuh,L=California,C=US
Elasticsearch Version: 7.10.2
Open Distro Security Version: 1.13.1.0
Contacting elasticsearch cluster 'elasticsearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/
Will update '_doc/config' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
11/24/2021 10:13:21 INFO: Done
11/24/2021 10:13:21 INFO: Installing Filebeat...
There are unfinished transactions remaining. You might consider running yum-complete-transaction, or "yum-complete-transaction --cleanup-only" and "yum history redo last", first to finish them. If those don't work you'll have to try removing/installing packages by hand (maybe package-cleanup can help).
wazuh/
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
11/24/2021 10:13:36 INFO: Filebeat started
11/24/2021 10:13:36 INFO: Done
11/24/2021 10:13:36 INFO: Installing Open Distro for Kibana...
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.gadix.com
 * extras: repo.ifca.es
 * updates: repo.ifca.es
Resolving Dependencies
There are unfinished transactions remaining. You might consider running yum-complete-transaction, or "yum-complete-transaction --cleanup-only" and "yum history redo last", first to finish them. If those don't work you'll have to try removing/installing packages by hand (maybe package-cleanup can help).
--> Running transaction check
---> Package opendistroforelasticsearch-kibana.x86_64 0:1.13.2-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                               Arch       Version       Repository
                                                                           Size
================================================================================
Installing:
 opendistroforelasticsearch-kibana     x86_64     1.13.2-1      wazuh     224 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 224 M
Installed size: 660 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : opendistroforelasticsearch-kibana-1.13.2-1.x86_64            1/1 
chown: cannot access ‘/usr/share/kibana/optimize’: No such file or directory
no optimize folder
  Verifying  : opendistroforelasticsearch-kibana-1.13.2-1.x86_64            1/1 

Installed:
  opendistroforelasticsearch-kibana.x86_64 0:1.13.2-1                           

Complete!
Attempting to transfer from https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.2.5_7.10.2-1.zip
Transferring 32888474 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete
11/24/2021 10:16:16 INFO: Kibana started
11/24/2021 10:16:16 INFO: Done
11/24/2021 10:16:18 INFO: Generating random passwords
11/24/2021 10:16:18 INFO: Done
11/24/2021 10:16:18 INFO: Creating backup...
Open Distro Security Admin v7
Will connect to localhost:9300 ... done
Connected as CN=admin,OU=Docu,O=Wazuh,L=California,C=US
Elasticsearch Version: 7.10.2
Open Distro Security Version: 1.13.1.0
Contacting elasticsearch cluster 'elasticsearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '_doc/config' into /usr/share/elasticsearch/backup/config.yml 
   SUCC: Configuration for 'config' stored in /usr/share/elasticsearch/backup/config.yml
Will retrieve '_doc/roles' into /usr/share/elasticsearch/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /usr/share/elasticsearch/backup/roles.yml
Will retrieve '_doc/rolesmapping' into /usr/share/elasticsearch/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /usr/share/elasticsearch/backup/roles_mapping.yml
Will retrieve '_doc/internalusers' into /usr/share/elasticsearch/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /usr/share/elasticsearch/backup/internal_users.yml
Will retrieve '_doc/actiongroups' into /usr/share/elasticsearch/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /usr/share/elasticsearch/backup/action_groups.yml
Will retrieve '_doc/tenants' into /usr/share/elasticsearch/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /usr/share/elasticsearch/backup/tenants.yml
Will retrieve '_doc/nodesdn' into /usr/share/elasticsearch/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /usr/share/elasticsearch/backup/nodes_dn.yml
Will retrieve '_doc/whitelist' into /usr/share/elasticsearch/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /usr/share/elasticsearch/backup/whitelist.yml
Will retrieve '_doc/audit' into /usr/share/elasticsearch/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /usr/share/elasticsearch/backup/audit.yml
11/24/2021 10:16:28 INFO: Backup created
11/24/2021 10:16:28 INFO: Generating hashes
11/24/2021 10:16:38 INFO: Hashes generated
11/24/2021 10:16:39 INFO: Filebeat started
11/24/2021 10:16:39 INFO: Kibana started
11/24/2021 10:16:39 INFO: Loading changes...
Open Distro Security Admin v7
Will connect to localhost:9300 ... done
Connected as CN=admin,OU=Docu,O=Wazuh,L=California,C=US
Elasticsearch Version: 7.10.2
Open Distro Security Version: 1.13.1.0
Contacting elasticsearch cluster 'elasticsearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/elasticsearch/plugins/opendistro_security/securityconfig
Will update '_doc/config' with ../securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with ../securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with ../securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with ../securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with ../securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with ../securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with ../securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with ../securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with ../securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
11/24/2021 10:16:51 INFO: Done
The password for wazuh is CtBZy-aczZ0zdAtRm011dsfKxK2TJXNE

The password for admin is b1KE6CXo6ky68hotNegUCTs4vpY5v7HT

The password for kibanaserver is bNWQOL4TpFFaaCXvlxppqSDgyLNJyvaw

The password for kibanaro is dlbhkqufTS1HBAkq8MiJyBg3HnBCt535

The password for logstash is pqU1TkswpgiriapES7HFm4NmsKxWS3ap

The password for readall is SaH2B4jrI7jdDlWOz3Qwp8zV8IjrDOU1

The password for snapshotrestore is L8PsAO9eltMqG9x_OwRk7lrVN2hn0s1w

The password for wazuh_admin is oiF5vEhjbIamQogtI7tSaK5SGUGTc3CB

The password for wazuh_user is a2P1faMwn9OkqtWsQD5y5kp81jBxq6Lj

11/24/2021 10:16:51 WARNING: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services.
11/24/2021 10:16:51 INFO: Checking the installation...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   528  100   528    0     0   1064      0 --:--:-- --:--:-- --:--:--  1066
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "kRq6fHIxQs2CFOFP6z8NcQ",
  "version" : {
    "number" : "7.10.2",
    "build_flavor" : "oss",
    "build_type" : "rpm",
    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
    "build_date" : "2021-01-13T00:42:12.435326Z",
    "build_snapshot" : false,
    "lucene_version" : "8.7.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
11/24/2021 10:16:51 INFO: Elasticsearch installation succeeded.
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
11/24/2021 10:16:52 INFO: Filebeat installation succeeded.
11/24/2021 10:16:52 INFO: Initializing Kibana (this may take a while)
.
{
   "data": {
      "affected_items": [
         {
            "id": 100,
            "name": "wazuh_rbac",
            "rule": {
               "FIND": {
                  "user_name": "wazuh"
               }
            },
            "roles": []
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Security rule was successfully created",
   "error": 0
}{
   "data": {
      "affected_items": [
         {
            "id": 1,
            "name": "administrator",
            "policies": [
               1,
               2,
               3,
               6,
               7,
               8,
               29,
               30,
               12,
               14,
               15,
               18,
               19,
               21,
               23,
               24,
               16,
               25,
               27,
               28,
               33,
               34,
               35
            ],
            "users": [
               1,
               2
            ],
            "rules": [
               1,
               2,
               100
            ]
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All security rules were linked to role 1",
   "error": 0
}11/24/2021 10:17:03 INFO: Installation finished
11/24/2021 10:17:03 INFO: You can access the web interface https://<kibana_ip>. The credentials are wazuh:CtBZy-aczZ0zdAtRm011dsfKxK2TJXNE
```

## Tests
Tested with and without debug in centos 7 and debian 9