### PR TITLE
Removed warning and added text in wazuh-passwords-tool.sh final message [master]

### DIFF
--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -393,11 +393,11 @@ runSecurityAdmin() {
 
     if [[ -n "${NUSER}" ]] && [[ -n ${AUTOPASS} ]]; then
         echo -e "The password for user '${NUSER}' is '${PASSWORD}'\n"
-        logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
     fi
 
     if [[ -n "${NUSER}" ]] && [[ -z ${AUTOPASS} ]]; then
-        logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
     fi    
 
     if [ -n "${CHANGEALL}" ]; then
@@ -406,7 +406,7 @@ runSecurityAdmin() {
         do
             echo -e "The password for ${USERS[i]} is ${PASSWORDS[i]}\n"
         done
-        logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services."
+        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
     fi 
 
 }

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -393,11 +393,11 @@ runSecurityAdmin() {
 
     if [[ -n "${NUSER}" ]] && [[ -n ${AUTOPASS} ]]; then
         echo -e "The password for user '${NUSER}' is '${PASSWORD}'\n"
-        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
+        logger "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password"
     fi
 
     if [[ -n "${NUSER}" ]] && [[ -z ${AUTOPASS} ]]; then
-        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
+        logger "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password"
     fi    
 
     if [ -n "${CHANGEALL}" ]; then
@@ -406,7 +406,7 @@ runSecurityAdmin() {
         do
             echo -e "The password for ${USERS[i]} is ${PASSWORDS[i]}\n"
         done
-        logger "Password changed. If this was executed in a distributed architecture remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml and restart the services. For more information: https://documentation.wazuh.com."
+        logger "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password"
     fi 
 
 }


### PR DESCRIPTION
|Related issue|
|---|
| closes #1015 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
I changed the wazuh-passwords-tool call to the logger and message so that the last message is not:
```
11/25/2021 08:21:34 WARNING: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services.
```
but:
```
11/25/2021 08:21:34 INFO: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password
```


## Logs example

<!--
Paste here related logs
-->

```
[vagrant@centos7 wazuh-packages]$ sudo bash unattended_scripts/tools/wazuh-passwords-tool.sh -a
11/25/2021 15:53:11 INFO: Generating random passwords
11/25/2021 15:53:11 INFO: Done
11/25/2021 15:53:11 INFO: Creating backup...
11/25/2021 15:53:17 INFO: Backup created
11/25/2021 15:53:17 INFO: Generating hashes
11/25/2021 15:53:26 INFO: Hashes generated
11/25/2021 15:53:27 INFO: Filebeat started
11/25/2021 15:53:27 INFO: Kibana started
11/25/2021 15:53:27 INFO: Loading changes...
11/25/2021 15:53:37 INFO: Done

11/25/2021 15:53:37 INFO: The password for wazuh is KT0gyzO06952HtMsXB9QEpI9zqaL2Wwz

11/25/2021 15:53:37 INFO: The password for admin is IDNKsgvo3wf2CCpK6Ae8WkB2jn9r4TcH

11/25/2021 15:53:37 INFO: The password for kibanaserver is NRr9DLaxDt2guOO-s7ZIUDzWCpkpdSsN

11/25/2021 15:53:37 INFO: The password for kibanaro is HgxjmUjZOCxJIHr5QZ_AscM3bmyCpZZm

11/25/2021 15:53:37 INFO: The password for logstash is 3ZA9aYEMkSJoHmEJ5OeEHX3uumHA_v8_

11/25/2021 15:53:37 INFO: The password for readall is ib10dcLXPW4SxsaGldWuSVLNh-4xt9Md

11/25/2021 15:53:37 INFO: The password for snapshotrestore is VD8EJwiTaEF6baTLiGC9QTwqw396Jk1Y

11/25/2021 15:53:37 INFO: The password for wazuh_admin is _MEohHGgJ4uvYr5NuPCd27j6hifkcXWU

11/25/2021 15:53:37 INFO: The password for wazuh_user is _7g-_c2Gtn84_GK9V-vbGjMUk7-UTP7O

11/25/2021 15:53:37 INFO: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password


[vagrant@centos7 wazuh-packages]$ 

```

## Tests


<!-- Minimum checks required -->
Tested on centos7 and debian9