### PR TITLE
Unattended changes the login screen in kibana [unified]

### DIFF
--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -81,23 +81,6 @@ preInstall() {
 
 }
 
-# Edit wazuh installation
-postInstall() {
-
-  # Edit window title
-  sed -i "s/null, \"Elastic\"/null, \"Wazuh\"/g" /usr/share/kibana/src/core/server/rendering/views/template.js
-
-  curl -so ${CUSTOM_PATH}/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz
-  tar -xf ${CUSTOM_PATH}/custom_welcome.tar.gz -C ${CUSTOM_PATH}
-  cp ${CUSTOM_PATH}/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/
-  cp ${CUSTOM_PATH}/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/
-  cp ${CUSTOM_PATH}/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs
-
-  # Add custom css in kibana
-  less ${CUSTOM_PATH}/customWelcomeKibana.css >> /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css
-
-}
-
 clean() {
 
   rm /securityadmin_demo.sh

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -29,7 +29,4 @@ sh ${UNATTENDED_PATH}/${INSTALLER}
 systemctl stop kibana filebeat elasticsearch
 systemctl enable wazuh-manager
 
-# Edit installation 
-postInstall
-
 clean

--- a/unattended_scripts/config/opendistro/kibana/customWelcomeKibana.css
+++ b/unattended_scripts/config/opendistro/kibana/customWelcomeKibana.css
@@ -1,0 +1,65 @@
+/*------------- WAZUH -------------*/
+.wz-login {
+  background: url(./wazuh_wazuh_bg.svg) !important;
+  width: 100% !important;
+  height: 100% !important;
+  background-size: cover !important;
+}
+
+.login-wrapper {
+  text-align: center;
+  width: 430px!important;
+  top: 55px;
+  border-radius: 1px;
+  padding: 1em;
+}
+
+#kibana-body > div > div.app-wrapper.hidden-chrome > div > div.application > div > ul > div.euiText.euiText--medium > div {
+  text-align: center;
+  padding-bottom: 10px;
+  color: #ffffff !important;
+  font-size: 35px !important;
+  font-weight: 300;
+}
+
+#kibana-body > div > div.app-wrapper.hidden-chrome > div > div.application > div > ul > div.euiText.euiText--small > div {
+  text-align: center;
+  padding-bottom: 15px;
+  color: #ffffff !important;
+  font-size: 16px !important;
+}
+
+#kibana-body > div > div.app-wrapper.hidden-chrome > div > div.application > div > ul > form {
+  padding: 16px;
+  box-shadow: 0 2px 2px -1px rgba(152, 162, 179, 0.3), 0 1px 5px -2px rgba(152, 162, 179, 0.3);
+  background-color: #FFF;
+  border: 1px solid #D3DAE6;
+  border-radius: 4px;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  margin-top: 32px;
+}
+
+.loginWelcome__logo {
+  display: inline-block;
+  width: 80px;
+  height: 80px;
+  line-height: 80px;
+  text-align: center;
+  background-color: #FFF;
+  border-radius: 100%;
+  padding: 16px;
+  box-shadow: 0 6px 12px -1px rgba(152, 162, 179, 0.2), 0 4px 4px -1px rgba(152, 162, 179, 0.2), 0 2px 2px 0 rgba(152, 162, 179, 0.2);
+  margin-bottom: 32px;
+}
+
+div.euiFormRow > div.euiFormRow__fieldWrapper > button {
+  background-color: #00a9e5!important;
+  border-color: #00a9e5!important;
+  color: #fff;
+}
+
+.loginWelcome__logo {
+  background: url(./wazuh_logo_circle.svg) center center no-repeat !important;
+}

--- a/unattended_scripts/install_functions/opendistro/kibana.sh
+++ b/unattended_scripts/install_functions/opendistro/kibana.sh
@@ -44,15 +44,7 @@ configureKibanaAIO() {
     eval "chmod 440 /etc/kibana/certs/kibana* ${debug}"
     eval "setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node ${debug}"
 
-    # Edit window title
-    eval "sed -i 's/null, \"Elastic\"/null, \"Wazuh\"/g' /usr/share/kibana/src/core/server/rendering/views/template.js ${debug}"
-    eval "curl -so ~/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz ${debug}"
-    eval "tar -xf ~/custom_welcome.tar.gz -C ~ ${debug}"
-    eval "cp ~/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
-    eval "cp ~/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
-    eval "cp -f ~/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs ${debug}"
-    eval "curl -so ~/customWelcomeKibana.css ${resources}/open-distro/kibana/customWelcomeKibana.css ${debug}"
-    eval "cat ~/customWelcomeKibana.css | tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css ${debug}"
+    modifyKibanaLogin
     
     # Start Kibana
     startService "kibana"
@@ -97,16 +89,8 @@ configureKibana() {
     
     logger "Kibana installed."
 
-    # Edit window title
-    eval "sed -i 's/null, \"Elastic\"/null, \"Wazuh\"/g' /usr/share/kibana/src/core/server/rendering/views/template.js ${debug}"
-    eval "curl -so ~/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz ${debug}"
-    eval "tar -xf ~/custom_welcome.tar.gz -C ~ ${debug}"
-    eval "cp ~/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
-    eval "cp ~/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
-    eval "cp -f ~/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs ${debug}"
-    eval "curl -so ~/customWelcomeKibana.css ${resources}/open-distro/kibana/customWelcomeKibana.css ${debug}"
-    eval "cat ~/customWelcomeKibana.css | tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css ${debug}"
-    
+    modifyKibanaLogin
+
     copyKibanacerts
     eval "chown -R kibana:kibana /etc/kibana/ ${debug}"
     eval "chmod -R 500 /etc/kibana/certs ${debug}"
@@ -143,4 +127,18 @@ initializeKibana() {
     echo "${conf}" > /usr/share/kibana/data/wazuh/config/wazuh.yml  
     logger $'\nYou can access the web interface https://'${kip}'. The credentials are admin:admin'    
 
+}
+
+modifyKibanaLogin() {
+    # Edit window title
+    eval "sed -i 's/null, \"Elastic\"/null, \"Wazuh\"/g' /usr/share/kibana/src/core/server/rendering/views/template.js ${debug}"
+
+    # Edit background and logos
+    eval "curl -so ~/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz ${debug}"
+    eval "tar -xf ~/custom_welcome.tar.gz -C ~ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp -f ~/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs ${debug}"
+    eval "curl -so ~/customWelcomeKibana.css ${resources}/open-distro/kibana/customWelcomeKibana.css ${debug}"
+    eval "cat ~/customWelcomeKibana.css | tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css ${debug}"
 }

--- a/unattended_scripts/install_functions/opendistro/kibana.sh
+++ b/unattended_scripts/install_functions/opendistro/kibana.sh
@@ -37,6 +37,16 @@ configureKibanaAIO() {
     eval "chmod 440 /etc/kibana/certs/kibana* ${debug}"
     eval "setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node ${debug}"
 
+    # Edit window title
+    eval "sed -i 's/null, \"Elastic\"/null, \"Wazuh\"/g' /usr/share/kibana/src/core/server/rendering/views/template.js ${debug}"
+    eval "curl -so ~/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz ${debug}"
+    eval "tar -xf ~/custom_welcome.tar.gz -C ~ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp -f ~/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs ${debug}"
+    eval "curl -so ~/customWelcomeKibana.css ${resources}/open-distro/kibana/customWelcomeKibana.css ${debug}"
+    eval "cat ~/customWelcomeKibana.css | tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css ${debug}"
+    
     # Start Kibana
     startService "kibana"
 }
@@ -80,6 +90,16 @@ configureKibana() {
     
     logger "Kibana installed."
 
+    # Edit window title
+    eval "sed -i 's/null, \"Elastic\"/null, \"Wazuh\"/g' /usr/share/kibana/src/core/server/rendering/views/template.js ${debug}"
+    eval "curl -so ~/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz ${debug}"
+    eval "tar -xf ~/custom_welcome.tar.gz -C ~ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_logo_circle.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp ~/custom_welcome/wazuh_wazuh_bg.svg /usr/share/kibana/src/core/server/core_app/assets/ ${debug}"
+    eval "cp -f ~/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs ${debug}"
+    eval "curl -so ~/customWelcomeKibana.css ${resources}/open-distro/kibana/customWelcomeKibana.css ${debug}"
+    eval "cat ~/customWelcomeKibana.css | tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css ${debug}"
+    
     copyKibanacerts
     initializeKibana kip
 }


### PR DESCRIPTION
|Related issue|
|---|
| closes #943 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Before starting the kibana service we use the same code used previously in the ova to change the kibana interface parameters and files. When kibana is started, the wazuh logo is shown, instead of the opendistro one.


## Logs example

<!--
Paste here related logs
-->

## Tests
Login screen after all-in-one installation in centos 7:
![custom_login_centos7](https://user-images.githubusercontent.com/61122643/145027494-a3354fad-c225-49b0-b4e9-7835417119b8.png)

The all-in-one installation runs correctly in Centos 7 and debian 9
