### PR TITLE
Fix filebeat local install unify unattended

### DIFF
--- a/unattended_scripts/install_functions/opendistro/common.sh
+++ b/unattended_scripts/install_functions/opendistro/common.sh
@@ -3,9 +3,9 @@ repobaseurl="https://packages.wazuh.com/4.x"
 
 getConfig() {
     if [ -n "${local}" ]; then
-        cp "$(pwd)/$config_path/$1" $2
+        cp ${base_path}/${config_path}/$1 $2
     else
-        curl -so $2 $resources_config/$1
+        curl -so $2 ${resources_config}/$1
     fi
 }
 
@@ -145,7 +145,7 @@ checkInstalled() {
 
     if [ -n "${wazuhinstalled}" ] || [ -n "${elasticinstalled}" ] || [ -n "${filebeatinstalled}" ] || [ -n "${kibanainstalled}" ]; then 
         if [ -n "${ow}" ]; then
-             overwrite
+            overwrite
         
         elif [ -n "${uninstall}" ]; then
             logger -w "Removing the installed items"
@@ -201,7 +201,7 @@ startService() {
 createCertificates() {
 
     if [ -n "${AIO}" ]; then
-        eval "getConfig certificate/instances_aio.yml ./instances.yml ${debug}"
+        eval "getConfig certificate/instances_aio.yml ${base_path}/instances.yml ${debug}"
     fi
 
     readInstances

--- a/unattended_scripts/install_functions/opendistro/common.sh
+++ b/unattended_scripts/install_functions/opendistro/common.sh
@@ -3,7 +3,7 @@ repobaseurl="https://packages.wazuh.com/4.x"
 
 getConfig() {
     if [ -n "${local}" ]; then
-        cp ./$config_path/$1 $2
+        cp "$(pwd)/$config_path/$1" $2
     else
         curl -so $2 $resources_config/$1
     fi

--- a/unattended_scripts/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_scripts/install_functions/opendistro/elasticsearch.sh
@@ -32,15 +32,15 @@ copyCertificatesElasticsearch() {
         name=${IMN[pos]}
     fi
 
-    eval "cp ./certs/${name}.pem /etc/elasticsearch/certs/elasticsearch.pem ${debug}"
-    eval "cp ./certs/${name}-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem ${debug}"
-    eval "cp ./certs/root-ca.pem /etc/elasticsearch/certs/ ${debug}"
-    eval "cp ./certs/admin.pem /etc/elasticsearch/certs/ ${debug}"
-    eval "cp ./certs/admin-key.pem /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/${name}.pem /etc/elasticsearch/certs/elasticsearch.pem ${debug}"
+    eval "cp ${base_path}/certs/${name}-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem ${debug}"
+    eval "cp ${base_path}/certs/root-ca.pem /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/admin.pem /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/admin-key.pem /etc/elasticsearch/certs/ ${debug}"
 }
 
 configureElasticsearchAIO() {
- 
+
     logger "Configuring Elasticsearch..."
 
     eval "getConfig elasticsearch/elasticsearch_unattended.yml /etc/elasticsearch/elasticsearch.yml  ${debug}"
@@ -53,9 +53,9 @@ configureElasticsearchAIO() {
     export JAVA_HOME=/usr/share/elasticsearch/jdk/
         
     eval "mkdir /etc/elasticsearch/certs/ ${debug}"
-    eval "cp ./certs/elasticsearch* /etc/elasticsearch/certs/ ${debug}"
-    eval "cp ./certs/root-ca.pem /etc/elasticsearch/certs/ ${debug}"
-    eval "cp ./certs/admin* /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/elasticsearch* /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/root-ca.pem /etc/elasticsearch/certs/ ${debug}"
+    eval "cp ${base_path}/certs/admin* /etc/elasticsearch/certs/ ${debug}"
     
     # Configure JVM options for Elasticsearch
     ram_gb=$(free -g | awk '/^Mem:/{print $2}')
@@ -77,9 +77,7 @@ configureElasticsearchAIO() {
     done  
     echo ""  
 
-    eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
-    eval "./securityadmin.sh -cd ../securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
-    eval "cd - ${debug}"
+    eval "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
     logger "Done"
 
 }
@@ -202,9 +200,7 @@ initializeElastic() {
     echo ""
 
     if [ -n "${single}" ]; then
-        eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
-        eval "./securityadmin.sh -cd ../securityconfig/ -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h ${nip} ${debug}"
-        cd -
+        eval "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h ${nip} ${debug}"
     fi
 
     logger "Done"

--- a/unattended_scripts/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_scripts/install_functions/opendistro/elasticsearch.sh
@@ -66,7 +66,7 @@ configureElasticsearchAIO() {
     fi    
     eval "sed -i "s/-Xms1g/-Xms${ram}g/" /etc/elasticsearch/jvm.options ${debug}"
     eval "sed -i "s/-Xmx1g/-Xmx${ram}g/" /etc/elasticsearch/jvm.options ${debug}"
-  
+
     eval "/usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer ${debug}"
     # Start Elasticsearch
     startService "elasticsearch"
@@ -79,6 +79,7 @@ configureElasticsearchAIO() {
 
     eval "cd /usr/share/elasticsearch/plugins/opendistro_security/tools/ ${debug}"
     eval "./securityadmin.sh -cd ../securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem ${debug}"
+    eval "cd - ${debug}"
     logger "Done"
 
 }

--- a/unattended_scripts/install_functions/opendistro/filebeat.sh
+++ b/unattended_scripts/install_functions/opendistro/filebeat.sh
@@ -49,9 +49,9 @@ configureFilebeat() {
     fi
 
     eval "mkdir /etc/filebeat/certs ${debug}"
-    eval "mv ./certs/${winame}.pem /etc/filebeat/certs/filebeat.pem ${debug}"
-    eval "mv ./certs/${winame}-key.pem /etc/filebeat/certs/filebeat-key.pem ${debug}"
-    eval "cp ./certs/root-ca.pem /etc/filebeat/certs/ ${debug}"
+    eval "mv ${base_path}/certs/${winame}.pem /etc/filebeat/certs/filebeat.pem ${debug}"
+    eval "mv ${base_path}/certs/${winame}-key.pem /etc/filebeat/certs/filebeat-key.pem ${debug}"
+    eval "cp ${base_path}/certs/root-ca.pem /etc/filebeat/certs/ ${debug}"
 
     logger "Done"
     logger "Starting Filebeat..."
@@ -64,8 +64,8 @@ configureFilebeatAIO() {
         eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
         eval "curl -s '${repobaseurl}'/filebeat/wazuh-filebeat-0.1.tar.gz --max-time 300 | tar -xvz -C /usr/share/filebeat/module ${debug}"
         eval "mkdir /etc/filebeat/certs ${debug}"
-        eval "cp ./certs/root-ca.pem /etc/filebeat/certs/ ${debug}"
-        eval "cp ./certs/filebeat* /etc/filebeat/certs/ ${debug}"
+        eval "cp ${base_path}/certs/root-ca.pem /etc/filebeat/certs/ ${debug}"
+        eval "cp ${base_path}/certs/filebeat* /etc/filebeat/certs/ ${debug}"
 
         # Start Filebeat
         startService "filebeat"

--- a/unattended_scripts/install_functions/opendistro/kibana.sh
+++ b/unattended_scripts/install_functions/opendistro/kibana.sh
@@ -23,7 +23,7 @@ configureKibanaAIO() {
     eval "chown -R kibana:kibana /usr/share/kibana/ ${debug}"
     eval "cd /usr/share/kibana ${debug}"
     eval "sudo -u kibana /usr/share/kibana/bin/kibana-plugin install '${repobaseurl}'/ui/kibana/wazuh_kibana-${WAZUH_VER}_${ELK_VER}-${WAZUH_KIB_PLUG_REV}.zip ${debug}"
-    eval "cd - ${debug}"
+    eval "cd ${base_path} ${debug}"
     if [  "$?" != 0  ]; then
         logger -e "Wazuh Kibana plugin could not be installed."
         rollBack
@@ -31,8 +31,7 @@ configureKibanaAIO() {
         exit 1;
     fi     
     eval "mkdir /etc/kibana/certs ${debug}"
-    eval "cp ./certs/kibana* /etc/kibana/certs/ ${debug}"
-    eval "cp ./certs/root-ca.pem /etc/kibana/certs/ ${debug}"
+    copyKibanacerts
     eval "chown -R kibana:kibana /etc/kibana/ ${debug}"
     eval "chmod -R 500 /etc/kibana/certs ${debug}"
     eval "chmod 440 /etc/kibana/certs/kibana* ${debug}"
@@ -52,7 +51,7 @@ configureKibana() {
         logger -e "Wazuh Kibana plugin could not be installed."
         exit 1;
     fi
-    cd -
+    eval "cd ${base_path} ${debug}"
     eval "setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node ${debug}"
     eval "mkdir /etc/kibana/certs ${debug}"
 
@@ -87,10 +86,9 @@ configureKibana() {
 
 
 copyKibanacerts() {
-
-    if [ -d ./certs ]; then
-        eval "cp ./certs/kibana* /etc/kibana/certs/ ${debug}"
-        eval "cp ./certs/root-ca.pem /etc/kibana/certs/ ${debug}"
+    if [ -d "${base_path}/certs" ]; then
+        eval "cp ${base_path}/certs/kibana* /etc/kibana/certs/ ${debug}"
+        eval "cp ${base_path}/certs/root-ca.pem /etc/kibana/certs/ ${debug}"
     else
         logger "No certificates found. Could not initialize Kibana"
         exit 1;

--- a/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
+++ b/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
@@ -61,8 +61,6 @@ getHelp() {
     echo -e "\t-k     | --kibana-certificates Creates the Kibana certificates."
     echo -e "\t-d     | --debug Enables verbose mode."
     exit 1 # Exit script after printing help    
-    exit 1 # Exit script after printing help    
-    exit 1 # Exit script after printing help    
 }
 
 readFile() {

--- a/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
+++ b/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
@@ -39,9 +39,9 @@ logger() {
 
 readInstances() {
 
-    if [ -f ./instances.yml ]; then
+    if [ -f ${base_path}/instances.yml ]; then
         logger "Configuration file found. Creating certificates..."
-        eval "mkdir ./certs $debug"
+        eval "mkdir ${base_path}/certs $debug"
     else
         logger -e "No configuration file found."
         exit 1;
@@ -52,20 +52,22 @@ readInstances() {
 }
 
 getHelp() {
-   echo ""
-   echo "Usage: $0 arguments"
-   echo -e "\t-a     | --admin-certificates Creates the admin certificates."
-   echo -e "\t-ca    | --root-ca-certificates Creates the root-ca certificates."
-   echo -e "\t-a     | --elasticsearch-certificates Creates the Elasticsearch certificates."
-   echo -e "\t-w     | --wazuh-certificates Creates the Wazuh server certificates."
-   echo -e "\t-k     | --kibana-certificates Creates the Kibana certificates."
-   echo -e "\t-d     | --debug Enables verbose mode."
-   exit 1 # Exit script after printing help    
+    echo ""
+    echo "Usage: $0 arguments"
+    echo -e "\t-a     | --admin-certificates Creates the admin certificates."
+    echo -e "\t-ca    | --root-ca-certificates Creates the root-ca certificates."
+    echo -e "\t-a     | --elasticsearch-certificates Creates the Elasticsearch certificates."
+    echo -e "\t-w     | --wazuh-certificates Creates the Wazuh server certificates."
+    echo -e "\t-k     | --kibana-certificates Creates the Kibana certificates."
+    echo -e "\t-d     | --debug Enables verbose mode."
+    exit 1 # Exit script after printing help    
+    exit 1 # Exit script after printing help    
+    exit 1 # Exit script after printing help    
 }
 
 readFile() {
 
-    IFS=$'\r\n' GLOBIGNORE='*' command eval  'INSTANCES=($(cat ./instances.yml))'
+    IFS=$'\r\n' GLOBIGNORE='*' command eval  'INSTANCES=($(cat ${base_path}/instances.yml))'
     for i in "${!INSTANCES[@]}"; do
     if [[ "${INSTANCES[$i]}" == "${ELASTICINSTANCES}" ]]; then
         ELASTICLIMITT=${i}
@@ -127,7 +129,7 @@ readFile() {
 
 generateCertificateconfiguration() {
 
-    cat > ./certs/${cname}.conf <<- EOF
+    cat > ${base_path}/certs/${cname}.conf <<- EOF
         [ req ]
         prompt = no
         default_bits = 2048
@@ -152,20 +154,20 @@ generateCertificateconfiguration() {
         IP.1 = cip
 	EOF
 
-    conf="$(awk '{sub("CN = cname", "CN = '${cname}'")}1' ./certs/$cname.conf)"
-    echo "${conf}" > ./certs/$cname.conf    
+    conf="$(awk '{sub("CN = cname", "CN = '${cname}'")}1' ${base_path}/certs/$cname.conf)"
+    echo "${conf}" > ${base_path}/certs/$cname.conf    
 
     isIP=$(echo "${cip}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
     isDNS=$(echo ${cip} | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" )
 
     if [[ -n "${isIP}" ]]; then
-        conf="$(awk '{sub("IP.1 = cip", "IP.1 = '${cip}'")}1' ./certs/$cname.conf)"
-        echo "${conf}" > ./certs/$cname.conf    
+        conf="$(awk '{sub("IP.1 = cip", "IP.1 = '${cip}'")}1' ${base_path}/certs/$cname.conf)"
+        echo "${conf}" > ${base_path}/certs/$cname.conf    
     elif [[ -n "${isDNS}" ]]; then
-        conf="$(awk '{sub("CN = cname", "CN =  '${cip}'")}1' ./certs/$cname.conf)"
-        echo "${conf}" > ./certs/$cname.conf     
-        conf="$(awk '{sub("IP.1 = cip", "DNS.1 = '${cip}'")}1' ./certs/$cname.conf)"
-        echo "${conf}" > ./certs/$cname.conf 
+        conf="$(awk '{sub("CN = cname", "CN =  '${cip}'")}1' ${base_path}/certs/$cname.conf)"
+        echo "${conf}" > ${base_path}/certs/$cname.conf     
+        conf="$(awk '{sub("IP.1 = cip", "DNS.1 = '${cip}'")}1' ${base_path}/certs/$cname.conf)"
+        echo "${conf}" > ${base_path}/certs/$cname.conf 
     else
         logger -e "The given information does not match with an IP or a DNS"  
         exit 1; 
@@ -175,22 +177,22 @@ generateCertificateconfiguration() {
 
 generateRootCAcertificate() {
 
-    eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ./certs/root-ca.key -out ./certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650 ${debug}"
+    eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/root-ca.key -out ${base_path}/certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650 ${debug}"
 
 }
 
 generateAdmincertificate() {
     
-    eval "openssl genrsa -out ./certs/admin-key-temp.pem 2048 ${debug}"
-    eval "openssl pkcs8 -inform PEM -outform PEM -in ./certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ./certs/admin-key.pem ${debug}"
-    eval "openssl req -new -key ./certs/admin-key.pem -out ./certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug}"
-    eval "openssl x509 -req -in ./certs/admin.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -sha256 -out ./certs/admin.pem ${debug}"
+    eval "openssl genrsa -out ${base_path}/certs/admin-key-temp.pem 2048 ${debug}"
+    eval "openssl pkcs8 -inform PEM -outform PEM -in ${base_path}/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${base_path}/certs/admin-key.pem ${debug}"
+    eval "openssl req -new -key ${base_path}/certs/admin-key.pem -out ${base_path}/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug}"
+    eval "openssl x509 -req -in ${base_path}/certs/admin.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -sha256 -out ${base_path}/certs/admin.pem ${debug}"
 
 }
 
 generateElasticsearchcertificates() {
 
-     logger "Creating the Elasticsearch certificates..."
+    logger "Creating the Elasticsearch certificates..."
 
     i=0
     while [ ${i} -lt ${#ELASTICNODES[@]} ]; do
@@ -204,9 +206,9 @@ generateElasticsearchcertificates() {
         cip=$(echo ${cip} | xargs)
 
         generateCertificateconfiguration cname cip
-        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ./certs/${cname}-key.pem -out ./certs/${cname}.csr -config ./certs/${cname}.conf -days 3650 ${debug}"
-        eval "openssl x509 -req -in ./certs/${cname}.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -out ./certs/${cname}.pem -extfile ./certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
-        eval "chmod 444 ./certs/${cname}-key.pem ${debug}"    
+        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/${cname}-key.pem -out ${base_path}/certs/${cname}.csr -config ${base_path}/certs/${cname}.conf -days 3650 ${debug}"
+        eval "openssl x509 -req -in ${base_path}/certs/${cname}.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -out ${base_path}/certs/${cname}.pem -extfile ${base_path}/certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
+        eval "chmod 444 ${base_path}/certs/${cname}-key.pem ${debug}"    
         i=$(( ${i} + 2 ))
     done
 
@@ -228,8 +230,8 @@ generateFilebeatcertificates() {
         cip=$(echo ${cip} | xargs)
 
         generateCertificateconfiguration cname cip
-        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ./certs/${cname}-key.pem -out ./certs/${cname}.csr -config ./certs/${cname}.conf -days 3650 ${debug}"
-        eval "openssl x509 -req -in ./certs/${cname}.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -out ./certs/${cname}.pem -extfile ./certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
+        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/${cname}-key.pem -out ${base_path}/certs/${cname}.csr -config ${base_path}/certs/${cname}.conf -days 3650 ${debug}"
+        eval "openssl x509 -req -in ${base_path}/certs/${cname}.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -out ${base_path}/certs/${cname}.pem -extfile ${base_path}/certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
         i=$(( ${i} + 2 ))
     done      
 
@@ -251,8 +253,8 @@ generateKibanacertificates() {
         cip=$(echo ${cip} | xargs)
 
         generateCertificateconfiguration cname cip
-        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ./certs/${cname}-key.pem -out ./certs/${cname}.csr -config ./certs/${cname}.conf -days 3650 ${debug}"
-        eval "openssl x509 -req -in ./certs/${cname}.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -out ./certs/${cname}.pem -extfile ./certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
+        eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/${cname}-key.pem -out ${base_path}/certs/${cname}.csr -config ${base_path}/certs/${cname}.conf -days 3650 ${debug}"
+        eval "openssl x509 -req -in ${base_path}/certs/${cname}.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -out ${base_path}/certs/${cname}.pem -extfile ${base_path}/certs/${cname}.conf -extensions v3_req -days 3650 ${debug}"
         i=$(( ${i} + 2 ))
     done 
 
@@ -260,11 +262,11 @@ generateKibanacertificates() {
 
 cleanFiles() {
 
-    eval "rm -rf ./certs/*.csr ${debug}"
-    eval "rm -rf ./certs/*.srl ${debug}"
-    eval "rm -rf ./certs/*.conf ${debug}"
-    eval "rm -rf ./certs/admin-key-temp.pem ${debug}"
-    logger "Certificates creation finished. They can be found in ./certs."
+    eval "rm -rf ${base_path}/certs/*.csr ${debug}"
+    eval "rm -rf ${base_path}/certs/*.srl ${debug}"
+    eval "rm -rf ${base_path}/certs/*.conf ${debug}"
+    eval "rm -rf ${base_path}/certs/admin-key-temp.pem ${debug}"
+    logger "Certificates creation finished. They can be found in ${base_path}/certs."
 
 }
 

--- a/unattended_scripts/unattended_installation.sh
+++ b/unattended_scripts/unattended_installation.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 ## Package vars
 WAZUH_MAJOR="4.2"
 WAZUH_VER="4.2.5"

--- a/unattended_scripts/unattended_installation.sh
+++ b/unattended_scripts/unattended_installation.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 ## Package vars
 WAZUH_MAJOR="4.2"
 WAZUH_VER="4.2.5"
@@ -16,6 +16,7 @@ config_path="config/opendistro"
 resources="https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/${WAZUH_MAJOR}"
 resources_functions="${resources}/${functions_path}"
 resources_config="${resources}/${config_path}"
+base_path="$(dirname $(realpath $0))"
 
 ## Show script usage
 getHelp() {
@@ -41,9 +42,9 @@ getHelp() {
 
 importFunction() {
     if [ -n "${local}" ]; then
-        . ./$functions_path/$1
+        . ${base_path}/${functions_path}/$1
     else
-        curl -so /tmp/$1 $resources_functions/$1
+        curl -so /tmp/$1 ${resources_functions}/$1
         . /tmp/$1
         rm -f /tmp/$1
     fi


### PR DESCRIPTION
|Related issue|
|---|
|#1036|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the unattended installation using local files. The current installation does not fail if there is a file that is not found, so as there is no debug mode it is not detected.

The problem is in the directory from where we want to copy files, in the last phase of Elasticsearch configuration, it enter in (`/usr/share/elasticsearch/plugins/opendistro_security/tools/`) directory but it does not restore the previous path when finished

This PR changes the copy command to use an absolute path $(pwd) instead of relative one (./), so that if there is ever a problem in a path it is detectable if debug mode is used. To correct the path a `cd -` has been incorporated in the last phase of Elasticsarch configuration

## Logs example

<!--
Paste here related logs
-->

[centos.log](https://github.com/wazuh/wazuh-packages/files/7642422/centos.log)


