### PR TITLE
Change realpath to readlink command - Unify unattended

### DIFF
--- a/unattended_scripts/unattended_installation.sh
+++ b/unattended_scripts/unattended_installation.sh
@@ -16,7 +16,7 @@ config_path="config/opendistro"
 resources="https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/${WAZUH_MAJOR}"
 resources_functions="${resources}/${functions_path}"
 resources_config="${resources}/${config_path}"
-base_path="$(dirname $(realpath $0))"
+base_path="$(dirname $(readlink -f $0))"
 
 ## Show script usage
 getHelp() {


### PR DESCRIPTION
|Related issue|
|---|
|Related to https://github.com/wazuh/wazuh-packages/issues/1036#issuecomment-988321494|



## Description

The realpath command is not a native GNU command and is added in the coreutils-8.22 package, this is a problem since older systems like OL6 have coreutils-8.4, which does not provide this command.

The solution is to use a native GNU command, which is `readlink -f`


## Logs example

Added echo to debug path for readlink command

<details><summary>CentOS 7</summary>

  [root@centos7 unattended_scripts]# bash unattended_installation.sh -A -l
  `readlink:	/home/vagrant/wazuh-packages/unattended_scripts`
  12/09/2021 13:40:51 INFO: Configuration file found. Creating certificates...
  12/09/2021 13:40:51 INFO: Creating the Elasticsearch certificates...
  12/09/2021 13:40:51 INFO: Creating Wazuh server certificates...
  12/09/2021 13:40:51 INFO: Creating Kibana certificate...
  12/09/2021 13:40:51 INFO: Certificates creation finished. They can be found in /home/vagrant/wazuh-packages/unattended_scripts/certs.
  12/09/2021 13:40:51 INFO: Starting the installation...
  12/09/2021 13:40:51 INFO: Starting the installation...
  12/09/2021 13:40:51 INFO: Starting the installation...
  12/09/2021 13:40:51 INFO: Installing all necessary utilities for the installation...
  12/09/2021 13:40:52 INFO: Done
  12/09/2021 13:40:52 INFO: Adding the Wazuh repository...
  12/09/2021 13:40:53 INFO: Done
  12/09/2021 13:40:53 INFO: Installing the Wazuh manager...
  12/09/2021 13:41:27 INFO: Done
  12/09/2021 13:41:44 INFO: Wazuh-manager started
  12/09/2021 13:41:44 INFO: Installing Open Distro for Elasticsearch...
  12/09/2021 13:42:24 INFO: Done
  12/09/2021 13:42:24 INFO: Configuring Elasticsearch...
  12/09/2021 13:42:32 INFO: Elasticsearch started
  12/09/2021 13:42:32 INFO: Initializing Elasticsearch...
  
  12/09/2021 13:42:41 INFO: Done
  12/09/2021 13:42:41 INFO: Installing Filebeat...
  12/09/2021 13:42:44 INFO: Filebeat started
  12/09/2021 13:42:44 INFO: Done
  12/09/2021 13:42:44 INFO: Installing Open Distro for Kibana...
  12/09/2021 13:43:47 INFO: Done
  12/09/2021 13:43:56 INFO: Kibana started

</details>

<details><summary>Oracle Linux 6 (fails due to elasticsearch, not related to readlink)</summary>

  [root@ip-172-31-17-15 unattended_scripts]# bash unattended_installation.sh -A -l
  `readlink: /home/ec2-user/wazuh-packages/unattended_scripts`
  12/09/2021 13:38:28 INFO: Configuration file found. Creating certificates...
  12/09/2021 13:38:28 INFO: Creating the Elasticsearch certificates...
  12/09/2021 13:38:28 INFO: Creating Wazuh server certificates...
  12/09/2021 13:38:29 INFO: Creating Kibana certificate...
  12/09/2021 13:38:29 INFO: Certificates creation finished. They can be found in /home/ec2-user/wazuh-packages/unattended_scripts/certs.
  12/09/2021 13:38:29 INFO: Starting the installation...
  12/09/2021 13:38:29 INFO: Starting the installation...
  12/09/2021 13:38:29 INFO: Starting the installation...
  12/09/2021 13:38:29 INFO: Installing all necessary utilities for the installation...
  12/09/2021 13:38:29 INFO: Done
  12/09/2021 13:38:29 INFO: Adding the Wazuh repository...
  12/09/2021 13:38:29 INFO: Wazuh repository already exists skipping
  12/09/2021 13:38:29 INFO: Done
  12/09/2021 13:38:29 INFO: Installing the Wazuh manager...
  12/09/2021 13:39:38 INFO: Done
  12/09/2021 13:39:59 INFO: Wazuh-manager started
  12/09/2021 13:39:59 INFO: Installing Open Distro for Elasticsearch...
  Elasticsearch installation failed
  12/09/2021 13:40:00 WARNING: Cleaning the installation
  12/09/2021 13:40:00 WARNING: Removing the Wazuh manager...
  12/09/2021 13:40:32 WARNING: Installation cleaned. Check the /var/log/wazuh-unattended-installation.log file to learn more about the issue.

</details>

## Tests

- [x] CentOS7
- [x] Oracle Linux 6