### PR TITLE
Fixed elasticsearch distributed installer

### DIFF
--- a/unattended_scripts/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_scripts/install_functions/opendistro/elasticsearch.sh
@@ -140,7 +140,7 @@ configureElasticsearch() {
                 pos="${i}";
             fi
         done
-        if [[ ! ${IMN[@]} == ${einame}  ]]; then
+        if [[ ! ${IMN[pos]} == ${einame}  ]]; then
             logger -e "The name given does not appear on the configuration file"
             exit 1;
         fi

--- a/unattended_scripts/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_scripts/install_functions/opendistro/elasticsearch.sh
@@ -177,11 +177,7 @@ configureElasticsearch() {
         echo "bootstrap.system_call_filter: false" >> /etc/elasticsearch/elasticsearch.yml
     fi
 
-    if [ -n "${single}" ]; then
-        copyCertificatesElasticsearch
-    else
-        copyCertificatesElasticsearch
-    fi
+    copyCertificatesElasticsearch
 
     eval "rm /etc/elasticsearch/certs/client-certificates.readme /etc/elasticsearch/certs/elasticsearch_elasticsearch_config_snippet.yml -f ${debug}"
     eval "/usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer ${debug}"

--- a/unattended_scripts/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_scripts/install_functions/opendistro/elasticsearch.sh
@@ -93,7 +93,7 @@ configureElasticsearch() {
     logger "Configuring Elasticsearch..."
 
     eval "getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/elasticsearch/elasticsearch.yml ${debug}"
-    eval "getConfig elasticsearch/roles/roles.ym /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml ${debug}"
+    eval "getConfig elasticsearch/roles/roles.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml ${debug}"
     eval "getConfig elasticsearch/roles/roles_mapping.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml ${debug}"
     eval "getConfig elasticsearch/roles/internal_users.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml ${debug}"
 
@@ -140,7 +140,7 @@ configureElasticsearch() {
                 pos="${i}";
             fi
         done
-        if [ ! ${IMN[@]} == ${einame}  ]; then
+        if [[ ! ${IMN[@]} == ${einame}  ]]; then
             logger -e "The name given does not appear on the configuration file"
             exit 1;
         fi
@@ -178,9 +178,9 @@ configureElasticsearch() {
     fi
 
     if [ -n "${single}" ]; then
-        copyCertificatesElasticsearch einame
+        copyCertificatesElasticsearch
     else
-        copyCertificatesElasticsearch einame pos
+        copyCertificatesElasticsearch
     fi
 
     eval "rm /etc/elasticsearch/certs/client-certificates.readme /etc/elasticsearch/certs/elasticsearch_elasticsearch_config_snippet.yml -f ${debug}"

--- a/unattended_scripts/install_functions/opendistro/kibana.sh
+++ b/unattended_scripts/install_functions/opendistro/kibana.sh
@@ -88,6 +88,9 @@ configureKibana() {
     logger "Kibana installed."
 
     copyKibanacerts
+    eval "chown -R kibana:kibana /etc/kibana/ ${debug}"
+    eval "chmod -R 500 /etc/kibana/certs ${debug}"
+    eval "chmod 440 /etc/kibana/certs/kibana* ${debug}"
     initializeKibana kip
 }
 
@@ -96,6 +99,7 @@ copyKibanacerts() {
     if [ -d "${base_path}/certs" ]; then
         eval "cp ${base_path}/certs/kibana* /etc/kibana/certs/ ${debug}"
         eval "cp ${base_path}/certs/root-ca.pem /etc/kibana/certs/ ${debug}"
+        
     else
         logger "No certificates found. Could not initialize Kibana"
         exit 1;

--- a/unattended_scripts/install_functions/opendistro/kibana.sh
+++ b/unattended_scripts/install_functions/opendistro/kibana.sh
@@ -99,7 +99,6 @@ copyKibanacerts() {
     if [ -d "${base_path}/certs" ]; then
         eval "cp ${base_path}/certs/kibana* /etc/kibana/certs/ ${debug}"
         eval "cp ${base_path}/certs/root-ca.pem /etc/kibana/certs/ ${debug}"
-        
     else
         logger "No certificates found. Could not initialize Kibana"
         exit 1;


### PR DESCRIPTION
|Related issue|
|---|
|closes #1062 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

I fixed a couple of bugs in the distributed elasticsearch installation. 
- Added a missing `l` for `getConfig roles.yml`
- Corrected missing brackets in condition
- Removed unused parameters in `copyCertificatesElasticsearch einame pos`
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example
`filebeat test output`:
```
[root@centos7 unattended_scripts]# filebeat test output
elasticsearch: https://192.168.56.16:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 192.168.56.16
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
```

<!--
Paste here related logs
-->

## Tests
- [x] Two nodes, one with elasticsearch/kibana and another with Wazuh manager and filebeat. 
- [x] Four nodes, elasticsearch cluster