### PR TITLE
Added mitigation function

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -136,6 +136,15 @@ checkArch() {
     
 }
 
+applyLog4j2Mitigation(){
+
+    mkdir /etc/elasticsearch/jvm.options.d
+    echo "-Dlog4j2.formatMsgNoLookups=true" > /etc/elasticsearch/jvm.options.d/disabledlog4j.options
+    chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options
+    chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options
+
+}
+
 startService() {
 
     if [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
@@ -314,7 +323,9 @@ installElasticsearch() {
         fi    
         eval "sed -i "s/-Xms1g/-Xms${ram}g/" /etc/elasticsearch/jvm.options ${debug}"
         eval "sed -i "s/-Xmx1g/-Xmx${ram}g/" /etc/elasticsearch/jvm.options ${debug}"
-     
+
+        applyLog4j2Mitigation
+
         eval "/usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer ${debug}"
         # Start Elasticsearch
         startService "elasticsearch"

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -138,10 +138,10 @@ checkArch() {
 
 applyLog4j2Mitigation(){
 
-    mkdir /etc/elasticsearch/jvm.options.d
-    echo "-Dlog4j2.formatMsgNoLookups=true" > /etc/elasticsearch/jvm.options.d/disabledlog4j.options
-    chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options
-    chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options
+    eval "mkdir /etc/elasticsearch/jvm.options.d ${debug}"
+    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
 
 }
 


### PR DESCRIPTION
This PR adds an additional configuration step to Opendistro for the Elasticsearch installation process. By adding this option we avoid the `log4j2` vulnerability until new Opendistro packages are released. 

```
[root@wazuh1 vagrant]# tree /etc/elasticsearch/
/etc/elasticsearch/
├── certs
│   ├── admin-key.pem
│   ├── admin.pem
│   ├── elasticsearch-key.pem
│   ├── elasticsearch.pem
│   └── root-ca.pem
├── elasticsearch.keystore
├── elasticsearch.yml
├── jvm.options
├── jvm.options.d
│   └── disabledlog4j.options
└── log4j2.properties
```
Elasticsearch status:
```
[root@wazuh1 vagrant]# systemctl status -l elasticsearch
● elasticsearch.service - Elasticsearch
   Loaded: loaded (/usr/lib/systemd/system/elasticsearch.service; enabled; vendor preset: disabled)
   Active: active (running) since lun 2021-12-13 15:59:06 UTC; 47s ago
     Docs: https://www.elastic.co
 Main PID: 15064 (java)
   CGroup: /system.slice/elasticsearch.service
           └─15064 /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djava.io.tmpdir=/tmp/elasticsearch-9577111286480430461 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/lib/elasticsearch -XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Dclk.tck=100 -Djdk.attach.allowAttachSelf=true -Djava.security.policy=file:///usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/es_security.policy -Dlog4j2.formatMsgNoLookups=true -XX:MaxDirectMemorySize=536870912 -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/etc/elasticsearch -Des.distribution.flavor=oss -Des.distribution.type=rpm -Des.bundled_jdk=true -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch -p /var/run/elasticsearch/elasticsearch.pid --quiet
```