### PR TITLE
Fix wrong healthcheck parameter

### DIFF
--- a/unattended_scripts/wazuh_install.sh
+++ b/unattended_scripts/wazuh_install.sh
@@ -175,7 +175,7 @@ main() {
         if [ -n "${ignore}" ]; then
             logger -w "Health-check ignored."
         else
-            healthCheck elastic
+            healthCheck elasticsearch
         fi
         checkSystem
         installPrerequisites


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes a wrong parameter used in the health check function which caused the function to not be executed when installing Elasticsearch


