### PR TITLE
Fix groupdel ossec error in upgrade to Master

### DIFF
--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -369,6 +369,8 @@ if id -g ossec > /dev/null 2>&1; then
     find %{_localstatedir} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
     userdel ossecr
   fi
+fi
+if grep -q ossec /etc/group; then
   groupdel ossec
 fi
 


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1034|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

I found that the groupdel ossec command would not be necessary, since with the userdel command the group is also deleted, since it is the only user that is part of that group, to avoid any inconvenience that may appear since someone can add another user to ossec group I add a validation.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->
Centos 7:

From agent:
![Screenshot_20211213_154031](https://user-images.githubusercontent.com/64099752/145871933-c85c5760-9ab1-4460-997d-f600e3b609e4.png)
From manager:
![Screenshot_20211213_154046](https://user-images.githubusercontent.com/64099752/145871947-95cd07f9-635f-4f42-a740-8e59928c509f.png)

Fedora 32:

From Agent:
![Screenshot_20211213_155610](https://user-images.githubusercontent.com/64099752/145871972-33fb5515-ef6b-4f34-9f25-55111d4f477a.png)

From Manager:
![Screenshot_20211213_155619](https://user-images.githubusercontent.com/64099752/145871985-ae7d0bd4-0744-4467-9c8f-35dc1b7eae1f.png)


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
