### PR TITLE
Remove wazuh user from unattended/OVA/AMI 4.3

### DIFF
--- a/ova/assets/custom/messages.sh
+++ b/ova/assets/custom/messages.sh
@@ -2,6 +2,7 @@
 
 DEBUG=$1
 WAZUH_VERSION=$2
+SYSTEM_USER=$3
 
 [[ ${DEBUG} = "yes" ]] && set -ex || set -e
 

--- a/ova/assets/custom/removeVagrant.service
+++ b/ova/assets/custom/removeVagrant.service
@@ -5,10 +5,10 @@ Description=Remove vagrant
 WantedBy=multi-user.target
 
 [Service]
-ExecStart=/bin/bash /home/wazuh/removeVagrant.sh
+ExecStart=/bin/bash /home/USER/removeVagrant.sh
 Type=simple
 User=root
 Group=root
-WorkingDirectory=/home/wazuh
+WorkingDirectory=/home/USER
 Restart=always
 RestartSec=3

--- a/ova/assets/custom/removeVagrant.sh
+++ b/ova/assets/custom/removeVagrant.sh
@@ -13,7 +13,7 @@ sed -i "/vagrant/d" /etc/pam.d/su
 rm /etc/sudoers.d/vagrant
 
 # Autodestroy
-rm /home/wazuh/removeVagrant.sh
+rm /home/USER/removeVagrant.sh
 rm /etc/systemd/system/removeVagrant.service
 rm /etc/systemd/system/multi-user.target.wants/removeVagrant.service
 systemctl daemon-reload

--- a/ova/assets/postProvision.sh
+++ b/ova/assets/postProvision.sh
@@ -6,13 +6,16 @@ DEBUG=$1
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ASSETS_PATH="${CURRENT_PATH}/assets"
 CUSTOM_PATH="${ASSETS_PATH}/custom"
+SYSTEM_USER="wazuh-user"
 
 systemctl stop wazuh-manager elasticsearch filebeat kibana
 
 # Remove everything related to vagrant
 mv ${CUSTOM_PATH}/removeVagrant.service /etc/systemd/system/
-mv ${CUSTOM_PATH}/removeVagrant.sh /home/wazuh/
-chmod 755 /home/wazuh/removeVagrant.sh
+sed -i "s/USER/${SYSTEM_USER}/g" /etc/systemd/system/removeVagrant.service
+mv ${CUSTOM_PATH}/removeVagrant.sh /home/${SYSTEM_USER}/
+sed -i "s/USER/${SYSTEM_USER}/g" /home/${SYSTEM_USER}/removeVagrant.sh
+chmod 755 /home/${SYSTEM_USER}/removeVagrant.sh
 systemctl daemon-reload
 systemctl enable removeVagrant.service
 

--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -23,61 +23,45 @@ systemConfig() {
   # Change root password (root:wazuh)
   sed -i "s/root:.*:/root:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41::0:99999:7:::/g" /etc/shadow 
 
-  # Add user wazuh (wazuh:wazuh)
-  adduser wazuh
-  sed -i "s/wazuh:!!/wazuh:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41/g" /etc/shadow 
+  # Add custom user ($1$pNjjEA7K$USjdNwjfh7A.vHCf8suK41 -> wazuh)
+  adduser ${SYSTEM_USER}
+  sed -i "s/${SYSTEM_USER}:!!/${SYSTEM_USER}:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41/g" /etc/shadow 
 
-  gpasswd -a wazuh wheel
-  hostname wazuh-manager
+  gpasswd -a ${SYSTEM_USER} wheel
+  hostname ${HOSTNAME}
 
   # AWS instance has this enabled
   sed -i "s/PermitRootLogin yes/#PermitRootLogin yes/g" /etc/ssh/sshd_config
 
-  # Ssh configuration
+  # SSH configuration
   sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
   echo "PermitRootLogin no" >> /etc/ssh/sshd_config
 
   # Edit system custom welcome messages
-  sh ${CUSTOM_PATH}/messages.sh ${DEBUG} ${WAZUH_VERSION}
+  bash ${CUSTOM_PATH}/messages.sh ${DEBUG} ${WAZUH_VERSION} ${SYSTEM_USER}
 
 }
 
 # Edit unattended installer
 preInstall() {
 
-  # Set debug mode
+  # Set debug mode in unattended script
   if [ "${DEBUG}" == "yes" ]; then
     sed -i "s/\#\!\/bin\/bash/\#\!\/bin\/bash\nset -x/g" ${UNATTENDED_PATH}/${INSTALLER}
   fi
 
   # Change repository if dev is specified
-  if [ "${PACKAGES_REPOSITORY}" = "dev" ]; then
+  if [ "${PACKAGES_REPOSITORY}" == "dev" ]; then
     sed -i "s/packages\.wazuh\.com/packages-dev\.wazuh\.com/g" ${UNATTENDED_PATH}/${INSTALLER} 
     sed -i "s/packages-dev\.wazuh\.com\/4\.x/packages-dev\.wazuh\.com\/pre-release/g" ${UNATTENDED_PATH}/${INSTALLER} 
   fi
 
-  # Remove kibana admin user
-  PATTERN="eval \"rm \/etc\/elasticsearch\/e"
-  FILE_PATH="\/usr\/share\/elasticsearch\/plugins\/opendistro_security\/securityconfig"
-  sed -i "s/${PATTERN}/sed -i \'\/^admin:\/,\/admin user\\\\\"\/d\' ${FILE_PATH}\/internal_users\.yml\n        ${PATTERN}/g" ${UNATTENDED_PATH}/${INSTALLER}
-
-  # Change user:password in curls
-  sed -i "s/admin:admin/wazuh:wazuh/g" ${UNATTENDED_PATH}/${INSTALLER}
-
-  # Replace admin/admin for wazuh/wazuh in filebeat.yml
-  PATTERN="eval \"curl -so \/etc\/filebeat\/wazuh-template"
-  sed -i "s/${PATTERN}/sed -i \"s\/admin\/wazuh\/g\" \/etc\/filebeat\/filebeat\.yml\n        ${PATTERN}/g" ${UNATTENDED_PATH}/${INSTALLER}
-
   # Disable passwords change
-  sed -i "s/wazuhpass=/#wazuhpass=/g" ${UNATTENDED_PATH}/${INSTALLER}
-  sed -i "s/changePasswords$/#changePasswords\nwazuhpass=\"wazuh\"/g" ${UNATTENDED_PATH}/${INSTALLER}
-  sed -i "s/ra=/#ra=/g" ${UNATTENDED_PATH}/${INSTALLER}
+  sed -i "s/changePasswords$/#changePasswords/g" ${UNATTENDED_PATH}/${INSTALLER}
 
   # Revert url to packages.wazuh.com to get filebeat gz
   sed -i "s/'\${repobaseurl}'\/filebeat/https:\/\/packages.wazuh.com\/4.x\/filebeat/g" ${UNATTENDED_PATH}/${INSTALLER}
 
-  # Add rbac permissions to Wazuh user and stop wazuh manager
-  sed -i "0,/setWazuhUserRBACPermissions/s/setWazuhUserRBACPermissions/setWazuhUserRBACPermissions\nsystemctl stop wazuh-manager/" ${UNATTENDED_PATH}/${INSTALLER}
 }
 
 # Edit wazuh installation

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -7,6 +7,8 @@ RESOURCES_PATH="/tmp/unattended_scripts"
 UNATTENDED_PATH="${RESOURCES_PATH}/open-distro/unattended-installation"
 INSTALLER="unattended-installation.sh"
 WAZUH_VERSION=$(cat ${UNATTENDED_PATH}/${INSTALLER} | grep "WAZUH_VER=" | cut -d "\"" -f 2)
+SYSTEM_USER="wazuh-user"
+HOSTNAME="wazuh-manager"
 
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ASSETS_PATH="${CURRENT_PATH}/assets"

--- a/unattended_scripts/open-distro/elasticsearch/roles/internal_users.yml
+++ b/unattended_scripts/open-distro/elasticsearch/roles/internal_users.yml
@@ -10,13 +10,6 @@ _meta:
 
 ## Demo users
 
-wazuh:
-  hash: "$2y$12$BeIKI3ilHXr5lFL3LR9lmeIA.AHaCqU1ll4D/GYjER70SaDEUuLGC"
-  reserved: true
-  backend_roles:
-  - "admin"
-  description: "Wazuh admin user"  
-
 admin:
   hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
   reserved: true

--- a/unattended_scripts/open-distro/elasticsearch/roles/roles_mapping.yml
+++ b/unattended_scripts/open-distro/elasticsearch/roles/roles_mapping.yml
@@ -14,7 +14,6 @@ all_access:
   reserved: false
   backend_roles:
   - "admin"
-  - "wazuh"
   description: "Maps admin to all_access"
 
 own_index:

--- a/unattended_scripts/open-distro/filebeat/7.x/filebeat_unattended.yml
+++ b/unattended_scripts/open-distro/filebeat/7.x/filebeat_unattended.yml
@@ -6,8 +6,8 @@ output.elasticsearch.hosts:
 
 output.elasticsearch:
   protocol: https
-  username: wazuh
-  password: wazuh
+  username: "admin"
+  password: admin
   ssl.certificate_authorities:
     - /etc/filebeat/certs/root-ca.pem
   ssl.certificate: "/etc/filebeat/certs/filebeat.pem"

--- a/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
+++ b/unattended_scripts/open-distro/tools/wazuh-passwords-tool.sh
@@ -170,11 +170,11 @@ readFileUsers() {
 
 It must have this format:
 User:
-   name: wazuh
-   password: wazuhpasword
+    name: wazuh
+    password: wazuhpasword
 User:
-   name: kibanaserver
-   password: kibanaserverpassword"
+    name: kibanaserver
+    password: kibanaserverpassword"
 	exit 1
     fi	
 
@@ -314,10 +314,10 @@ changePassword() {
     if [ -n "${CHANGEALL}" ]; then
         for i in "${!PASSWORDS[@]}"
         do
-           awk -v new=${HASHES[i]} 'prev=="'${USERS[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+            awk -v new=${HASHES[i]} 'prev=="'${USERS[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
 
-            if [ "${USERS[i]}" == "wazuh" ]; then
-                wazuhpass=${PASSWORDS[i]}
+            if [ "${USERS[i]}" == "admin" ]; then
+                adminpass=${PASSWORDS[i]}
             elif [ "${USERS[i]}" == "kibanaserver" ]; then
                 kibpass=${PASSWORDS[i]}
             fi  
@@ -326,15 +326,15 @@ changePassword() {
     else
         awk -v new="$HASH" 'prev=="'${NUSER}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
 
-        if [ "${NUSER}" == "wazuh" ]; then
-            wazuhpass=${PASSWORD}
+        if [ "${NUSER}" == "admin" ]; then
+            adminpass=${PASSWORD}
         elif [ "${NUSER}" == "kibanaserver" ]; then
             kibpass=${PASSWORD}
         fi        
 
     fi
     
-    if [ "${NUSER}" == "wazuh" ] || [ -n "${CHANGEALL}" ]; then
+    if [ "${NUSER}" == "admin" ] || [ -n "${CHANGEALL}" ]; then
 
         if [ "${SYS_TYPE}" == "yum" ]; then
             hasfilebeat=$(yum list installed 2>/dev/null | grep filebeat)
@@ -344,12 +344,12 @@ changePassword() {
             hasfilebeat=$(apt list --installed  2>/dev/null | grep filebeat)
         fi 
 
-        wazuhold=$(grep "password:" /etc/filebeat/filebeat.yml )
+        adminold=$(grep "password:" /etc/filebeat/filebeat.yml )
         ra="  password: "
-        wazuhold="${wazuhold//$ra}"
+        adminold="${adminold//$ra}"
 
         if [ -n "${hasfilebeat}" ]; then
-            conf="$(awk '{sub("  password: '${wazuhold}'", "  password: '${wazuhpass}'")}1' /etc/filebeat/filebeat.yml)"
+            conf="$(awk '{sub("  password: '${adminold}'", "  password: '${adminpass}'")}1' /etc/filebeat/filebeat.yml)"
             echo "${conf}" > /etc/filebeat/filebeat.yml  
             restartService "filebeat"
         fi 

--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -98,16 +98,16 @@ startService() {
 
 ## Show script usage
 getHelp() {
-   echo ""
-   echo "Usage: $0 arguments"
-   echo -e "\t-e     | --install-elasticsearch Installs Open Distro for Elasticsearch (cannot be used together with option -k)"
-   echo -e "\t-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)"
-   echo -e "\t-n     | --node-name Name of the node"
-   echo -e "\t-c     | --create-certificates Generates the certificates for all the indicated nodes"
-   echo -e "\t-d     | --debug Shows the complete installation output"
-   echo -e "\t-i     | --ignore-health-check Ignores the health-check"
-   echo -e "\t-h     | --help Shows help"
-   exit 1 # Exit script after printing help
+    echo ""
+    echo "Usage: $0 arguments"
+    echo -e "\t-e     | --install-elasticsearch Installs Open Distro for Elasticsearch (cannot be used together with option -k)"
+    echo -e "\t-k     | --install-kibana Installs Open Distro for Kibana (cannot be used together with option -e)"
+    echo -e "\t-n     | --node-name Name of the node"
+    echo -e "\t-c     | --create-certificates Generates the certificates for all the indicated nodes"
+    echo -e "\t-d     | --debug Shows the complete installation output"
+    echo -e "\t-i     | --ignore-health-check Ignores the health-check"
+    echo -e "\t-h     | --help Shows help"
+    exit 1 # Exit script after printing help
 }
 
 ## Checks if the configuration file or certificates exist

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -19,10 +19,10 @@ OD_VER="1.13.2"
 OD_REV="1"
 WAZUH_KIB_PLUG_REV="1"
 ow=""
-repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
-repobaseurl="https://packages-dev.wazuh.com/pre-release"
+repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
+repobaseurl="https://packages.wazuh.com/4.x"
 filebeat_wazuh_template_url="https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json"
-resources="https://packages-dev.wazuh.com/resources/${WAZUH_MAJOR}"
+resources="https://packages.wazuh.com/resources/${WAZUH_MAJOR}"
 
 if [ -n "$(command -v yum)" ]; then
     sys_type="yum"
@@ -628,6 +628,10 @@ main() {
             "-h"|"--help")
                 getHelp
                 ;;
+            "-d"|"--dev")
+                development=1
+                shift 1
+                ;;
             *)
                 getHelp
             esac
@@ -640,6 +644,12 @@ main() {
     fi
 
     eval "touch /var/log/wazuh-unattended-installation.log"
+
+    if [ -n "${development}" ]; then
+        repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
+        repobaseurl="https://packages-dev.wazuh.com/pre-release"
+        resources="https://packages-dev.wazuh.com/resources/${WAZUH_MAJOR}"
+    fi
 
     if [ -n "${verbose}" ]; then
         debug='2>&1 | tee -a /var/log/wazuh-unattended-installation.log'

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -379,8 +379,7 @@ installKibana() {
         exit 1;
     else    
         kibanainstalled="1"
-        #eval "curl -so /etc/kibana/kibana.yml ${resources}/open-distro/kibana/7.x/kibana_unattended.yml --max-time 300 ${debug}"
-        eval "cp  /unattended_scripts/open-distro/kibana/7.x/kibana_unattended.yml /etc/kibana/kibana.yml"
+        eval "curl -so /etc/kibana/kibana.yml ${resources}/open-distro/kibana/7.x/kibana_unattended.yml --max-time 300 ${debug}"
         eval "mkdir /usr/share/kibana/data ${debug}"
         eval "chown -R kibana:kibana /usr/share/kibana/ ${debug}"
         eval "sudo -u kibana /usr/share/kibana/bin/kibana-plugin install '${repobaseurl}'/ui/kibana/wazuh_kibana-${WAZUH_VER}_${ELK_VER}-${WAZUH_KIB_PLUG_REV}.zip ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-packages/issues/952|



## Description

This PR remove the wazuh user from the unattended installer and removes its references in the OVA and AMI
This PR also add a development flag to use packages-dev repository and simplifies the main of unattended-installation.sh script

## Logs example and Tests

Logs and tests can be found in:

- https://github.com/wazuh/wazuh-packages/issues/952#issuecomment-992706967
- https://github.com/wazuh/wazuh-packages/issues/952#issuecomment-993688542

Related to race condition between elasticsearch and filebeat when services start:

```
ERROR        [publisher_pipeline_output]        pipeline/output.go:154        Failed to connect to backoff(elasticsearch(https://127.0.0.1:9200)): Get "https://127.0.0.1:9200": dial tcp 127.0.0.1:9200: connect: connection refused
```

The rest of errors/warnings have been detected in 4.2 and the unified unattended

- https://github.com/wazuh/wazuh-packages/issues/1036
- Same as https://github.com/wazuh/wazuh-packages/issues/847 (4.2)

