### PR TITLE
Update the Windows build environment's base image to Ubuntu 21.04

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 # Installing necessary packages
 RUN apt-get update && \


### PR DESCRIPTION
|Related issue|
|---|
|#1077|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to update the Windows compiler base image to Ubuntu 21.04 to get MinGW to the build environment.

## Logs example

I checked that the related PR's branch (https://github.com/wazuh/wazuh/pull/11354) works with this change:

```sh
$ ./generate_compiled_windows_agent.sh -b 11025-win-dw2-dll --jobs 4
(...)
Done building winagent
(...)
Package windows_agent_1.zip added to /root/wazuh-packages/windows
```
```sh
$ unzip windows_agent_1.zip
$ find wazuh-11025-win-dw2-dll -name "wazuh-agent-4.4.0.exe"
wazuh-11025-win-dw2-dll/src/win32/wazuh-agent-4.4.0.exe
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
