### PR TITLE
Increase admin.pem cert expiration date unify-unattended

### DIFF
--- a/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
+++ b/unattended_scripts/install_functions/opendistro/wazuh-cert-tool.sh
@@ -204,7 +204,7 @@ generateAdmincertificate() {
     eval "openssl genrsa -out ${base_path}/certs/admin-key-temp.pem 2048 ${debug_cert}"
     eval "openssl pkcs8 -inform PEM -outform PEM -in ${base_path}/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${base_path}/certs/admin-key.pem ${debug_cert}"
     eval "openssl req -new -key ${base_path}/certs/admin-key.pem -out ${base_path}/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug_cert}"
-    eval "openssl x509 -req -in ${base_path}/certs/admin.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -sha256 -out ${base_path}/certs/admin.pem ${debug_cert}"
+    eval "openssl x509 -days 3650 -req -in ${base_path}/certs/admin.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -sha256 -out ${base_path}/certs/admin.pem ${debug_cert}"
 
 }
 

--- a/unattended_scripts/tools/wazuh-cert-tool.sh
+++ b/unattended_scripts/tools/wazuh-cert-tool.sh
@@ -184,7 +184,7 @@ generateAdmincertificate() {
     eval "openssl genrsa -out ./certs/admin-key-temp.pem 2048 ${debug}"
     eval "openssl pkcs8 -inform PEM -outform PEM -in ./certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ./certs/admin-key.pem ${debug}"
     eval "openssl req -new -key ./certs/admin-key.pem -out ./certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug}"
-    eval "openssl x509 -req -in ./certs/admin.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -days 730 -sha256 -out ./certs/admin.pem ${debug}"
+    eval "openssl x509 -req -in ./certs/admin.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -sha256 -out ./certs/admin.pem ${debug}"
 
 }
 

--- a/unattended_scripts/tools/wazuh-cert-tool.sh
+++ b/unattended_scripts/tools/wazuh-cert-tool.sh
@@ -184,7 +184,7 @@ generateAdmincertificate() {
     eval "openssl genrsa -out ./certs/admin-key-temp.pem 2048 ${debug}"
     eval "openssl pkcs8 -inform PEM -outform PEM -in ./certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ./certs/admin-key.pem ${debug}"
     eval "openssl req -new -key ./certs/admin-key.pem -out ./certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug}"
-    eval "openssl x509 -req -in ./certs/admin.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -sha256 -out ./certs/admin.pem ${debug}"
+    eval "openssl x509 -req -in ./certs/admin.csr -CA ./certs/root-ca.pem -CAkey ./certs/root-ca.key -CAcreateserial -days 730 -sha256 -out ./certs/admin.pem ${debug}"
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-jenkins/issues/3133|


## Description

This PR fixes a problem with the expiration date of the admin.pem certificate, which keeps its expiration date by default (1 month), this fix equates the date to the other certificates (3650 days)

## Logs example and Tests

Before fix

```
[root@centos7 certs]# openssl x509 -enddate -noout -in admin.pem
notAfter=Dec 15 14:38:20 2021 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in elasticsearch.pem 
notAfter=Nov 13 14:38:20 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in filebeat.pem 
notAfter=Nov 13 14:38:20 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in kibana.pem 
notAfter=Nov 13 14:38:21 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in root-ca.pem 
notAfter=Nov 13 14:38:20 2031 GMT
```


After fix

```
[root@centos7 certs]# openssl x509 -enddate -noout -in admin.pem
notAfter=Dec 14 19:46:45 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in elasticsearch.pem 
notAfter=Dec 14 19:46:45 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in filebeat.pem 
notAfter=Dec 14 19:46:45 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in kibana.pem 
notAfter=Dec 14 19:46:45 2031 GMT
[root@centos7 certs]# openssl x509 -enddate -noout -in root-ca.pem 
notAfter=Dec 14 19:46:45 2031 GMT

```