### PR TITLE
Increase admin.pem cert expiration date stable

### DIFF
--- a/unattended_scripts/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+++ b/unattended_scripts/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
@@ -184,7 +184,7 @@ generateAdmincertificate() {
     eval "openssl genrsa -out ~/certs/admin-key-temp.pem 2048 ${debug}"
     eval "openssl pkcs8 -inform PEM -outform PEM -in ~/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ~/certs/admin-key.pem ${debug}"
     eval "openssl req -new -key ~/certs/admin-key.pem -out ~/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin' ${debug}"
-    eval "openssl x509 -req -in ~/certs/admin.csr -CA ~/certs/root-ca.pem -CAkey ~/certs/root-ca.key -CAcreateserial -sha256 -out ~/certs/admin.pem ${debug}"
+    eval "openssl x509 -req -days 3650 -in ~/certs/admin.csr -CA ~/certs/root-ca.pem -CAkey ~/certs/root-ca.key -CAcreateserial -sha256 -out ~/certs/admin.pem ${debug}"
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-jenkins/issues/3133|


## Description

This PR fixes a problem with the expiration date of the admin.pem certificate, which keeps its expiration date by default (1 month), this fix equates the date to the other certificates (3650 days)

## Logs example and Tests

Same changes and test as https://github.com/wazuh/wazuh-packages/pull/1083