### PR TITLE
Removed the parameters for node names in the unattended installer

### DIFF
--- a/unattended_scripts/wazuh_install.sh
+++ b/unattended_scripts/wazuh_install.sh
@@ -43,10 +43,10 @@ getHelp() {
     echo -e "        -a,  --all-in-one"
     echo -e "                All-In-One installation."
     echo -e ""
-    echo -e "        -w,  --wazuh-server"
+    echo -e "        -w,  --wazuh-server <wazuh-node-name>"
     echo -e "                Wazuh server installation. It includes Filebeat."
     echo -e ""
-    echo -e "        -e,  --elasticsearch"
+    echo -e "        -e,  --elasticsearch <elasticsearch-node-name>"
     echo -e "                Elasticsearch installation."
     echo -e ""
     echo -e "        -k,  --kibana"
@@ -54,12 +54,6 @@ getHelp() {
     echo -e ""
     echo -e "        -c,  --create-certificates"
     echo -e "                Create certificates from instances.yml file."
-    echo -e ""
-    echo -e "        -en, --elasticsearch-node-name"
-    echo -e "                Name of the elasticsearch node, used for distributed installations."
-    echo -e ""
-    echo -e "        -wn, --wazuh-node-name"
-    echo -e "                Name of the wazuh node, used for distributed installations."
     echo -e ""
     echo -e "        -wk, --wazuh-key <wazuh-cluster-key>"
     echo -e "                Use this option as well as a wazuh_cluster_config.yml configuration file to automatically configure the wazuh cluster when using a multi-node installation."
@@ -148,25 +142,18 @@ main() {
                 ;;
             "-w"|"--wazuh-server")
                 wazuh=1
+                winame=$2
                 shift 1
                 ;;
             "-e"|"--elasticsearch")
                 elasticsearch=1
-                shift 1
+                einame=$2
+                shift 2
                 ;;
             "-k"|"--kibana")
                 kibana=1
                 shift 1
                 ;;
-            "-en"|"--elasticsearch-node-name")
-                einame=$2
-                shift 2
-                ;;
-            "-wn"|"--wazuh-node-name")
-                winame=$2
-                shift 2
-                ;;
-
             "-c"|"--create-certificates")
                 certificates=1
                 shift 1


### PR DESCRIPTION
|Related issue|
|---|
| closes #1071 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR removes the parameters `-wn|--wazuh-node-name` and `-en|--elastic-node-name`. The names of the nodes must now be passed after the parameters `-w|--wazuh-server` and `-e|--elasticsearch`
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example
```
[vagrant@centos7 unattended_scripts]$ bash wazuh_install.sh -h

NAME
        wazuh_install.sh - Install and configure Wazuh All-In-One components.

SYNOPSIS
        wazuh_install.sh [OPTIONS]

DESCRIPTION
        -a,  --all-in-one
                All-In-One installation.

        -w,  --wazuh-server <wazuh-node-name>
                Wazuh server installation. It includes Filebeat.

        -e,  --elasticsearch <elasticsearch-node-name>
                Elasticsearch installation.

        -k,  --kibana
                Kibana installation.

        -c,  --create-certificates
                Create certificates from instances.yml file.

        -wk, --wazuh-key <wazuh-cluster-key>
                Use this option as well as a wazuh_cluster_config.yml configuration file to automatically configure the wazuh cluster when using a multi-node installation.

        -v,  --verbose
                Shows the complete installation output.

        -i,  --ignore-health-check
                Ignores the health-check.

        -l,  --local
                Use local files.

        -d,  --dev
                Use development repository.

        -h,  --help
                Shows help.

[vagrant@centos7 unattended_scripts]$ 

```
<!--
Paste here related logs
-->

## Tests

