### PR TITLE
Update g++ to fix undefined behavior on opensuse tumbleweed

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -12,24 +12,24 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
-RUN apt-get update && apt-get build-dep python3.2 -y 
+RUN apt-get update && apt-get build-dep python3.2 -y
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64:${LD_LIBRARY_PATH}"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64:${LD_LIBRARY_PATH}"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CXX=/usr/local/gcc-5.5.0/bin/g++ \
-        CC=/usr/local/gcc-5.5.0/bin/gcc && \
+    ./bootstrap --no-system-curl CXX=/usr/local/gcc-9.4.0/bin/g++ \
+        CC=/usr/local/gcc-9.4.0/bin/gcc && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
 

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -17,6 +17,18 @@ RUN apt-get update &&  apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
     ./bootstrap --no-system-curl && \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -17,6 +17,19 @@ RUN apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
+    linux32 ./contrib/download_prerequisites && \
+    linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --with-arch=armv7-a \
+        --with-fpu=vfpv3-d16 --with-float=hard --enable-languages=c,c++ \
+       --disable-multilib --disable-libsanitizer && \
+    linux32 make -j$(nproc) && linux32 make install && \
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
     linux32 ./bootstrap --no-system-curl && \

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -17,22 +17,22 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
 RUN apt-get update && apt-get build-dep python3.2 -y
 RUN sed -i "s;/\* To add :#define SO_REUSEPORT 15 \*/;#define SO_REUSEPORT 15;g" /usr/include/asm-generic/socket.h
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib:${LD_LIBRARY_PATH}"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib:${LD_LIBRARY_PATH}"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CXX=/usr/local/gcc-5.5.0/bin/g++ \
-        CC=/usr/local/gcc-5.5.0/bin/gcc && \
+    linux32 ./bootstrap --no-system-curl CXX=/usr/local/gcc-9.4.0/bin/g++ \
+        CC=/usr/local/gcc-9.4.0/bin/gcc && \
     linux32 make -j$(nproc) && linux32 make install && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake && cd / && rm -rf cmake-*
 

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -14,22 +14,22 @@ RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /et
 
 RUN apt-get update && apt-get build-dep python3.5 -y
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64:${LD_LIBRARY_PATH}"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64:${LD_LIBRARY_PATH}"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CXX=/usr/local/gcc-5.5.0/bin/g++ \
-        CC=/usr/local/gcc-5.5.0/bin/gcc && \
+    ./bootstrap --no-system-curl CXX=/usr/local/gcc-9.4.0/bin/g++ \
+        CC=/usr/local/gcc-9.4.0/bin/gcc && \
     make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
     cd / && rm -rf cmake-*
 

--- a/rpms/CentOS/5/i386/Dockerfile
+++ b/rpms/CentOS/5/i386/Dockerfile
@@ -23,16 +23,16 @@ RUN curl -OL http://packages.wazuh.com/utils/curl/curl-7.63.0.tar.gz && \
     linux32 ./configure --with-ssl=/usr/local/ssl && \
     linux32 make -j2 && linux32 make install && cd / && rm -rf curl*
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib --disable-libsanitizer && \
     linux32 make -j2 && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz && \
     tar -zxvf cmake-3.12.4.tar.gz && cd cmake-3.12.4 && \

--- a/rpms/CentOS/5/x86_64/Dockerfile
+++ b/rpms/CentOS/5/x86_64/Dockerfile
@@ -29,17 +29,17 @@ RUN curl -OL http://packages.wazuh.com/utils/curl/curl-7.63.0.tar.gz && \
     tar xf curl-7.63.0.tar.gz && cd curl-7.63.0 && ./configure --with-ssl=/usr/local/ssl && \
     make -j2 && make install && cd / && rm -rf curl*
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     make -j2 && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz && \
     tar -zxvf cmake-3.12.4.tar.gz && cd cmake-3.12.4 && \

--- a/rpms/CentOS/6/i386/Dockerfile
+++ b/rpms/CentOS/6/i386/Dockerfile
@@ -40,22 +40,22 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     linux32 make -j$(nproc) && linux32 make install && cd / && rm -rf cmake-*
 
 # Add the scripts to build the RPM package

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -40,22 +40,22 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     make -j$(nproc) && make install && cd / && rm -rf cmake-*
 
 # Add the scripts to build the RPM package

--- a/rpms/CentOS/7/aarch64/Dockerfile
+++ b/rpms/CentOS/7/aarch64/Dockerfile
@@ -24,22 +24,22 @@ RUN yum install -y gcc make wget git \
     redhat-rpm-config sqlite-devel gdb tar tcl-devel tix-devel tk-devel \
     valgrind-devel python-rpm-macros python34 nodejs
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ --disable-multilib \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer --disable-bootstrap && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     make -j$(nproc) && make install && cd / && rm -rf cmake-*
 
 RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \

--- a/rpms/CentOS/7/armv7hl/Dockerfile
+++ b/rpms/CentOS/7/armv7hl/Dockerfile
@@ -3,23 +3,23 @@ FROM arm32v7/centos:7
 ADD build_deps.sh /build_deps.sh
 RUN sh build_deps.sh
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \
-    linux32 ./configure --prefix=/usr/local/gcc-5.5.0 --with-arch=armv7-a \
+    linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --with-arch=armv7-a \
         --with-float=hard --enable-languages=c,c++ --disable-multilib \
-        --disable-libsanitizer --disable-bootstrap && \
+        --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    linux32 ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     linux32 make -j$(nproc) && linux32 make install && cd / && rm -rf cmake-*
 
 RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \

--- a/rpms/CentOS/7/ppc64le/Dockerfile
+++ b/rpms/CentOS/7/ppc64le/Dockerfile
@@ -21,22 +21,22 @@ RUN yum install -y \
     http://packages.wazuh.com/utils/nodejs/npm-5.6.0-1.8.9.4.2.el7.ppc64le.rpm \
     http://packages.wazuh.com/utils/nodejs/nodejs-debuginfo-8.9.4-2.el7.ppc64le.rpm
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     make -j$(nproc) && make install && cd / && rm -rf cmake-* && \
     ln -sf /usr/bin/rpmbuild /usr/local/bin/rpmbuild
 

--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -19,22 +19,22 @@ RUN yum -y install epel-release && \
 
 RUN yum-builddep python34 -y
 
-RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && \
-    tar xzf gcc-5.5.0.tar.gz  && cd gcc-5.5.0/ && \
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \
-    ./configure --prefix=/usr/local/gcc-5.5.0 --enable-languages=c,c++ \
-        --disable-multilib --disable-libsanitizer --disable-bootstrap && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
+        --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-5.5.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
 
-ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-5.5.0/include/c++/5.5.0/"
-ENV LD_LIBRARY_PATH "/usr/local/gcc-5.5.0/lib64/"
-ENV PATH "/usr/local/gcc-5.5.0/bin:${PATH}"
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
-    ./bootstrap --no-system-curl CC=/usr/local/gcc-5.5.0/bin/gcc \
-        CXX=/usr/local/gcc-5.5.0/bin/g++ && \
+    ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
     make -j$(nproc) && make install && cd / && rm -rf cmake-*
 
 RUN curl -OL http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \


### PR DESCRIPTION
|Related issue|
|---|
|Closes [core#10967](https://github.com/wazuh/wazuh/issues/10967)|

## Description
This bug has been found to manifest itself when binaries are compiled with g ++ and then packed into an rpm, causing the problem of sometimes not starting the wazuh-modulesd process

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
