### PR TITLE
Fix log4j mitigation options file 4.2

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -63,7 +63,7 @@ checkArch() {
 applyLog4j2Mitigation(){
 
     eval "mkdir /etc/elasticsearch/jvm.options.d ${debug}"
-    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options 2>&1"
     eval "chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
     eval "chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
 

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -139,7 +139,7 @@ checkArch() {
 applyLog4j2Mitigation(){
 
     eval "mkdir /etc/elasticsearch/jvm.options.d ${debug}"
-    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options 2>&1"
     eval "chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
     eval "chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
 


### PR DESCRIPTION
Related https://github.com/wazuh/wazuh-packages/pull/1069

## Description

The command that adds the option to the .options file redirects the output to the debug file, this causes the content to not be added to the disabledlog4j.options file, so the fix is not applied. This PR corrects this redirection so that it is correctly added to the destination file

## Logs example

Malformed command:

```
eval 'echo '\''-Dlog4j2.formatMsgNoLookups=true'\'' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options >> /var/log/wazuh-unattended-installation.log 2>&1'
```

Fixed command:

```
eval 'echo '\''-Dlog4j2.formatMsgNoLookups=true'\'' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options 2>&1'
```

```
[root@centos7 vagrant]# cat /etc/elasticsearch/jvm.options.d/disabledlog4j.options 
-Dlog4j2.formatMsgNoLookups=true
```

AMI /var/log/elasticsearch/wazuh-cluster.log:

```
[2021-12-20T21:50:51,061][INFO ][o.e.n.Node               ] [node-1] JVM home [/usr/share/elasticsearch/jdk], using bundled JDK [true]
$ty.policy, -Dlog4j2.formatMsgNoLookups=true, -XX:MaxDirectMemorySize=3758096384, -Des.path.home=/usr/share/elasticsearch, -Des.path.conf=/etc/elasticsearch, -Des.distribution.flavor=oss, -Des.distribution.type=rpm, -Des.bundled_jdk=tru$
[2021-12-20T21:50:59,699][INFO ][c.a.o.s.s.t.OpenDistroSSLConfig] [node-1] SSL dual mode is disabled
```