### PR TITLE
Fix wazuh password tool unify

### DIFF
--- a/unattended_scripts/install_functions/opendistro/wazuh-passwords-tool.sh
+++ b/unattended_scripts/install_functions/opendistro/wazuh-passwords-tool.sh
@@ -136,7 +136,7 @@ getNetworkHost() {
 checkInstalledPass() {
     
     if [ "${sys_type}" == "yum" ]; then
-        elasticsearchinstalled=$(yum list installed 2>/dev/null | grep elasticsearch-oss$)
+        elasticsearchinstalled=$(yum list installed 2>/dev/null | grep elasticsearch-oss)
     elif [ "${sys_type}" == "zypper" ]; then
         elasticsearchinstalled=$(zypper packages --installed | grep elasticsearch-oss | grep i+ | grep noarch)
     elif [ "${sys_type}" == "apt-get" ]; then
@@ -218,7 +218,7 @@ readUsers() {
 
 readFileUsers() {
 
-    filecorrect=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*\w+\s*)+\Z' ${p_file})
+    filecorrect=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' ${p_file})
     if [ ${filecorrect} -ne 1 ]; then
 	logger_pass -e "The password file doesn't have a correct format.
 
@@ -430,7 +430,7 @@ runSecurityAdmin() {
     
     logger_pass "Loading changes..."
     eval "cp /usr/share/elasticsearch/backup/* /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ ${debug_pass}"
-    eval "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -nhnv -cacert /usr/share/elasticsearch/plugins/opendistro_security/tools/${capem} -cert /usr/share/elasticsearch/plugins/opendistro_security/tools/${adminpem} -key /usr/share/elasticsearch/plugins/opendistro_security/tools/${adminkey} -icl -h ${IP} ${debug_pass}"
+    eval "/usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug_pass}"
     if [  "$?" != 0  ]; then
         logger_pass -e "Could not load the changes."
         exit 1;


### PR DESCRIPTION
Related https://github.com/wazuh/wazuh-packages/issues/1057



## Description

This PR fixes a problem in the wazuh-password-tool.sh script that prevents changing the passwords of opendistro users by specifying a file. Also, this PR add to password validation the character `-` to allow AMI-style passwords. Detection of elasticsearch package installation is also fixed.


## Logs example

<details><summary>Install stage</summary>

  ```
  [root@centos8 vagrant]# bash wazuh_install.sh -a -l -d
  12/21/2021 17:57:18 INFO: Configuration file found. Creating certificates...
  12/21/2021 17:57:18 INFO: Creating the Elasticsearch certificates...
  12/21/2021 17:57:18 INFO: Creating Wazuh server certificates...
  12/21/2021 17:57:18 INFO: Creating Kibana certificate...
  12/21/2021 17:57:18 INFO: Certificates creation finished. They can be found in /vagrant/certs.
  12/21/2021 17:57:18 INFO: Generating random passwords
  12/21/2021 17:57:18 INFO: Done
  12/21/2021 17:57:18 INFO: Starting the installation...
  12/21/2021 17:57:18 INFO: Installing all necessary utilities for the installation...
  12/21/2021 17:57:20 INFO: Done
  12/21/2021 17:57:20 INFO: Adding the Wazuh repository...
  12/21/2021 17:57:21 INFO: Done
  12/21/2021 17:57:21 INFO: Installing the Wazuh manager...
  12/21/2021 17:58:10 INFO: Done
  12/21/2021 17:58:24 INFO: Wazuh-manager started
  12/21/2021 17:58:24 INFO: Installing Open Distro for Elasticsearch...
  12/21/2021 17:58:54 INFO: Done
  12/21/2021 17:58:54 INFO: Configuring Elasticsearch...
  12/21/2021 17:58:55 INFO: Starting Elasticsearch...
  12/21/2021 17:59:03 INFO: Elasticsearch started
  12/21/2021 17:59:03 INFO: Initializing Elasticsearch...
  12/21/2021 17:59:11 INFO: Done
  12/21/2021 17:59:11 INFO: Installing Filebeat...
  12/21/2021 17:59:17 INFO: Starting Filebeat...
  12/21/2021 17:59:18 INFO: Filebeat started
  12/21/2021 17:59:18 INFO: Done
  12/21/2021 17:59:18 INFO: Installing Open Distro for Kibana...
  12/21/2021 18:00:19 INFO: Done
  12/21/2021 18:00:29 INFO: Kibana started
  12/21/2021 18:00:29 INFO: Initializing Kibana (this may take a while)
  12/21/2021 18:00:39 INFO: You can access the web interface https://localhost. The credentials are admin:admin
  12/21/2021 18:00:41 INFO: Creating backup...
  12/21/2021 18:00:44 INFO: Backup created
  12/21/2021 18:00:44 INFO: Generating hashes
  12/21/2021 18:00:49 INFO: Hashes generated
  12/21/2021 18:00:49 INFO: Filebeat started
  12/21/2021 18:00:49 INFO: Kibana started
  12/21/2021 18:00:49 INFO: Loading changes...
  12/21/2021 18:00:54 INFO: Done
  
  12/21/2021 18:00:54 INFO: The password for admin is HXtqyYZHq2Zs7DhSGLYBlH98pqbnlBqB
  
  12/21/2021 18:00:54 INFO: The password for wazuh is 4z4PSyYwJzkFziElws8u2NMP9v1nzKjf
  
  12/21/2021 18:00:54 INFO: The password for kibanaserver is zILbzSG3vlAm27EnY8cqy6s1uJYjMxL3
  
  12/21/2021 18:00:54 INFO: The password for kibanaro is l2TKDCBpEZk7xTw96vxzsS248furdNBL
  
  12/21/2021 18:00:54 INFO: The password for logstash is Vfiwo3dBQ5t0jG1uYqxkKwXt7oFVFDcV
  
  12/21/2021 18:00:54 INFO: The password for readall is uaMQWr8xT5z70nn78Hq0mRG0hhu8xT2b
  
  12/21/2021 18:00:54 INFO: The password for snapshotrestore is UeGqSz1Pzgxpb2w7zUmTXavRptd8a9Xt
  
  12/21/2021 18:00:54 INFO: The password for wazuh_admin is kgKfDO2MH8QJBjzog3ZN2kp56KhklEuX
  
  12/21/2021 18:00:54 INFO: The password for wazuh_user is EkWQSMZKFylAy3WuA9Uf0f4eCnDHbtQI
  
  12/21/2021 18:00:54 WARNING: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services.
  
  12/21/2021 18:00:54 INFO: Setting the Wazuh repository to production
  12/21/2021 18:00:54 INFO: Done
  ```

</details>

<details><summary>Change passwords with file. Added -v to passwords</summary>

  ```
  [root@centos8 vagrant]# bash install_functions/opendistro/wazuh-passwords-tool.sh -f password_file.yml 
  12/21/2021 18:05:12 INFO: Creating backup...
  12/21/2021 18:05:15 INFO: Backup created
  12/21/2021 18:05:15 INFO: Generating hashes
  12/21/2021 18:05:20 INFO: Hashes generated
  12/21/2021 18:05:20 INFO: Filebeat started
  12/21/2021 18:05:20 INFO: Kibana started
  12/21/2021 18:05:20 INFO: Loading changes...
  12/21/2021 18:05:24 INFO: Done
  
  12/21/2021 18:05:24 INFO: The password for admin is HXtqyYZHq2Zs7DhSGLYBlH98pqbnlBqB-v
  
  12/21/2021 18:05:24 INFO: The password for wazuh is 4z4PSyYwJzkFziElws8u2NMP9v1nzKjf-v
  
  12/21/2021 18:05:24 INFO: The password for kibanaserver is zILbzSG3vlAm27EnY8cqy6s1uJYjMxL3-v
  
  12/21/2021 18:05:24 INFO: The password for kibanaro is l2TKDCBpEZk7xTw96vxzsS248furdNBL-v
  
  12/21/2021 18:05:24 INFO: The password for logstash is Vfiwo3dBQ5t0jG1uYqxkKwXt7oFVFDcV-v
  
  12/21/2021 18:05:24 INFO: The password for readall is uaMQWr8xT5z70nn78Hq0mRG0hhu8xT2b-v
  
  12/21/2021 18:05:24 INFO: The password for snapshotrestore is UeGqSz1Pzgxpb2w7zUmTXavRptd8a9Xt-v
  
  12/21/2021 18:05:24 INFO: The password for wazuh_admin is kgKfDO2MH8QJBjzog3ZN2kp56KhklEuX-v
  
  12/21/2021 18:05:24 INFO: The password for wazuh_user is EkWQSMZKFylAy3WuA9Uf0f4eCnDHbtQI-v
  
  12/21/2021 18:05:24 WARNING: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services.
  ```

</details>

<details><summary>Password file generation</summary>

  ```
  [root@centos8 vagrant]# bash install_functions/opendistro/wazuh-passwords-tool.sh -gf mycustompasswords.yml
  12/21/2021 18:14:15 INFO: Generating random passwords
  12/21/2021 18:14:15 INFO: Done
  [root@centos8 vagrant]# cat mycustompasswords.yml 
  User:
    name: admin
    password: 2Tdy8P6L3fETsmogsl2mj9TiOy25ziOC
  User:
    name: wazuh
    password: 5ec4yAjEVQMwaLblmRRaXeQrIWa6iwac
  User:
    name: kibanaserver
    password: dMQjQz98XuPX7MHVXjEjkXtwbzaKyiHw
  User:
    name: kibanaro
    password: ZkBRWpO3xXBLCatR0xbXvtfydPi5ziGq
  User:
    name: logstash
    password: P3Q7xctp3omZNG3POQlYsCGj6pDFNRoI
  User:
    name: readall
    password: bJ22jPsOuW0XAxjaVA7GNsfls8Qov5Oi
  User:
    name: snapshotrestore
    password: QKMO24dMoasNPzBU0CwNhJ8n3VuAZnuk
  User:
    name: wazuh_admin
    password: ImSo5qLsIzt77MpJ9vHf6GLVlPbbn3TL
  User:
    name: wazuh_user
    password: otdl4lXuPUHWNUQHm2QodpH3SWmQ0IzH
  [root@centos8 vagrant]#
  ```

</details>
