### PR TITLE
Added new log4j remediation 4.2

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -62,10 +62,23 @@ checkArch() {
 
 applyLog4j2Mitigation(){
 
-    eval "mkdir /etc/elasticsearch/jvm.options.d ${debug}"
-    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options 2>&1"
-    eval "chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
-    eval "chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "curl -so /tmp/apache-log4j-2.17.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.17.0/apache-log4j-2.17.0-bin.tar.gz ${debug}"
+    eval "tar -xf /tmp/apache-log4j-2.17.0-bin.tar.gz -C /tmp/"
+
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar /usr/share/elasticsearch/lib/  ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar /usr/share/elasticsearch/lib/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-slf4j-impl-2.17.0.jar /usr/share/elasticsearch/plugins/opendistro_security/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar /usr/share/elasticsearch/performance-analyzer-rca/lib/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar /usr/share/elasticsearch/performance-analyzer-rca/lib/ ${debug}"
+
+    eval "rm -f /usr/share/elasticsearch/lib//log4j-api-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/plugins/opendistro_security/log4j-slf4j-impl-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-api-2.13.0.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-core-2.13.0.jar ${debug}"
+
+    eval "rm -rf /tmp/apache-log4j-2.17.0-bin ${debug}"
+    eval "rm -f /tmp/apache-log4j-2.17.0-bin.tar.gz ${debug}"
 
 }
 

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -138,10 +138,23 @@ checkArch() {
 
 applyLog4j2Mitigation(){
 
-    eval "mkdir /etc/elasticsearch/jvm.options.d ${debug}"
-    eval "echo '-Dlog4j2.formatMsgNoLookups=true' > /etc/elasticsearch/jvm.options.d/disabledlog4j.options 2>&1"
-    eval "chmod 2750 /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
-    eval "chown root:elasticsearch /etc/elasticsearch/jvm.options.d/disabledlog4j.options ${debug}"
+    eval "curl -so /tmp/apache-log4j-2.17.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.17.0/apache-log4j-2.17.0-bin.tar.gz ${debug}"
+    eval "tar -xf /tmp/apache-log4j-2.17.0-bin.tar.gz -C /tmp/"
+
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar /usr/share/elasticsearch/lib/  ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar /usr/share/elasticsearch/lib/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-slf4j-impl-2.17.0.jar /usr/share/elasticsearch/plugins/opendistro_security/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar /usr/share/elasticsearch/performance-analyzer-rca/lib/ ${debug}"
+    eval "cp /tmp/apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar /usr/share/elasticsearch/performance-analyzer-rca/lib/ ${debug}"
+
+    eval "rm -f /usr/share/elasticsearch/lib//log4j-api-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/plugins/opendistro_security/log4j-slf4j-impl-2.11.1.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-api-2.13.0.jar ${debug}"
+    eval "rm -f /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-core-2.13.0.jar ${debug}"
+
+    eval "rm -rf /tmp/apache-log4j-2.17.0-bin ${debug}"
+    eval "rm -f /tmp/apache-log4j-2.17.0-bin.tar.gz ${debug}"
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
| Related PR: https://github.com/wazuh/wazuh-packages/pull/1069 | 


## Description

This PR adds a new mitigation to the log4j vulnerabilities since the current mitigation is not fully effective. This new mitigation updates the versions of the JAR to 2.17


## Logs example and Tests

<details><summary>Install</summary>

  ```
  [root@centos8 unattended-installation]# bash unattended-installation.sh 
  12/22/2021 19:15:22 INFO: Starting the installation...
  12/22/2021 19:15:22 INFO: Installing all necessary utilities for the installation...
  12/22/2021 19:15:30 INFO: Done
  12/22/2021 19:15:30 INFO: Adding the Wazuh repository...
  12/22/2021 19:15:30 INFO: Done
  12/22/2021 19:15:30 INFO: Installing the Wazuh manager...
  12/22/2021 19:16:21 INFO: Done
  12/22/2021 19:16:35 INFO: Wazuh-manager started
  12/22/2021 19:16:35 INFO: Installing Open Distro for Elasticsearch...
  12/22/2021 19:17:02 INFO: Done
  12/22/2021 19:17:02 INFO: Configuring Elasticsearch...
  12/22/2021 19:17:03 INFO: Configuration file found. Creating certificates...
  12/22/2021 19:17:03 INFO: Creating the Elasticsearch certificates...
  12/22/2021 19:17:03 INFO: Creating Wazuh server certificates...
  12/22/2021 19:17:03 INFO: Creating Kibana certificate...
  12/22/2021 19:17:03 INFO: Certificates creation finished. They can be found in ~/certs.
  12/22/2021 19:17:03 INFO: Certificates created
  12/22/2021 19:17:13 INFO: Elasticsearch started
  12/22/2021 19:17:13 INFO: Initializing Elasticsearch...
  
  12/22/2021 19:17:22 INFO: Done
  12/22/2021 19:17:22 INFO: Installing Filebeat...
  12/22/2021 19:17:25 INFO: Filebeat started
  12/22/2021 19:17:25 INFO: Done
  12/22/2021 19:17:25 INFO: Installing Open Distro for Kibana...
  12/22/2021 19:18:30 INFO: Kibana started
  12/22/2021 19:18:30 INFO: Done
  12/22/2021 19:18:31 INFO: Generating random passwords
  12/22/2021 19:18:31 INFO: Done
  12/22/2021 19:18:31 INFO: Creating backup...
  12/22/2021 19:18:37 INFO: Backup created
  12/22/2021 19:18:37 INFO: Generating hashes
  12/22/2021 19:18:42 INFO: Hashes generated
  12/22/2021 19:18:43 INFO: Filebeat started
  12/22/2021 19:18:43 INFO: Kibana started
  12/22/2021 19:18:43 INFO: Loading changes...
  12/22/2021 19:18:49 INFO: Done
  The password for wazuh is wvUQHGpA3Fc98MvcBYw4FZTwIgKfS8p6
  
  The password for admin is l9PFis_EcKb40yknZFj9tne2XchsXESk
  
  The password for kibanaserver is 94VuHu31UtHF6VAH8sVJlLHZohyoSWCh
  
  The password for kibanaro is cPpQ8f9JnbqI_q91RNYcrQDw-6os9gLS
  
  The password for logstash is fvzvVK7nKm-IUcpi8YWkodbwFXr76IwB
  
  The password for readall is lzrHdfT9QBSY5Zn4ph2ygA6jPqSothHy
  
  The password for snapshotrestore is gHU0tRr9dVjnjrHtiJ-exf0TRKq9ZtHB
  
  The password for wazuh_admin is whBwd1V_Vgojs14JGYvwEkKDC5vkau2Z
  
  The password for wazuh_user is DCrDwSXoSMoMlPwYhPFLHKDabfkObkR2
  
  12/22/2021 19:18:49 INFO: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/kibana/kibana.yml if necessary and restart the services. More info: https://documentation.wazuh.com/current/user-manual/elasticsearch/elastic-tuning.html#change-users-password
  12/22/2021 19:18:49 INFO: Checking the installation...
  12/22/2021 19:18:49 INFO: Elasticsearch installation succeeded.
  12/22/2021 19:18:49 INFO: Filebeat installation succeeded.
  12/22/2021 19:18:49 INFO: Initializing Kibana (this may take a while)
  .
  12/22/2021 19:18:59 INFO: Installation finished
  12/22/2021 19:18:59 INFO: You can access the web interface https://<kibana_ip>. The credentials are wazuh:wvUQHGpA3Fc98MvcBYw4FZTwIgKfS8p6
  ```

</details>

<details><summary>Files</summary>

  ```
  [root@centos8 log4shell-jar-scripts]# find /usr/share/elasticsearch/ -name "*log4j*"
  /usr/share/elasticsearch/lib/log4j-api-2.17.0.jar
  /usr/share/elasticsearch/lib/log4j-core-2.17.0.jar
  /usr/share/elasticsearch/plugins/opendistro_security/log4j-slf4j-impl-2.17.0.jar
  /usr/share/elasticsearch/performance-analyzer-rca/pa_config/log4j2.xml
  /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-api-2.17.0.jar
  /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-core-2.17.0.jar
  ```

</details>

<details><summary>Vulnerabilities scan 2.11/2.13</summary>

  ```
  [root@centos8 log4shell-jar-scripts]# ./log4shell scan /usr/share/elasticsearch/
  2:15PM Scan Result: Identified vulnerable path 
  cve: CVE-2021-44228 
  fileName: org/apache/logging/log4j/core/net/JndiManager.class 
  hash: 293d7e83d4197f0496855f40a7745cfcdd10026dc057dfc1816de57295be88a6 
  path: /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar 
  severity: 10.0 
  versionInfo: "2.10.0, 2.11.0, 2.11.1, 2.11.2, 2.9.0, 2.9.1"
  2:15PM Scan Result: Identified vulnerable path 
  cve: CVE-2021-44228 
  fileName: org/apache/logging/log4j/core/net/JndiManager.class 
  hash: c3e95da6542945c1a096b308bf65bbd7fcb96e3d201e5a2257d85d4dedc6a078 
  path: /usr/share/elasticsearch/performance-analyzer-rca/lib/log4j-core-2.13.0.jar 
  severity: 10.0 
  versionInfo: "2.13.0, 2.13.1, 2.13.2, 2.13.3"
  ```

</details>

<details><summary>Vulnerabilities scan 2.17</summary>

  ```
  [root@centos8 log4shell-jar-scripts]# ./log4shell scan /usr/share/elasticsearch/
  [root@centos8 log4shell-jar-scripts]# 
  
  [root@centos8 log4shell-jar-scripts]# ./find-bad-deps.sh /usr/share/elasticsearch/
  No bad packages were found with known any hashes.
  [root@centos8 log4shell-jar-scripts]#
  ```

</details>