### PR TITLE
Fix linux wpk generation 4.3

### DIFF
--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -OL http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     ldconfig -v && cd / && rm -rf openssl-1.1.1a*
 
 RUN pip3 install cryptography==2.9.2 typing awscli
+RUN pip3 install --upgrade botocore==1.20.54
 
 ADD wpkpack.py /usr/local/bin/wpkpack
 ADD run.sh /usr/local/bin/run


### PR DESCRIPTION


## Description

With the update to gcc9 in the package creation containers, the pip3 botocore package has been updated to a higher version than supported. This causes the linux wpk to fail.

This PR fixes the botocore version in the linux wpk Dockerfile

### Tests

Error: https://ci.wazuh.info/job/Packages_builder/78923/console
Fixed: https://ci.wazuh.info/view/Packages/job/Packages_builder/78980/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
