### PR TITLE
Fix unattended distributed check 4.3

### DIFF
--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -595,15 +595,15 @@ healthCheck() {
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
     ram_gb=$(free --giga | awk '/^Mem:/{print $2}')
     if [ -n "${elastic}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 2 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 2GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 4 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 4GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."
         fi
     elif [ -n "${kibana}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 2 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 2GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 4 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 4GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."

--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -595,15 +595,15 @@ healthCheck() {
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
     ram_gb=$(free -m | awk '/^Mem:/{print $2}')
     if [ -n "${elastic}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 3700 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."
         fi
     elif [ -n "${kibana}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 3700 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."

--- a/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/elastic-stack-installation.sh
@@ -593,17 +593,17 @@ checkNodes() {
 healthCheck() {
 
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
-    ram_gb=$(free -m | awk '/^Mem:/{print $2}')
+    ram_gb=$(free --giga | awk '/^Mem:/{print $2}')
     if [ -n "${elastic}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 2 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 2GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."
         fi
     elif [ -n "${kibana}" ]; then
-        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]; then
-            logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+        if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 2 ]; then
+            logger -e "Your system does not meet the recommended minimum hardware requirements of 2GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
             exit 1;
         else
             logger "Starting the installation..."

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -259,11 +259,11 @@ configureFilebeat() {
 ## Health check
 healthCheck() {
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
-    ram_gb=$(free -m | awk '/^Mem:/{print $2}')
+    ram_gb=$(free --giga | awk '/^Mem:/{print $2}')
 
-    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]
+    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 2 ]
     then
-        logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores . If you want to proceed with the installation use the -i option to ignore these requirements."
+        logger -e "Your system does not meet the recommended minimum hardware requirements of 2GB of RAM and 2 CPU cores . If you want to proceed with the installation use the -i option to ignore these requirements."
         exit 1;
     else
         logger "Starting the installation..."

--- a/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -261,7 +261,7 @@ healthCheck() {
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
     ram_gb=$(free -m | awk '/^Mem:/{print $2}')
 
-    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 3700 ]
+    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1837 ]
     then
         logger -e "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores . If you want to proceed with the installation use the -i option to ignore these requirements."
         exit 1;

--- a/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
+++ b/unattended_scripts/open-distro/unattended-installation/unattended-installation.sh
@@ -556,7 +556,7 @@ networkCheck() {
 specsCheck() {
 
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
-    ram_gb=$(free -m | awk '/^Mem:/{print $2}')
+    ram_gb=$(free --giga | awk '/^Mem:/{print $2}')
     
 }
 
@@ -564,8 +564,8 @@ specsCheck() {
 healthCheck() {
 
     specsCheck
-    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 3700 ]; then
-        logger -e "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
+    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 4 ]; then
+        logger -e "Your system does not meet the recommended minimum hardware requirements of 4GB of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
         exit 1;
     else
         logger "Starting the installation..."


### PR DESCRIPTION
This PR corrects the check of the necessary requirements for the wazuh distributed installation, since 2GB of ram are necessary instead of 4GB.

The new parameter would return the memory value in Gigabytes, so even though the physically available memory in MB is always somewhat less than that total, we make sure that the physical requirements are met:

```
free --giga | awk '/^Mem:/{print $2}'
4
```

This fix is determined by the requirements established in: https://documentation.wazuh.com/current/installation-guide/requirements.html