### PR TITLE
Add new `wodles/gcloud` files and folders to Solaris11 SPEC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Add new GCloud integration files to Solaris 11 [#1126](https://github.com/wazuh/wazuh-packages/pull/1126)
 - Update SPECS [#689](https://github.com/wazuh/wazuh-packages/pull/689)
 - Fix `find` error in CentOS 5 building [#888](https://github.com/wazuh/wazuh-packages/pull/888)
 - Add new SCA files to Solaris 11 [#944](https://github.com/wazuh/wazuh-packages/pull/944)

--- a/solaris/solaris11/SPECS/template_agent_v4.3.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.3.0.json
@@ -1895,6 +1895,46 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/gcloud/buckets": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/buckets/access_logs.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/buckets/bucket.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/pubsub": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/gcloud/pubsub/subscriber.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/oscap": {
         "class": "static",
         "group": "wazuh",


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1125 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we add the files added in https://github.com/wazuh/wazuh/pull/9279 to the `wodles/gcloud` folder to the Solaris11 SPEC.
<!--
Add a clear description of how the problem has been solved.
-->

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
