### PR TITLE
Fix client keys Ownership for 3.7.x and previous versions to Master

### DIFF
--- a/debs/SPECS/4.4.0/wazuh-manager/debian/preinst
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/preinst
@@ -33,6 +33,9 @@ case "$1" in
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
             ${DIR}/bin/ossec-control stop > /dev/null 2>&1 || ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
+            if pgrep -f ossec-authd > /dev/null 2>&1; then
+                kill -15 $(pgrep -f ossec-authd)
+            fi
 
             if [ -d ${DIR}/logs/ossec ]; then
                 mv ${DIR}/logs/ossec ${DIR}/logs/wazuh

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -200,6 +200,9 @@ if [ $1 = 2 ]; then
   fi
   %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1 || %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
 fi
+if pgrep -f ossec-authd > /dev/null 2>&1; then
+    kill -15 $(pgrep -f ossec-authd)
+fi
 
 # Remove/relocate existing SQLite databases
 rm -f %{_localstatedir}/var/db/cluster.db* || true


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1025|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The ownership change process is moved so that it is the last thing to do in the upgrade process

A validation is added for the ossec-authd daemon, if it is started, the process is eliminated before the upgrade
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests
https://devel.ci.wazuh.info/view/Tests/job/Test_upgrade_tier/1496/consoleFull

![Screenshot_20211228_081025](https://user-images.githubusercontent.com/64099752/147560343-9a1ea20c-ecde-4023-840d-024b23b27326.png)
![Screenshot_20211228_081044](https://user-images.githubusercontent.com/64099752/147560373-c1f8be1f-551e-4df9-adf1-68fd1cb84e3d.png)


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
