### PR TITLE
Add fimdblib to SPECS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.4.0]
 
+- Add `libfimdb` [#989](https://github.com/wazuh/wazuh-packages/issues/989)
 ## [v4.3.0]
 
 - Update SPECS [#1014](https://github.com/wazuh/wazuh-packages/pull/1014)

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -545,6 +545,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libfimdb.so
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -180,7 +180,7 @@ fi
 # Create the wazuh user if it doesn't exists
 if ! id -u wazuh > /dev/null 2>&1; then
   useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
-fi 
+fi
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
@@ -660,6 +660,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libfimdb.so
 %{_localstatedir}/lib/libpython3.9.so.1.0
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
 %attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log

--- a/solaris/solaris11/SPECS/template_agent_v4.4.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.4.0.json
@@ -687,6 +687,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib/libfimdb.so": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/lib/libsysinfo.so": {
         "class": "static",
         "group": "wazuh",


### PR DESCRIPTION
|Related issue|
|---|
|#989|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team!

As part of the development of the issue https://github.com/wazuh/wazuh/issues/9103, we need to update the SPECS files to be able to generate properly the new packages.

The main branch of this development is the following https://github.com/wazuh/wazuh/tree/9103-replace-fim-db-dbsync

Closes #989 

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] Solaris
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
