### PR TITLE
Changed condition to check node names

### DIFF
--- a/unattended_scripts/install_functions/opendistro/common.sh
+++ b/unattended_scripts/install_functions/opendistro/common.sh
@@ -62,21 +62,21 @@ function checkNames() {
     fi
 
     if [[ -n ${einame} ]]; then
-        if [ ! -n "$(echo ${elasticsearch_node_names[@]} | grep -w $einame)" ]; then
+        if [[ ! -n "$(echo ${elasticsearch_node_names[@]} | grep -w $einame)" ]]; then
             logger -e "The name given for the Elasticsearch node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${winame} ]]; then
-        if [ ! -n "$(echo ${wazuh_servers_node_names[@]} | grep -w $winame)" ]; then
+        if [[ ! -n "$(echo ${wazuh_servers_node_names[@]} | grep -w $winame)" ]]; then
             logger -e "The name given for the Wazuh server node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${kiname} ]]; then
-        if [ ! -n "$(echo ${kibana_node_names[@]} | grep -w $kiname)" ]; then
+        if [[ ! -n "$(echo ${kibana_node_names[@]} | grep -w $kiname)" ]]; then
             logger -e "The name given for the Kibana node does not appear on the configuration file."
             exit 1
         fi

--- a/unattended_scripts/install_functions/opendistro/common.sh
+++ b/unattended_scripts/install_functions/opendistro/common.sh
@@ -62,21 +62,21 @@ function checkNames() {
     fi
 
     if [[ -n ${einame} ]]; then
-        if [[ ! "${elasticsearch_node_names[@]}" =~ "${einame}" ]]; then
+        if [ ! -n "$(echo ${elasticsearch_node_names[@]} | grep -w $einame)" ]; then
             logger -e "The name given for the Elasticsearch node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${winame} ]]; then
-        if [[ ! "${wazuh_servers_node_names[@]}" =~ "${winame}" ]]; then
+        if [ ! -n "$(echo ${wazuh_servers_node_names[@]} | grep -w $winame)" ]; then
             logger -e "The name given for the Wazuh server node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${kiname} ]]; then
-        if [[ ! "${kibana_node_names[@]}" =~ "${kiname}" ]]; then
+        if [ ! -n "$(echo ${kibana_node_names[@]} | grep -w $kiname)" ]; then
             logger -e "The name given for the Kibana node does not appear on the configuration file."
             exit 1
         fi

--- a/unattended_scripts/install_functions/opendistro/common.sh
+++ b/unattended_scripts/install_functions/opendistro/common.sh
@@ -62,21 +62,21 @@ function checkNames() {
     fi
 
     if [[ -n ${einame} ]]; then
-        if [[ ! -n "$(echo ${elasticsearch_node_names[@]} | grep -w $einame)" ]]; then
+        if [[ -z "$(echo ${elasticsearch_node_names[@]} | grep -w $einame)" ]]; then
             logger -e "The name given for the Elasticsearch node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${winame} ]]; then
-        if [[ ! -n "$(echo ${wazuh_servers_node_names[@]} | grep -w $winame)" ]]; then
+        if [[ -z "$(echo ${wazuh_servers_node_names[@]} | grep -w $winame)" ]]; then
             logger -e "The name given for the Wazuh server node does not appear on the configuration file."
             exit 1
         fi
     fi
 
     if [[ -n ${kiname} ]]; then
-        if [[ ! -n "$(echo ${kibana_node_names[@]} | grep -w $kiname)" ]]; then
+        if [[ -z "$(echo ${kibana_node_names[@]} | grep -w $kiname)" ]]; then
             logger -e "The name given for the Kibana node does not appear on the configuration file."
             exit 1
         fi

--- a/unattended_scripts/wazuh_install.sh
+++ b/unattended_scripts/wazuh_install.sh
@@ -195,7 +195,7 @@ function main() {
                     exit 1
                 fi
                 wazuh=1
-                winame=$2
+                winame="$2"
                 shift 2
                 ;;
             "-e"|"--elasticsearch")
@@ -205,7 +205,7 @@ function main() {
                     exit 1
                 fi
                 elasticsearch=1
-                einame=$2
+                einame="$2"
                 shift 2
                 ;;
             "-k"|"--kibana")
@@ -215,7 +215,7 @@ function main() {
                     exit 1
                 fi
                 kibana=1
-                kiname=$2
+                kiname="$2"
                 shift 2
                 ;;
             "-c"|"--create-certificates")


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR changes the condition that checks if the names of the nodes are in the configuration file. Previously, as it used a regex, it would detect `elasticsearch` was in the file if there was a node named `elasticsearch1` in the file.