### PR TITLE
Fix echo redirection in Debian postinst

### DIFF
--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -197,7 +197,7 @@ case "$1" in
 
 
     *)
-        echo "postinst called with unknown argument \`$1'" >22
+        echo "postinst called with unknown argument \`$1'" >2
         exit 1
     ;;
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -290,7 +290,7 @@ case "$1" in
 
 
     *)
-        echo "postinst called with unknown argument \`$1'" >22
+        echo "postinst called with unknown argument \`$1'" >2
         exit 1
     ;;
 


### PR DESCRIPTION
|Related issue|
|---|
|#1148|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes a minor error in the posinstall script of Debian packages.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
