### PR TITLE
Fix certificates creation using parameters unify

### DIFF
--- a/unattended_installer/install_functions/opendistro/wazuh-cert-tool.sh
+++ b/unattended_installer/install_functions/opendistro/wazuh-cert-tool.sh
@@ -257,6 +257,8 @@ function main() {
             esac
         done
 
+        readConfig
+
         if [ -n "${debugEnabled}" ]; then
             debug_cert="2>&1 | tee -a ${logfile}"
         fi


### PR DESCRIPTION
|Related issue|
|---|
|-|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The use of parameters does not produce the reading of the config.yml file, so it does not generate the certificates, this PR corrects this behavior

## Logs example

<!--
Paste here related logs
-->

```
[root@wazuh-manager ~]# ls certs
ls: cannot access certs: No such file or directory
[root@wazuh-manager ~]# bash wazuh-cert-tool.sh -w -k
11/01/2022 22:15:00 INFO: Creating the Wazuh server certificates.
11/01/2022 22:15:00 INFO: Wazuh server certificates created.
11/01/2022 22:15:00 INFO: Creating the Kibana certificate.
11/01/2022 22:15:00 INFO: Kibana certificates created.
[root@wazuh-manager ~]# ls certs
filebeat.conf  filebeat.csr  filebeat-key.pem  kibana.conf  kibana.csr  kibana-key.pem
[root@wazuh-manager ~]#
```