### PR TITLE
Fix certificates creation using parameters 4.3

### DIFF
--- a/unattended_scripts/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+++ b/unattended_scripts/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
@@ -311,6 +311,8 @@ main() {
             esac
         done    
 
+        readInstances
+
         if [ -n "${debugEnabled}" ]; then
             debug=""           
         fi


### PR DESCRIPTION
|Related issue|
|---|
|-|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The use of parameters does not produce the reading of the instances.yml file, so it does not generate the certificates, this PR corrects this behavior

## Logs example

<!--
Paste here related logs
-->

```
[root@wazuh-manager ~]# ls certs/
[root@wazuh-manager ~]# bash wazuh-cert-tool.sh -k -w
01/11/2022 21:43:25 INFO: Configuration file found. Creating certificates...
01/11/2022 21:43:25 INFO: Creating Wazuh server certificates...
01/11/2022 21:43:25 INFO: Wazuh server certificates created.
01/11/2022 21:43:25 INFO: Creating Kibana certificate...
01/11/2022 21:43:25 INFO: Kibana certificates created.
[root@wazuh-manager ~]# ls certs/
wazuh.conf  wazuh.csr  wazuh-key.pem  kibana.conf  kibana.csr  kibana-key.pem
[root@wazuh-manager ~]#
```