### PR TITLE
Add azure wodle to Solaris11 and RPM agent SPEC files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.4.0]
 
 - Update SPECS [#1014](https://github.com/wazuh/wazuh-packages/pull/1014)
+- Add Azure integration files to Solaris 11 and RPM SPECS [#1167](https://github.com/wazuh/wazuh-packages/pull/1167)
 
 ## [v4.3.0]
 

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -602,6 +602,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
 %attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
+packages/%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
 %attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud

--- a/solaris/solaris11/SPECS/template_agent_v4.4.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.4.0.json
@@ -1839,6 +1839,22 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/azure": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure-logs": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/docker": {
         "class": "static",
         "group": "wazuh",


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1122 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we modify the Solaris11 and RPM SPEC files to consider the addition of the Azure integration to agents made for wazuh/wazuh#10662, which is expected to be released in `4.4.0`.

## Tests
We tested the modified packages by creating a Solaris11 and a RPM package and installing them in a Solaris11 and a Centos 8 machine respectively. Everything worked as expected, as can be seen in the following output:

<details><summary>Package installation and file permissions in Solaris11</summary>


```
root@solaris-11:/tmp# pkg install -g ./wazuh-agent_v4.4.0-sol11-i386.p5p wazuh-agent
           Packages to install:  1
            Services to change:  1
       Create boot environment: No
Create backup boot environment: No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1         86/86      5.7/5.7 95.8M/s

PHASE                                          ITEMS
Installing new actions                       137/137
Updating package state database                 Done 
Updating package cache                           0/0 
Updating image state                            Done 
Creating fast lookup database                   Done 
Updating package cache                           3/3 
root@solaris-11:/tmp# l
bash: l: command not found
root@solaris-11:/tmp# cd /var/ossec
root@solaris-11:/var/ossec# ls
active-response  backup           etc              logs             ruleset          var
agentless        bin              lib              queue            tmp              wodles
root@solaris-11:/var/ossec# cd wodles
root@solaris-11:/var/ossec/wodles# ll
bash: ll: command not found
root@solaris-11:/var/ossec/wodles# ls -l
total 13
-rwxr-x---   1 root     wazuh          0 Jan 13 17:40 __init__.py
drwxr-x---   2 root     wazuh          3 Jan 13 17:40 aws
drwxr-x---   2 root     wazuh          3 Jan 13 17:40 azure
drwxr-x---   2 root     wazuh          3 Jan 13 17:40 docker
drwxr-x---   2 root     wazuh          2 Jan 13 17:40 gcloud
root@solaris-11:/var/ossec/wodles# ls -l azure
total 72
-rwxr-x---   1 root     wazuh      36332 Jan 13 17:40 azure-logs
```


</details>

<details><summary>Package installation and file permissions in Centos 8</summary>

```
[root@9e957f5544e7 /]# yum install /tmp/wazuh-agent-4.4.0-1.x86_64.rpm 
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:01:01 ago on Thu Jan 13 16:04:42 2022.
Dependencies resolved.
=============================================================================================
 Package              Architecture    Version                    Repository             Size
=============================================================================================
Installing:
 wazuh-agent          x86_64          4.4.0-1                    @commandline          8.2 M
Installing dependencies:
 initscripts          x86_64          10.00.15-1.el8             baseos                339 k

Transaction Summary
=============================================================================================
Install  2 Packages

Total size: 8.6 M
Total download size: 339 k
Installed size: 25 M
Is this ok [y/N]: y
Downloading Packages:
initscripts-10.00.15-1.el8.x86_64.rpm                        1.1 MB/s | 339 kB     00:00    
---------------------------------------------------------------------------------------------
Total                                                        738 kB/s | 339 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                     1/1 
  Installing       : initscripts-10.00.15-1.el8.x86_64                                   1/2 
  Running scriptlet: initscripts-10.00.15-1.el8.x86_64                                   1/2 
  Running scriptlet: wazuh-agent-4.4.0-1.x86_64                                          2/2 
  Installing       : wazuh-agent-4.4.0-1.x86_64                                          2/2 
  Running scriptlet: wazuh-agent-4.4.0-1.x86_64                                          2/2 
  Verifying        : initscripts-10.00.15-1.el8.x86_64                                   1/2 
  Verifying        : wazuh-agent-4.4.0-1.x86_64                                          2/2 

Installed:
  initscripts-10.00.15-1.el8.x86_64                wazuh-agent-4.4.0-1.x86_64               

Complete!
[root@9e957f5544e7 /]# ls -l /var/ossec/wodles
total 20
-rwxr-x--- 1 root wazuh    0 Jan 13 16:02 __init__.py
drwxr-x--- 2 root wazuh 4096 Jan 13 16:05 aws
drwxr-x--- 2 root wazuh 4096 Jan 13 16:05 azure
drwxr-x--- 2 root wazuh 4096 Jan 13 16:05 docker
drwxr-x--- 4 root wazuh 4096 Jan 13 16:05 gcloud
-rwxr-x--- 1 root wazuh 2080 Jan 13 16:02 utils.py
[root@9e957f5544e7 /]# ls -l /var/ossec/wodles/azure/
total 36
-rwxr-x--- 1 root wazuh 36332 Jan 13 16:02 azure-logs

```

</details>

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
