### PR TITLE
Add cluster checks to kibana installation

### DIFF
--- a/tests/unattended/unit/docker-unit-testing-tool/Dockerfile
+++ b/tests/unattended/unit/docker-unit-testing-tool/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine
+FROM alpine:latest
 RUN apk add --no-cache bash coreutils diffutils
 RUN mkdir -p /tests/unattended/
 
-ADD entrypoint.sh /usr/local/bin/test_file
+COPY entrypoint.sh /usr/local/bin/test_file
 RUN chmod +x /usr/local/bin/test_file
 
 # Set the entrypoint

--- a/tests/unattended/unit/suites/test-kibana.sh
+++ b/tests/unattended/unit/suites/test-kibana.sh
@@ -206,8 +206,7 @@ test-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct() 
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
     u_pass="user_password"
-    @mock curl -XGET https://1.1.1.1/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mocktrue grep -q "200 OK"
+    @mock curl -XGET https://1.1.1.1/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "200"
     wazuh_servers_node_names=("wazuh1")
     wazuh_servers_node_ips=("2.2.2.2")
     initializeKibana
@@ -218,14 +217,12 @@ test-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct-as
     sed -i 's,url: https://localhost,url: https://2.2.2.2,g' /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
-
 test-ASSERT-FAIL-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-error() {
     load-initializeKibana
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
     u_pass="user_password"
-    @mock curl -XGET https://1.1.1.1/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mockfalse grep -q "200 OK"
+    @mock curl -XGET https://1.1.1.1/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "0"
     wazuh_servers_node_names=("wazuh1")
     wazuh_servers_node_ips=("2.2.2.2")
     initializeKibana
@@ -236,8 +233,7 @@ test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct(
     kibana_node_names=("kibana1" "kibana2")
     kibana_node_ips=("1.1.1.1" "1.1.1.2")
     u_pass="user_password"
-    @mock curl -XGET https://1.1.1.1/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mocktrue grep -q "200 OK"
+    @mock curl -XGET https://1.1.1.1/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "200"
     wazuh_servers_node_names=("wazuh1" "wazuh2")
     wazuh_servers_node_types=("worker" "master")
     wazuh_servers_node_ips=("1.1.2.1" "1.1.2.2")
@@ -254,12 +250,42 @@ test-ASSERT-FAIL-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-c
     kibana_node_names=("kibana1" "kibana2")
     kibana_node_ips=("1.1.1.1" "1.1.1.2")
     u_pass="user_password"
-    @mock curl -XGET https://1.1.2.2/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mockfalse grep -q "200 OK"
+    force=
+    @mock curl -XGET https://1.1.1.1/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "0"
     wazuh_servers_node_names=("wazuh1" "wazuh2")
     wazuh_servers_node_types=("worker" "master")
     wazuh_servers_node_ips=("1.1.2.1" "1.1.2.2")
     initializeKibana
+}
+
+test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force() {
+    load-initializeKibana
+    kibana_node_names=("kibana1" "kibana2")
+    kibana_node_ips=("1.1.1.1" "1.1.1.2")
+    u_pass="user_password"
+    force=1
+    @mock curl -XGET https://1.1.1.1/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "0"
+    wazuh_servers_node_names=("wazuh1" "wazuh2")
+    wazuh_servers_node_types=("worker" "master")
+    wazuh_servers_node_ips=("1.1.2.1" "1.1.2.2")
+    initializeKibana
+}
+
+test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force-assert() {
+    getPass  admin
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sleep  10
+    sed  -i  's,url: https://localhost,url: https://1.1.2.2,g'  /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
 function load-initializeKibanaAIO() {
@@ -271,8 +297,7 @@ test-initializeKibanaAIO-curl-correct() {
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
     u_pass="user_password"
-    @mock curl -XGET https://localhost/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mocktrue grep -q "200 OK"
+    @mock curl -XGET https://localhost/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "200"
     initializeKibanaAIO
 }
 
@@ -284,8 +309,7 @@ test-initializeKibanaAIO-curl-correct-assert() {
 test-ASSERT-FAIL-initializeKibanaAIO-curl-error() {
     load-initializeKibanaAIO
     u_pass="user_password"
-    @mock curl -XGET https://localhost/status -I -uadmin:"${u_pass}" -k -s --max-time 300 === @out "200 OK"
-    @mockfalse grep -q "200 OK"
+    @mock curl -XGET https://localhost/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "0"
     initializeKibanaAIO
 }
 

--- a/unattended_installer/install_functions/opendistro/checks.sh
+++ b/unattended_installer/install_functions/opendistro/checks.sh
@@ -237,21 +237,20 @@ function checkNames() {
         exit 1
     fi
 
-    if [ -n "${winame}" ] && [ -z $(echo "${wazuh_servers_node_names[@]}" | grep -w ${winame}) ]; then
+    if [ -n "${winame}" ] && [ -z "$(echo "${wazuh_servers_node_names[@]}" | grep -w "${winame}")" ]; then
         logger -e "The Wazuh server node name ${winame} does not appear on the configuration file."
         exit 1
     fi 
 
-    if [ -n "${einame}" ] && [ -z $(echo "${elasticsearch_node_names[@]}" | grep -w ${einame}) ]; then
+    if [ -n "${einame}" ] && [ -z "$(echo "${elasticsearch_node_names[@]}" | grep -w "${einame}")" ]; then
         logger -e "The Elasticsearch node name ${einame} does not appear on the configuration file."
         exit 1
     fi
 
-    if [ -n "${kiname}" ] && [ -z $(echo "${kibana_node_names[@]}" | grep -w ${kiname}) ]; then
+    if [ -n "${kiname}" ] && [ -z "$(echo "${kibana_node_names[@]}" | grep -w "${kiname}")" ]; then
         logger -e "The Kibana node name ${kiname} does not appear on the configuration file."
         exit 1
     fi
-
 
 }
 

--- a/unattended_installer/install_functions/opendistro/kibana.sh
+++ b/unattended_installer/install_functions/opendistro/kibana.sh
@@ -134,23 +134,17 @@ function initializeKibana() {
         for i in "${!elasticsearch_node_ips[@]}"; do
             curl=$(curl -XGET https://${elasticsearch_node_ips[i]}:9200/ -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)
             exit_code=$?
-            if [[ "${curl}" -eq "503" ]]; then
-                cluster_init=1
-            fi
             if [[ "${exit_code}" -eq "7" ]]; then
                 failed_connect=1
                 logger "${flag}" "Failed to connect with node ${elasticsearch_node_names[i]}. Connection refused."
             fi 
         done
-        if [ -n "${cluster_init}" ]; then
-            logger "${flag}" "Opendistro cluster not initialized."
-        fi
         if [ -z "${force}" ]; then
-            logger "To ignore Elasticsearch cluster related errors during Kibana installation use teh -F option"
+            logger "If want to install Kibana without waiting for the Elasticsearch cluster, use the -F option"
             rollBack
             exit 1
         else
-            logger "When Kibana is able to connect to your elasticsearch cluster, you can access the web interface https://${nodes_kibana_ip}. The credentials are admin:${u_pass}"
+            logger "When Kibana is able to connect to your Elasticsearch cluster, you can access the web interface https://${nodes_kibana_ip}. The credentials are admin:${u_pass}"
         fi
     else
         logger "You can access the web interface https://${nodes_kibana_ip}. The credentials are admin:${u_pass}"

--- a/unattended_installer/install_functions/opendistro/kibana.sh
+++ b/unattended_installer/install_functions/opendistro/kibana.sh
@@ -127,10 +127,9 @@ function initializeKibana() {
     if [ ${j} -eq 12 ]; then
         flag="-w"
         if [ -z "${force}" ]; then
-            msg="If you want to ignore this error use the -F option"
             flag="-e"
         fi
-        logger "${flag}" "Cannot connect to Kibana. ${msg}"
+        logger "${flag}" "Cannot connect to Kibana."
 
         for i in "${!elasticsearch_node_ips[@]}"; do
             curl=$(curl -XGET https://${elasticsearch_node_ips[i]}:9200/ -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)
@@ -140,13 +139,14 @@ function initializeKibana() {
             fi
             if [[ "${exit_code}" -eq "7" ]]; then
                 failed_connect=1
-                logger "${flag}" "Failed to connect with node ${elasticsearch_node_names[i]}. Connection refused. ${msg}"
+                logger "${flag}" "Failed to connect with node ${elasticsearch_node_names[i]}. Connection refused."
             fi 
         done
         if [ -n "${cluster_init}" ]; then
-            logger "${flag}" "Opendistro cluster not initialized. ${msg}"
+            logger "${flag}" "Opendistro cluster not initialized."
         fi
         if [ -z "${force}" ]; then
+            logger "To ignore Elasticsearch cluster related errors during Kibana installation use teh -F option"
             rollBack
             exit 1
         else

--- a/unattended_installer/install_functions/opendistro/kibana.sh
+++ b/unattended_installer/install_functions/opendistro/kibana.sh
@@ -129,6 +129,7 @@ function initializeKibana() {
         if [ -z "${force}" ]; then
             flag="-e"
         fi
+        failed_nodes=()
         logger "${flag}" "Cannot connect to Kibana."
 
         for i in "${!elasticsearch_node_ips[@]}"; do
@@ -136,9 +137,10 @@ function initializeKibana() {
             exit_code=$?
             if [[ "${exit_code}" -eq "7" ]]; then
                 failed_connect=1
-                logger "${flag}" "Failed to connect with node ${elasticsearch_node_names[i]}. Connection refused."
+                failed_nodes+=("${elasticsearch_node_names[i]}")
             fi 
         done
+        logger "${flag}" "Failed to connect with ${failed_nodes[*]}. Connection refused."
         if [ -z "${force}" ]; then
             logger "If want to install Kibana without waiting for the Elasticsearch cluster, use the -F option"
             rollBack

--- a/unattended_installer/install_functions/opendistro/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/opendistro/wazuh-passwords-tool.sh
@@ -536,9 +536,13 @@ readUsers() {
 restartService() {
 
     if ps -e | grep -E -q "^\ *1\ .*systemd$"; then
+        eval "systemctl daemon-reload ${debug_pass}"
         eval "systemctl restart ${1}.service ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [[ $(type -t rollBack) == "function" ]]; then
+                rollBack
+            fi
             exit 1;
         else
             logger_pass "${1^} started"
@@ -547,6 +551,9 @@ restartService() {
         eval "/etc/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [[ $(type -t rollBack) == "function" ]]; then
+                rollBack
+            fi
             exit 1;
         else
             logger_pass "${1^} started"
@@ -555,11 +562,17 @@ restartService() {
         eval "/etc/rc.d/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [[ $(type -t rollBack) == "function" ]]; then
+                rollBack
+            fi
             exit 1;
         else
             logger_pass "${1^} started"
         fi             
     else
+        if [[ $(type -t rollBack) == "function" ]]; then
+            rollBack
+        fi
         logger_pass -e "${1^} could not start. No service manager found on the system."
         exit 1;
     fi

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -88,6 +88,9 @@ function getHelp() {
     echo -e "        -f,  --fileconfig <path-to-config-yml>"
     echo -e "                Path to config file. By default: ${base_path}/config.yml"
     echo -e ""
+    echo -e "        -F,  --force-kibana"
+    echo -e "                Ignore Elasticsearch cluster related errors in kibana installation"
+    echo -e ""
     echo -e "        -h,  --help"
     echo -e "                Shows help."
     echo -e ""
@@ -222,6 +225,10 @@ function main() {
                 fi
                 config_file=${2}
                 shift 2
+                ;;
+            "-F"|"--force-kibana")
+                force=1
+                shift 1
                 ;;
             "-h"|"--help")
                 getHelp


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds check for the elasticsearch cluster to the kibana installation.

## Logs example

<!--
Paste here related logs
-->
```
### Failure ##
[root@centos repo]# ./wazuh_install.sh -l -k KI_C -d
20/01/2022 09:48:35 INFO: Check recommended minimum hardware requirements for Kibana done.
20/01/2022 09:48:35 INFO: Starting all necessary utility installation.
20/01/2022 09:48:35 INFO: All necessary utility installation finished.
20/01/2022 09:48:35 INFO: Adding the Wazuh repository.
20/01/2022 09:48:36 INFO: Wazuh repository added.
20/01/2022 09:48:36 INFO: Starting Kibana installation.
20/01/2022 09:50:02 INFO: Kibana installation finished.
20/01/2022 09:50:23 INFO: Wazuh Kibana plugin installed.
20/01/2022 09:50:24 INFO: Kibana certificate setup finished.
20/01/2022 09:50:24 INFO: Setting passwords.
20/01/2022 09:50:25 INFO: Kibana started
20/01/2022 09:50:25 INFO: Starting service kibana.
20/01/2022 09:50:25 INFO: Kibana service started.
20/01/2022 09:50:25 INFO: Starting Kibana (this may take a while).
20/01/2022 09:52:26 ERROR: Cannot connect to Kibana.
20/01/2022 09:52:26 ERROR: Failed to connect with nodes ES_U ES_C. Connection refused.
20/01/2022 09:52:26 INFO: If want to install Kibana without waiting for the Elasticsearch cluster, use the -F option
20/01/2022 09:52:26 INFO: Cleaning the installation.
20/01/2022 09:52:26 WARNING: Removing Kibana.
20/01/2022 09:52:29 INFO: Installation cleaned. Check the /var/log/wazuh-unattended-installation.log file to learn more about the issue.

##### Ignore ####
[root@centos repo]# ./wazuh_install.sh -l -d -o -k KI_C -F
19/01/2022 16:27:42 INFO: Check recommended minimum hardware requirements for Kibana done.
19/01/2022 16:27:42 INFO: Starting all necessary utility installation.
19/01/2022 16:27:43 INFO: All necessary utility installation finished.
19/01/2022 16:27:43 INFO: Adding the Wazuh repository.
19/01/2022 16:27:43 INFO: Wazuh repository added.
19/01/2022 16:27:43 INFO: Starting Kibana installation.
19/01/2022 16:28:40 INFO: Kibana installation finished.
19/01/2022 16:28:58 INFO: Wazuh Kibana plugin installed.
19/01/2022 16:29:00 INFO: Kibana certificate setup finished.
19/01/2022 16:29:00 INFO: Setting passwords.
19/01/2022 16:29:00 INFO: Kibana started
19/01/2022 16:29:00 INFO: Starting service kibana.
19/01/2022 16:29:01 INFO: Kibana service started.
19/01/2022 16:29:01 INFO: Starting Kibana (this may take a while).
19/01/2022 16:31:02 WARNING: Cannot connect to Kibana.
19/01/2022 16:31:02 WARNING: Failed to connect with nodes ES_U ES_C. Connection refused.
19/01/2022 16:31:02 INFO: When Kibana is able to connect to your elasticsearch cluster, you can access the web interface https://172.16.1.29. The credentials are admin:NS2dx84IEmNanHnO1N6EHlfAB1K26ygB
19/01/2022 16:31:02 INFO: The Wazuh repository set to production.
19/01/2022 16:31:02 INFO: Installation finished.

### OK installation###

[root@centos repo]# ./wazuh_install.sh -l -d -o -k KI_C
19/01/2022 16:36:11 INFO: Check recommended minimum hardware requirements for Kibana done.
19/01/2022 16:36:11 INFO: Starting all necessary utility installation.
19/01/2022 16:36:11 INFO: All necessary utility installation finished.
19/01/2022 16:36:11 INFO: Adding the Wazuh repository.
19/01/2022 16:36:13 INFO: Wazuh repository added.
19/01/2022 16:36:13 INFO: Starting Kibana installation.
19/01/2022 16:37:08 INFO: Kibana installation finished.
19/01/2022 16:37:25 INFO: Wazuh Kibana plugin installed.
19/01/2022 16:37:27 INFO: Kibana certificate setup finished.
19/01/2022 16:37:27 INFO: Setting passwords.
19/01/2022 16:37:28 INFO: Kibana started
19/01/2022 16:37:28 INFO: Starting service kibana.
19/01/2022 16:37:28 INFO: Kibana service started.
19/01/2022 16:37:28 INFO: Starting Kibana (this may take a while).
19/01/2022 16:37:38 INFO: You can access the web interface https://172.16.1.29. The credentials are admin:NS2dx84IEmNanHnO1N6EHlfAB1K26ygB
19/01/2022 16:37:38 INFO: The Wazuh repository set to production.
19/01/2022 16:37:38 INFO: Installation finished.
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
