### PR TITLE
Fix RPM wazuh-agent package build

### DIFF
--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -602,7 +602,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/aws
 %attr(750, root, wazuh) %{_localstatedir}/wodles/aws/*
-packages/%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
+%dir %attr(750, root, wazuh) %{_localstatedir}/wodles/azure
 %attr(750, root, wazuh) %{_localstatedir}/wodles/azure/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/docker
 %attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -634,7 +634,7 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Sat Apr 24 2021 support <info@wazuh.com> - 3.13.3
 - More info: https://documentation.wazuh.com/current/release-notes/
-* Mon Apr 22 2021 support <info@wazuh.com> - 4.1.5
+* Thu Apr 22 2021 support <info@wazuh.com> - 4.1.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Mar 29 2021 support <info@wazuh.com> - 4.1.4
 - More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we fix the error introduced in #1167, which added a typo by mistake in [this line](https://github.com/wazuh/wazuh-packages/blob/master/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec#L605).
This PR also fixes the weekday of the `v4.1.5` release in the agent SPEC, given that April 22th 2021 was Thursday instead of Monday.
<!--
Add a clear description of how the problem has been solved.
-->


## Tests
To test that the package build was fixed we created a package using the `fix/rpm-build` branch and then installed it in a Centos8 machine. As can be seen in the following shell output, it's working as expected.

<details><summary>Installation on Centos8 output</summary>

```
[root@8b0db96dfa33 /]# yum install /tmp/wazuh-agent-4.4.0-1.x86_64.rpm 
Failed to set locale, defaulting to C.UTF-8
CentOS Linux 8 - AppStream                                                                                                                                  13 MB/s | 8.4 MB     00:00    
CentOS Linux 8 - BaseOS                                                                                                                                    7.5 MB/s | 4.6 MB     00:00    
CentOS Linux 8 - Extras                                                                                                                                     32 kB/s |  10 kB     00:00    
Dependencies resolved.
===========================================================================================================================================================================================
 Package                                      Architecture                            Version                                          Repository                                     Size
===========================================================================================================================================================================================
Installing:
 wazuh-agent                                  x86_64                                  4.4.0-1                                          @commandline                                  8.5 M
Installing dependencies:
 initscripts                                  x86_64                                  10.00.15-1.el8                                   baseos                                        339 k

Transaction Summary
===========================================================================================================================================================================================
Install  2 Packages

Total size: 8.9 M
Total download size: 339 k
Installed size: 26 M
Is this ok [y/N]: y
Downloading Packages:
initscripts-10.00.15-1.el8.x86_64.rpm                                                                                                                      628 kB/s | 339 kB     00:00    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                      366 kB/s | 339 kB     00:00     
warning: /var/cache/dnf/baseos-f6a80ba95cf937f2/packages/initscripts-10.00.15-1.el8.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 8483c65d: NOKEY
CentOS Linux 8 - BaseOS                                                                                                                                    1.6 MB/s | 1.6 kB     00:00    
Importing GPG key 0x8483C65D:
 Userid     : "CentOS (CentOS Official Signing Key) <security@centos.org>"
 Fingerprint: 99DB 70FA E1D7 CE22 7FB6 4882 05B5 55B3 8483 C65D
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Is this ok [y/N]: y
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                   1/1 
  Installing       : initscripts-10.00.15-1.el8.x86_64                                                                                                                                 1/2 
  Running scriptlet: initscripts-10.00.15-1.el8.x86_64                                                                                                                                 1/2 
  Running scriptlet: wazuh-agent-4.4.0-1.x86_64                                                                                                                                        2/2 
  Installing       : wazuh-agent-4.4.0-1.x86_64                                                                                                                                        2/2 
  Running scriptlet: wazuh-agent-4.4.0-1.x86_64                                                                                                                                        2/2 
  Verifying        : initscripts-10.00.15-1.el8.x86_64                                                                                                                                 1/2 
  Verifying        : wazuh-agent-4.4.0-1.x86_64                                                                                                                                        2/2 

Installed:
  initscripts-10.00.15-1.el8.x86_64                                                               wazuh-agent-4.4.0-1.x86_64                                                              

Complete!
```
</details>

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
