### PR TITLE
Unit testing using Bach [wazuh-cert-tool.sh]

### DIFF
--- a/tests/unattended/unit/suites/test-checks.sh
+++ b/tests/unattended/unit/suites/test-checks.sh
@@ -11,7 +11,7 @@ function load-checkSystem() {
     @load_function "${base_dir}/checks.sh" checkSystem
 }
 
-test-ASSERT-FAIL-checkSystem-empty() {
+test-ASSERT-FAIL-1-checkSystem-empty() {
     load-checkSystem
     @mock command -v yum === @false
     @mock command -v zypper === @false
@@ -19,7 +19,7 @@ test-ASSERT-FAIL-checkSystem-empty() {
     checkSystem
 }
 
-test-checkSystem-yum() {
+test-2-checkSystem-yum() {
     load-checkSystem
     @mock command -v yum === @echo /usr/bin/yum
     @mock command -v zypper === @false
@@ -29,14 +29,14 @@ test-checkSystem-yum() {
     echo "$sep"
 }
 
-test-checkSystem-yum-assert() {
+test-2-checkSystem-yum-assert() {
     sys_type="yum"
     sep="-"
     echo "$sys_type"
     echo "$sep"
 }
 
-test-checkSystem-zypper() {
+test-3-checkSystem-zypper() {
     load-checkSystem
     @mock command -v yum === @false
     @mock command -v zypper === @echo /usr/bin/zypper
@@ -46,14 +46,14 @@ test-checkSystem-zypper() {
     @echo "$sep"
 }
 
-test-checkSystem-zypper-assert() {
+test-3-checkSystem-zypper-assert() {
     sys_type="zypper"
     sep="-"
     @echo "$sys_type"
     @echo "$sep"
 }
 
-test-checkSystem-apt() {
+test-4-checkSystem-apt() {
     load-checkSystem
     @mock command -v yum === @false
     @mock command -v zypper === @false
@@ -63,7 +63,7 @@ test-checkSystem-apt() {
     echo "$sep"
 }
 
-test-checkSystem-apt-assert() {
+test-4-checkSystem-apt-assert() {
     sys_type="apt-get"
     sep="="
     echo "$sys_type"
@@ -74,28 +74,28 @@ function load-checkNames() {
     @load_function "${base_dir}/checks.sh" checkNames
 }
 
-test-ASSERT-FAIL-checkNames-elastic-kibana-equals() {
+test-ASSERT-FAIL-5-checkNames-elastic-kibana-equals() {
     load-checkNames
     einame="node1"
     kiname="node1"
     checkNames
 }
 
-test-ASSERT-FAIL-checkNames-elastic-wazuh-equals() {
+test-ASSERT-FAIL-6-checkNames-elastic-wazuh-equals() {
     load-checkNames
     einame="node1"
     winame="node1"
     checkNames
 }
 
-test-ASSERT-FAIL-checkNames-kibana-wazuh-equals() {
+test-ASSERT-FAIL-7-checkNames-kibana-wazuh-equals() {
     load-checkNames
     kiname="node1"
     winame="node1"
     checkNames
 }
 
-test-ASSERT-FAIL-checkNames-wazuh-node-name-not-in-config() {
+test-ASSERT-FAIL-8-checkNames-wazuh-node-name-not-in-config() {
     load-checkNames
     winame="node1"
     wazuh_servers_node_names=(wazuh node10)
@@ -104,7 +104,7 @@ test-ASSERT-FAIL-checkNames-wazuh-node-name-not-in-config() {
     checkNames
 }
 
-test-ASSERT-FAIL-checkNames-kibana-node-name-not-in-config() {
+test-ASSERT-FAIL-9-checkNames-kibana-node-name-not-in-config() {
     load-checkNames
     kiname="node1"
     kibana_node_names=(kibana node10)
@@ -113,7 +113,7 @@ test-ASSERT-FAIL-checkNames-kibana-node-name-not-in-config() {
     checkNames
 }
 
-test-ASSERT-FAIL-checkNames-elasticsearch-node-name-not-in-config() {
+test-ASSERT-FAIL-10-checkNames-elasticsearch-node-name-not-in-config() {
     load-checkNames
     einame="node1"
     elasticsearch_node_names=(elasticsearch node10)
@@ -122,7 +122,7 @@ test-ASSERT-FAIL-checkNames-elasticsearch-node-name-not-in-config() {
     checkNames
 }
 
-test-checkNames-all-correct-installing-elastic() {
+test-11-checkNames-all-correct-installing-elastic() {
     load-checkNames
     einame="elasticsearch1"
     kiname="kibana1"
@@ -141,7 +141,7 @@ test-checkNames-all-correct-installing-elastic() {
     @assert-success
 }
 
-test-checkNames-all-correct-installing-wazuh() {
+test-12-checkNames-all-correct-installing-wazuh() {
     load-checkNames
     einame="elasticsearch1"
     kiname="kibana1"
@@ -160,7 +160,7 @@ test-checkNames-all-correct-installing-wazuh() {
     @assert-success
 }
 
-test-checkNames-all-correct-installing-kibana() {
+test-13-checkNames-all-correct-installing-kibana() {
     load-checkNames
     einame="elasticsearch1"
     kiname="kibana1"
@@ -184,20 +184,20 @@ function load-checkArch() {
     @load_function "${base_dir}/checks.sh" checkArch
 }
 
-test-checkArch-x86_64() {
+test-14-checkArch-x86_64() {
     @mock uname -m === @out x86_64
     load-checkArch
     checkArch
     @assert-success
 }
 
-test-ASSERT-FAIL-checkArch-empty() {
+test-ASSERT-FAIL-15-checkArch-empty() {
     @mock uname -m === @out
     load-checkArch
     checkArch
 }
 
-test-ASSERT-FAIL-checkArch-i386() {
+test-ASSERT-FAIL-16-checkArch-i386() {
     @mock uname -m === @out i386
     load-checkArch
     checkArch
@@ -207,7 +207,7 @@ function load-checkArguments {
     @load_function "${base_dir}/checks.sh" checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-certs-file-present() {
+test-ASSERT-FAIL-17-checkArguments-install-aio-certs-file-present() {
     load-checkArguments
     AIO=1
     tar_file="tarfile.tar"
@@ -217,7 +217,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-certs-file-present() {
 
 }
 
-test-ASSERT-FAIL-checkArguments-certificate-creation-certs-file-present() {
+test-ASSERT-FAIL-18-checkArguments-certificate-creation-certs-file-present() {
     load-checkArguments
     certificates=1
     tar_file="tarfile.tar"
@@ -226,7 +226,7 @@ test-ASSERT-FAIL-checkArguments-certificate-creation-certs-file-present() {
     @rm $tar_file
 }
 
-test-ASSERT-FAIL-checkArguments-overwrite-with-no-component-installed() {
+test-ASSERT-FAIL-19-checkArguments-overwrite-with-no-component-installed() {
     load-checkArguments
     overwrite=1
     AIO=
@@ -236,7 +236,7 @@ test-ASSERT-FAIL-checkArguments-overwrite-with-no-component-installed() {
     checkArguments
 }
 
-test-checkArguments-uninstall-no-component-installed() {
+test-20-checkArguments-uninstall-no-component-installed() {
     load-checkArguments
     uninstall=1
     elasticsearchinstalled=""
@@ -251,56 +251,56 @@ test-checkArguments-uninstall-no-component-installed() {
     @assert-success
 }
 
-test-ASSERT-FAIL-checkArguments-uninstall-and-aio() {
+test-ASSERT-FAIL-21-checkArguments-uninstall-and-aio() {
     load-checkArguments
     uninstall=1
     AIO=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-uninstall-and-wazuh() {
+test-ASSERT-FAIL-22-checkArguments-uninstall-and-wazuh() {
     load-checkArguments
     uninstall=1
     wazuh=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-uninstall-and-kibana() {
+test-ASSERT-FAIL-23-checkArguments-uninstall-and-kibana() {
     load-checkArguments
     uninstall=1
     kibana=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-uninstall-and-elasticsearch() {
+test-ASSERT-FAIL-24-checkArguments-uninstall-and-elasticsearch() {
     load-checkArguments
     uninstall=1
     elasticsearch=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-and-elastic () {
+test-ASSERT-FAIL-25-checkArguments-install-aio-and-elastic () {
     load-checkArguments
     AIO=1
     elasticsearch=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-and-wazuh () {
+test-ASSERT-FAIL-26-checkArguments-install-aio-and-wazuh () {
     load-checkArguments
     AIO=1
     wazuh=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-and-kibana () {
+test-ASSERT-FAIL-27-checkArguments-install-aio-and-kibana () {
     load-checkArguments
     AIO=1
     kibana=1
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-wazuh-installed-no-overwrite() {
+test-ASSERT-FAIL-28-checkArguments-install-aio-wazuh-installed-no-overwrite() {
     load-checkArguments
     AIO=1
     wazuhinstalled=1
@@ -308,7 +308,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-wazuh-installed-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-wazuh-files-no-overwrite() {
+test-ASSERT-FAIL-29-checkArguments-install-aio-wazuh-files-no-overwrite() {
     load-checkArguments
     AIO=1
     wazuh_remaining_files=1
@@ -316,7 +316,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-wazuh-files-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-elastic-installed-no-overwrite() {
+test-ASSERT-FAIL-30-checkArguments-install-aio-elastic-installed-no-overwrite() {
     load-checkArguments
     AIO=1
     elasticsearchinstalled=1
@@ -324,7 +324,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-elastic-installed-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-elastic-files-no-overwrite() {
+test-ASSERT-FAIL-31-checkArguments-install-aio-elastic-files-no-overwrite() {
     load-checkArguments
     AIO=1
     elastic_remaining_files=1
@@ -332,7 +332,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-elastic-files-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-kibana-installed-no-overwrite() {
+test-ASSERT-FAIL-32-checkArguments-install-aio-kibana-installed-no-overwrite() {
     load-checkArguments
     AIO=1
     kibanainstalled=1
@@ -340,7 +340,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-kibana-installed-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-aio-kibana-files-no-overwrite() {
+test-ASSERT-FAIL-33-checkArguments-install-aio-kibana-files-no-overwrite() {
     load-checkArguments
     AIO=1
     kibana_remaining_files=1
@@ -348,7 +348,7 @@ test-ASSERT-FAIL-checkArguments-install-aio-kibana-files-no-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-wazuh-installed-overwrite() {
+test-34-checkArguments-install-aio-wazuh-installed-overwrite() {
     load-checkArguments
     AIO=1
     wazuhinstalled=1
@@ -356,11 +356,11 @@ test-checkArguments-install-aio-wazuh-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-wazuh-installed-overwrite-assert() {
+test-34-checkArguments-install-aio-wazuh-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-aio-wazuh-files-overwrite() {
+test-35-checkArguments-install-aio-wazuh-files-overwrite() {
     load-checkArguments
     AIO=1
     wazuh_remaining_files=1
@@ -368,11 +368,11 @@ test-checkArguments-install-aio-wazuh-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-wazuh-files-overwrite-assert() {
+test-35-checkArguments-install-aio-wazuh-files-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-aio-elastic-installed-overwrite() {
+test-36-checkArguments-install-aio-elastic-installed-overwrite() {
     load-checkArguments
     AIO=1
     elasticsearchinstalled=1
@@ -380,11 +380,11 @@ test-checkArguments-install-aio-elastic-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-elastic-installed-overwrite-assert() {
+test-36-checkArguments-install-aio-elastic-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-aio-elastic-files-overwrite() {
+test-37-checkArguments-install-aio-elastic-files-overwrite() {
     load-checkArguments
     AIO=1
     elastic_remaining_files=1
@@ -392,11 +392,11 @@ test-checkArguments-install-aio-elastic-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-elastic-files-overwrite-assert() {
+test-37-checkArguments-install-aio-elastic-files-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-aio-kibana-installed-overwrite() {
+test-38-checkArguments-install-aio-kibana-installed-overwrite() {
     load-checkArguments
     AIO=1
     kibanainstalled=1
@@ -404,11 +404,11 @@ test-checkArguments-install-aio-kibana-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-kibana-installed-overwrite-assert() {
+test-38-checkArguments-install-aio-kibana-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-aio-kibana-files-overwrite() {
+test-39-checkArguments-install-aio-kibana-files-overwrite() {
     load-checkArguments
     AIO=1
     kibana_remaining_files=1
@@ -416,11 +416,11 @@ test-checkArguments-install-aio-kibana-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-aio-kibana-files-overwrite-assert() {
+test-39-checkArguments-install-aio-kibana-files-overwrite-assert() {
     rollBack
 }
 
-test-ASSERT-FAIL-checkArguments-install-elastic-already-installed-no-overwrite() {
+test-ASSERT-FAIL-40-checkArguments-install-elastic-already-installed-no-overwrite() {
     load-checkArguments
     elasticsearch=1
     elasticsearchinstalled=1
@@ -428,7 +428,7 @@ test-ASSERT-FAIL-checkArguments-install-elastic-already-installed-no-overwrite()
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-elastic-remaining-files-no-overwrite() {
+test-ASSERT-FAIL-41-checkArguments-install-elastic-remaining-files-no-overwrite() {
     load-checkArguments
     elasticsearch=1
     elastic_remaining_files=1
@@ -436,7 +436,7 @@ test-ASSERT-FAIL-checkArguments-install-elastic-remaining-files-no-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-elastic-already-installed-overwrite() {
+test-42-checkArguments-install-elastic-already-installed-overwrite() {
     load-checkArguments
     elasticsearch=1
     elasticsearchinstalled=1
@@ -444,11 +444,11 @@ test-checkArguments-install-elastic-already-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-elastic-already-installed-overwrite-assert() {
+test-42-checkArguments-install-elastic-already-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-elastic-remaining-files-overwrite() {
+test-43-checkArguments-install-elastic-remaining-files-overwrite() {
     load-checkArguments
     elasticsearch=1
     elastic_remaining_files=1
@@ -456,11 +456,11 @@ test-checkArguments-install-elastic-remaining-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-elastic-remaining-files-overwrite-assert() {
+test-43-checkArguments-install-elastic-remaining-files-overwrite-assert() {
     rollBack
 }
 
-test-ASSERT-FAIL-checkArguments-install-wazuh-already-installed-no-overwrite() {
+test-ASSERT-FAIL-44-checkArguments-install-wazuh-already-installed-no-overwrite() {
     load-checkArguments
     wazuh=1
     wazuhinstalled=1
@@ -468,7 +468,7 @@ test-ASSERT-FAIL-checkArguments-install-wazuh-already-installed-no-overwrite() {
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-wazuh-remaining-files-no-overwrite() {
+test-ASSERT-FAIL-45-checkArguments-install-wazuh-remaining-files-no-overwrite() {
     load-checkArguments
     wazuh=1
     wazuh_remaining_files=1
@@ -476,7 +476,7 @@ test-ASSERT-FAIL-checkArguments-install-wazuh-remaining-files-no-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-wazuh-already-installed-overwrite() {
+test-46-checkArguments-install-wazuh-already-installed-overwrite() {
     load-checkArguments
     wazuh=1
     wazuhinstalled=1
@@ -484,11 +484,11 @@ test-checkArguments-install-wazuh-already-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-wazuh-already-installed-overwrite-assert() {
+test-46-checkArguments-install-wazuh-already-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-wazuh-remaining-files-overwrite() {
+test-47-checkArguments-install-wazuh-remaining-files-overwrite() {
     load-checkArguments
     wazuh=1
     wazuh_remaining_files=1
@@ -496,11 +496,11 @@ test-checkArguments-install-wazuh-remaining-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-wazuh-remaining-files-overwrite-assert() {
+test-47-checkArguments-install-wazuh-remaining-files-overwrite-assert() {
     rollBack
 }
 
-test-ASSERT-FAIL-checkArguments-install-wazuh-filebeat-already-installed-no-overwrite() {
+test-ASSERT-FAIL-48-checkArguments-install-wazuh-filebeat-already-installed-no-overwrite() {
     load-checkArguments
     wazuh=1
     filebeatinstalled=1
@@ -508,7 +508,7 @@ test-ASSERT-FAIL-checkArguments-install-wazuh-filebeat-already-installed-no-over
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-wazuh-filebeat-remaining-files-no-overwrite() {
+test-ASSERT-FAIL-49-checkArguments-install-wazuh-filebeat-remaining-files-no-overwrite() {
     load-checkArguments
     wazuh=1
     filebeat_remaining_files=1
@@ -516,7 +516,7 @@ test-ASSERT-FAIL-checkArguments-install-wazuh-filebeat-remaining-files-no-overwr
     checkArguments
 }
 
-test-checkArguments-install-wazuh-filebeat-already-installed-overwrite() {
+test-50-checkArguments-install-wazuh-filebeat-already-installed-overwrite() {
     load-checkArguments
     wazuh=1
     filebeatinstalled=1
@@ -524,11 +524,11 @@ test-checkArguments-install-wazuh-filebeat-already-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-wazuh-filebeat-already-installed-overwrite-assert() {
+test-50-checkArguments-install-wazuh-filebeat-already-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-wazuh-filebeat-remaining-files-overwrite() {
+test-51-checkArguments-install-wazuh-filebeat-remaining-files-overwrite() {
     load-checkArguments
     wazuh=1
     filebeat_remaining_files=1
@@ -536,11 +536,11 @@ test-checkArguments-install-wazuh-filebeat-remaining-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-wazuh-filebeat-remaining-files-overwrite-assert() {
+test-51-checkArguments-install-wazuh-filebeat-remaining-files-overwrite-assert() {
     rollBack
 }
 
-test-ASSERT-FAIL-checkArguments-install-kibana-already-installed-no-overwrite() {
+test-ASSERT-FAIL-52-checkArguments-install-kibana-already-installed-no-overwrite() {
     load-checkArguments
     kibana=1
     kibanainstalled=1
@@ -548,7 +548,7 @@ test-ASSERT-FAIL-checkArguments-install-kibana-already-installed-no-overwrite() 
     checkArguments
 }
 
-test-ASSERT-FAIL-checkArguments-install-kibana-remaining-files-no-overwrite() {
+test-ASSERT-FAIL-53-checkArguments-install-kibana-remaining-files-no-overwrite() {
     load-checkArguments
     kibana=1
     kibana_remaining_files=1
@@ -556,7 +556,7 @@ test-ASSERT-FAIL-checkArguments-install-kibana-remaining-files-no-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-kibana-already-installed-overwrite() {
+test-54-checkArguments-install-kibana-already-installed-overwrite() {
     load-checkArguments
     kibana=1
     kibanainstalled=1
@@ -564,11 +564,11 @@ test-checkArguments-install-kibana-already-installed-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-kibana-already-installed-overwrite-assert() {
+test-54-checkArguments-install-kibana-already-installed-overwrite-assert() {
     rollBack
 }
 
-test-checkArguments-install-kibana-remaining-files-overwrite() {
+test-55-checkArguments-install-kibana-remaining-files-overwrite() {
     load-checkArguments
     kibana=1
     kibana_remaining_files=1
@@ -576,7 +576,7 @@ test-checkArguments-install-kibana-remaining-files-overwrite() {
     checkArguments
 }
 
-test-checkArguments-install-kibana-remaining-files-overwrite-assert() {
+test-55-checkArguments-install-kibana-remaining-files-overwrite-assert() {
     rollBack
 }
 
@@ -585,13 +585,13 @@ function load-checkHealth() {
     @mocktrue checkSpecs
 }
 
-test-checkHealth-no-installation() {
+test-56-checkHealth-no-installation() {
     load-checkHealth
     checkHealth
     @assert-success
 }
 
-test-ASSERT-FAIL-checkHealth-AIO-1-core-3700-ram() {
+test-ASSERT-FAIL-57-checkHealth-AIO-1-core-3700-ram() {
     load-checkHealth
     cores=1
     ram_gb=3700
@@ -599,7 +599,7 @@ test-ASSERT-FAIL-checkHealth-AIO-1-core-3700-ram() {
     checkHealth
 }
 
-test-ASSERT-FAIL-checkHealth-AIO-2-cores-3000-ram() {
+test-ASSERT-FAIL-58-checkHealth-AIO-2-cores-3000-ram() {
     load-checkHealth
     cores=2
     ram_gb=3000
@@ -607,7 +607,7 @@ test-ASSERT-FAIL-checkHealth-AIO-2-cores-3000-ram() {
     checkHealth
 }
 
-test-checkHealth-AIO-2-cores-4gb() {
+test-59-checkHealth-AIO-2-cores-4gb() {
     load-checkHealth
     cores=2
     ram_gb=3700
@@ -616,7 +616,7 @@ test-checkHealth-AIO-2-cores-4gb() {
     @assert-success
 }
 
-test-ASSERT-FAIL-checkHealth-elasticsearch-1-core-3700-ram() {
+test-ASSERT-FAIL-60-checkHealth-elasticsearch-1-core-3700-ram() {
     load-checkHealth
     cores=1
     ram_gb=3700
@@ -624,7 +624,7 @@ test-ASSERT-FAIL-checkHealth-elasticsearch-1-core-3700-ram() {
     checkHealth
 }
 
-test-ASSERT-FAIL-checkHealth-elasticsearch-2-cores-3000-ram() {
+test-ASSERT-FAIL-61-checkHealth-elasticsearch-2-cores-3000-ram() {
     load-checkHealth
     cores=2
     ram_gb=3000
@@ -632,7 +632,7 @@ test-ASSERT-FAIL-checkHealth-elasticsearch-2-cores-3000-ram() {
     checkHealth
 }
 
-test-checkHealth-elasticsearch-2-cores-3700-ram() {
+test-62-checkHealth-elasticsearch-2-cores-3700-ram() {
     load-checkHealth
     cores=2
     ram_gb=3700
@@ -641,7 +641,7 @@ test-checkHealth-elasticsearch-2-cores-3700-ram() {
     @assert-success
 }
 
-test-ASSERT-FAIL-checkHealth-kibana-1-core-3700-ram() {
+test-ASSERT-FAIL-63-checkHealth-kibana-1-core-3700-ram() {
     load-checkHealth
     cores=1
     ram_gb=3700
@@ -649,7 +649,7 @@ test-ASSERT-FAIL-checkHealth-kibana-1-core-3700-ram() {
     checkHealth
 }
 
-test-ASSERT-FAIL-checkHealth-kibana-2-cores-3000-ram() {
+test-ASSERT-FAIL-64-checkHealth-kibana-2-cores-3000-ram() {
     load-checkHealth
     cores=2
     ram_gb=3000
@@ -657,7 +657,7 @@ test-ASSERT-FAIL-checkHealth-kibana-2-cores-3000-ram() {
     checkHealth
 }
 
-test-checkHealth-kibana-2-cores-3700-ram() {
+test-65-checkHealth-kibana-2-cores-3700-ram() {
     load-checkHealth
     cores=2
     ram_gb=3700
@@ -666,7 +666,7 @@ test-checkHealth-kibana-2-cores-3700-ram() {
     @assert-success
 }
 
-test-ASSERT-FAIL-checkHealth-wazuh-1-core-1700-ram() {
+test-ASSERT-FAIL-66-checkHealth-wazuh-1-core-1700-ram() {
     load-checkHealth
     cores=1
     ram_gb=1700
@@ -674,7 +674,7 @@ test-ASSERT-FAIL-checkHealth-wazuh-1-core-1700-ram() {
     checkHealth
 }
 
-test-ASSERT-FAIL-checkHealth-wazuh-2-cores-1000-ram() {
+test-ASSERT-FAIL-67-checkHealth-wazuh-2-cores-1000-ram() {
     load-checkHealth
     cores=2
     ram_gb=1000
@@ -682,7 +682,7 @@ test-ASSERT-FAIL-checkHealth-wazuh-2-cores-1000-ram() {
     checkHealth
 }
 
-test-checkHealth-wazuh-2-cores-1700-ram() {
+test-68-checkHealth-wazuh-2-cores-1700-ram() {
     load-checkHealth
     cores=2
     ram_gb=1700
@@ -695,7 +695,7 @@ function load-checkIfInstalled() {
     @load_function "${base_dir}/checks.sh" checkIfInstalled
 }
 
-test-checkIfInstalled-all-installed-yum() {
+test-69-checkIfInstalled-all-installed-yum() {
     load-checkIfInstalled
     sys_type="yum"
 
@@ -745,7 +745,7 @@ test-checkIfInstalled-all-installed-yum() {
 
 }
 
-test-checkIfInstalled-all-installed-yum-assert() {
+test-69-checkIfInstalled-all-installed-yum-assert() {
     @echo "wazuh-manager.x86_64 4.3.0-1 @wazuh"
     @echo 1
 
@@ -759,7 +759,7 @@ test-checkIfInstalled-all-installed-yum-assert() {
     @echo 1
 }
 
-test-checkIfInstalled-all-installed-zypper() {
+test-70-checkIfInstalled-all-installed-zypper() {
     load-checkIfInstalled
     sys_type="zypper"
 
@@ -810,7 +810,7 @@ test-checkIfInstalled-all-installed-zypper() {
 
 }
 
-test-checkIfInstalled-all-installed-zypper-assert() {
+test-70-checkIfInstalled-all-installed-zypper-assert() {
     @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
     @echo 1
 
@@ -824,7 +824,7 @@ test-checkIfInstalled-all-installed-zypper-assert() {
     @echo 1
 }
 
-test-checkIfInstalled-all-installed-apt() {
+test-71-checkIfInstalled-all-installed-apt() {
     load-checkIfInstalled
     sys_type="apt-get"
 
@@ -874,7 +874,7 @@ test-checkIfInstalled-all-installed-apt() {
 
 }
 
-test-checkIfInstalled-all-installed-apt-assert() {
+test-71-checkIfInstalled-all-installed-apt-assert() {
     @echo "wazuh-manager/now 4.2.5-1 amd64 [installed,local]"
     @echo 1
 
@@ -888,7 +888,7 @@ test-checkIfInstalled-all-installed-apt-assert() {
     @echo 1
 }
 
-test-checkIfInstalled-nothing-installed-apt() {
+test-72-checkIfInstalled-nothing-installed-apt() {
     load-checkIfInstalled
     sys_type="apt-get"
 
@@ -917,7 +917,7 @@ test-checkIfInstalled-nothing-installed-apt() {
     @echo $kibana_remaining_files
 }
 
-test-checkIfInstalled-nothing-installed-apt-assert() {
+test-72-checkIfInstalled-nothing-installed-apt-assert() {
     @echo ""
     @echo ""
 
@@ -931,7 +931,7 @@ test-checkIfInstalled-nothing-installed-apt-assert() {
     @echo ""
 }
 
-test-checkIfInstalled-nothing-installed-yum() {
+test-73-checkIfInstalled-nothing-installed-yum() {
     load-checkIfInstalled
     sys_type="yum"
 
@@ -960,7 +960,7 @@ test-checkIfInstalled-nothing-installed-yum() {
     @echo $kibana_remaining_files
 }
 
-test-checkIfInstalled-nothing-installed-yum-assert() {
+test-73-checkIfInstalled-nothing-installed-yum-assert() {
     @echo ""
     @echo ""
 
@@ -974,7 +974,7 @@ test-checkIfInstalled-nothing-installed-yum-assert() {
     @echo ""
 }
 
-test-checkIfInstalled-nothing-installed-zypper() {
+test-74-checkIfInstalled-nothing-installed-zypper() {
     load-checkIfInstalled
     sys_type="zypper"
 
@@ -1004,7 +1004,7 @@ test-checkIfInstalled-nothing-installed-zypper() {
     @echo $kibana_remaining_files
 }
 
-test-checkIfInstalled-nothing-installed-zypper-assert() {
+test-74-checkIfInstalled-nothing-installed-zypper-assert() {
     @echo ""
     @echo ""
 
@@ -1022,7 +1022,7 @@ function load-checkPreviousCertificates() {
     @load_function "${base_dir}/checks.sh" checkPreviousCertificates
 }
 
-test-ASSERT-FAIL-checkPreviousCertificates-no-tar_file() {
+test-ASSERT-FAIL-75-checkPreviousCertificates-no-tar_file() {
     load-checkPreviousCertificates
     tar_file=/tmp/tarfile.tar
     if [ -f $tar_file ]; then
@@ -1031,7 +1031,7 @@ test-ASSERT-FAIL-checkPreviousCertificates-no-tar_file() {
     checkPreviousCertificates
 }
 
-test-ASSERT-FAIL-checkPreviousCertificates-einame-not-in-tar_file() {
+test-ASSERT-FAIL-76-checkPreviousCertificates-einame-not-in-tar_file() {
     load-checkPreviousCertificates
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
@@ -1043,7 +1043,7 @@ test-ASSERT-FAIL-checkPreviousCertificates-einame-not-in-tar_file() {
     @rm /tmp/tarfile.tar
 }
 
-test-ASSERT-FAIL-checkPreviousCertificates-kiname-not-in-tar_file() {
+test-ASSERT-FAIL-77-checkPreviousCertificates-kiname-not-in-tar_file() {
     load-checkPreviousCertificates
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
@@ -1055,7 +1055,7 @@ test-ASSERT-FAIL-checkPreviousCertificates-kiname-not-in-tar_file() {
     @rm /tmp/tarfile.tar
 }
 
-test-ASSERT-FAIL-checkPreviousCertificates-winame-not-in-tar_file() {
+test-ASSERT-FAIL-78-checkPreviousCertificates-winame-not-in-tar_file() {
     load-checkPreviousCertificates
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
@@ -1067,7 +1067,7 @@ test-ASSERT-FAIL-checkPreviousCertificates-winame-not-in-tar_file() {
     @rm /tmp/tarfile.tar
 }
 
-test-checkPreviousCertificates-all-correct() {
+test-79-checkPreviousCertificates-all-correct() {
     load-checkPreviousCertificates
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar

--- a/tests/unattended/unit/suites/test-common.sh
+++ b/tests/unattended/unit/suites/test-common.sh
@@ -11,17 +11,17 @@ function load-getConfig() {
     @load_function "${base_dir}/common.sh" getConfig
 }
 
-test-ASSERT-FAIL-getConfig-no-args() {
+test-ASSERT-FAIL-01-getConfig-no-args() {
     load-getConfig
     getConfig
 }
 
-test-ASSERT-FAIL-getConfig-one-argument() {
+test-ASSERT-FAIL-02-getConfig-one-argument() {
     load-getConfig
     getConfig "elasticsearch"
 }
 
-test-getConfig-local() {
+test-03-getConfig-local() {
     load-getConfig
     base_path="/tmp"
     config_path="example"
@@ -29,11 +29,11 @@ test-getConfig-local() {
     getConfig elasticsearch.yml /tmp/elasticsearch/elasticsearch.yml
 }
 
-test-getConfig-local-assert() {
+test-03-getConfig-local-assert() {
     cp /tmp/example/elasticsearch.yml /tmp/elasticsearch/elasticsearch.yml
 }
 
-test-getConfig-online() {
+test-04-getConfig-online() {
     load-getConfig
     base_path="/tmp"
     config_path="example"
@@ -42,11 +42,11 @@ test-getConfig-online() {
     getConfig elasticsearch.yml /tmp/elasticsearch/elasticsearch.yml
 }
 
-test-getConfig-online-assert() {
+test-04-getConfig-online-assert() {
     curl -f -so /tmp/elasticsearch/elasticsearch.yml example.com/config/elasticsearch.yml
 }
 
-test-getConfig-local-error() {
+test-05-getConfig-local-error() {
     load-getConfig
     base_path="/tmp"
     config_path="example"
@@ -55,12 +55,12 @@ test-getConfig-local-error() {
     getConfig elasticsearch.yml /tmp/elasticsearch/elasticsearch.yml
 }
 
-test-getConfig-local-error-assert() {
+test-05-getConfig-local-error-assert() {
     rollBack
     exit 1
 }
 
-test-getConfig-online-error() {
+test-06-getConfig-online-error() {
     load-getConfig
     base_path="/tmp"
     config_path="example"
@@ -70,7 +70,7 @@ test-getConfig-online-error() {
     getConfig elasticsearch.yml /tmp/elasticsearch/elasticsearch.yml
 }
 
-test-getConfig-online-error-assert() {
+test-06-getConfig-online-error-assert() {
     rollBack
     exit 1
 }
@@ -79,7 +79,7 @@ function load-installPrerequisites() {
     @load_function "${base_dir}/common.sh" installPrerequisites
 }
 
-test-installPrerequisites-yum-no-openssl() {
+test-07-installPrerequisites-yum-no-openssl() {
     @mock command -v openssl === @false
     load-installPrerequisites
     sys_type="yum"
@@ -87,11 +87,11 @@ test-installPrerequisites-yum-no-openssl() {
     installPrerequisites
 }
 
-test-installPrerequisites-yum-no-openssl-assert() {
+test-07-installPrerequisites-yum-no-openssl-assert() {
     yum install curl unzip wget libcap tar gnupg openssl -y
 }
 
-test-installPrerequisites-yum() {
+test-08-installPrerequisites-yum() {
     @mock command -v openssl === @echo /usr/bin/openssl
     load-installPrerequisites
     sys_type="yum"
@@ -99,11 +99,11 @@ test-installPrerequisites-yum() {
     installPrerequisites
 }
 
-test-installPrerequisites-yum-assert() {
+test-08-installPrerequisites-yum-assert() {
     yum install curl unzip wget libcap tar gnupg -y
 }
 
-test-installPrerequisites-zypper-no-openssl() {
+test-09-installPrerequisites-zypper-no-openssl() {
     @mock command -v openssl === @false
     @mocktrue zypper -n install libcap-progs tar gnupg
     load-installPrerequisites
@@ -112,12 +112,12 @@ test-installPrerequisites-zypper-no-openssl() {
     installPrerequisites
 }
 
-test-installPrerequisites-zypper-no-openssl-assert() {
+test-09-installPrerequisites-zypper-no-openssl-assert() {
     zypper -n install curl unzip wget
     zypper -n install libcap-progs tar gnupg openssl
 }
 
-test-installPrerequisites-zypper-no-libcap-progs() {
+test-10-installPrerequisites-zypper-no-libcap-progs() {
     @mock command -v openssl === @out /usr/bin/openssl
     @mockfalse zypper -n install libcap-progs tar gnupg
     load-installPrerequisites
@@ -126,12 +126,12 @@ test-installPrerequisites-zypper-no-libcap-progs() {
     installPrerequisites
 }
 
-test-installPrerequisites-zypper-no-libcap-progs-assert() {
+test-10-installPrerequisites-zypper-no-libcap-progs-assert() {
     zypper -n install curl unzip wget
     zypper -n install libcap2 tar gnupg
 }
 
-test-installPrerequisites-apt-no-openssl() {
+test-11-installPrerequisites-apt-no-openssl() {
     @mock command -v openssl === @false
     load-installPrerequisites
     sys_type="apt-get"
@@ -139,12 +139,12 @@ test-installPrerequisites-apt-no-openssl() {
     installPrerequisites
 }
 
-test-installPrerequisites-apt-no-openssl-assert() {
+test-11-installPrerequisites-apt-no-openssl-assert() {
     apt-get update -q
     apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg openssl -y
 }
 
-test-installPrerequisites-apt() {
+test-12-installPrerequisites-apt() {
     @mock command -v openssl === @out /usr/bin/openssl
     load-installPrerequisites
     sys_type="apt-get"
@@ -152,7 +152,7 @@ test-installPrerequisites-apt() {
     installPrerequisites
 }
 
-test-installPrerequisites-apt-assert() {
+test-12-installPrerequisites-apt-assert() {
     apt-get update -q
     apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg -y
 }
@@ -161,7 +161,7 @@ function load-addWazuhrepo() {
     @load_function "${base_dir}/common.sh" addWazuhrepo
 }
 
-test-addWazuhrepo-yum() {
+test-13-addWazuhrepo-yum() {
     load-addWazuhrepo
     development=1
     sys_type="yum"
@@ -173,12 +173,12 @@ test-addWazuhrepo-yum() {
     addWazuhrepo
 }
 
-test-addWazuhrepo-yum-assert() {
+test-13-addWazuhrepo-yum-assert() {
     rm -f /etc/yum.repos.d/wazuh.repo
     rpm --import
 }
 
-test-addWazuhrepo-zypper() {
+test-14-addWazuhrepo-zypper() {
     load-addWazuhrepo
     development=1
     sys_type="zypper"
@@ -193,12 +193,12 @@ test-addWazuhrepo-zypper() {
     addWazuhrepo
 }
 
-test-addWazuhrepo-zypper-assert() {
+test-14-addWazuhrepo-zypper-assert() {
     rm -f /etc/zypp/repos.d/wazuh.repo
     rpm --import
 }
 
-test-addWazuhrepo-apt() {
+test-15-addWazuhrepo-apt() {
     load-addWazuhrepo
     development=1
     sys_type="apt-get"
@@ -215,12 +215,12 @@ test-addWazuhrepo-apt() {
     addWazuhrepo
 }
 
-test-addWazuhrepo-apt-assert() {
+test-15-addWazuhrepo-apt-assert() {
     rm -f /etc/apt/sources.list.d/wazuh.list
     apt-get update -q
 }
 
-test-addWazuhrepo-apt-file-present() {
+test-16-addWazuhrepo-apt-file-present() {
     load-addWazuhrepo
     development=""
     @mkdir -p /etc/yum.repos.d
@@ -230,7 +230,7 @@ test-addWazuhrepo-apt-file-present() {
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-addWazuhrepo-zypper-file-present() {
+test-17-addWazuhrepo-zypper-file-present() {
     load-addWazuhrepo
     development=""
     @mkdir -p /etc/zypp/repos.d/
@@ -240,7 +240,7 @@ test-addWazuhrepo-zypper-file-present() {
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-addWazuhrepo-yum-file-present() {
+test-18-addWazuhrepo-yum-file-present() {
     load-addWazuhrepo
     development=""
     @mkdir -p /etc/apt/sources.list.d/
@@ -254,14 +254,14 @@ function load-restoreWazuhrepo() {
     @load_function "${base_dir}/common.sh" restoreWazuhrepo
 }
 
-test-restoreWazuhrepo-no-dev() {
+test-19-restoreWazuhrepo-no-dev() {
     load-restoreWazuhrepo
     development=""
     restoreWazuhrepo
     @assert-success
 }
 
-test-restoreWazuhrepo-yum() {
+test-20-restoreWazuhrepo-yum() {
     load-restoreWazuhrepo
     development="1"
     sys_type="yum"
@@ -271,13 +271,13 @@ test-restoreWazuhrepo-yum() {
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-restoreWazuhrepo-yum-assert() {
+test-20-restoreWazuhrepo-yum-assert() {
     sed -i 's/-dev//g' /etc/yum.repos.d/wazuh.repo
     sed -i 's/pre-release/4.x/g' /etc/yum.repos.d/wazuh.repo
     sed -i 's/unstable/stable/g' /etc/yum.repos.d/wazuh.repo
 }
 
-test-restoreWazuhrepo-apt() {
+test-21-restoreWazuhrepo-apt() {
     load-restoreWazuhrepo
     development="1"
     sys_type="apt-get"
@@ -287,13 +287,13 @@ test-restoreWazuhrepo-apt() {
     @rm /etc/apt/sources.list.d/wazuh.list
 }
 
-test-restoreWazuhrepo-apt-assert() {
+test-21-restoreWazuhrepo-apt-assert() {
     sed -i 's/-dev//g' /etc/apt/sources.list.d/wazuh.list
     sed -i 's/pre-release/4.x/g' /etc/apt/sources.list.d/wazuh.list
     sed -i 's/unstable/stable/g' /etc/apt/sources.list.d/wazuh.list
 }
 
-test-restoreWazuhrepo-zypper() {
+test-22-restoreWazuhrepo-zypper() {
     load-restoreWazuhrepo
     development="1"
     sys_type="zypper"
@@ -303,46 +303,46 @@ test-restoreWazuhrepo-zypper() {
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-restoreWazuhrepo-zypper-assert() {
+test-22-restoreWazuhrepo-zypper-assert() {
     sed -i 's/-dev//g' /etc/zypp/repos.d/wazuh.repo
     sed -i 's/pre-release/4.x/g' /etc/zypp/repos.d/wazuh.repo
     sed -i 's/unstable/stable/g' /etc/zypp/repos.d/wazuh.repo
 }
 
-test-restoreWazuhrepo-yum-no-file() {
+test-23-restoreWazuhrepo-yum-no-file() {
     load-restoreWazuhrepo
     development="1"
     sys_type="yum"
     restoreWazuhrepo
 }
 
-test-restoreWazuhrepo-yum-no-file-assert() {
+test-23-restoreWazuhrepo-yum-no-file-assert() {
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
     sed -i 's/unstable/stable/g'
 }
 
-test-restoreWazuhrepo-apt-no-file() {
+test-24-restoreWazuhrepo-apt-no-file() {
     load-restoreWazuhrepo
     development="1"
     sys_type="yum"
     restoreWazuhrepo
 }
 
-test-restoreWazuhrepo-apt-no-file-assert() {
+test-24-restoreWazuhrepo-apt-no-file-assert() {
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
     sed -i 's/unstable/stable/g'
 }
 
-test-restoreWazuhrepo-zypper-no-file() {
+test-25-restoreWazuhrepo-zypper-no-file() {
     load-restoreWazuhrepo
     development="1"
     sys_type="yum"
     restoreWazuhrepo
 }
 
-test-restoreWazuhrepo-zypper-no-file-assert() {
+test-25-restoreWazuhrepo-zypper-no-file-assert() {
     file="/etc/zypp/repos.d/wazuh.repo"
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
@@ -353,7 +353,7 @@ function load-createClusterKey {
     @load_function "${base_dir}/common.sh" createClusterKey
 }
 
-test-createClusterKey() {
+test-26-createClusterKey() {
     load-createClusterKey
     base_path=/tmp
     @mkdir -p /tmp/certs
@@ -368,7 +368,7 @@ function load-rollBack {
     @load_function "${base_dir}/common.sh" rollBack
 }
 
-test-rollBack-aio-all-installed-yum() {
+test-27-rollBack-aio-all-installed-yum() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -384,7 +384,7 @@ test-rollBack-aio-all-installed-yum() {
     rollBack
 }
 
-test-rollBack-aio-all-installed-yum-assert() {
+test-27-rollBack-aio-all-installed-yum-assert() {
     yum remove wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -410,7 +410,7 @@ test-rollBack-aio-all-installed-yum-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-aio-all-installed-zypper() {
+test-28-rollBack-aio-all-installed-zypper() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -426,7 +426,7 @@ test-rollBack-aio-all-installed-zypper() {
     rollBack
 }
 
-test-rollBack-aio-all-installed-zypper-assert() {
+test-28-rollBack-aio-all-installed-zypper-assert() {
     zypper -n remove wazuh-manager
     rm -f /etc/init.d/wazuh-manager
     
@@ -451,7 +451,7 @@ test-rollBack-aio-all-installed-zypper-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-aio-all-installed-apt() {
+test-29-rollBack-aio-all-installed-apt() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -467,7 +467,7 @@ test-rollBack-aio-all-installed-apt() {
     rollBack
 }
 
-test-rollBack-aio-all-installed-apt-assert() {
+test-29-rollBack-aio-all-installed-apt-assert() {
     apt remove --purge wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -491,7 +491,7 @@ test-rollBack-aio-all-installed-apt-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-elasticsearch-installation-all-installed-yum() {
+test-30-rollBack-elasticsearch-installation-all-installed-yum() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -507,7 +507,7 @@ test-rollBack-elasticsearch-installation-all-installed-yum() {
     rollBack
 }
 
-test-rollBack-elasticsearch-installation-all-installed-yum-assert() {
+test-30-rollBack-elasticsearch-installation-all-installed-yum-assert() {
     yum remove opendistroforelasticsearch -y
     yum remove elasticsearch* -y
     yum remove opendistro-* -y
@@ -517,7 +517,7 @@ test-rollBack-elasticsearch-installation-all-installed-yum-assert() {
     rm -rf /etc/elasticsearch/
 }
 
-test-rollBack-elasticsearch-installation-all-installed-zypper() {
+test-31-rollBack-elasticsearch-installation-all-installed-zypper() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -533,7 +533,7 @@ test-rollBack-elasticsearch-installation-all-installed-zypper() {
     rollBack
 }
 
-test-rollBack-elasticsearch-installation-all-installed-zypper-assert() {
+test-31-rollBack-elasticsearch-installation-all-installed-zypper-assert() {
     zypper -n remove opendistroforelasticsearch elasticsearch* opendistro-*
     
     rm -rf /var/lib/elasticsearch/
@@ -541,7 +541,7 @@ test-rollBack-elasticsearch-installation-all-installed-zypper-assert() {
     rm -rf /etc/elasticsearch/
 }
 
-test-rollBack-elasticsearch-installation-all-installed-apt() {
+test-32-rollBack-elasticsearch-installation-all-installed-apt() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -557,7 +557,7 @@ test-rollBack-elasticsearch-installation-all-installed-apt() {
     rollBack
 }
 
-test-rollBack-elasticsearch-installation-all-installed-apt-assert() {
+test-32-rollBack-elasticsearch-installation-all-installed-apt-assert() {
     apt remove --purge ^elasticsearch* ^opendistro-* ^opendistroforelasticsearch -y
     
     rm -rf /var/lib/elasticsearch/
@@ -565,7 +565,7 @@ test-rollBack-elasticsearch-installation-all-installed-apt-assert() {
     rm -rf /etc/elasticsearch/
 }
 
-test-rollBack-wazuh-installation-all-installed-yum() {
+test-33-rollBack-wazuh-installation-all-installed-yum() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -581,7 +581,7 @@ test-rollBack-wazuh-installation-all-installed-yum() {
     rollBack
 }
 
-test-rollBack-wazuh-installation-all-installed-yum-assert() {
+test-33-rollBack-wazuh-installation-all-installed-yum-assert() {
     yum remove wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -593,7 +593,7 @@ test-rollBack-wazuh-installation-all-installed-yum-assert() {
     rm -rf /etc/filebeat/
 }
 
-test-rollBack-wazuh-installation-all-installed-zypper() {
+test-34-rollBack-wazuh-installation-all-installed-zypper() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -609,7 +609,7 @@ test-rollBack-wazuh-installation-all-installed-zypper() {
     rollBack
 }
 
-test-rollBack-wazuh-installation-all-installed-zypper-assert() {
+test-34-rollBack-wazuh-installation-all-installed-zypper-assert() {
     zypper -n remove wazuh-manager
     rm -f /etc/init.d/wazuh-manager
     
@@ -622,7 +622,7 @@ test-rollBack-wazuh-installation-all-installed-zypper-assert() {
     rm -rf /etc/filebeat/
 }
 
-test-rollBack-wazuh-installation-all-installed-apt() {
+test-35-rollBack-wazuh-installation-all-installed-apt() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -638,7 +638,7 @@ test-rollBack-wazuh-installation-all-installed-apt() {
     rollBack
 }
 
-test-rollBack-wazuh-installation-all-installed-apt-assert() {
+test-35-rollBack-wazuh-installation-all-installed-apt-assert() {
     apt remove --purge wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -650,7 +650,7 @@ test-rollBack-wazuh-installation-all-installed-apt-assert() {
     rm -rf /etc/filebeat/
 }
 
-test-rollBack-kibana-installation-all-installed-yum() {
+test-36-rollBack-kibana-installation-all-installed-yum() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -666,7 +666,7 @@ test-rollBack-kibana-installation-all-installed-yum() {
     rollBack
 }
 
-test-rollBack-kibana-installation-all-installed-yum-assert() {
+test-36-rollBack-kibana-installation-all-installed-yum-assert() {
     yum remove opendistroforelasticsearch-kibana -y
     
     rm -rf /var/lib/kibana/
@@ -674,7 +674,7 @@ test-rollBack-kibana-installation-all-installed-yum-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-kibana-installation-all-installed-zypper() {
+test-37-rollBack-kibana-installation-all-installed-zypper() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -690,7 +690,7 @@ test-rollBack-kibana-installation-all-installed-zypper() {
     rollBack
 }
 
-test-rollBack-kibana-installation-all-installed-zypper-assert() {
+test-37-rollBack-kibana-installation-all-installed-zypper-assert() {
     zypper -n remove opendistroforelasticsearch-kibana
     
     rm -rf /var/lib/kibana/
@@ -698,7 +698,7 @@ test-rollBack-kibana-installation-all-installed-zypper-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-kibana-installation-all-installed-apt() {
+test-38-rollBack-kibana-installation-all-installed-apt() {
     load-rollBack
     elasticsearchinstalled=1
     wazuhinstalled=1
@@ -714,7 +714,7 @@ test-rollBack-kibana-installation-all-installed-apt() {
     rollBack
 }
 
-test-rollBack-kibana-installation-all-installed-apt-assert() {
+test-38-rollBack-kibana-installation-all-installed-apt-assert() {
     apt remove --purge opendistroforelasticsearch-kibana -y
     
     rm -rf /var/lib/kibana/
@@ -722,7 +722,7 @@ test-rollBack-kibana-installation-all-installed-apt-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-aio-nothing-installed() {
+test-39-rollBack-aio-nothing-installed() {
     load-rollBack
     elasticsearchinstalled=
     wazuhinstalled=
@@ -739,7 +739,7 @@ test-rollBack-aio-nothing-installed() {
     @assert-success
 }
 
-test-rollBack-aio-all-remaining-files-yum() {
+test-40-rollBack-aio-all-remaining-files-yum() {
     load-rollBack
     elasticsearchinstalled=
     wazuhinstalled=
@@ -755,7 +755,7 @@ test-rollBack-aio-all-remaining-files-yum() {
     rollBack
 }
 
-test-rollBack-aio-all-remaining-files-yum-assert() {
+test-40-rollBack-aio-all-remaining-files-yum-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -771,7 +771,7 @@ test-rollBack-aio-all-remaining-files-yum-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-aio-all-remaining-files-zypper() {
+test-41-rollBack-aio-all-remaining-files-zypper() {
     load-rollBack
     elasticsearchinstalled=
     wazuhinstalled=
@@ -787,7 +787,7 @@ test-rollBack-aio-all-remaining-files-zypper() {
     rollBack
 }
 
-test-rollBack-aio-all-remaining-files-zypper-assert() {
+test-41-rollBack-aio-all-remaining-files-zypper-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -803,7 +803,7 @@ test-rollBack-aio-all-remaining-files-zypper-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-aio-all-remaining-files-apt() {
+test-42-rollBack-aio-all-remaining-files-apt() {
     load-rollBack
     elasticsearchinstalled=
     wazuhinstalled=
@@ -819,7 +819,7 @@ test-rollBack-aio-all-remaining-files-apt() {
     rollBack
 }
 
-test-rollBack-aio-all-remaining-files-apt-assert() {
+test-42-rollBack-aio-all-remaining-files-apt-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -835,7 +835,7 @@ test-rollBack-aio-all-remaining-files-apt-assert() {
     rm -rf /etc/kibana/
 }
 
-test-rollBack-nothing-installed-remove-yum-repo() {
+test-43-rollBack-nothing-installed-remove-yum-repo() {
     load-rollBack
     @mkdir -p /etc/yum.repos.d
     @touch /etc/yum.repos.d/wazuh.repo
@@ -843,11 +843,11 @@ test-rollBack-nothing-installed-remove-yum-repo() {
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-rollBack-nothing-installed-remove-yum-repo-assert() {
+test-43-rollBack-nothing-installed-remove-yum-repo-assert() {
     rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-rollBack-nothing-installed-remove-zypper-repo() {
+test-44-rollBack-nothing-installed-remove-zypper-repo() {
     load-rollBack
     @mkdir -p /etc/zypp/repos.d
     @touch /etc/zypp/repos.d/wazuh.repo
@@ -855,11 +855,11 @@ test-rollBack-nothing-installed-remove-zypper-repo() {
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-rollBack-nothing-installed-remove-zypper-repo-assert() {
+test-44-rollBack-nothing-installed-remove-zypper-repo-assert() {
     rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-rollBack-nothing-installed-remove-zypper-repo() {
+test-45-rollBack-nothing-installed-remove-zypper-repo() {
     load-rollBack
     @mkdir -p /etc/apt/sources.list.d
     @touch /etc/apt/sources.list.d/wazuh.list
@@ -867,33 +867,33 @@ test-rollBack-nothing-installed-remove-zypper-repo() {
     @rm /etc/apt/sources.list.d/wazuh.list
 }
 
-test-rollBack-nothing-installed-remove-zypper-repo-assert() {
+test-45-rollBack-nothing-installed-remove-zypper-repo-assert() {
     rm /etc/apt/sources.list.d/wazuh.list
 }
 
-test-rollBack-nothing-installed-remove-/var/log/elasticsearch/() {
+test-46-rollBack-nothing-installed-remove-/var/log/elasticsearch/() {
     load-rollBack
     @mkdir -p /var/log/elasticsearch/
     rollBack
     @rmdir /var/log/elasticsearch
 }
 
-test-rollBack-nothing-installed-remove-/var/log/elasticsearch/-assert() {
+test-46-rollBack-nothing-installed-remove-/var/log/elasticsearch/-assert() {
     rm -rf /var/log/elasticsearch/
 }
 
-test-rollBack-nothing-installed-remove-/var/log/filebeat/() {
+test-47-rollBack-nothing-installed-remove-/var/log/filebeat/() {
     load-rollBack
     @mkdir -p /var/log/filebeat/
     rollBack
     @rmdir /var/log/filebeat/
 }
 
-test-rollBack-nothing-installed-remove-/var/log/filebeat/-assert() {
+test-47-rollBack-nothing-installed-remove-/var/log/filebeat/-assert() {
     rm -rf /var/log/filebeat/
 }
 
-test-rollBack-nothing-installed-remove-/securityadmin_demo.sh() {
+test-48-rollBack-nothing-installed-remove-/securityadmin_demo.sh() {
     load-rollBack
     #@mocktrue -f /securityadmin_demo.sh
     @touch /securityadmin_demo.sh
@@ -901,11 +901,11 @@ test-rollBack-nothing-installed-remove-/securityadmin_demo.sh() {
     @rm /securityadmin_demo.sh
 }
 
-test-rollBack-nothing-installed-remove-/securityadmin_demo.sh-assert() {
+test-48-rollBack-nothing-installed-remove-/securityadmin_demo.sh-assert() {
     rm -f /securityadmin_demo.sh
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/wazuh-manager.service() {
+test-49-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/wazuh-manager.service() {
     load-rollBack
     @mkdir -p /etc/systemd/system/multi-user.target.wants/
     @touch /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
@@ -913,11 +913,11 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wan
     @rm /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/wazuh-manager.service-assert() {
+test-49-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/wazuh-manager.service-assert() {
     rm -f /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/filebeat.service() {
+test-50-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/filebeat.service() {
     load-rollBack
     @mkdir -p /etc/systemd/system/multi-user.target.wants/
     @touch /etc/systemd/system/multi-user.target.wants/filebeat.service
@@ -925,11 +925,11 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wan
     @rm /etc/systemd/system/multi-user.target.wants/filebeat.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/filebeat.service-assert() {
+test-50-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/filebeat.service-assert() {
     rm -f /etc/systemd/system/multi-user.target.wants/filebeat.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/elasticsearch.service() {
+test-51-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/elasticsearch.service() {
     load-rollBack
     @mkdir -p /etc/systemd/system/multi-user.target.wants/
     @touch /etc/systemd/system/multi-user.target.wants/elasticsearch.service
@@ -937,11 +937,11 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wan
     @rm /etc/systemd/system/multi-user.target.wants/elasticsearch.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/elasticsearch.service-assert() {
+test-51-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/elasticsearch.service-assert() {
     rm -f /etc/systemd/system/multi-user.target.wants/elasticsearch.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/kibana.service() {
+test-52-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/kibana.service() {
     load-rollBack
     @mkdir -p /etc/systemd/system/multi-user.target.wants/
     @touch /etc/systemd/system/multi-user.target.wants/kibana.service
@@ -949,11 +949,11 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wan
     @rm /etc/systemd/system/multi-user.target.wants/kibana.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/kibana.service-assert() {
+test-52-rollBack-nothing-installed-remove-/etc/systemd/system/multi-user.target.wants/kibana.service-assert() {
     rm -f /etc/systemd/system/multi-user.target.wants/kibana.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/kibana.service() {
+test-53-rollBack-nothing-installed-remove-/etc/systemd/system/kibana.service() {
     load-rollBack
     @mkdir -p /etc/systemd/system/
     @touch /etc/systemd/system/kibana.service
@@ -961,11 +961,11 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/kibana.service() {
     @rm /etc/systemd/system/kibana.service
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/kibana.service-assert() {
+test-53-rollBack-nothing-installed-remove-/etc/systemd/system/kibana.service-assert() {
     rm -f /etc/systemd/system/kibana.service
 }
 
-test-rollBack-nothing-installed-remove-/lib/firewalld/services/kibana.xml() {
+test-54-rollBack-nothing-installed-remove-/lib/firewalld/services/kibana.xml() {
     load-rollBack
     @mkdir -p /lib/firewalld/services/
     @touch /lib/firewalld/services/kibana.xml
@@ -973,11 +973,11 @@ test-rollBack-nothing-installed-remove-/lib/firewalld/services/kibana.xml() {
     @rm /lib/firewalld/services/kibana.xml
 }
 
-test-rollBack-nothing-installed-remove-/lib/firewalld/services/kibana.xml-assert() {
+test-54-rollBack-nothing-installed-remove-/lib/firewalld/services/kibana.xml-assert() {
     rm -f /lib/firewalld/services/kibana.xml
 }
 
-test-rollBack-nothing-installed-remove-/lib/firewalld/services/elasticsearch.xml() {
+test-55-rollBack-nothing-installed-remove-/lib/firewalld/services/elasticsearch.xml() {
     load-rollBack
     @mkdir -p /lib/firewalld/services/
     @touch /lib/firewalld/services/elasticsearch.xml
@@ -985,11 +985,11 @@ test-rollBack-nothing-installed-remove-/lib/firewalld/services/elasticsearch.xml
     @rm /lib/firewalld/services/elasticsearch.xml
 }
 
-test-rollBack-nothing-installed-remove-/lib/firewalld/services/elasticsearch.xml-assert() {
+test-55-rollBack-nothing-installed-remove-/lib/firewalld/services/elasticsearch.xml-assert() {
     rm -f /lib/firewalld/services/elasticsearch.xml
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/elasticsearch.service.wants() {
+test-56-rollBack-nothing-installed-remove-/etc/systemd/system/elasticsearch.service.wants() {
     load-rollBack
     #@mocktrue -d /etc/systemd/system/elasticsearch.service.wants
     @mkdir -p /etc/systemd/system/elasticsearch.service.wants
@@ -997,7 +997,7 @@ test-rollBack-nothing-installed-remove-/etc/systemd/system/elasticsearch.service
     @rmdir /etc/systemd/system/elasticsearch.service.wants
 }
 
-test-rollBack-nothing-installed-remove-/etc/systemd/system/elasticsearch.service.wants-assert() {
+test-56-rollBack-nothing-installed-remove-/etc/systemd/system/elasticsearch.service.wants-assert() {
     rm -rf /etc/systemd/system/elasticsearch.service.wants
 }
 
@@ -1005,14 +1005,14 @@ function load-createCertificates() {
     @load_function "${base_dir}/common.sh" createCertificates
 }
 
-test-createCertificates-aio() {
+test-57-createCertificates-aio() {
     load-createCertificates
     AIO=1
     base_path=/tmp
     createCertificates
 }
 
-test-createCertificates-aio-assert() {
+test-57-createCertificates-aio-assert() {
     getConfig certificate/config_aio.yml /tmp/config.yml
 
     readConfig
@@ -1027,13 +1027,13 @@ test-createCertificates-aio-assert() {
     cleanFiles
 }
 
-test-createCertificates-no-aio() {
+test-58-createCertificates-no-aio() {
     load-createCertificates
     base_path=/tmp
     createCertificates
 }
 
-test-createCertificates-no-aio-assert() {
+test-58-createCertificates-no-aio-assert() {
 
     readConfig
 
@@ -1051,13 +1051,13 @@ function load-changePasswords() {
     @load_function "${base_dir}/common.sh" changePasswords
 }
 
-test-ASSERT-FAIL-changePasswords-no-tarfile() {
+test-ASSERT-FAIL-59-changePasswords-no-tarfile() {
     load-changePasswords
     tar_file=
     changePasswords
 }
 
-test-changePasswords-with-tarfile() {
+test-60-changePasswords-with-tarfile() {
     load-changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
@@ -1068,7 +1068,7 @@ test-changePasswords-with-tarfile() {
     @rm /tmp/password_file.yml
 }
 
-test-changePasswords-with-tarfile-assert() {
+test-60-changePasswords-with-tarfile-assert() {
     checkInstalledPass
     readPasswordFileUsers
     changePassword
@@ -1076,7 +1076,7 @@ test-changePasswords-with-tarfile-assert() {
     @echo 
 }
 
-test-changePasswords-with-tarfile-aio() {
+test-61-changePasswords-with-tarfile-aio() {
     load-changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
@@ -1088,7 +1088,7 @@ test-changePasswords-with-tarfile-aio() {
     @rm /tmp/password_file.yml
 }
 
-test-changePasswords-with-tarfile-aio-assert() {
+test-61-changePasswords-with-tarfile-aio-assert() {
     checkInstalledPass
     readUsers
     readPasswordFileUsers
@@ -1101,7 +1101,7 @@ test-changePasswords-with-tarfile-aio-assert() {
     @echo 1
 }
 
-test-changePasswords-with-tarfile-start-elastic-cluster() {
+test-62-changePasswords-with-tarfile-start-elastic-cluster() {
     load-changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
@@ -1113,7 +1113,7 @@ test-changePasswords-with-tarfile-start-elastic-cluster() {
     @rm /tmp/password_file.yml
 }
 
-test-changePasswords-with-tarfile-start-elastic-cluster-assert() {
+test-62-changePasswords-with-tarfile-start-elastic-cluster-assert() {
     checkInstalledPass
     readUsers
     readPasswordFileUsers
@@ -1130,7 +1130,7 @@ function load-getPass() {
     @load_function "${base_dir}/common.sh" getPass
 }
 
-test-getPass-no-args() {
+test-63-getPass-no-args() {
     load-getPass
     users=(kibanaserver admin)
     passwords=(kibanaserver_pass admin_pass)
@@ -1138,11 +1138,11 @@ test-getPass-no-args() {
     @echo $u_pass
 }
 
-test-getPass-no-args-assert() {
+test-63-getPass-no-args-assert() {
     @echo
 }
 
-test-getPass-admin() {
+test-64-getPass-admin() {
     load-getPass
     users=(kibanaserver admin)
     passwords=(kibanaserver_pass admin_pass)
@@ -1150,7 +1150,7 @@ test-getPass-admin() {
     @echo $u_pass
 }
 
-test-getPass-admin-assert() {
+test-64-getPass-admin-assert() {
     @echo admin_pass
 }
 
@@ -1158,12 +1158,12 @@ function load-startService() {
     @load_function "${base_dir}/common.sh" startService
 }
 
-test-ASSERT-FAIL-startService-no-args() {
+test-ASSERT-FAIL-65-startService-no-args() {
     load-startService
     startService
 }
 
-test-ASSERT-FAIL-startService-no-service-manager() {
+test-ASSERT-FAIL-66-startService-no-service-manager() {
     load-startService
     @mockfalse ps -e
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
@@ -1172,7 +1172,7 @@ test-ASSERT-FAIL-startService-no-service-manager() {
     startService wazuh-manager
 }
 
-test-startService-systemd() {
+test-67-startService-systemd() {
     load-startService
     @mockfalse ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
@@ -1180,13 +1180,13 @@ test-startService-systemd() {
     startService wazuh-manager
 }
 
-test-startService-systemd-assert() {
+test-67-startService-systemd-assert() {
     systemctl daemon-reload
     systemctl enable wazuh-manager.service
     systemctl start wazuh-manager.service
 }
 
-test-startService-systemd-error() {
+test-68-startService-systemd-error() {
     load-startService
     @mock ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
@@ -1195,14 +1195,14 @@ test-startService-systemd-error() {
     startService wazuh-manager
 }
 
-test-startService-systemd-error-assert() {
+test-68-startService-systemd-error-assert() {
     systemctl daemon-reload
     systemctl enable wazuh-manager.service
     rollBack
     exit 1
 }
 
-test-startService-initd() {
+test-69-startService-initd() {
     load-startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
@@ -1214,7 +1214,7 @@ test-startService-initd() {
     @rm /etc/init.d/wazuh-manager
 }
 
-test-startService-initd-assert() {
+test-69-startService-initd-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     chkconfig wazuh-manager on
@@ -1223,7 +1223,7 @@ test-startService-initd-assert() {
     @rm /etc/init.d/wazuh-manager
 }
 
-test-startService-initd-error() {
+test-70-startService-initd-error() {
     load-startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
@@ -1235,7 +1235,7 @@ test-startService-initd-error() {
     @rm /etc/init.d/wazuh-manager
 }
 
-test-startService-initd-error-assert() {
+test-70-startService-initd-error-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     @chmod +x /etc/init.d/wazuh-manager
@@ -1247,7 +1247,7 @@ test-startService-initd-error-assert() {
     @rm /etc/init.d/wazuh-manager
 }
 
-test-startService-rc.d/init.d() {
+test-71-startService-rc.d/init.d() {
     load-startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
@@ -1261,7 +1261,7 @@ test-startService-rc.d/init.d() {
     @rm /etc/rc.d/init.d/wazuh-manager
 }
 
-test-startService-rc.d/init.d-assert() {
+test-71-startService-rc.d/init.d-assert() {
     @mkdir -p /etc/rc.d/init.d
     @touch /etc/rc.d/init.d/wazuh-manager
     @chmod +x /etc/rc.d/init.d/wazuh-manager
@@ -1269,41 +1269,18 @@ test-startService-rc.d/init.d-assert() {
     @rm /etc/rc.d/init.d/wazuh-manager
 }
 
-# test-startService-rc.d/init.d-error() {
-#     load-startService
-#     @mock ps -e === @out 
-#     @mockfalse grep -E -q "^\ *1\ .*systemd$"
-#     @mockfalse grep -E -q "^\ *1\ .*init$"
-#     @mkdir -p /etc/rc.d/init.d
-#     @touch /etc/rc.d/init.d/wazuh-manager
-#     @chmod +x /etc/rc.d/init.d/wazuh-manager
-#     @mockfalse /etc/rc.d/init.d/wazuh-manager
-#     startService wazuh-manager
-#     @rm /etc/rc.d/init.d/wazuh-manager
-# }
-
-# test-startService-rc.d/init.d-error-assert() {
-#     @mkdir -p /etc/rc.d/init.d
-#     @touch /etc/rc.d/init.d/wazuh-manager
-#     @chmod +x /etc/rc.d/init.d/wazuh-manager
-#     /etc/rc.d/init.d/wazuh-manager start
-#     rollBack
-#     exit 1
-#     @rm /etc/rc.d/init.d/wazuh-manager
-# }
-
 function load-readPasswordFileUsers() {
     @load_function "${base_dir}/common.sh" readPasswordFileUsers
 }
 
-test-ASSERT-FAIL-readPasswordFileUsers-file-incorrect() {
+test-ASSERT-FAIL-72-readPasswordFileUsers-file-incorrect() {
     load-readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 0
     readPasswordFileUsers
 }
 
-test-readPasswordFileUsers-changeall-correct() {
+test-73-readPasswordFileUsers-changeall-correct() {
     load-readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
@@ -1320,14 +1297,14 @@ test-readPasswordFileUsers-changeall-correct() {
     @echo ${passwords[*]}
 }
 
-test-readPasswordFileUsers-changeall-correct-assert() {
+test-73-readPasswordFileUsers-changeall-correct-assert() {
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
 }
 
-test-readPasswordFileUsers-changeall-user-doesnt-exist() {
+test-74-readPasswordFileUsers-changeall-user-doesnt-exist() {
     load-readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
@@ -1344,14 +1321,14 @@ test-readPasswordFileUsers-changeall-user-doesnt-exist() {
     @echo ${passwords[*]}
 }
 
-test-readPasswordFileUsers-changeall-user-doesnt-exist-assert() {
+test-74-readPasswordFileUsers-changeall-user-doesnt-exist-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
 }
 
-test-readPasswordFileUsers-no-changeall-kibana-correct() {
+test-75-readPasswordFileUsers-no-changeall-kibana-correct() {
     load-readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
@@ -1369,14 +1346,14 @@ test-readPasswordFileUsers-no-changeall-kibana-correct() {
     @echo ${passwords[*]}
 }
 
-test-readPasswordFileUsers-no-changeall-kibana-correct-assert() {
+test-75-readPasswordFileUsers-no-changeall-kibana-correct-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword adminpassword
     @echo kibanaserver admin
     @echo kibanaserverpassword adminpassword
 }
 
-test-readPasswordFileUsers-no-changeall-filebeat-correct() {
+test-76-readPasswordFileUsers-no-changeall-filebeat-correct() {
     load-readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
@@ -1394,7 +1371,7 @@ test-readPasswordFileUsers-no-changeall-filebeat-correct() {
     @echo ${passwords[*]}
 }
 
-test-readPasswordFileUsers-no-changeall-filebeat-correct-assert() {
+test-76-readPasswordFileUsers-no-changeall-filebeat-correct-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword adminpassword
     @echo admin

--- a/tests/unattended/unit/suites/test-elasticsearch.sh
+++ b/tests/unattended/unit/suites/test-elasticsearch.sh
@@ -6,18 +6,13 @@ source "${base_dir}"/bach.sh
 @setup-test {
     @ignore logger
     e_certs_path="/etc/elasticsearch/certs/"
-    # wazuh_version="4.3.0"
-    # elasticsearch_oss_version="7.10.2"
-    # wazuh_kibana_plugin_revision="1"
-    # repobaseurl="https://packages.wazuh.com/4.x"
-    # kibana_wazuh_plugin="${repobaseurl}/ui/kibana/wazuh_kibana-${wazuh_version}_${elasticsearch_oss_version}-${wazuh_kibana_plugin_revision}.zip"
 }
 
 function load-copyCertificatesElasticsearch() {
     @load_function "${base_dir}/elasticsearch.sh" copyCertificatesElasticsearch
 }
 
-test-ASSERT-FAIL-copyCertificatesElasticsearch-no-tarfile() {
+test-ASSERT-FAIL-01-copyCertificatesElasticsearch-no-tarfile() {
     load-copyCertificatesElasticsearch
     tar_file=/tmp/tarfile.tar
     if [ -f ${tar_file} ]; then
@@ -26,7 +21,7 @@ test-ASSERT-FAIL-copyCertificatesElasticsearch-no-tarfile() {
     copyCertificatesElasticsearch
 }
 
-test-copyCertificatesElasticsearch() {
+test-02-copyCertificatesElasticsearch() {
     load-copyCertificatesElasticsearch
     tar_file=/tmp/tarfile.tar
     @touch ${tar_file}
@@ -36,7 +31,7 @@ test-copyCertificatesElasticsearch() {
     copyCertificatesElasticsearch
 }
 
-test-copyCertificatesElasticsearch-assert() {
+test-02-copyCertificatesElasticsearch-assert() {
     tar -xf /tmp/tarfile.tar -C /etc/elasticsearch/certs/ ./elastic1.pem  && mv /etc/elasticsearch/certs/elastic1.pem /etc/elasticsearch/certs/elasticsearch.pem
     tar -xf /tmp/tarfile.tar -C /etc/elasticsearch/certs/ ./elastic1-key.pem  && mv /etc/elasticsearch/certs/elastic1-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
     tar -xf /tmp/tarfile.tar -C /etc/elasticsearch/certs/ ./root-ca.pem
@@ -48,7 +43,7 @@ function load-installElasticsearch() {
     @load_function "${base_dir}/elasticsearch.sh" installElasticsearch
 }
 
-test-installElasticsearch-zypper() {
+test-03-installElasticsearch-zypper() {
     load-installElasticsearch
     sys_type="zypper"
     opendistro_version="1.13.2"
@@ -56,11 +51,11 @@ test-installElasticsearch-zypper() {
     installElasticsearch
 }
 
-test-installElasticsearch-zypper-assert() {
+test-03-installElasticsearch-zypper-assert() {
     zypper -n install opendistroforelasticsearch=1.13.2-1
 }
 
-test-ASSERT-FAIL-installElasticsearch-zypper-error() {
+test-ASSERT-FAIL-04-installElasticsearch-zypper-error() {
     load-installElasticsearch
     sys_type="zypper"
     opendistro_version="1.13.2"
@@ -69,7 +64,7 @@ test-ASSERT-FAIL-installElasticsearch-zypper-error() {
     installElasticsearch
 }
 
-test-installElasticsearch-yum() {
+test-05-installElasticsearch-yum() {
     load-installElasticsearch
     sys_type="yum"
     sep="-"
@@ -78,11 +73,11 @@ test-installElasticsearch-yum() {
     installElasticsearch
 }
 
-test-installElasticsearch-yum-assert() {
+test-05-installElasticsearch-yum-assert() {
     yum install opendistroforelasticsearch-1.13.2-1 -y
 }
 
-test-ASSERT-FAIL-installElasticsearch-yum-error() {
+test-ASSERT-FAIL-06-installElasticsearch-yum-error() {
     load-installElasticsearch
     sys_type="yum"
     sep="-"
@@ -92,7 +87,7 @@ test-ASSERT-FAIL-installElasticsearch-yum-error() {
     installElasticsearch
 }
 
-test-installElasticsearch-apt() {
+test-07-installElasticsearch-apt() {
     load-installElasticsearch
     sys_type="apt-get"
     sep="="
@@ -101,11 +96,11 @@ test-installElasticsearch-apt() {
     installElasticsearch
 }
 
-test-installElasticsearch-apt-assert() {
+test-07-installElasticsearch-apt-assert() {
     apt install elasticsearch-oss opendistroforelasticsearch -y 
 }
 
-test-ASSERT-FAIL-installElasticsearch-apt-error() {
+test-ASSERT-FAIL-08-installElasticsearch-apt-error() {
     load-installElasticsearch
     sys_type="apt-get"
     sep="="
@@ -119,7 +114,7 @@ function load-configureElasticsearch() {
     @load_function "${base_dir}/elasticsearch.sh" configureElasticsearch
 }
 
-test-configureElasticsearch-dist-one-elastic-node() {
+test-09-configureElasticsearch-dist-one-elastic-node() {
     load-configureElasticsearch
     elasticsearch_node_names=("elastic1")
     elasticsearch_node_ips=("1.1.1.1")
@@ -131,8 +126,7 @@ test-configureElasticsearch-dist-one-elastic-node() {
     configureElasticsearch
 }
 
-
-test-configureElasticsearch-dist-one-elastic-node-assert() {
+test-09-configureElasticsearch-dist-one-elastic-node-assert() {
     getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/elasticsearch/elasticsearch.yml
     getConfig elasticsearch/roles/roles.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml
     getConfig elasticsearch/roles/roles_mapping.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml
@@ -153,7 +147,7 @@ test-configureElasticsearch-dist-one-elastic-node-assert() {
 
 }
 
-test-configureElasticsearch-dist-two-elastic-nodes() {
+test-10-configureElasticsearch-dist-two-elastic-nodes() {
     load-configureElasticsearch
     elasticsearch_node_names=("elastic1" "elastic2")
     elasticsearch_node_ips=("1.1.1.1", "1.1.2.2")
@@ -165,8 +159,7 @@ test-configureElasticsearch-dist-two-elastic-nodes() {
     configureElasticsearch
 }
 
-
-test-configureElasticsearch-dist-two-elastic-nodes-assert() {
+test-10-configureElasticsearch-dist-two-elastic-nodes-assert() {
     getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/elasticsearch/elasticsearch.yml
     getConfig elasticsearch/roles/roles.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml
     getConfig elasticsearch/roles/roles_mapping.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml
@@ -190,7 +183,7 @@ function load-configureElasticsearchAIO() {
     @load_function "${base_dir}/elasticsearch.sh" configureElasticsearchAIO
 }
 
-test-configureElasticsearch-AIO() {
+test-11-configureElasticsearch-AIO() {
     load-configureElasticsearchAIO
     elasticsearch_node_names=("elastic1")
     elasticsearch_node_ips=("1.1.1.1")
@@ -199,8 +192,7 @@ test-configureElasticsearch-AIO() {
     configureElasticsearchAIO
 }
 
-
-test-configureElasticsearch-AIO-assert() {
+test-11-configureElasticsearch-AIO-assert() {
     getConfig elasticsearch/elasticsearch_all_in_one.yml /etc/elasticsearch/elasticsearch.yml
     getConfig elasticsearch/roles/roles.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml
     getConfig elasticsearch/roles/roles_mapping.yml /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles_mapping.yml
@@ -222,7 +214,7 @@ function load-initializeElasticsearch() {
     @load_function "${base_dir}/elasticsearch.sh" initializeElasticsearch
 }
 
-test-initializeElasticsearch-one-node() {
+test-12-initializeElasticsearch-one-node() {
     load-initializeElasticsearch
     elasticsearch_node_names=("elastic1")
     elasticsearch_node_ips=("1.1.1.1")
@@ -232,13 +224,13 @@ test-initializeElasticsearch-one-node() {
     @echo ${start_elastic_cluster}
 }
 
-test-initializeElasticsearch-one-node-assert() {
+test-12-initializeElasticsearch-one-node-assert() {
     startElasticsearchCluster
     changePasswords
     @echo 1
 }
 
-test-initializeElasticsearch-two-nodes() {
+test-13-initializeElasticsearch-two-nodes() {
     load-initializeElasticsearch
     elasticsearch_node_names=("elastic1" "elastic2")
     elasticsearch_node_ips=("1.1.1.1" "1.1.2.2")
@@ -248,7 +240,7 @@ test-initializeElasticsearch-two-nodes() {
     @assert-success
 }
 
-test-ASSERT-FAIL-initializeElasticsearch-error-connecting() {
+test-ASSERT-FAIL-14-initializeElasticsearch-error-connecting() {
     load-initializeElasticsearch
     elasticsearch_node_names=("elastic1")
     elasticsearch_node_ips=("1.1.1.1")
@@ -261,12 +253,12 @@ function load-applyLog4j2Mitigation() {
     @load_function "${base_dir}/elasticsearch.sh" applyLog4j2Mitigation
 }
 
-test-applyLog4j2Mitigation() {
+test-15-applyLog4j2Mitigation() {
     load-applyLog4j2Mitigation
     applyLog4j2Mitigation
 }
 
-test-applyLog4j2Mitigation-assert() {
+test-15-applyLog4j2Mitigation-assert() {
     curl -so /tmp/apache-log4j-2.17.1-bin.tar.gz https://packages.wazuh.com/utils/log4j/apache-log4j-2.17.1-bin.tar.gz
     tar -xf /tmp/apache-log4j-2.17.1-bin.tar.gz -C /tmp/
 

--- a/tests/unattended/unit/suites/test-filebeat.sh
+++ b/tests/unattended/unit/suites/test-filebeat.sh
@@ -16,7 +16,7 @@ function load-copyCertificatesFilebeat() {
     @load_function "${base_dir}/filebeat.sh" copyCertificatesFilebeat
 }
 
-test-ASSERT-FAIL-copyCertificatesFilebeat-no-tarfile() {
+test-ASSERT-FAIL-01-copyCertificatesFilebeat-no-tarfile() {
     load-copyCertificatesFilebeat
     tar_file=/tmp/tarfile.tar
     if [ -f ${tar_file} ]; then
@@ -25,7 +25,7 @@ test-ASSERT-FAIL-copyCertificatesFilebeat-no-tarfile() {
     copyCertificatesFilebeat
 }
 
-test-copyCertificatesFilebeat-AIO() {
+test-02-copyCertificatesFilebeat-AIO() {
     load-copyCertificatesFilebeat
     tar_file=/tmp/tarfile.tar
     @touch ${tar_file}
@@ -34,12 +34,12 @@ test-copyCertificatesFilebeat-AIO() {
     copyCertificatesFilebeat
 }
 
-test-copyCertificatesFilebeat-AIO-assert() {
+test-02-copyCertificatesFilebeat-AIO-assert() {
     tar -xf /tmp/tarfile.tar -C /etc/filebeat/certs/ --wildcards ./filebeat*
     tar -xf /tmp/tarfile.tar -C /etc/filebeat/certs/ ./root-ca.pem
 }
 
-test-copyCertificatesFilebeat-distributed() {
+test-03-copyCertificatesFilebeat-distributed() {
     load-copyCertificatesFilebeat
     tar_file=/tmp/tarfile.tar
     @touch ${tar_file}
@@ -49,7 +49,7 @@ test-copyCertificatesFilebeat-distributed() {
     copyCertificatesFilebeat
 }
 
-test-copyCertificatesFilebeat-distributed-assert() {
+test-03-copyCertificatesFilebeat-distributed-assert() {
     tar -xf /tmp/tarfile.tar -C /etc/filebeat/certs/ ./wazuh1.pem
     mv /etc/filebeat/certs/wazuh1.pem /etc/filebeat/certs/filebeat.pem
     tar -xf /tmp/tarfile.tar -C /etc/filebeat/certs/ ./wazuh1-key.pem
@@ -61,18 +61,18 @@ function load-installFilebeat() {
     @load_function "${base_dir}/filebeat.sh" installFilebeat
 }
 
-test-installFilebeat-zypper() {
+test-04-installFilebeat-zypper() {
     load-installFilebeat
     sys_type="zypper"
     elasticsearch_oss_version="7.10.2"
     installFilebeat
 }
 
-test-installFilebeat-zypper-assert() {
+test-04-installFilebeat-zypper-assert() {
     zypper -n install filebeat-7.10.2
 }
 
-test-ASSERT-FAIL-installFilebeat-zypper-error() {
+test-ASSERT-FAIL-05-installFilebeat-zypper-error() {
     load-installFilebeat
     sys_type="zypper"
     elasticsearch_oss_version="7.10.2"
@@ -80,7 +80,7 @@ test-ASSERT-FAIL-installFilebeat-zypper-error() {
     installFilebeat
 }
 
-test-installFilebeat-yum() {
+test-06-installFilebeat-yum() {
     load-installFilebeat
     sys_type="yum"
     sep="-"
@@ -88,11 +88,11 @@ test-installFilebeat-yum() {
     installFilebeat
 }
 
-test-installFilebeat-yum-assert() {
+test-06-installFilebeat-yum-assert() {
     yum install filebeat-7.10.2 -y -q
 }
 
-test-ASSERT-FAIL-installFilebeat-yum-error() {
+test-ASSERT-FAIL-07-installFilebeat-yum-error() {
     load-installFilebeat
     sys_type="yum"
     sep="-"
@@ -101,7 +101,7 @@ test-ASSERT-FAIL-installFilebeat-yum-error() {
     installFilebeat
 }
 
-test-installFilebeat-apt() {
+test-08-installFilebeat-apt() {
     load-installFilebeat
     sys_type="apt-get"
     sep="="
@@ -109,11 +109,11 @@ test-installFilebeat-apt() {
     installFilebeat
 }
 
-test-installFilebeat-apt-assert() {
+test-08-installFilebeat-apt-assert() {
     apt-get install filebeat=7.10.2 -y -q
 }
 
-test-ASSERT-FAIL-installFilebeat-apt-error() {
+test-ASSERT-FAIL-09-installFilebeat-apt-error() {
     load-installFilebeat
     sys_type="apt-get"
     sep="="
@@ -126,7 +126,7 @@ function load-configureFilebeat() {
     @load_function "${base_dir}/filebeat.sh" configureFilebeat
 }
 
-test-configureFilebeat-no-previous-variables() {
+test-10-configureFilebeat-no-previous-variables() {
     load-configureFilebeat
     filebeat_wazuh_template=""
     filebeat_wazuh_module=""
@@ -135,7 +135,7 @@ test-configureFilebeat-no-previous-variables() {
     configureFilebeat
 }
 
-test-configureFilebeat-no-previous-variables-assert() {
+test-10-configureFilebeat-no-previous-variables-assert() {
     getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     curl -so /etc/filebeat/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
@@ -144,7 +144,7 @@ test-configureFilebeat-no-previous-variables-assert() {
     copyCertificatesFilebeat
 }
 
-test-configureFilebeat-one-elastic-node() {
+test-11-configureFilebeat-one-elastic-node() {
     load-configureFilebeat
     @mocktrue curl -s ${filebeat_wazuh_module} --max-time 300
     @mock tar -xvz -C /usr/share/filebeat/module
@@ -153,7 +153,7 @@ test-configureFilebeat-one-elastic-node() {
     configureFilebeat
 }
 
-test-configureFilebeat-one-elastic-node-assert() {
+test-11-configureFilebeat-one-elastic-node-assert() {
     getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
@@ -163,7 +163,7 @@ test-configureFilebeat-one-elastic-node-assert() {
     copyCertificatesFilebeat
 }
 
-test-configureFilebeat-more-than-one-elastic-node() {
+test-12-configureFilebeat-more-than-one-elastic-node() {
     load-configureFilebeat
     @mocktrue curl -s ${filebeat_wazuh_module} --max-time 300
     @mock tar -xvz -C /usr/share/filebeat/module
@@ -172,7 +172,7 @@ test-configureFilebeat-more-than-one-elastic-node() {
     configureFilebeat
 }
 
-test-configureFilebeat-more-than-one-elastic-node-assert() {
+test-12-configureFilebeat-more-than-one-elastic-node-assert() {
     getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
@@ -187,7 +187,7 @@ function load-configureFilebeatAIO() {
     @load_function "${base_dir}/filebeat.sh" configureFilebeatAIO
 }
 
-test-configureFilebeatAIO-no-previous-variables() {
+test-13-configureFilebeatAIO-no-previous-variables() {
     load-configureFilebeatAIO
     filebeat_wazuh_template=""
     filebeat_wazuh_module=""
@@ -196,7 +196,7 @@ test-configureFilebeatAIO-no-previous-variables() {
     configureFilebeatAIO
 }
 
-test-configureFilebeatAIO-no-previous-variables-assert() {
+test-13-configureFilebeatAIO-no-previous-variables-assert() {
     getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
     curl -so /etc/filebeat/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
@@ -204,14 +204,14 @@ test-configureFilebeatAIO-no-previous-variables-assert() {
     copyCertificatesFilebeat
 }
 
-test-configureFilebeatAIO() {
+test-14-configureFilebeatAIO() {
     load-configureFilebeatAIO
     @mocktrue curl -s ${filebeat_wazuh_module} --max-time 300
     @mock tar -xvz -C /usr/share/filebeat/module
     configureFilebeatAIO
 }
 
-test-configureFilebeatAIO-assert() {
+test-1-configureFilebeatAIO-assert() {
     getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json

--- a/tests/unattended/unit/suites/test-kibana.sh
+++ b/tests/unattended/unit/suites/test-kibana.sh
@@ -17,7 +17,7 @@ function load-copyKibanacerts() {
     @load_function "${base_dir}/kibana.sh" copyKibanacerts
 }
 
-test-ASSERT-FAIL-copyKibanacerts-no-tarfile() {
+test-ASSERT-FAIL-01-copyKibanacerts-no-tarfile() {
     load-copyKibanacerts
     tar_file=/tmp/tarfile.tar
     if [ -f ${tar_file} ]; then
@@ -26,7 +26,7 @@ test-ASSERT-FAIL-copyKibanacerts-no-tarfile() {
     copyKibanacerts
 }
 
-test-copyKibanacerts() {
+test-02-copyKibanacerts() {
     load-copyKibanacerts
     tar_file=/tmp/tarfile.tar
     @touch ${tar_file}
@@ -36,7 +36,7 @@ test-copyKibanacerts() {
     copyKibanacerts
 }
 
-test-copyKibanacerts-assert() {
+test-02-copyKibanacerts-assert() {
     mkdir /etc/kibana/certs
     tar -xf /tmp/tarfile.tar -C /etc/kibana/certs/ ./kibana1.pem  && mv /etc/kibana/certs/kibana1.pem /etc/kibana/certs/kibana.pem
     tar -xf /tmp/tarfile.tar -C /etc/kibana/certs/ ./kibana1-key.pem  && mv /etc/kibana/certs/kibana1-key.pem /etc/kibana/certs/kibana-key.pem
@@ -50,18 +50,18 @@ function load-installKibana() {
     @load_function "${base_dir}/kibana.sh" installKibana
 }
 
-test-installKibana-zypper() {
+test-03-installKibana-zypper() {
     load-installKibana
     sys_type="zypper"
     opendistro_version="1.13.2"
     installKibana
 }
 
-test-installKibana-zypper-assert() {
+test-03-installKibana-zypper-assert() {
     zypper -n install opendistroforelasticsearch-kibana=1.13.2
 }
 
-test-ASSERT-FAIL-installKibana-zypper-error() {
+test-ASSERT-FAIL-04-installKibana-zypper-error() {
     load-installKibana
     sys_type="zypper"
     opendistro_version="1.13.2"
@@ -69,7 +69,7 @@ test-ASSERT-FAIL-installKibana-zypper-error() {
     installKibana
 }
 
-test-installKibana-yum() {
+test-05-installKibana-yum() {
     load-installKibana
     sys_type="yum"
     sep="-"
@@ -77,11 +77,11 @@ test-installKibana-yum() {
     installKibana
 }
 
-test-installKibana-yum-assert() {
+test-05-installKibana-yum-assert() {
     yum install opendistroforelasticsearch-kibana-1.13.2 -y 
 }
 
-test-ASSERT-FAIL-installKibana-yum-error() {
+test-ASSERT-FAIL-06-installKibana-yum-error() {
     load-installKibana
     sys_type="yum"
     sep="-"
@@ -90,7 +90,7 @@ test-ASSERT-FAIL-installKibana-yum-error() {
     installKibana
 }
 
-test-installKibana-apt() {
+test-07-installKibana-apt() {
     load-installKibana
     sys_type="apt-get"
     sep="="
@@ -98,11 +98,11 @@ test-installKibana-apt() {
     installKibana
 }
 
-test-installKibana-apt-assert() {
+test-07-installKibana-apt-assert() {
     apt-get install opendistroforelasticsearch-kibana=1.13.2 -y 
 }
 
-test-ASSERT-FAIL-installKibana-apt-error() {
+test-ASSERT-FAIL-08-installKibana-apt-error() {
     load-installKibana
     sys_type="apt-get"
     sep="="
@@ -115,7 +115,7 @@ function load-configureKibana() {
     @load_function "${base_dir}/kibana.sh" configureKibana
 }
 
-test-configureKibana-dist-one-kibana-node-one-elastic-node() {
+test-09-configureKibana-dist-one-kibana-node-one-elastic-node() {
     load-configureKibana
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
@@ -124,8 +124,7 @@ test-configureKibana-dist-one-kibana-node-one-elastic-node() {
     configureKibana
 }
 
-
-test-configureKibana-dist-one-kibana-node-one-elastic-node-assert() {
+test-09-configureKibana-dist-one-kibana-node-one-elastic-node-assert() {
     getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
     mkdir /usr/share/kibana/data
     chown -R kibana:kibana /usr/share/kibana/
@@ -137,7 +136,7 @@ test-configureKibana-dist-one-kibana-node-one-elastic-node-assert() {
     copyKibanacerts
 }
 
-test-configureKibana-dist-two-kibana-nodes-two-elastic-nodes() {
+test-10-configureKibana-dist-two-kibana-nodes-two-elastic-nodes() {
     load-configureKibana
     kiname="kibana2"
     kibana_node_names=("kibana1" "kibana2")
@@ -147,7 +146,7 @@ test-configureKibana-dist-two-kibana-nodes-two-elastic-nodes() {
     configureKibana
 }
 
-test-configureKibana-dist-two-kibana-nodes-two-elastic-nodes-assert() {
+test-10-configureKibana-dist-two-kibana-nodes-two-elastic-nodes-assert() {
     getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
     mkdir /usr/share/kibana/data
     chown -R kibana:kibana /usr/share/kibana/
@@ -161,7 +160,7 @@ test-configureKibana-dist-two-kibana-nodes-two-elastic-nodes-assert() {
     copyKibanacerts
 }
 
-test-ASSERT-FAIL-configureKibana-dist-error-downloading-plugin() {
+test-ASSERT-FAIL-11-configureKibana-dist-error-downloading-plugin() {
     load-configureKibana
     @mockfalse sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.3.0_7.10.2-1.zip
     configureKibana
@@ -171,7 +170,7 @@ function load-configureKibanaAIO() {
     @load_function "${base_dir}/kibana.sh" configureKibanaAIO
 }
 
-test-configureKibana-AIO() {
+test-12-configureKibana-AIO() {
     load-configureKibanaAIO
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
@@ -180,8 +179,7 @@ test-configureKibana-AIO() {
     configureKibanaAIO
 }
 
-
-test-configureKibana-AIO-assert() {
+test-12-configureKibana-AIO-assert() {
     getConfig kibana/kibana_unattended.yml /etc/kibana/kibana.yml
     mkdir /usr/share/kibana/data
     chown -R kibana:kibana /usr/share/kibana/
@@ -191,7 +189,7 @@ test-configureKibana-AIO-assert() {
     modifyKibanaLogin
 }
 
-test-ASSERT-FAIL-configureKibanaAIO-error-downloading-plugin() {
+test-ASSERT-FAIL-13-configureKibanaAIO-error-downloading-plugin() {
     load-configureKibanaAIO
     @mockfalse sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.3.0_7.10.2-1.zip
     configureKibanaAIO
@@ -201,7 +199,7 @@ function load-initializeKibana() {
     @load_function "${base_dir}/kibana.sh" initializeKibana
 }
 
-test-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct() {
+test-14-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct() {
     load-initializeKibana
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
@@ -212,12 +210,12 @@ test-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct() 
     initializeKibana
 }
 
-test-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct-assert() {
+test-14-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct-assert() {
     getPass "admin"
     sed -i 's,url: https://localhost,url: https://2.2.2.2,g' /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
-test-ASSERT-FAIL-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-error() {
+test-ASSERT-FAIL-15-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-error() {
     load-initializeKibana
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
@@ -228,7 +226,7 @@ test-ASSERT-FAIL-initializeKibana-distributed-one-kibana-node-one-wazuh-node-cur
     initializeKibana
 }
 
-test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct() {
+test-16-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct() {
     load-initializeKibana
     kibana_node_names=("kibana1" "kibana2")
     kibana_node_ips=("1.1.1.1" "1.1.1.2")
@@ -240,12 +238,12 @@ test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct(
     initializeKibana
 }
 
-test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct-assert() {
+test-16-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct-assert() {
     getPass "admin"
     sed -i 's,url: https://localhost,url: https://1.1.2.2,g' /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
-test-ASSERT-FAIL-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error() {
+test-ASSERT-FAIL-17-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error() {
     load-initializeKibana
     kibana_node_names=("kibana1" "kibana2")
     kibana_node_ips=("1.1.1.1" "1.1.1.2")
@@ -258,7 +256,7 @@ test-ASSERT-FAIL-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-c
     initializeKibana
 }
 
-test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force() {
+test-18-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force() {
     load-initializeKibana
     kibana_node_names=("kibana1" "kibana2")
     kibana_node_ips=("1.1.1.1" "1.1.1.2")
@@ -271,7 +269,7 @@ test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-fo
     initializeKibana
 }
 
-test-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force-assert() {
+test-18-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force-assert() {
     getPass  admin
     sleep  10
     sleep  10
@@ -292,7 +290,7 @@ function load-initializeKibanaAIO() {
     @load_function "${base_dir}/kibana.sh" initializeKibanaAIO
 }
 
-test-initializeKibanaAIO-curl-correct() {
+test-19-initializeKibanaAIO-curl-correct() {
     load-initializeKibanaAIO
     kibana_node_names=("kibana1")
     kibana_node_ips=("1.1.1.1")
@@ -301,12 +299,12 @@ test-initializeKibanaAIO-curl-correct() {
     initializeKibanaAIO
 }
 
-test-initializeKibanaAIO-curl-correct-assert() {
+test-19-initializeKibanaAIO-curl-correct-assert() {
     getPass "admin"
 }
 
 
-test-ASSERT-FAIL-initializeKibanaAIO-curl-error() {
+test-ASSERT-FAIL-20-initializeKibanaAIO-curl-error() {
     load-initializeKibanaAIO
     u_pass="user_password"
     @mock curl -XGET https://localhost/status -uadmin:user_password -k -w %{http_code} -s -o /dev/null === @out "0"
@@ -317,14 +315,14 @@ function load-modifyKibanaLogin() {
     @load_function "${base_dir}/kibana.sh" modifyKibanaLogin
 }
 
-test-modifyKibanaLogin() {
+test-21-modifyKibanaLogin() {
     load-modifyKibanaLogin
     @mocktrue cat /tmp/customWelcomeKibana.css
     @mock tee -a /usr/share/kibana/src/core/server/core_app/assets/legacy_light_theme.css
     modifyKibanaLogin
 }
 
-test-modifyKibanaLogin-assert() {
+test-21-modifyKibanaLogin-assert() {
     sed -i 's/null, "Elastic"/null, "Wazuh"/g' /usr/share/kibana/src/core/server/rendering/views/template.js
     curl -so /tmp/custom_welcome.tar.gz https://wazuh-demo.s3-us-west-1.amazonaws.com/custom_welcome_opendistro_docker.tar.gz
     tar -xf /tmp/custom_welcome.tar.gz -C /tmp

--- a/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
@@ -13,12 +13,12 @@ function load-cleanFiles() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" cleanFiles
 }
 
-test-cleanFiles-1() {
+test-1-cleanFiles() {
     load-cleanFiles
     cleanFiles
 }
 
-test-cleanFiles-1-assert() {
+test-1-cleanFiles-assert() {
     rm -f /tmp/wazuh-cert-tool/certs/*.csr
     rm -f /tmp/wazuh-cert-tool/certs/*.srl
     rm -f /tmp/wazuh-cert-tool/certs/*.conf
@@ -29,13 +29,17 @@ function load-checkOpenSSL() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" checkOpenSSL
 }
 
-test-ASSERT-FAIL-checkOpenSSL-no-openssl-2() {
+test-2-checkOpenSSL-no-openssl() {
     load-checkOpenSSL
-    @mock command -v openssl === @out ""
+    @mockfalse command -v openssl
     checkOpenSSL
 }
 
-test-checkOpenSSL-correct-3() {
+test-2-checkOpenSSL-no-openssl-assert() {
+    exit 1
+}
+
+test-3-checkOpenSSL-correct() {
     load-checkOpenSSL
     @mock command -v openssl === @out "/bin/openssl"
     checkOpenSSL
@@ -46,12 +50,12 @@ function load-generateAdmincertificate() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateAdmincertificate
 }
 
-test-generateAdmincertificate-4() {
+test-4-generateAdmincertificate() {
     load-generateAdmincertificate
     generateAdmincertificate
 }
 
-test-generateAdmincertificate-4-assert() {
+test-4-generateAdmincertificate-assert() {
     openssl genrsa -out /tmp/wazuh-cert-tool/certs/admin-key-temp.pem 2048
     openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-cert-tool/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-cert-tool/certs/admin-key.pem
     openssl req -new -key /tmp/wazuh-cert-tool/certs/admin-key.pem -out /tmp/wazuh-cert-tool/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin'
@@ -62,7 +66,7 @@ function load-generateCertificateconfiguration() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateCertificateconfiguration
 }
 
-test-generateCertificateconfiguration-IP-5() {
+test-5-generateCertificateconfiguration-IP() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
@@ -77,18 +81,18 @@ test-generateCertificateconfiguration-IP-5() {
     @rmdir /tmp/wazuh-cert-tool/certs
 }
 
-test-generateCertificateconfiguration-IP-5-assert() {
+test-5-generateCertificateconfiguration-IP-assert() {
     echo "conf"
     echo "conf2"
 }
 
-test-generateCertificateconfiguration-DNS-6() {
+test-6-generateCertificateconfiguration-DNS() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
     @mock echo 1.1.1.1 === @out ""
     @mock awk "{sub(\"CN = cname\", \"CN = wazuh1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf"
-    @mock awk "{sub(\"CN = cname\", \"CN = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
+    @mock awk "{sub(\"CN = cname\", \"CN =  1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
     @mock awk "{sub(\"IP.1 = cip\", \"DNS.1 = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf3"
     @mock grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" === @out ""
     @mock grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" === @out "1.1.1.1"
@@ -98,13 +102,13 @@ test-generateCertificateconfiguration-DNS-6() {
     @rmdir /tmp/wazuh-cert-tool/certs
 }
 
-test-generateCertificateconfiguration-DNS-6-assert() {
+test-6-generateCertificateconfiguration-DNS-assert() {
     echo "conf"
     echo "conf2"
     echo "conf3"
 }
 
-test-ASSERT-FAIL-generateCertificateconfiguration-error-7() {
+test-7-generateCertificateconfiguration-error() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
@@ -112,12 +116,17 @@ test-ASSERT-FAIL-generateCertificateconfiguration-error-7() {
     @mock awk "{sub(\"CN = cname\", \"CN = wazuh1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf"
     @mock awk "{sub(\"CN = cname\", \"CN = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
     @mock awk "{sub(\"IP.1 = cip\", \"DNS.1 = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf3"
-    @mock grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" === @out ""
-    @mock grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" === @out ""
+    @mockfalse grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"
+    @mockfalse grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$"
     @mocktrue cat
     generateCertificateconfiguration "wazuh1" "1.1.1.1"
     @rm /tmp/wazuh-cert-tool/certs/wazuh1.conf
     @rmdir /tmp/wazuh-cert-tool/certs
+}
+
+test-7-generateCertificateconfiguration-error-assert() {
+    echo "conf"
+    exit 1
 }
 
 
@@ -125,19 +134,693 @@ function load-generateRootCAcertificate() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateRootCAcertificate
 }
 
-test-generateRootCAcertificate-8() {
+test-8-generateRootCAcertificate() {
     load-generateRootCAcertificate
     generateRootCAcertificate
 }
 
-test-generateRootCAcertificate-8-assert() {
-    openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/root-ca.key -out ${base_path}/certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650
+test-8-generateRootCAcertificate-assert() {
+    openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/root-ca.key -out /tmp/wazuh-cert-tool/certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650
 }
 
 function load-generateElasticsearchcertificates() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateElasticsearchcertificates
 }
 
-test-generateElasticsearchcertificates-no-nodes-9() {
+test-9-generateElasticsearchcertificates-no-nodes() {
+    load-generateElasticsearchcertificates
+    elasticsearch_node_names=()
+    generateElasticsearchcertificates
+    @assert-success
+}
+
+test-10-generateElasticsearchcertificates-two-nodes() {
+    load-generateElasticsearchcertificates
+    elasticsearch_node_names=("elastic1" "elastic2")
+    elasticsearch_node_ips=("1.1.1.1" "1.1.1.2")
+    generateElasticsearchcertificates
+}
+
+test-10-generateElasticsearchcertificates-two-nodes-assert() {
+    generateCertificateconfiguration elastic1 1.1.1.1
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/elastic1-key.pem -out /tmp/wazuh-cert-tool/certs/elastic1.csr -config /tmp/wazuh-cert-tool/certs/elastic1.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/elastic1.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/elastic1.pem -extfile /tmp/wazuh-cert-tool/certs/elastic1.conf -extensions v3_req -days 3650
+    chmod 444 /tmp/wazuh-cert-tool/certs/elastic1-key.pem
+    generateCertificateconfiguration elastic2 1.1.1.2
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/elastic2-key.pem -out /tmp/wazuh-cert-tool/certs/elastic2.csr -config /tmp/wazuh-cert-tool/certs/elastic2.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/elastic2.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/elastic2.pem -extfile /tmp/wazuh-cert-tool/certs/elastic2.conf -extensions v3_req -days 3650
+    chmod 444 /tmp/wazuh-cert-tool/certs/elastic2-key.pem
+
+}
+
+function load-generateFilebeatcertificates() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateFilebeatcertificates
+}
+
+test-11-generateFilebeatcertificates-no-nodes() {
+    load-generateFilebeatcertificates
+    wazuh_servers_node_names=()
+    generateFilebeatcertificates
+    @assert-success
+}
+
+test-12-generateFilebeatcertificates-two-nodes() {
+    load-generateFilebeatcertificates
+    wazuh_servers_node_names=("wazuh1" "wazuh2")
+    wazuh_servers_node_ips=("1.1.1.1" "1.1.1.2")
+    generateFilebeatcertificates
+}
+
+test-12-generateFilebeatcertificates-two-nodes-assert() {
+    generateCertificateconfiguration "wazuh1" "1.1.1.1"
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/wazuh1-key.pem -out /tmp/wazuh-cert-tool/certs/wazuh1.csr -config /tmp/wazuh-cert-tool/certs/wazuh1.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/wazuh1.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/wazuh1.pem -extfile /tmp/wazuh-cert-tool/certs/wazuh1.conf -extensions v3_req -days 3650
+    generateCertificateconfiguration "wazuh2" "1.1.1.2"
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/wazuh2-key.pem -out /tmp/wazuh-cert-tool/certs/wazuh2.csr -config /tmp/wazuh-cert-tool/certs/wazuh2.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/wazuh2.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/wazuh2.pem -extfile /tmp/wazuh-cert-tool/certs/wazuh2.conf -extensions v3_req -days 3650
+
+}
+
+function load-generateKibanacertificates() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateKibanacertificates
+}
+
+test-13-generateKibanacertificates-no-nodes() {
+    load-generateKibanacertificates
+    kibana_node_names=()
+    generateKibanacertificates
+    @assert-success
+}
+
+test-14-generateKibanacertificates-two-nodes() {
+    load-generateKibanacertificates
+    kibana_node_names=("kibana1" "kibana2")
+    kibana_node_ips=("1.1.1.1" "1.1.1.2")
+    generateKibanacertificates
+}
+
+test-14-generateKibanacertificates-two-nodes-assert() {
+    generateCertificateconfiguration "kibana1" "1.1.1.1"
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/kibana1-key.pem -out /tmp/wazuh-cert-tool/certs/kibana1.csr -config /tmp/wazuh-cert-tool/certs/kibana1.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/kibana1.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/kibana1.pem -extfile /tmp/wazuh-cert-tool/certs/kibana1.conf -extensions v3_req -days 3650
+    chmod 444 /tmp/wazuh-cert-tool/certs/kibana1-key.pem
+    generateCertificateconfiguration "kibana2" "1.1.1.2"
+    openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/kibana2-key.pem -out /tmp/wazuh-cert-tool/certs/kibana2.csr -config /tmp/wazuh-cert-tool/certs/kibana2.conf -days 3650
+    openssl x509 -req -in /tmp/wazuh-cert-tool/certs/kibana2.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -out /tmp/wazuh-cert-tool/certs/kibana2.pem -extfile /tmp/wazuh-cert-tool/certs/kibana2.conf -extensions v3_req -days 3650
+    chmod 444 /tmp/wazuh-cert-tool/certs/kibana2-key.pem
+}
+
+function load-readConfig() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" readConfig
+    config_file="${base_path}/config.yml"
+}
+
+test-ASSERT-FAIL-15-readConfig-empty-file() {
+    load-readConfig
+    @mkdir -p ${base_dir}
+    @rm "${config_file}"
+    @touch ${config_file}
+    readConfig
+    @rm ${config_file}
+}
+
+test-ASSERT-FAIL-16-readConfig-no-file() {
+    load-readConfig
+    @rm "${config_file}"
+    readConfig
+}
+
+test-ASSERT-FAIL-17-readConfig-duplicated-elastic-node-names() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
     
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2 1.1.1.3"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 1.1.1.3 === @out "1.1.1.1 1.1.1.2 1.1.1.3"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo master
+    @mocktrue echo worker
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-18-readConfig-duplicated-elastic-node-ips() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.1"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.1 === @out "1.1.1.1"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo master
+    @mocktrue echo worker
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-19-readConfig-duplicated-wazuh-node-names() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh1 === @out "(wazuh1)"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo wazuh1
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-20-readConfig-duplicated-wazuh-node-ips() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "1.1.2.1"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo master
+    @mocktrue echo worker
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-21-readConfig-duplicated-kibana-node-names() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana1"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "(1.1.2.1)"
+    @mock echo kibana1 kibana1 === @out "(kibana1)"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo master
+    @mocktrue echo worker
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-22-readConfig-duplicated-kibana-node-ips() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.1.3.1"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "1.1.2.1"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.1 === @out "1.1.3.1"
+    @mocktrue echo master
+    @mocktrue echo worker
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-23-readConfig-different-number-of-wazuh-names-and-ips() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 === @out "(wazuh1)"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "1.1.2.1"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo wazuh1
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-24-readConfig-incorrect-wazuh-node-type() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "worker master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "1.1.2.1"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mock echo wazuh1
+    @mock echo wazuh2
+    @mockfalse grep -ioq master
+    @mockfalse grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-25-readConfig-wazuh-node-type-one-node() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 === @out "wazuh1"
+    @mock echo 1.1.2.1 1.1.2.1 === @out "1.1.2.1"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mock echo wazuh1
+    @mockfalse grep -ioq master
+    @mockfalse grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-26-readConfig-less-wazuh-node-types-than-nodes() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "master"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mock echo wazuh1
+    @mock echo wazuh2
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+    
+    readConfig
+    @rm "${config_file}"
+}
+
+test-ASSERT-FAIL-27-readConfig-different-number-of-kibana-names-and-ips() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.1.3.2 1.1.3.3"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "master worker"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 1.1.3.3=== @out "1.1.3.1 1.1.3.2 1.1.3.)"
+
+    @mock echo wazuh1
+    @mock echo wazuh2
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+
+    readConfig
+    @rm "${config_file}"
+}
+
+test-28-readConfig-everything-correct() {
+    load-readConfig
+    @mkdir -p "${base_path}"
+    @touch "${config_file}"
+    @echo "config_file" > "${config_file}"
+    
+    @mock parse_yaml /tmp/wazuh-cert-tool/config.yml === @out
+    @mock grep nodes_elasticsearch_name === @out "elastic1 elastic2"
+    @mock sed 's/nodes_elasticsearch_name=//'
+    @mock grep nodes_wazuh_servers_name === @out "wazuh1 wazuh2"
+    @mock sed 's/nodes_wazuh_servers_name=//'
+    @mock grep nodes_kibana_name === @out "kibana1 kibana2"
+    @mock sed 's/nodes_kibana_name=//'
+
+    @mock grep nodes_elasticsearch_ip === @out "1.1.1.1 1.1.1.2"
+    @mock sed 's/nodes_elasticsearch_ip=//'
+    @mock grep nodes_wazuh_servers_ip === @out "1.1.2.1 1.1.2.2"
+    @mock sed 's/nodes_wazuh_servers_ip=//'
+    @mock grep nodes_kibana_ip === @out "1.1.3.1 1.1.3.2"
+    @mock sed 's/nodes_kibana_ip=//'
+
+    @mock grep nodes_wazuh_servers_node_type === @out "master worker"
+    @mock sed 's/nodes_wazuh_servers_node_type=//'
+
+    @mock tr ' ' '\n'
+    @mock sort -u
+    @mock tr '\n' ' '
+    @mock echo elastic1 elastic2 === @out "elastic1 elastic2"
+    @mock echo 1.1.1.1 1.1.1.2 === @out "1.1.1.1 1.1.1.2"
+    @mock echo wazuh1 wazuh2 === @out "wazuh1 wazuh2"
+    @mock echo 1.1.2.1 1.1.2.2 === @out "1.1.2.1 1.1.2.2"
+    @mock echo kibana1 kibana2 === @out "kibana1 kibana2"
+    @mock echo 1.1.3.1 1.1.3.2 === @out "1.1.3.1 1.1.3.2"
+
+    @mocktrue echo "master"
+    @mocktrue echo "worker"
+    @mocktrue grep -ioq master
+    @mocktrue grep -ioq worker
+
+    @mock wc -l
+    @mock grep -io master === @out 1
+    @mock grep -io worker === @out 1
+
+    readConfig
+    @rm "${config_file}"
+    @echo "${elasticsearch_node_names[@]}"
+    @echo "${elasticsearch_node_ips[@]}"
+    @echo "${wazuh_servers_node_names[@]}"
+    @echo "${wazuh_servers_node_ips[@]}"
+    @echo "${kibana_node_names[@]}"
+    @echo "${kibana_node_ips[@]}"
+}
+
+test-28-readConfig-everything-correct-assert() {
+    @echo elastic1 elastic2
+    @echo 1.1.1.1 1.1.1.2
+    @echo wazuh1 wazuh2
+    @echo 1.1.2.1 1.1.2.2
+    @echo kibana1 kibana2
+    @echo 1.1.3.1 1.1.3.2
 }

--- a/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
@@ -13,12 +13,12 @@ function load-cleanFiles() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" cleanFiles
 }
 
-test-1-cleanFiles() {
+test-01-cleanFiles() {
     load-cleanFiles
     cleanFiles
 }
 
-test-1-cleanFiles-assert() {
+test-01-cleanFiles-assert() {
     rm -f /tmp/wazuh-cert-tool/certs/*.csr
     rm -f /tmp/wazuh-cert-tool/certs/*.srl
     rm -f /tmp/wazuh-cert-tool/certs/*.conf
@@ -29,17 +29,17 @@ function load-checkOpenSSL() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" checkOpenSSL
 }
 
-test-2-checkOpenSSL-no-openssl() {
+test-02-checkOpenSSL-no-openssl() {
     load-checkOpenSSL
     @mockfalse command -v openssl
     checkOpenSSL
 }
 
-test-2-checkOpenSSL-no-openssl-assert() {
+test-02-checkOpenSSL-no-openssl-assert() {
     exit 1
 }
 
-test-3-checkOpenSSL-correct() {
+test-03-checkOpenSSL-correct() {
     load-checkOpenSSL
     @mock command -v openssl === @out "/bin/openssl"
     checkOpenSSL
@@ -50,12 +50,12 @@ function load-generateAdmincertificate() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateAdmincertificate
 }
 
-test-4-generateAdmincertificate() {
+test-04-generateAdmincertificate() {
     load-generateAdmincertificate
     generateAdmincertificate
 }
 
-test-4-generateAdmincertificate-assert() {
+test-04-generateAdmincertificate-assert() {
     openssl genrsa -out /tmp/wazuh-cert-tool/certs/admin-key-temp.pem 2048
     openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-cert-tool/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-cert-tool/certs/admin-key.pem
     openssl req -new -key /tmp/wazuh-cert-tool/certs/admin-key.pem -out /tmp/wazuh-cert-tool/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin'
@@ -66,7 +66,7 @@ function load-generateCertificateconfiguration() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateCertificateconfiguration
 }
 
-test-5-generateCertificateconfiguration-IP() {
+test-05-generateCertificateconfiguration-IP() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
@@ -81,12 +81,12 @@ test-5-generateCertificateconfiguration-IP() {
     @rmdir /tmp/wazuh-cert-tool/certs
 }
 
-test-5-generateCertificateconfiguration-IP-assert() {
+test-05-generateCertificateconfiguration-IP-assert() {
     echo "conf"
     echo "conf2"
 }
 
-test-6-generateCertificateconfiguration-DNS() {
+test-06-generateCertificateconfiguration-DNS() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
@@ -102,13 +102,13 @@ test-6-generateCertificateconfiguration-DNS() {
     @rmdir /tmp/wazuh-cert-tool/certs
 }
 
-test-6-generateCertificateconfiguration-DNS-assert() {
+test-06-generateCertificateconfiguration-DNS-assert() {
     echo "conf"
     echo "conf2"
     echo "conf3"
 }
 
-test-7-generateCertificateconfiguration-error() {
+test-07-generateCertificateconfiguration-error() {
     load-generateCertificateconfiguration
     @mkdir -p /tmp/wazuh-cert-tool/certs
     @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
@@ -124,7 +124,7 @@ test-7-generateCertificateconfiguration-error() {
     @rmdir /tmp/wazuh-cert-tool/certs
 }
 
-test-7-generateCertificateconfiguration-error-assert() {
+test-07-generateCertificateconfiguration-error-assert() {
     echo "conf"
     exit 1
 }
@@ -134,12 +134,12 @@ function load-generateRootCAcertificate() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateRootCAcertificate
 }
 
-test-8-generateRootCAcertificate() {
+test-08-generateRootCAcertificate() {
     load-generateRootCAcertificate
     generateRootCAcertificate
 }
 
-test-8-generateRootCAcertificate-assert() {
+test-08-generateRootCAcertificate-assert() {
     openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/root-ca.key -out /tmp/wazuh-cert-tool/certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650
 }
 
@@ -147,7 +147,7 @@ function load-generateElasticsearchcertificates() {
     @load_function "${base_dir}/wazuh-cert-tool.sh" generateElasticsearchcertificates
 }
 
-test-9-generateElasticsearchcertificates-no-nodes() {
+test-09-generateElasticsearchcertificates-no-nodes() {
     load-generateElasticsearchcertificates
     elasticsearch_node_names=()
     generateElasticsearchcertificates

--- a/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-cert-tool.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+base_dir="$(cd "$(dirname "$BASH_SOURCE")"; pwd -P; cd - >/dev/null;)"
+source "${base_dir}"/bach.sh
+
+@setup-test {
+    @ignore logger_cert
+    debug_cert=
+    base_path="/tmp/wazuh-cert-tool"
+}
+
+function load-cleanFiles() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" cleanFiles
+}
+
+test-cleanFiles-1() {
+    load-cleanFiles
+    cleanFiles
+}
+
+test-cleanFiles-1-assert() {
+    rm -f /tmp/wazuh-cert-tool/certs/*.csr
+    rm -f /tmp/wazuh-cert-tool/certs/*.srl
+    rm -f /tmp/wazuh-cert-tool/certs/*.conf
+    rm -f /tmp/wazuh-cert-tool/certs/admin-key-temp.pem
+}
+
+function load-checkOpenSSL() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" checkOpenSSL
+}
+
+test-ASSERT-FAIL-checkOpenSSL-no-openssl-2() {
+    load-checkOpenSSL
+    @mock command -v openssl === @out ""
+    checkOpenSSL
+}
+
+test-checkOpenSSL-correct-3() {
+    load-checkOpenSSL
+    @mock command -v openssl === @out "/bin/openssl"
+    checkOpenSSL
+    @assert-success
+}
+
+function load-generateAdmincertificate() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateAdmincertificate
+}
+
+test-generateAdmincertificate-4() {
+    load-generateAdmincertificate
+    generateAdmincertificate
+}
+
+test-generateAdmincertificate-4-assert() {
+    openssl genrsa -out /tmp/wazuh-cert-tool/certs/admin-key-temp.pem 2048
+    openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-cert-tool/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-cert-tool/certs/admin-key.pem
+    openssl req -new -key /tmp/wazuh-cert-tool/certs/admin-key.pem -out /tmp/wazuh-cert-tool/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Docu/CN=admin'
+    openssl x509 -days 3650 -req -in /tmp/wazuh-cert-tool/certs/admin.csr -CA /tmp/wazuh-cert-tool/certs/root-ca.pem -CAkey /tmp/wazuh-cert-tool/certs/root-ca.key -CAcreateserial -sha256 -out /tmp/wazuh-cert-tool/certs/admin.pem
+}
+
+function load-generateCertificateconfiguration() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateCertificateconfiguration
+}
+
+test-generateCertificateconfiguration-IP-5() {
+    load-generateCertificateconfiguration
+    @mkdir -p /tmp/wazuh-cert-tool/certs
+    @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @mock echo 1.1.1.1 === @out ""
+    @mock awk '{sub("CN = cname", "CN = wazuh1")}1' "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf"
+    @mock awk "{sub(\"IP.1 = cip\", \"IP.1 = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
+    @mock grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" === @out "1.1.1.1"
+    @mock grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" === @out ""
+    @mocktrue cat
+    generateCertificateconfiguration "wazuh1" "1.1.1.1"
+    @rm /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @rmdir /tmp/wazuh-cert-tool/certs
+}
+
+test-generateCertificateconfiguration-IP-5-assert() {
+    echo "conf"
+    echo "conf2"
+}
+
+test-generateCertificateconfiguration-DNS-6() {
+    load-generateCertificateconfiguration
+    @mkdir -p /tmp/wazuh-cert-tool/certs
+    @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @mock echo 1.1.1.1 === @out ""
+    @mock awk "{sub(\"CN = cname\", \"CN = wazuh1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf"
+    @mock awk "{sub(\"CN = cname\", \"CN = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
+    @mock awk "{sub(\"IP.1 = cip\", \"DNS.1 = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf3"
+    @mock grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" === @out ""
+    @mock grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" === @out "1.1.1.1"
+    @mocktrue cat
+    generateCertificateconfiguration "wazuh1" "1.1.1.1"
+    @rm /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @rmdir /tmp/wazuh-cert-tool/certs
+}
+
+test-generateCertificateconfiguration-DNS-6-assert() {
+    echo "conf"
+    echo "conf2"
+    echo "conf3"
+}
+
+test-ASSERT-FAIL-generateCertificateconfiguration-error-7() {
+    load-generateCertificateconfiguration
+    @mkdir -p /tmp/wazuh-cert-tool/certs
+    @touch /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @mock echo 1.1.1.1 === @out ""
+    @mock awk "{sub(\"CN = cname\", \"CN = wazuh1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf"
+    @mock awk "{sub(\"CN = cname\", \"CN = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf2"
+    @mock awk "{sub(\"IP.1 = cip\", \"DNS.1 = 1.1.1.1\")}1" "/tmp/wazuh-cert-tool/certs/wazuh1.conf" === @out "conf3"
+    @mock grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" === @out ""
+    @mock grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" === @out ""
+    @mocktrue cat
+    generateCertificateconfiguration "wazuh1" "1.1.1.1"
+    @rm /tmp/wazuh-cert-tool/certs/wazuh1.conf
+    @rmdir /tmp/wazuh-cert-tool/certs
+}
+
+
+function load-generateRootCAcertificate() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateRootCAcertificate
+}
+
+test-generateRootCAcertificate-8() {
+    load-generateRootCAcertificate
+    generateRootCAcertificate
+}
+
+test-generateRootCAcertificate-8-assert() {
+    openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-cert-tool/certs/root-ca.key -out ${base_path}/certs/root-ca.pem -batch -subj '/OU=Docu/O=Wazuh/L=California/' -days 3650
+}
+
+function load-generateElasticsearchcertificates() {
+    @load_function "${base_dir}/wazuh-cert-tool.sh" generateElasticsearchcertificates
+}
+
+test-generateElasticsearchcertificates-no-nodes-9() {
+    
+}

--- a/tests/unattended/unit/suites/test-wazuh.sh
+++ b/tests/unattended/unit/suites/test-wazuh.sh
@@ -11,7 +11,7 @@ function load-installWazuh() {
     @load_function "${base_dir}/wazuh.sh" installWazuh
 }
 
-test-installWazuh-zypper-error() {
+test-01-installWazuh-zypper-error() {
     load-installWazuh
     sys_type="zypper"
     wazuh_version=1
@@ -20,12 +20,12 @@ test-installWazuh-zypper-error() {
     installWazuh
 }
 
-test-installWazuh-zypper-error-assert() {
+test-01-installWazuh-zypper-error-assert() {
     rollBack
     exit 1
 }
 
-test-installWazuh-apt-error() {
+test-02-installWazuh-apt-error() {
     load-installWazuh
     sys_type="apt-get"
     sep="="
@@ -35,12 +35,12 @@ test-installWazuh-apt-error() {
     installWazuh
 }
 
-test-installWazuh-apt-error-assert() {
+test-02-installWazuh-apt-error-assert() {
     rollBack
     exit 1
 }
 
-test-installWazuh-yum-error() {
+test-03-installWazuh-yum-error() {
     load-installWazuh
     sys_type="yum"
     sep="-"
@@ -50,12 +50,12 @@ test-installWazuh-yum-error() {
     installWazuh
 }
 
-test-installWazuh-yum-error-assert() {
+test-03-installWazuh-yum-error-assert() {
     rollBack
     exit 1
 }
 
-test-installWazuh-zypper() {
+test-04-installWazuh-zypper() {
     load-installWazuh
     sys_type="zypper"
     wazuh_version=1
@@ -64,12 +64,12 @@ test-installWazuh-zypper() {
     @echo $wazuhinstalled
 }
 
-test-installWazuh-zypper-assert() {
+test-04-installWazuh-zypper-assert() {
     zypper -n install wazuh-manager=1-1
     @echo 1
 }
 
-test-installWazuh-apt() {
+test-05-installWazuh-apt() {
     load-installWazuh
     sys_type="apt-get"
     sep="="
@@ -79,12 +79,12 @@ test-installWazuh-apt() {
     @echo $wazuhinstalled
 }
 
-test-installWazuh-apt-assert() {
+test-05-installWazuh-apt-assert() {
     apt-get install wazuh-manager=1-1 -y
     @echo 1
 }
 
-test-installWazuh-yum() {
+test-06-installWazuh-yum() {
     load-installWazuh
     sys_type="yum"
     sep="-"
@@ -94,7 +94,7 @@ test-installWazuh-yum() {
     @echo $wazuhinstalled
 }
 
-test-installWazuh-yum-assert() {
+test-06-installWazuh-yum-assert() {
     yum install wazuh-manager-1-1 -y
     @echo 1
 }
@@ -103,7 +103,7 @@ function load-configureWazuhCluster() {
     @load_function "${base_dir}/wazuh.sh" configureWazuhCluster
 }
 
-test-configureWazuhCluster() {
+test-07-configureWazuhCluster() {
     load-configureWazuhCluster
     wazuh_servers_node_names=("wazuh" "node10")
     wazuh_servers_node_types=("master" "worker")
@@ -121,7 +121,7 @@ test-configureWazuhCluster() {
     @echo $master_address
 }
 
-test-configureWazuhCluster-assert() {
+test-07-configureWazuhCluster-assert() {
     @echo 0
     @echo "1.1.1.1"
 }


### PR DESCRIPTION
closes #1197 

Used https://bach.sh/ to create unit tests for each function. In the directory tests/unattended there is a file called test-{script-name}.sh for each script in unattended installer. Inside that file are defined the unit tests for each function of {script-name}.sh. To call them we use the auxiliary script unit-test.sh, which creates a docker environment in which to run the tests.

Example of output:
```
[verdx@verdx unit]$ bash unit-tests.sh -f wazuh-cert-tool
24/01/2022 16:45:06 INFO: Docker image found.
24/01/2022 16:45:06 INFO: Unit tests for wazuh-cert-tool.sh.
1..28
ok 1 - 06 generateCertificateconfiguration DNS
ok 2 - 04 generateAdmincertificate
ok 3 - 01 cleanFiles
ok 4 - ASSERT FAIL 16 readConfig no file
ok 5 - ASSERT FAIL 19 readConfig duplicated wazuh node names
ok 6 - 07 generateCertificateconfiguration error
ok 7 - ASSERT FAIL 22 readConfig duplicated kibana node ips
ok 8 - ASSERT FAIL 15 readConfig empty file
ok 9 - ASSERT FAIL 21 readConfig duplicated kibana node names
ok 10 - 28 readConfig everything correct
ok 11 - ASSERT FAIL 24 readConfig incorrect wazuh node type
ok 12 - 14 generateKibanacertificates two nodes
ok 13 - 11 generateFilebeatcertificates no nodes
ok 14 - 03 checkOpenSSL correct
ok 15 - ASSERT FAIL 23 readConfig different number of wazuh names and ips
ok 16 - ASSERT FAIL 25 readConfig wazuh node type one node
ok 17 - 08 generateRootCAcertificate
ok 18 - ASSERT FAIL 17 readConfig duplicated elastic node names
ok 19 - 02 checkOpenSSL no openssl
ok 20 - 10 generateElasticsearchcertificates two nodes
ok 21 - ASSERT FAIL 18 readConfig duplicated elastic node ips
ok 22 - 13 generateKibanacertificates no nodes
ok 23 - ASSERT FAIL 20 readConfig duplicated wazuh node ips
ok 24 - ASSERT FAIL 26 readConfig less wazuh node types than nodes
ok 25 - ASSERT FAIL 27 readConfig different number of kibana names and ips
ok 26 - 05 generateCertificateconfiguration IP
ok 27 - 12 generateFilebeatcertificates two nodes
ok 28 - 09 generateElasticsearchcertificates no nodes
# -----
# All tests: 28, failed: 0, skipped: 0
24/01/2022 16:45:14 INFO: All unit tests for the functions in wazuh-cert-tool.sh finished.
24/01/2022 16:45:14 INFO: Cleaning temporary files.
[verdx@verdx unit]$ 

```