### PR TITLE
Unit testing using Bach [wazuh-passwords-tool.sh]

### DIFF
--- a/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
@@ -425,3 +425,374 @@ test-ASSERT-FAIL-16-checkInstalledPass-nothing-installed-zypper() {
 
     checkInstalledPass
 }
+
+function load-checkUser() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" checkUser
+}
+
+test-ASSERT-FAIL-17-checkUser-no-nuser() {
+    load-checkUser
+    users=( "kibanaserver" "admin" )
+    nuser=
+    checkUser
+}
+
+test-ASSERT-FAIL-18-checkUser-incorrect-user() {
+    load-checkUser
+    users=( "kibanaserver" "admin" )
+    nuser="wazuh"
+    checkUser
+}
+
+test-19-checkUser-correct() {
+    load-checkUser
+    users=( "kibanaserver" "admin" )
+    nuser="admin"
+    checkUser
+    @assert-success
+}
+
+function load-generatePasswordFile() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" generatePasswordFile
+}
+
+test-20-generatePasswordFile() {
+    load-generatePasswordFile
+    gen_file="/tmp/genfile.yml"
+    passwords=("pass" "pass" "pass" "pass" "pass" "pass" "pass" "pass")
+    generatePasswordFile
+}
+
+test-20-generatePasswordFile-assert() {
+    generatePassword
+    echo "User:"
+    echo "  name: admin"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: kibanaserver"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: kibanaro"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: logstash"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: readall"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: snapshotrestore"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: wazuh_admin"
+    echo "  password: pass"
+    echo "User:"
+    echo "  name: wazuh_user"
+    echo "  password: pass"
+}
+
+function load-getNetworkHost() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" getNetworkHost
+}
+
+test-21-getNetworkHost() {
+    load-getNetworkHost
+    @mock grep -hr "network.host:" /etc/elasticsearch/elasticsearch.yml === @out "network.host: 1.1.1.1"
+    getNetworkHost
+    @echo ${IP}
+}
+
+test-21-getNetworkHost-assert() {
+    @echo 1.1.1.1
+}
+
+test-22-getNetworkHost-interface() {
+    load-getNetworkHost
+    @mock grep -hr "network.host:" /etc/elasticsearch/elasticsearch.yml === @out "network.host: _wlps01_"
+    @mock ip -o -4 addr list wlps01 === @out "1.1.1.1"
+    @mock awk '{print $4}' === @out ""
+    @mock cut -d/ -f1 === @out ""
+    getNetworkHost
+    @echo ${IP}
+}
+
+test-22-getNetworkHost-interface-assert() {
+    @echo 1.1.1.1
+}
+
+test-23-getNetworkHost-localhost() {
+    load-getNetworkHost
+    @mock grep -hr "network.host:" /etc/elasticsearch/elasticsearch.yml === @out "network.host: 0.0.0.0"
+    getNetworkHost
+    @echo ${IP}
+}
+
+test-23-getNetworkHost-localhost-assert() {
+    @echo "localhost"
+}
+
+function load-readAdmincerts() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" readAdmincerts
+}
+
+test-ASSERT-FAIL-24-readAdmincerts-no-admin.pem() {
+    load-readAdmincerts
+    if [[ -f /etc/elasticsearch/certs/admin.pem ]]; then
+        @rm -f /etc/elasticsearch/certs/admin.pem
+    fi
+    readAdmincerts
+}
+
+test-ASSERT-FAIL-25-readAdmincerts-no-admin_key.pem() {
+    load-readAdmincerts
+    @mkdir -p /etc/elasticsearch/certs
+    if [[ ! -f /etc/elasticsearch/certs/admin.pem ]]; then
+        @touch /etc/elasticsearch/certs/admin.pem
+    fi
+    if [[ -f /etc/elasticsearch/certs/admin-key.pem ]]; then
+        @rm -f /etc/elasticsearch/certs/admin-key.pem
+    fi
+
+    if [[ -f /etc/elasticsearch/certs/admin.key ]]; then
+        @rm -f /etc/elasticsearch/certs/admin.key
+    fi
+    readAdmincerts
+    @rm /etc/elasticsearch/certs/admin.pem
+    @rmdir /etc/elasticsearch/certs
+}
+
+test-26-readAdmincerts-all-correct-admin_key.pem() {
+    load-readAdmincerts
+    @mkdir -p /etc/elasticsearch/certs
+    if [[ ! -f /etc/elasticsearch/certs/admin.pem ]]; then
+        @touch /etc/elasticsearch/certs/admin.pem
+    fi
+    if [[ ! -f /etc/elasticsearch/certs/admin-key.pem ]]; then
+        @touch /etc/elasticsearch/certs/admin-key.pem
+    fi
+
+    if [[ -f /etc/elasticsearch/certs/admin.key ]]; then
+        @rm -f /etc/elasticsearch/certs/admin.key
+    fi
+    readAdmincerts
+    @rm /etc/elasticsearch/certs/admin.pem
+    @rm /etc/elasticsearch/certs/admin-key.pem
+    @rmdir /etc/elasticsearch/certs
+    @echo $adminpem
+    @echo $adminkey
+}
+
+test-26-readAdmincerts-all-correct-admin_key.pem-assert() {
+    @echo "/etc/elasticsearch/certs/admin.pem"
+    @echo "/etc/elasticsearch/certs/admin-key.pem"
+}
+
+test-27-readAdmincerts-all-correct-admin.key() {
+    load-readAdmincerts
+    @mkdir -p /etc/elasticsearch/certs
+    if [[ ! -f /etc/elasticsearch/certs/admin.pem ]]; then
+        @touch /etc/elasticsearch/certs/admin.pem
+    fi
+    if [[ -f /etc/elasticsearch/certs/admin-key.pem ]]; then
+        @rm -f /etc/elasticsearch/certs/admin-key.pem
+    fi
+
+    if [[ ! -f /etc/elasticsearch/certs/admin.key ]]; then
+        @touch /etc/elasticsearch/certs/admin.key
+    fi
+    readAdmincerts
+    @rm /etc/elasticsearch/certs/admin.pem
+    @rm /etc/elasticsearch/certs/admin.key
+    @rmdir /etc/elasticsearch/certs
+    @echo $adminpem
+    @echo $adminkey
+}
+
+test-27-readAdmincerts-all-correct-admin.key-assert() {
+    @echo "/etc/elasticsearch/certs/admin.pem"
+    @echo "/etc/elasticsearch/certs/admin.key"
+}
+
+function load-readUsers() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" readUsers
+}
+
+test-28-readUsers() {
+    load-readUsers
+    @mock grep -B 1 hash: /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml === @out
+    @mock grep -v hash: === @out
+    @mock grep -v "-" === @out
+    @mock awk '{ print substr( $0, 1, length($0)-1 ) }' === @out "kibanaserver admin"
+    readUsers
+    @echo ${users[@]}
+}
+
+test-28-readUsers-assert() {
+    @echo "kibanaserver admin"
+}
+
+function load-restartService() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" restartService
+}
+
+test-ASSERT-FAIL-29-restartService-no-args() {
+    load-restartService
+    restartService
+}
+
+test-ASSERT-FAIL-30-restartService-no-service-manager() {
+    load-restartService
+    @mockfalse ps -e
+    @mockfalse grep -E -q "^\ *1\ .*systemd$"
+    @mockfalse grep -E -q "^\ *1\ .*init$"
+    @rm /etc/init.d/wazuh
+    restartService wazuh-manager
+}
+
+test-31-restartService-systemd() {
+    load-restartService
+    @mockfalse ps -e === @out 
+    @mocktrue grep -E -q "^\ *1\ .*systemd$"
+    @mockfalse grep -E -q "^\ *1\ .*init$"
+    restartService wazuh-manager
+}
+
+test-31-restartService-systemd-assert() {
+    systemctl daemon-reload
+    systemctl restart wazuh-manager.service
+}
+
+test-32-restartService-systemd-error() {
+    load-restartService
+    @mock ps -e === @out 
+    @mocktrue grep -E -q "^\ *1\ .*systemd$"
+    @mockfalse grep -E -q "^\ *1\ .*init$"
+    @mockfalse systemctl restart wazuh-manager.service
+    @mock type -t rollBack === @out "function"
+    restartService wazuh-manager
+}
+
+test-32-restartService-systemd-error-assert() {
+    systemctl daemon-reload
+    rollBack
+    exit 1
+}
+
+test-33-restartService-initd() {
+    load-restartService
+    @mock ps -e === @out 
+    @mockfalse grep -E -q "^\ *1\ .*systemd$"
+    @mocktrue grep -E -q "^\ *1\ .*init$"
+    @mkdir -p /etc/init.d
+    @touch /etc/init.d/wazuh-manager
+    @chmod +x /etc/init.d/wazuh-manager
+    restartService wazuh-manager
+    @rm /etc/init.d/wazuh-manager
+}
+
+test-33-restartService-initd-assert() {
+    @mkdir -p /etc/init.d
+    @touch /etc/init.d/wazuh-manager
+    /etc/init.d/wazuh-manager restart
+    @rm /etc/init.d/wazuh-manager
+}
+
+test-34-restartService-initd-error() {
+    load-restartService
+    @mock ps -e === @out 
+    @mockfalse grep -E -q "^\ *1\ .*systemd$"
+    @mocktrue grep -E -q "^\ *1\ .*init$"
+    @mkdir -p /etc/init.d
+    @touch /etc/init.d/wazuh-manager
+    #/etc/init.d/wazuh-manager is not executable -> It will fail
+    @mock type -t rollBack === @out "function"
+    restartService wazuh-manager
+    @rm /etc/init.d/wazuh-manager
+}
+
+test-34-restartService-initd-error-assert() {
+    @mkdir -p /etc/init.d
+    @touch /etc/init.d/wazuh-manager
+    @chmod +x /etc/init.d/wazuh-manager
+    /etc/init.d/wazuh-manager restart
+    rollBack
+    exit 1
+    @rm /etc/init.d/wazuh-manager
+}
+
+test-35-restartService-rc.d/init.d() {
+    load-restartService
+    @mock ps -e === @out 
+    @mockfalse grep -E -q "^\ *1\ .*systemd$"
+    @mockfalse grep -E -q "^\ *1\ .*init$"
+
+    @mkdir -p /etc/rc.d/init.d
+    @touch /etc/rc.d/init.d/wazuh-manager
+    @chmod +x /etc/rc.d/init.d/wazuh-manager
+
+    restartService wazuh-manager
+    @rm /etc/rc.d/init.d/wazuh-manager
+}
+
+test-35-restartService-rc.d/init.d-assert() {
+    @mkdir -p /etc/rc.d/init.d
+    @touch /etc/rc.d/init.d/wazuh-manager
+    @chmod +x /etc/rc.d/init.d/wazuh-manager
+    /etc/rc.d/init.d/wazuh-manager start
+    @rm /etc/rc.d/init.d/wazuh-manager
+}
+
+function load-generateHash() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" generateHash
+}
+
+test-36-generateHash-changeall() {
+    load-generateHash
+    passwords=("kibanaserverpassword" "adminpassword")
+    changeall=1
+    @mock grep -v WARNING === @out ""
+    @mock bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "kibanaserverpassword" === @out "11111111"
+    @mock bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "adminpassword" === @out "22222222"
+    generateHash
+    @echo ${hashes[@]}
+}
+
+test-36-generateHash-changeall-assert() {
+    @echo "11111111 22222222"
+}
+
+test-ASSERT-FAIL-37-generateHash-changeall-error() {
+    load-generateHash
+    passwords=("kibanaserverpassword" "adminpassword")
+    changeall=1
+    @mockfalse grep -v WARNING
+    @mock bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "kibanaserverpassword" === @out "11111111"
+    @mockfalse bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "adminpassword"
+    generateHash
+    @echo ${hashes[@]}
+}
+
+test-38-generateHash-nuser() {
+    load-generateHash
+    nuser="kibanaserver"
+    password="kibanaserverpassword"
+    changeall=
+    @mock grep -v WARNING === @out ""
+    @mock bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "kibanaserverpassword" === @out "11111111"
+    generateHash
+    @echo ${hash}
+}
+
+test-38-generateHash-nuser-assert() {
+    @echo "11111111"
+}
+
+test-ASSERT-FAIL-39-generateHash-nuser-error() {
+    load-generateHash
+    nuser="kibanaserver"
+    password="kibanaserverpassword"
+    changeall=
+    @mockfalse grep -v WARNING
+    @mockfalse bash /usr/share/elasticsearch/plugins/opendistro_security/tools/hash.sh -p "kibanaserverpassword"
+    generateHash
+}

--- a/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
@@ -266,62 +266,32 @@ test-11-checkInstalledPass-all-installed-yum() {
 
     @mocktrue yum list installed
 
-    @mock grep wazuh-manager === @echo wazuh-manager.x86_64  4.3.0-1  @wazuh
-    @mkdir /var/ossec/
-
     @mock grep opendistroforelasticsearch === @echo opendistroforelasticsearch.x86_64 1.13.2-1 @wazuh
     @mock grep -v kibana
-    @mkdir /var/lib/elasticsearch/
-    @mkdir /usr/share/elasticsearch/
-    @mkdir /etc/elasticsearch/
 
     @mock grep filebeat === @echo filebeat.x86_64 7.10.2-1 @wazuh
-    @mkdir /var/lib/filebeat/
-    @mkdir /usr/share/filebeat/
-    @mkdir /etc/filebeat/
 
     @mock grep opendistroforelasticsearch-kibana === @echo opendistroforelasticsearch-kibana.x86_64
-    @mkdir /var/lib/kibana/
-    @mkdir /usr/share/kibana/
-    @mkdir /etc/kibana/
+
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
+    adminpem=
+    adminkey=
 
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-    @rmdir /var/ossec
 
     @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-    @rmdir /var/lib/elasticsearch/
-    @rmdir /usr/share/elasticsearch/
-    @rmdir /etc/elasticsearch/
-
     @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-    @rmdir /var/lib/filebeat/
-    @rmdir /usr/share/filebeat/
-    @rmdir /etc/filebeat/
-
     @echo $kibanainstalled
-    @echo $kibana_remaining_files
-    @rmdir /var/lib/kibana/
-    @rmdir /usr/share/kibana/
-    @rmdir /etc/kibana/
-
 }
 
 test-11-checkInstalledPass-all-installed-yum-assert() {
-    @echo "wazuh-manager.x86_64 4.3.0-1 @wazuh"
-    @echo 1
+
+    readAdmincerts
 
     @echo "opendistroforelasticsearch.x86_64 1.13.2-1 @wazuh"
-    @echo 1
-
     @echo "filebeat.x86_64 7.10.2-1 @wazuh"
-    @echo 1
-
     @echo "opendistroforelasticsearch-kibana.x86_64"
-    @echo 1
 }
 
 test-12-checkInstalledPass-all-installed-zypper() {
@@ -331,62 +301,33 @@ test-12-checkInstalledPass-all-installed-zypper() {
     @mocktrue zypper packages
     @mock grep i+
 
-    @mock grep wazuh-manager === @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
-    @mkdir /var/ossec
-
     @mock grep opendistroforelasticsearch === @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch | 1.13.2-1 | x86_64"
     @mock grep -v kibana
-    @mkdir /var/lib/elasticsearch/
-    @mkdir /usr/share/elasticsearch
-    @mkdir /etc/elasticsearch
 
     @mock grep filebeat === @echo "i+ | EL-20211102 - Wazuh | filebeat | 7.10.2-1 | x86_64"
-    @mkdir /var/lib/filebeat/
-    @mkdir /usr/share/filebeat
-    @mkdir /etc/filebeat
 
     @mock grep opendistroforelasticsearch-kibana === @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch-kibana | 1.13.2-1 | x86_64"
-    @mkdir /var/lib/kibana/
-    @mkdir /usr/share/kibana
-    @mkdir /etc/kibana
+
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
+    adminpem=
+    adminkey=
 
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-    @rmdir /var/ossec
 
     @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-    @rmdir /var/lib/elasticsearch/
-    @rmdir /usr/share/elasticsearch
-    @rmdir /etc/elasticsearch
-
     @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-    @rmdir /var/lib/filebeat/
-    @rmdir /usr/share/filebeat
-    @rmdir /etc/filebeat
-
     @echo $kibanainstalled
-    @echo $kibana_remaining_files
-    @rmdir /var/lib/kibana/
-    @rmdir /usr/share/kibana
-    @rmdir /etc/kibana
 
 }
 
 test-12-checkInstalledPass-all-installed-zypper-assert() {
-    @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
-    @echo 1
+
+    readAdmincerts
 
     @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch | 1.13.2-1 | x86_64"
-    @echo 1
-
     @echo "i+ | EL-20211102 - Wazuh | filebeat | 7.10.2-1 | x86_64"
-    @echo 1
-
     @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch-kibana | 1.13.2-1 | x86_64"
-    @echo 1
 }
 
 test-13-checkInstalledPass-all-installed-apt() {
@@ -395,65 +336,36 @@ test-13-checkInstalledPass-all-installed-apt() {
 
     @mocktrue apt list --installed
 
-    @mock grep wazuh-manager === @echo wazuh-manager/now 4.2.5-1 amd64 [installed,local]
-    @mkdir /var/ossec
-
     @mock grep opendistroforelasticsearch === @echo opendistroforelasticsearch/stable,now 1.13.2-1 amd64 [installed]
     @mock grep -v kibana
-    @mkdir /var/lib/elasticsearch/
-    @mkdir /usr/share/elasticsearch
-    @mkdir /etc/elasticsearch
 
     @mock grep filebeat === @echo filebeat/now 7.10.2 amd64 [installed,local]
-    @mkdir /var/lib/filebeat/
-    @mkdir /usr/share/filebeat
-    @mkdir /etc/filebeat
 
     @mock grep opendistroforelasticsearch-kibana === @echo opendistroforelasticsearch-kibana/now 1.13.2 amd64 [installed,local]
-    @mkdir /var/lib/kibana/
-    @mkdir /usr/share/kibana
-    @mkdir /etc/kibana
+
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
+    adminpem=
+    adminkey=
 
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-    @rmdir /var/ossec
 
     @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-    @rmdir /var/lib/elasticsearch/
-    @rmdir /usr/share/elasticsearch
-    @rmdir /etc/elasticsearch
-
     @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-    @rmdir /var/lib/filebeat/
-    @rmdir /usr/share/filebeat
-    @rmdir /etc/filebeat
-
     @echo $kibanainstalled
-    @echo $kibana_remaining_files
-    @rmdir /var/lib/kibana/
-    @rmdir /usr/share/kibana
-    @rmdir /etc/kibana
 
 }
 
 test-13-checkInstalledPass-all-installed-apt-assert() {
-    @echo "wazuh-manager/now 4.2.5-1 amd64 [installed,local]"
-    @echo 1
+
+    readAdmincerts
 
     @echo "opendistroforelasticsearch/stable,now 1.13.2-1 amd64 [installed]"
-    @echo 1
-
     @echo "filebeat/now 7.10.2 amd64 [installed,local]"
-    @echo 1
-
     @echo "opendistroforelasticsearch-kibana/now 1.13.2 amd64 [installed,local]"
-    @echo 1
 }
 
-test-14-checkInstalledPass-nothing-installed-apt() {
+test-ASSERT-FAIL-14-checkInstalledPass-nothing-installed-apt() {
     load-checkInstalledPass
     sys_type="apt-get"
 
@@ -468,35 +380,12 @@ test-14-checkInstalledPass-nothing-installed-apt() {
 
     @mock grep opendistroforelasticsearch-kibana
 
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-
-    @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-
-    @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-
-    @echo $kibanainstalled
-    @echo $kibana_remaining_files
 }
 
-test-14-checkInstalledPass-nothing-installed-apt-assert() {
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-}
-
-test-15-checkInstalledPass-nothing-installed-yum() {
+test-ASSERT-FAIL-15-checkInstalledPass-nothing-installed-yum() {
     load-checkInstalledPass
     sys_type="yum"
 
@@ -511,35 +400,12 @@ test-15-checkInstalledPass-nothing-installed-yum() {
 
     @mock grep opendistroforelasticsearch-kibana
 
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-
-    @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-
-    @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-
-    @echo $kibanainstalled
-    @echo $kibana_remaining_files
 }
 
-test-15-checkInstalledPass-nothing-installed-yum-assert() {
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-}
-
-test-16-checkInstalledPass-nothing-installed-zypper() {
+test-ASSERT-FAIL-16-checkInstalledPass-nothing-installed-zypper() {
     load-checkInstalledPass
     sys_type="zypper"
 
@@ -555,30 +421,7 @@ test-16-checkInstalledPass-nothing-installed-zypper() {
 
     @mock grep opendistroforelasticsearch-kibana
 
+    @mock grep "opendistro_security.ssl.transport.pemtrustedcas_filepath: " /etc/elasticsearch/elasticsearch.yml === @out "pem_path"
+
     checkInstalledPass
-    @echo $wazuhinstalled
-    @echo $wazuh_remaining_files
-
-    @echo $elasticsearchinstalled
-    @echo $elastic_remaining_files
-
-    @echo $filebeatinstalled
-    @echo $filebeat_remaining_files
-
-    @echo $kibanainstalled
-    @echo $kibana_remaining_files
-}
-
-test-16-checkInstalledPass-nothing-installed-zypper-assert() {
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
-
-    @echo ""
-    @echo ""
 }

--- a/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+set -euo pipefail
+base_dir="$(cd "$(dirname "$BASH_SOURCE")"; pwd -P; cd - >/dev/null;)"
+source "${base_dir}"/bach.sh
+
+@setup-test {
+    @ignore logger_pass
+}
+
+function load-readFileUsers() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" readFileUsers
+}
+
+test-ASSERT-FAIL-01-readFileUsers-file-incorrect() {
+    load-readFileUsers
+    p_file=/tmp/passfile.yml
+    @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 0
+    readFileUsers
+}
+
+test-02-readFileUsers-changeall-correct() {
+    load-readFileUsers
+    p_file=/tmp/passfile.yml
+    @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
+    @mock grep name: /tmp/passfile.yml === @echo wazuh kibanaserver
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    @mock grep password: /tmp/passfile.yml === @echo wazuhpassword kibanaserverpassword
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    changeall=1
+    users=( wazuh kibanaserver )
+    readFileUsers
+    @echo ${fileusers[*]}
+    @echo ${filepasswords[*]}
+    @echo ${users[*]}
+    @echo ${passwords[*]}
+}
+
+test-02-readFileUsers-changeall-correct-assert() {
+    @echo wazuh kibanaserver
+    @echo wazuhpassword kibanaserverpassword
+    @echo wazuh kibanaserver
+    @echo wazuhpassword kibanaserverpassword
+}
+
+test-03-readFileUsers-changeall-user-doesnt-exist() {
+    load-readFileUsers
+    p_file=/tmp/passfile.yml
+    @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
+    @mock grep name: /tmp/passfile.yml === @out wazuh kibanaserver admin
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    @mock grep password: /tmp/passfile.yml === @out wazuhpassword kibanaserverpassword
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    changeall=1
+    users=( wazuh kibanaserver )
+    readFileUsers
+    @echo ${fileusers[*]}
+    @echo ${filepasswords[*]}
+    @echo ${users[*]}
+    @echo ${passwords[*]}
+}
+
+test-03-readFileUsers-changeall-user-doesnt-exist-assert() {
+    @echo wazuh kibanaserver admin
+    @echo wazuhpassword kibanaserverpassword
+    @echo wazuh kibanaserver
+    @echo wazuhpassword kibanaserverpassword
+}
+
+test-04-readFileUsers-no-changeall-correct() {
+    load-readFileUsers
+    p_file=/tmp/passfile.yml
+    @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
+    @mock grep name: /tmp/passfile.yml === @out wazuh kibanaserver admin
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    @mock grep password: /tmp/passfile.yml === @out wazuhpassword kibanaserverpassword adminpassword
+    @mock awk '{ print substr( $2, 1, length($2) ) }'
+    changeall=
+    kibanainstalled=1
+    kibana=1
+    users=( kibanaserver admin )
+    readFileUsers
+    @echo ${fileusers[*]}
+    @echo ${filepasswords[*]}
+    @echo ${users[*]}
+    @echo ${passwords[*]}
+}
+
+test-04-readFileUsers-no-changeall-correct-assert() {
+    @echo wazuh kibanaserver admin
+    @echo wazuhpassword kibanaserverpassword adminpassword
+    @echo kibanaserver admin
+    @echo kibanaserverpassword adminpassword
+}
+
+function load-changePassword() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" changePassword
+}
+
+test-05-changePassword-changeall-all-users-all-installed() {
+    load-changePassword
+    changeall=1
+    elasticsearchinstalled=1
+    filebeatinstalled=1
+    kibanainstalled=1
+    users=( "kibanaserver" "admin" )
+    passwords=( "kibanaserverpassword" "adminpassword" )
+    hashes=( "11" "22")
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/filebeat
+    @touch /etc/filebeat/filebeat.yml
+    @mkdir -p /etc/kibana
+    @touch /etc/kibana/kibana.yml
+    @mock grep "password:" /etc/filebeat/filebeat.yml === @out "wazuhpasswordold"
+    @mock awk '{sub("password: .*", "password: adminpassword")}1' /etc/filebeat/filebeat.yml === @out "admin_configuration_string"
+    @mock grep "password:" /etc/kibana/kibana.yml === @out "kibanapasswordold"
+    @mock awk '{sub("elasticsearch.password: .*", "elasticsearch.password: kibanaserverpassword")}1' /etc/kibana/kibana.yml === @out "kibanaserver_configuration_string"
+    changePassword
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/filebeat/filebeat.yml
+    @rm /etc/kibana/kibana.yml
+}
+
+test-05-changePassword-changeall-all-users-all-installed-assert() {
+    awk -v new=11 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+    awk -v new=22 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+    echo "admin_configuration_string"
+    restartService "filebeat"
+    echo "kibanaserver_configuration_string"
+    restartService "kibana"
+}
+
+test-06-changePassword-nuser-kibanaserver-kibana-installed() {
+    load-changePassword
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/kibana
+    @touch /etc/kibana/kibana.yml
+    nuser="kibanaserver"
+    password="kibanaserverpassword"
+    hash="11"
+    kibanainstalled=1
+    elasticsearchinstalled=1
+    @mock grep "password:" /etc/kibana/kibana.yml === @out "kibanapasswordold"
+    @mock awk '{sub("elasticsearch.password: .*", "elasticsearch.password: kibanaserverpassword")}1' /etc/kibana/kibana.yml === @out "kibanaserver_configuration_string"
+    changePassword
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/kibana/kibana.yml
+}
+
+test-06-changePassword-nuser-kibanaserver-kibana-installed-assert() {
+    awk -v new="11" 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+    echo "kibanaserver_configuration_string"
+    restartService "kibana"
+}
+
+test-07-changePassword-nuser-kibanaserver-kibana-not-installed() {
+    load-changePassword
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/kibana
+    @touch /etc/kibana/kibana.yml
+    nuser="kibanaserver"
+    password="kibanaserverpassword"
+    hash="11"
+    kibanainstalled=
+    elasticsearchinstalled=1
+    @mock grep "password:" /etc/kibana/kibana.yml === @out "kibanapasswordold"
+    @mock awk '{sub("elasticsearch.password: .*", "elasticsearch.password: kibanaserverpassword")}1' /etc/kibana/kibana.yml === @out "kibanaserver_configuration_string"
+    changePassword
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/kibana/kibana.yml
+}
+
+test-07-changePassword-nuser-kibanaserver-kibana-not-installed-assert() {
+    awk -v new="11" 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+}
+
+test-08-changePassword-nuser-admin-filebeat-installed() {
+    load-changePassword
+    changeall=
+    elasticsearchinstalled=1
+    filebeatinstalled=1
+    nuser="admin"
+    password="adminpassword"
+    hash="11"
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/filebeat
+    @touch /etc/filebeat/filebeat.yml
+    @mock grep "password:" /etc/filebeat/filebeat.yml === @out "wazuhpasswordold"
+    @mock awk '{sub("password: .*", "password: adminpassword")}1' /etc/filebeat/filebeat.yml === @out "admin_configuration_string"
+    changePassword
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/filebeat/filebeat.yml
+}
+
+test-08-changePassword-nuser-admin-filebeat-installed-assert() {
+    awk -v new=11 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+    echo "admin_configuration_string"
+    restartService "filebeat"
+}
+
+test-09-changePassword-nuser-admin-filebeat-not-installed() {
+    load-changePassword
+    changeall=
+    elasticsearchinstalled=1
+    filebeatinstalled=
+    nuser="admin"
+    password="adminpassword"
+    hash="11"
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/filebeat
+    @touch /etc/filebeat/filebeat.yml
+    @mock grep "password:" /etc/filebeat/filebeat.yml === @out "wazuhpasswordold"
+    @mock awk '{sub("password: .*", "password: adminpassword")}1' /etc/filebeat/filebeat.yml === @out "admin_configuration_string"
+    changePassword
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/filebeat/filebeat.yml
+}
+
+test-09-changePassword-nuser-admin-filebeat-not-installed-assert() {
+    awk -v new=11 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/elasticsearch/backup/internal_users.yml
+    mv -f internal_users.yml_tmp /usr/share/elasticsearch/backup/internal_users.yml
+}
+
+test-10-changePassword-changeall-all-users-nothing-installed() {
+    load-changePassword
+    changeall=1
+    elasticsearchinstalled=
+    filebeatinstalled=
+    kibanainstalled=
+    users=( "kibanaserver" "admin" )
+    passwords=( "kibanaserverpassword" "adminpassword" )
+    hashes=( "11" "22")
+    @mkdir -p /usr/share/elasticsearch/backup/
+    @touch /usr/share/elasticsearch/backup/internal_users.yml
+    @mkdir -p /etc/filebeat
+    @touch /etc/filebeat/filebeat.yml
+    @mkdir -p /etc/kibana
+    @touch /etc/kibana/kibana.yml
+    @mock grep "password:" /etc/filebeat/filebeat.yml === @out "wazuhpasswordold"
+    @mock awk '{sub("password: .*", "password: adminpassword")}1' /etc/filebeat/filebeat.yml === @out "admin_configuration_string"
+    @mock grep "password:" /etc/kibana/kibana.yml === @out "kibanapasswordold"
+    @mock awk '{sub("elasticsearch.password: .*", "elasticsearch.password: kibanaserverpassword")}1' /etc/kibana/kibana.yml === @out "kibanaserver_configuration_string"
+    changePassword
+    @assert-success
+    @rm /usr/share/elasticsearch/backup/internal_users.yml
+    @rm /etc/filebeat/filebeat.yml
+    @rm /etc/kibana/kibana.yml
+}
+
+function load-checkInstalledPass() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" checkInstalledPass
+}
+
+test-11-checkInstalledPass-all-installed-yum() {
+    load-checkInstalledPass
+    sys_type="yum"
+
+    @mocktrue yum list installed
+
+    @mock grep wazuh-manager === @echo wazuh-manager.x86_64  4.3.0-1  @wazuh
+    @mkdir /var/ossec/
+
+    @mock grep opendistroforelasticsearch === @echo opendistroforelasticsearch.x86_64 1.13.2-1 @wazuh
+    @mock grep -v kibana
+    @mkdir /var/lib/elasticsearch/
+    @mkdir /usr/share/elasticsearch/
+    @mkdir /etc/elasticsearch/
+
+    @mock grep filebeat === @echo filebeat.x86_64 7.10.2-1 @wazuh
+    @mkdir /var/lib/filebeat/
+    @mkdir /usr/share/filebeat/
+    @mkdir /etc/filebeat/
+
+    @mock grep opendistroforelasticsearch-kibana === @echo opendistroforelasticsearch-kibana.x86_64
+    @mkdir /var/lib/kibana/
+    @mkdir /usr/share/kibana/
+    @mkdir /etc/kibana/
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+    @rmdir /var/ossec
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+    @rmdir /var/lib/elasticsearch/
+    @rmdir /usr/share/elasticsearch/
+    @rmdir /etc/elasticsearch/
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+    @rmdir /var/lib/filebeat/
+    @rmdir /usr/share/filebeat/
+    @rmdir /etc/filebeat/
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+    @rmdir /var/lib/kibana/
+    @rmdir /usr/share/kibana/
+    @rmdir /etc/kibana/
+
+}
+
+test-11-checkInstalledPass-all-installed-yum-assert() {
+    @echo "wazuh-manager.x86_64 4.3.0-1 @wazuh"
+    @echo 1
+
+    @echo "opendistroforelasticsearch.x86_64 1.13.2-1 @wazuh"
+    @echo 1
+
+    @echo "filebeat.x86_64 7.10.2-1 @wazuh"
+    @echo 1
+
+    @echo "opendistroforelasticsearch-kibana.x86_64"
+    @echo 1
+}
+
+test-12-checkInstalledPass-all-installed-zypper() {
+    load-checkInstalledPass
+    sys_type="zypper"
+
+    @mocktrue zypper packages
+    @mock grep i+
+
+    @mock grep wazuh-manager === @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
+    @mkdir /var/ossec
+
+    @mock grep opendistroforelasticsearch === @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch | 1.13.2-1 | x86_64"
+    @mock grep -v kibana
+    @mkdir /var/lib/elasticsearch/
+    @mkdir /usr/share/elasticsearch
+    @mkdir /etc/elasticsearch
+
+    @mock grep filebeat === @echo "i+ | EL-20211102 - Wazuh | filebeat | 7.10.2-1 | x86_64"
+    @mkdir /var/lib/filebeat/
+    @mkdir /usr/share/filebeat
+    @mkdir /etc/filebeat
+
+    @mock grep opendistroforelasticsearch-kibana === @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch-kibana | 1.13.2-1 | x86_64"
+    @mkdir /var/lib/kibana/
+    @mkdir /usr/share/kibana
+    @mkdir /etc/kibana
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+    @rmdir /var/ossec
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+    @rmdir /var/lib/elasticsearch/
+    @rmdir /usr/share/elasticsearch
+    @rmdir /etc/elasticsearch
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+    @rmdir /var/lib/filebeat/
+    @rmdir /usr/share/filebeat
+    @rmdir /etc/filebeat
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+    @rmdir /var/lib/kibana/
+    @rmdir /usr/share/kibana
+    @rmdir /etc/kibana
+
+}
+
+test-12-checkInstalledPass-all-installed-zypper-assert() {
+    @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
+    @echo 1
+
+    @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch | 1.13.2-1 | x86_64"
+    @echo 1
+
+    @echo "i+ | EL-20211102 - Wazuh | filebeat | 7.10.2-1 | x86_64"
+    @echo 1
+
+    @echo "i+ | EL-20211102 - Wazuh | opendistroforelasticsearch-kibana | 1.13.2-1 | x86_64"
+    @echo 1
+}
+
+test-13-checkInstalledPass-all-installed-apt() {
+    load-checkInstalledPass
+    sys_type="apt-get"
+
+    @mocktrue apt list --installed
+
+    @mock grep wazuh-manager === @echo wazuh-manager/now 4.2.5-1 amd64 [installed,local]
+    @mkdir /var/ossec
+
+    @mock grep opendistroforelasticsearch === @echo opendistroforelasticsearch/stable,now 1.13.2-1 amd64 [installed]
+    @mock grep -v kibana
+    @mkdir /var/lib/elasticsearch/
+    @mkdir /usr/share/elasticsearch
+    @mkdir /etc/elasticsearch
+
+    @mock grep filebeat === @echo filebeat/now 7.10.2 amd64 [installed,local]
+    @mkdir /var/lib/filebeat/
+    @mkdir /usr/share/filebeat
+    @mkdir /etc/filebeat
+
+    @mock grep opendistroforelasticsearch-kibana === @echo opendistroforelasticsearch-kibana/now 1.13.2 amd64 [installed,local]
+    @mkdir /var/lib/kibana/
+    @mkdir /usr/share/kibana
+    @mkdir /etc/kibana
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+    @rmdir /var/ossec
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+    @rmdir /var/lib/elasticsearch/
+    @rmdir /usr/share/elasticsearch
+    @rmdir /etc/elasticsearch
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+    @rmdir /var/lib/filebeat/
+    @rmdir /usr/share/filebeat
+    @rmdir /etc/filebeat
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+    @rmdir /var/lib/kibana/
+    @rmdir /usr/share/kibana
+    @rmdir /etc/kibana
+
+}
+
+test-13-checkInstalledPass-all-installed-apt-assert() {
+    @echo "wazuh-manager/now 4.2.5-1 amd64 [installed,local]"
+    @echo 1
+
+    @echo "opendistroforelasticsearch/stable,now 1.13.2-1 amd64 [installed]"
+    @echo 1
+
+    @echo "filebeat/now 7.10.2 amd64 [installed,local]"
+    @echo 1
+
+    @echo "opendistroforelasticsearch-kibana/now 1.13.2 amd64 [installed,local]"
+    @echo 1
+}
+
+test-14-checkInstalledPass-nothing-installed-apt() {
+    load-checkInstalledPass
+    sys_type="apt-get"
+
+    @mocktrue apt list --installed
+
+    @mock grep wazuh-manager
+
+    @mock grep opendistroforelasticsearch
+    @mock grep -v kibana
+
+    @mock grep filebeat
+
+    @mock grep opendistroforelasticsearch-kibana
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+}
+
+test-14-checkInstalledPass-nothing-installed-apt-assert() {
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+}
+
+test-15-checkInstalledPass-nothing-installed-yum() {
+    load-checkInstalledPass
+    sys_type="yum"
+
+    @mocktrue yum list installed
+
+    @mock grep wazuh-manager
+
+    @mock grep opendistroforelasticsearch
+    @mock grep -v kibana
+
+    @mock grep filebeat
+
+    @mock grep opendistroforelasticsearch-kibana
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+}
+
+test-15-checkInstalledPass-nothing-installed-yum-assert() {
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+}
+
+test-16-checkInstalledPass-nothing-installed-zypper() {
+    load-checkInstalledPass
+    sys_type="zypper"
+
+    @mocktrue zypper packages
+    @mock grep i+
+
+    @mock grep wazuh-manager
+
+    @mock grep opendistroforelasticsearch
+    @mock grep -v kibana
+
+    @mock grep filebeat
+
+    @mock grep opendistroforelasticsearch-kibana
+
+    checkInstalledPass
+    @echo $wazuhinstalled
+    @echo $wazuh_remaining_files
+
+    @echo $elasticsearchinstalled
+    @echo $elastic_remaining_files
+
+    @echo $filebeatinstalled
+    @echo $filebeat_remaining_files
+
+    @echo $kibanainstalled
+    @echo $kibana_remaining_files
+}
+
+test-16-checkInstalledPass-nothing-installed-zypper-assert() {
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+
+    @echo ""
+    @echo ""
+}

--- a/tests/unattended/unit/unit-tests.sh
+++ b/tests/unattended/unit/unit-tests.sh
@@ -4,7 +4,7 @@ today="$(date +"%d_%m_%y")"
 logfile="./${today}-unit_test.log"
 echo "-------------------------" >> ${logfile}
 debug=">> ${logfile}"
-ALL_FILES=("common" "checks" "wazuh" "filebeat" "kibana" "elasticsearch")
+ALL_FILES=("common" "checks" "wazuh" "filebeat" "kibana" "elasticsearch" "wazuh-cert-tool" "wazuh-passwords-tool")
 IMAGE_NAME="unattended-installer-unit-tests-launcher"
 SHARED_VOLUME="$(pwd -P)/tmp/"
 
@@ -69,7 +69,7 @@ function testFile() {
     elif [ -f ../../../unattended_installer/install_functions/elasticsearch_basic/${1}.sh ]; then
         eval "cp ../../../unattended_installer/install_functions/elasticsearch_basic/${1}.sh ${SHARED_VOLUME} ${debug}"
     elif [ -f ../../../unattended_installer/${1}.sh ]; then
-        eval "cp ../../../unattended_installer/${1}.sh ${debug}"
+        eval "cp ../../../unattended_installer/${1}.sh ${SHARED_VOLUME} ${debug}"
     else 
         logger -e "File ${1}.sh could not be found."
         return


### PR DESCRIPTION
closes #1202

Used https://bach.sh/ to create unit tests for each function. In the directory tests/unattended there is a file called test-{script-name}.sh for each script in unattended installer. Inside that file are defined the unit tests for each function of {script-name}.sh. To call them we use the auxiliary script unit-test.sh, which creates a docker environment in which to run the tests.

Example of output:
```
[verdx@verdx unit]$ bash unit-tests.sh -f wazuh-passwords-tool
25/01/2022 15:32:53 INFO: Docker image found.
25/01/2022 15:32:53 INFO: Unit tests for wazuh-passwords-tool.sh.
1..39
ok 1 - 34 restartService initd error
ok 2 - 10 changePassword changeall all users nothing installed
ok 3 - 05 changePassword changeall all users all installed
ok 4 - 35 restartService rc.d/init.d
ok 5 - 04 readFileUsers no changeall correct
ok 6 - 38 generateHash nuser
ok 7 - 20 generatePasswordFile
ok 8 - 09 changePassword nuser admin filebeat not installed
ok 9 - ASSERT FAIL 18 checkUser incorrect user
ok 10 - ASSERT FAIL 17 checkUser no nuser
ok 11 - ASSERT FAIL 25 readAdmincerts no admin_key.pem
ok 12 - ASSERT FAIL 37 generateHash changeall error
ok 13 - 19 checkUser correct
ok 14 - 27 readAdmincerts all correct admin.key
ok 15 - 13 checkInstalledPass all installed apt
ok 16 - ASSERT FAIL 16 checkInstalledPass nothing installed zypper
ok 17 - 08 changePassword nuser admin filebeat installed
ok 18 - ASSERT FAIL 14 checkInstalledPass nothing installed apt
ok 19 - 36 generateHash changeall
ok 20 - 02 readFileUsers changeall correct
ok 21 - 23 getNetworkHost localhost
ok 22 - 21 getNetworkHost
ok 23 - 07 changePassword nuser kibanaserver kibana not installed
ok 24 - ASSERT FAIL 39 generateHash nuser error
ok 25 - ASSERT FAIL 30 restartService no service manager
ok 26 - 33 restartService initd
ok 27 - 32 restartService systemd error
ok 28 - 03 readFileUsers changeall user doesnt exist
ok 29 - 06 changePassword nuser kibanaserver kibana installed
ok 30 - 22 getNetworkHost interface
ok 31 - ASSERT FAIL 15 checkInstalledPass nothing installed yum
ok 32 - ASSERT FAIL 29 restartService no args
ok 33 - ASSERT FAIL 24 readAdmincerts no admin.pem
ok 34 - 11 checkInstalledPass all installed yum
ok 35 - 12 checkInstalledPass all installed zypper
ok 36 - ASSERT FAIL 01 readFileUsers file incorrect
ok 37 - 31 restartService systemd
ok 38 - 28 readUsers
ok 39 - 26 readAdmincerts all correct admin_key.pem
# -----
# All tests: 39, failed: 0, skipped: 0
25/01/2022 15:32:59 INFO: All unit tests for the functions in wazuh-passwords-tool.sh finished.
25/01/2022 15:32:59 INFO: Cleaning temporary files.

```