### PR TITLE
[Kibana app] Support `pluginPlatform.version` property in the app manifest

### DIFF
--- a/wazuhapp/Docker/build.sh
+++ b/wazuhapp/Docker/build.sh
@@ -55,7 +55,8 @@ prepare_env() {
     wazuh_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                     print(pkg["version"])')
     kibana_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
-                     print(pkg["kibana"]["version"])')
+                    plugin_platform_version=pkg.get("pluginPlatform", {}).get("version") or pkg.get("kibana", {}).get("version");\
+                    print(plugin_platform_version)')
     aux_kibana_version=$kibana_version
 
     if [ "${wazuh_version}" \< "4.2.2" ] && [ "${kibana_version}" \> "7.10.2" ]; then


### PR DESCRIPTION
|Related issue|
|---|
| None |

## Description
This PR adds compatibility to use the `pluginPlatform.version` property `package.json`. It keeps the compatibility with previous versions that used `kibana.version`.

Starting with the Kibana apps for Wazuh `4.3.0`, the `kibana` property in the root of `package.json` was renamed to `pluginPlatform`.

## Logs example

<!--
Paste here related logs
-->

## Tests

<!-- Minimum checks required -->
- Build the Kibana app package:
  - [x] using `pluginPlatform.version` property
  - [x] using `kibana.version` property