### PR TITLE
Fix rollBack and uninstall improvement

### DIFF
--- a/unattended_installer/install_functions/opendistro/elasticsearch.sh
+++ b/unattended_installer/install_functions/opendistro/elasticsearch.sh
@@ -148,6 +148,7 @@ function initializeElasticsearch() {
 
 function installElasticsearch() {
 
+    uninstall_module_name="elasticsearch"
     logger "Starting Open Distro for Elasticsearch installation."
 
     if [ "${sys_type}" == "yum" ]; then

--- a/unattended_installer/install_functions/opendistro/filebeat.sh
+++ b/unattended_installer/install_functions/opendistro/filebeat.sh
@@ -54,6 +54,7 @@ function copyCertificatesFilebeat() {
 
 function installFilebeat() {
 
+    uninstall_module_name="filebeat"
     logger "Starting filebeat installation."
     
     if [ "${sys_type}" == "zypper" ]; then

--- a/unattended_installer/install_functions/opendistro/kibana.sh
+++ b/unattended_installer/install_functions/opendistro/kibana.sh
@@ -159,6 +159,7 @@ function initializeKibanaAIO() {
 
 function installKibana() {
     
+    uninstall_module_name="kibana"
     logger "Starting Kibana installation."
     if [ "${sys_type}" == "zypper" ]; then
         eval "zypper -n install opendistroforelasticsearch-kibana=${opendistro_version} ${debug}"

--- a/unattended_installer/install_functions/opendistro/wazuh.sh
+++ b/unattended_installer/install_functions/opendistro/wazuh.sh
@@ -43,6 +43,7 @@ function configureWazuhCluster() {
 
 function installWazuh() {
 
+    uninstall_module_name="wazuh"
     logger "Starting the Wazuh manager installation."
     if [ "${sys_type}" == "zypper" ]; then
         eval "${sys_type} -n install wazuh-manager=${wazuh_version}-${wazuh_revision} ${debug}"

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -111,7 +111,7 @@ function getHelp() {
     echo -e "        -t,  --tar <path-to-certs-tar>"
     echo -e "                Path to tar containing certificate files. By default: ${base_path}/configurations.tar"
     echo -e ""
-    echo -e "        -u,  --uninstall"
+    echo -e "        -u,  --uninstall <app-module-name>"
     echo -e "                Uninstalls all Wazuh components. NOTE: This will erase all the existing configuration and data."
     echo -e ""
     echo -e "        -v,  --verbose"
@@ -284,8 +284,14 @@ function main() {
                 shift 2
                 ;;
             "-u"|"--uninstall")
+                if [ -z "${2}" ]; then
+                    logger -e "Error on arguments. Probably missing <app-module-name> after -u|--uninstall."
+                    getHelp
+                    exit 1
+                fi
                 uninstall=1
-                shift 1
+                uninstall_module_name="${2}"
+                shift 2
                 ;;
             "-v"|"--verbose")
                 debugEnabled=1


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1210 |

## Description

The script needs to be able to run custom uninstallations:

- -u all
  - To uninstall all.
- -u wazuh
  - To uninstall just wazuh.
- -u elasticsearch
  - To uninstall only elasticsearch.
- -u kibana
  - To uninstall just Kibana.

