### PR TITLE
Add missing required packages to the unattended installation scripts

### DIFF
--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -1,4 +1,4 @@
-# Wazuh installer - common.sh functions. 
+# Wazuh installer - common.sh functions.
 # Copyright (C) 2015, Wazuh Inc.
 #
 # This program is a free software; you can redistribute it
@@ -89,7 +89,7 @@ function changePasswords() {
             readUsers
         fi
         readPasswordFileUsers
-    else 
+    else
         logger -e "Cannot find passwords-file. Exiting"
         exit 1
     fi
@@ -98,7 +98,7 @@ function changePasswords() {
         createBackUp
         generateHash
     fi
-    
+
     changePassword
 
     if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
@@ -221,11 +221,11 @@ User:
         finalusers=()
         finalpasswords=()
 
-        if [ -n "${dashboardinstalled}" ] &&  [ -n "${dashboard}" ]; then 
+        if [ -n "${dashboardinstalled}" ] &&  [ -n "${dashboard}" ]; then
             users=( kibanaserver admin )
         fi
 
-        if [ -n "${filebeatinstalled}" ] && [ -n "${wazuh}" ]; then 
+        if [ -n "${filebeatinstalled}" ] && [ -n "${wazuh}" ]; then
             users=( admin )
         fi
 
@@ -275,7 +275,7 @@ function rollBack() {
 
     if [ -z "${uninstall}" ]; then
         logger "Cleaning the installation."
-    fi  
+    fi
 
     if [ -f "/etc/yum.repos.d/wazuh.repo" ]; then
         eval "rm /etc/yum.repos.d/wazuh.repo"
@@ -294,7 +294,7 @@ function rollBack() {
             eval "rm -f /etc/init.d/wazuh-manager ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
             eval "apt remove --purge wazuh-manager -y ${debug}"
-        fi 
+        fi
     fi
 
     if [[ ( -n "${wazuh_remaining_files}"  || -n "${wazuhinstalled}" ) && ( -n "${wazuh}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
@@ -309,7 +309,7 @@ function rollBack() {
             eval "zypper -n remove wazuh-indexer ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
             eval "apt remove --purge ^wazuh-indexer -y ${debug}"
-        fi 
+        fi
     fi
 
     if [[ ( -n "${indexer_remaining_files}" || -n "${indexerchinstalled}" ) && ( -n "${indexer}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
@@ -406,7 +406,7 @@ function startService() {
             exit 1
         else
             logger "${1^} service started."
-        fi     
+        fi
     elif [ -x "/etc/rc.d/init.d/${1}" ] ; then
         eval "/etc/rc.d/init.d/${1} start ${debug}"
         if [  "$?" != 0  ]; then

--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -164,7 +164,7 @@ function installPrerequisites() {
         eval "zypper -n install libcap-progs tar gnupg ${openssl} ${debug} || zypper -n install libcap2 tar gnupg ${openssl} ${debug}"
     elif [ "${sys_type}" == "apt-get" ]; then
         eval "apt-get update -q ${debug}"
-        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg ${openssl} -y ${debug}"
+        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin tar software-properties-common gnupg ${openssl} -y ${debug}"
     fi
 
     if [  "$?" != 0  ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11936|

## Description

As shown in the issue above, @tonoitp reported that the unattended installer won't run on a minimal Debian system due to some missing packages that are not available by default.

In fact, the Wazuh installation documentation ([Wazuh server > step-by-step](https://documentation.wazuh.com/current/installation-guide/open-distro/all-in-one-deployment/all-in-one.html)) reads that we need to install some packages that don't appear in the unattended installation script:

|Package|Assets provided|
|---|---|
|`software-properties-common`|`add-apt-repository` and repository validation|
|`lsb-release`|`lsb_release` (Debian package post-installation)|
|`gnupg`|`apt-key add` operation|

Seeing that packages `wazuh-manager` and `wazuh-agent` already depend on `lsb-release`: [debian/control](https://github.com/wazuh/wazuh-packages/blob/fa86abc4efb462cf56c43f215051a85d46364e93/debs/SPECS/4.2.5/wazuh-manager/debian/control#L11). However, the documentation still indicates that the package must be installed.

## Logs example

- Without `gnupg`:
```sh
# curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
(23) Failed writing body
```
- Without `software-properties-common`
```sh
# echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
# apt-get update
Err:3 https://packages.wazuh.com/4.x/apt stable Release
  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 52.84.65.34 443]
```

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
