### PR TITLE
Added detection of operative system to the unattended installer

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -6,19 +6,21 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-systems_list=("centos","ubuntu","debian","fedora","amazonlinux","redhat","opensuse-leap", "opensuse-tumbleweed","suse","oraclelinux","rocky","alma")
+systems_list=("centos","ubuntu","debian","fedora","amzn","rhel","opensuse-leap", "opensuse-tumbleweed","sles","ol","rocky","almalinux")
 centos_version=("7","8")
 ubuntu_version=("16","18","20")
 debian_version=("8","9","10","11")
 fedora_version=("31","32","33","34","35")
-amazon_version=("2_base")
+amazon_version=("2")
 redhat_version=("7","8")
 opensuse_version=("15")
 opensuse_subversion=("3","2")
 suse_version=("12","15")
 oracle_version=("7","8")
-rocky_version=("8.5")
-alma_version=("8.5")
+rocky_version=("8")
+rocky_subversion=("5")
+alma_version=("8")
+alma_subversion=("5")
 
 function checkArch() {
 
@@ -391,15 +393,6 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "fedora" ] && ! (echo ${fedora_version} | grep -w -q ${DIST_VER}); then
-        if [ -n "${force_os}" ]; then
-            logger -w "Unattended installation not supported for this version of Fedora, only 31 and later. Option --force-os used"
-        else
-            logger -e "Unattended installation not supported for this version of Fedora, only 31 and later. Use option --force-os to force the installation"
-            exit 1
-        fi
-    fi
-
     if [ "${DIST_NAME}" == "amazonlinux" ] && ! (echo ${amazon_version} | grep -w -q ${DIST_VER}); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of Amazon Linux, only version 2 is supported. Option --force-os used"
@@ -409,7 +402,7 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "redhat" ] && ! (echo ${redhat_version} | grep -w -q ${DIST_VER}); then
+    if [ "${DIST_NAME}" == "rhel" ] && ! (echo ${redhat_version} | grep -w -q ${DIST_VER}); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of RedHat, only 7 and 8. Option --force-os used"
         else
@@ -418,7 +411,7 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "opensuse-leap" ] && ( ( ! (echo ${opensuse_version} | grep -w -q ${DIST_VER}) ) || ( (echo ${opensuse_version} | grep -w -q ${DIST_VER}) && | (echo ${opensuse_version} | grep -w -q ${DIST_VER}) ) ); then
+    if [ "${DIST_NAME}" == "opensuse-leap" ] && ( ( ! (echo ${opensuse_version} | grep -w -q ${DIST_VER}) ) || ( (echo ${opensuse_version} | grep -w -q ${DIST_VER}) && ! (echo ${opensuse_subversion} | grep -w -q ${DIST_SUBVER}) ) ); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of OpenSuse, only 15.2, 15.3 and Tumbleweed. Option --force-os used"
         else
@@ -427,7 +420,7 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "suse" ] && ! (echo ${suse_version} | grep -w -q ${DIST_VER}); then
+    if [ "${DIST_NAME}" == "sles" ] && ! (echo ${suse_version} | grep -w -q ${DIST_VER}); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of Suse, only 12 and 15. Option --force-os used"
         else
@@ -445,7 +438,7 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "rockylinux" ] && ! (echo ${rocky_version} | grep -w -q ${DIST_VER}); then
+    if [ "${DIST_NAME}" == "rockylinux" ] && ( ! (echo ${rocky_version} | grep -w -q ${DIST_VER}) || ! (echo ${rocky_subversion} | grep -w -q ${DIST_SUBVER}) ); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of Rocky Linux, only 8.5 vesion is supported. Option --force-os used"
         else
@@ -454,7 +447,7 @@ function checkDist() {
         fi
     fi
 
-    if [ "${DIST_NAME}" == "almalinux" ] && ! (echo ${alma_version} | grep -w -q ${DIST_VER}); then
+    if [ "${DIST_NAME}" == "almalinux" ] && ( ! (echo ${alma_version} | grep -w -q ${DIST_VER}) || ! (echo ${alma_subversion} | grep -w -q ${DIST_SUBVER}) ); then
         if [ -n "${force_os}" ]; then
             logger -w "Unattended installation not supported for this version of Alma Linux, only 8.5 vesion is supported. Option --force-os used"
         else

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -6,21 +6,11 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-systems_list=("centos","ubuntu","debian","fedora","amzn","rhel","opensuse-leap", "opensuse-tumbleweed","sles","ol","rocky","almalinux")
+systems_list=("centos","ubuntu","amzn","rhel")
 centos_version=("7","8")
 ubuntu_version=("16","18","20")
-debian_version=("8","9","10","11")
-fedora_version=("31","32","33","34","35")
 amazon_version=("2")
 redhat_version=("7","8")
-opensuse_version=("15")
-opensuse_subversion=("3","2")
-suse_version=("12","15")
-oracle_version=("7","8")
-rocky_version=("8")
-rocky_subversion=("5")
-alma_version=("8")
-alma_subversion=("5")
 
 function checkArch() {
 

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -6,6 +6,20 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
+systems_list=("centos","ubuntu","debian","fedora","amazonlinux","redhat","opensuse-leap", "opensuse-tumbleweed","suse","oraclelinux","rocky","alma")
+centos_version=("7","8")
+ubuntu_version=("16","18","20")
+debian_version=("8","9","10","11")
+fedora_version=("31","32","33","34","35")
+amazon_version=("2_base")
+redhat_version=("7","8")
+opensuse_version=("15")
+opensuse_subversion=("3","2")
+suse_version=("12","15")
+oracle_version=("7","8")
+rocky_version=("8.5")
+alma_version=("8.5")
+
 function checkArch() {
 
     arch=$(uname -m)
@@ -329,4 +343,123 @@ function checkSystem() {
         exit 1
     fi
 
+}
+
+function checkDist() {
+    if (echo ${system_version} | grep -w -q ${DIST_NAME}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this operating system. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this operating system. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "centos" ] && ! (echo ${centos_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of CentOS, only 7 and later. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of CentOS, only 7 and later. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "ubuntu" ] && ! (echo ${ubuntu_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Ubuntu, only xenial, bionic or focal. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Ubuntu, only xenial, bionic or focal. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "debian" ] && ! (echo ${debian_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Debian, only jessy, stretch, buster and bullseye. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Debian, only jessy, stretch, buster and bullseye. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "fedora" ] && ! (echo ${fedora_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Fedora, only 31 and later. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Fedora, only 31 and later. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "fedora" ] && ! (echo ${fedora_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Fedora, only 31 and later. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Fedora, only 31 and later. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "amazonlinux" ] && ! (echo ${amazon_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Amazon Linux, only version 2 is supported. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Amazon Linux, only version 2 is supported. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "redhat" ] && ! (echo ${redhat_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of RedHat, only 7 and 8. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of RedHat, only 7 and 8. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "opensuse-leap" ] && ( ( ! (echo ${opensuse_version} | grep -w -q ${DIST_VER}) ) || ( (echo ${opensuse_version} | grep -w -q ${DIST_VER}) && | (echo ${opensuse_version} | grep -w -q ${DIST_VER}) ) ); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of OpenSuse, only 15.2, 15.3 and Tumbleweed. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of OpenSuse, only 15.2, 15.3 and Tumbleweed. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "suse" ] && ! (echo ${suse_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Suse, only 12 and 15. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Suse, only 12 and 15. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "oraclelinux" ] && ! (echo ${oracle_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Oracle Linux, only 7 and 8. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Oracle Linux, only 7 and 8. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "rockylinux" ] && ! (echo ${rocky_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Rocky Linux, only 8.5 vesion is supported. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Rocky Linux, only 8.5 vesion is supported. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
+
+    if [ "${DIST_NAME}" == "almalinux" ] && ! (echo ${alma_version} | grep -w -q ${DIST_VER}); then
+        if [ -n "${force_os}" ]; then
+            logger -w "Unattended installation not supported for this version of Alma Linux, only 8.5 vesion is supported. Option --force-os used"
+        else
+            logger -e "Unattended installation not supported for this version of Alma Linux, only 8.5 vesion is supported. Use option --force-os to force the installation"
+            exit 1
+        fi
+    fi
 }

--- a/unattended_installer/install_functions/dist-detect.sh
+++ b/unattended_installer/install_functions/dist-detect.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+
+# Wazuh Distribution Detector
+# Copyright (C) 2015, Wazuh Inc.
+# November 18, 2016.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Default values
+DIST_NAME="Linux"
+DIST_VER="0"
+DIST_SUBVER="0"
+
+if [ -r "/etc/os-release" ]; then
+    . /etc/os-release
+    DIST_NAME=$ID
+    DIST_VER=$(echo $VERSION_ID | sed -rn 's/[^0-9]*([0-9]+).*/\1/p')
+    if [ "X$DIST_VER" = "X" ]; then
+        DIST_VER="0"
+    fi
+    if [ "$DIST_NAME" = "amzn" ] && [ "$DIST_VER" != "2" ]; then
+        DIST_VER="1"
+    fi
+    DIST_SUBVER=$(echo $VERSION_ID | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
+    if [ "X$DIST_SUBVER" = "X" ]; then
+        DIST_SUBVER="0"
+    fi
+fi
+
+if [ ! -r "/etc/os-release" ] || [ "$DIST_NAME" = "centos" ]; then
+    # CentOS
+    if [ -r "/etc/centos-release" ]; then
+        DIST_NAME="centos"
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/centos-release`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.*([0-9]{0,2}).*/\1/p' /etc/centos-release`
+
+    # Fedora
+    elif [ -r "/etc/fedora-release" ]; then
+        DIST_NAME="fedora"
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2}) .*/\1/p' /etc/fedora-release`
+
+    # RedHat
+    elif [ -r "/etc/redhat-release" ]; then
+        if grep -q "CentOS" /etc/redhat-release; then
+            DIST_NAME="centos"
+        else
+            DIST_NAME="rhel"
+        fi
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/redhat-release`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.*([0-9]{0,2}).*/\1/p' /etc/redhat-release`
+
+    # Ubuntu
+    elif [ -r "/etc/lsb-release" ]; then
+        . /etc/lsb-release
+        DIST_NAME="ubuntu"
+        DIST_VER=$(echo $DISTRIB_RELEASE | sed -rn 's/.*([0-9][0-9])\.[0-9][0-9].*/\1/p')
+        DIST_SUBVER=$(echo $DISTRIB_RELEASE | sed -rn 's/.*[0-9][0-9]\.([0-9][0-9]).*/\1/p')
+
+    # Gentoo
+    elif [ -r "/etc/gentoo-release" ]; then
+        DIST_NAME="gentoo"
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9]{1,2}.*/\1/p' /etc/gentoo-release`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]{1,2}).*/\1/p' /etc/gentoo-release`
+
+    # SuSE
+    elif [ -r "/etc/SuSE-release" ]; then
+        DIST_NAME="suse"
+        DIST_VER=`sed -rn 's/.*VERSION = ([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
+        DIST_SUBVER=`sed -rn 's/.*PATCHLEVEL = ([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
+        if [ "$DIST_SUBVER" = "" ]; then #openSuse
+          DIST_SUBVER=`sed -rn 's/.*VERSION = ([0-9]{1,2})\.([0-9]{1,2}).*/\1/p' /etc/SuSE-release`
+        fi
+
+    # Arch
+    elif [ -r "/etc/arch-release" ]; then
+        DIST_NAME="arch"
+        DIST_VER=$(uname -r | sed -rn 's/[^0-9]*([0-9]+).*/\1/p')
+        DIST_SUBVER=$(uname -r | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
+
+    # Debian
+    elif [ -r "/etc/debian_version" ]; then
+        DIST_NAME="debian"
+        DIST_VER=`sed -rn 's/[^0-9]*([0-9]+).*/\1/p' /etc/debian_version`
+        DIST_SUBVER=`sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p' /etc/debian_version`
+
+    # Slackware
+    elif [ -r "/etc/slackware-version" ]; then
+        DIST_NAME="slackware"
+        DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.[0-9].*/\1/p' /etc/slackware-version`
+        DIST_SUBVER=`sed -rn 's/.* [0-9]{1,2}\.([0-9]).*/\1/p' /etc/slackware-version`
+
+    # Darwin
+    elif [ "$(uname)" = "Darwin" ]; then
+        DIST_NAME="darwin"
+        DIST_VER=$(uname -r | sed -En 's/[^0-9]*([0-9]+).*/\1/p')
+        DIST_SUBVER=$(uname -r | sed -En 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
+
+    # Solaris / SunOS
+    elif [ "$(uname)" = "SunOS" ]; then
+        DIST_NAME="sunos"
+        DIST_VER=$(uname -r | cut -d\. -f1)
+        DIST_SUBVER=$(uname -r | cut -d\. -f2)
+
+    # HP-UX
+    elif [ "$(uname)" = "HP-UX" ]; then
+        DIST_NAME="HP-UX"
+        DIST_VER=$(uname -r | cut -d\. -f2)
+        DIST_SUBVER=$(uname -r | cut -d\. -f3)
+
+    # AIX
+    elif [ "$(uname)" = "AIX" ]; then
+        DIST_NAME="AIX"
+        DIST_VER=$(oslevel | cut -d\. -f1)
+        DIST_SUBVER=$(oslevel | cut -d\. -f2)
+
+    # BSD
+    elif [ "X$(uname)" = "XOpenBSD" -o "X$(uname)" = "XNetBSD" -o "X$(uname)" = "XFreeBSD" -o "X$(uname)" = "XDragonFly" ]; then
+        DIST_NAME="bsd"
+        DIST_VER=$(uname -r | sed -rn 's/[^0-9]*([0-9]+).*/\1/p')
+        DIST_SUBVER=$(uname -r | sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p')
+
+    elif [ "X$(uname)" = "XLinux" ]; then
+        DIST_NAME="Linux"
+
+    fi
+    if [ "X$DIST_SUBVER" = "X" ]; then
+        DIST_SUBVER="0"
+    fi
+fi

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -86,7 +86,9 @@ function getHelp() {
     echo -e "        -F,  --force-dashboard"
     echo -e "                Ignore indexer cluster related errors in kibana installation"
     echo -e ""
-    echo -e "        -h,  --help"
+    echo -e "        -Fos,  --force-os"
+    echo -e "                Force the installation on not supported operating systems and versions"
+    echo -e ""
     echo -e "                Shows help."
     echo -e ""
     echo -e "        -i,  --ignore-health-check"
@@ -228,8 +230,12 @@ function main() {
                 config_file="${2}"
                 shift 2
                 ;;
-            "-F"|"--force-kibana")
+            "-F"|"--force-dashboard")
                 force=1
+                shift 1
+                ;;
+            "-Fos"|"--force-os")
+                force_os=1
                 shift 1
                 ;;
             "-h"|"--help")
@@ -348,6 +354,8 @@ function main() {
     fi
     checkArch
     checkSystem
+    . "${base_path}/${functions_path}/dist-detect.sh"
+    checkDist
     if [ -n "${ignore}" ]; then
         logger -w "Health-check ignored."
     else


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1228|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Using the tool https://github.com/wazuh/wazuh/blob/v4.3.0-rc3/src/init/dist-detect.sh the unattended installer now detects the operative system and if it is not supported and the option -Fos|--force-os hasn`t been specified it stops the installation.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Testing
 - [x] Centos
 - [x] Ubuntu
 - [x] Debian
 - [x] Opensuse
 - [x] Fedora
 - [x] Amazon linux
 - [x] RedHat
 - [x] Suse
 - [x] Oracle
 - [x] Rocky
 - [x] Alma
