### PR TITLE
Unattended installer modules functions must be prefixed by module name. 

### DIFF
--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -36,10 +36,10 @@ function addWazuhrepo() {
     if [ ! -f "/etc/yum.repos.d/wazuh.repo" ] && [ ! -f "/etc/zypp/repos.d/wazuh.repo" ] && [ ! -f "/etc/apt/sources.list.d/wazuh.list" ] ; then
         if [ "${sys_type}" == "yum" ]; then
             eval "rpm --import ${repogpg} ${debug}"
-            eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\$releasever - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo ${debug}"
+            eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "zypper" ]; then
             eval "rpm --import ${repogpg} ${debug}"
-            eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\$releasever - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/zypp/repos.d/wazuh.repo ${debug}"
+            eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/zypp/repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
             eval "curl -s ${repogpg} --max-time 300 | apt-key add - ${debug}"
             eval "echo \"deb ${repobaseurl}/apt/ ${reporelease} main\" | tee /etc/apt/sources.list.d/wazuh.list ${debug}"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -8,9 +8,9 @@
 
 readonly d_certs_path="/etc/wazuh-dashboard/certs/"
 
-function configureDashboard() {
+function dashboard_configure() {
 
-    copyDashboardcerts
+    dashboard_copyCertificates
 
     if [ -n "${AIO}" ]; then
         eval "getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/dashboard.yml ${debug}"
@@ -44,7 +44,7 @@ function configureDashboard() {
 
 }
 
-function copyDashboardcerts() {
+function dashboard_copyCertificates() {
 
     eval "rm -f ${d_certs_path}/* ${debug}"
     if [ -f "${tar_file}" ]; then
@@ -65,7 +65,7 @@ function copyDashboardcerts() {
 
 }
 
-function initializeDashboard() {
+function dashboard_initialize() {
 
     logger "Starting Wazuh dashboard  (this may take a while)."
     getPass "admin"
@@ -127,7 +127,7 @@ function initializeDashboard() {
 
 }
 
-function initializeDashboardAIO() {
+function dashboard_initializeAIO() {
 
     logger "Starting Wazuh dashboard (this may take a while)."
     getPass "admin"
@@ -145,7 +145,7 @@ function initializeDashboardAIO() {
 
 }
 
-function installDashboard() {
+function dashboard_install() {
     
     logger "Starting Wazuh dashboard installation."
     if [ "${sys_type}" == "zypper" ]; then

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -8,7 +8,7 @@
 
 readonly f_cert_path="/etc/filebeat/certs/"
 
-function configureFilebeat(){
+function filebeat_configure(){
 
     eval "curl -so /etc/filebeat/wazuh-template.json ${filebeat_wazuh_template} --max-time 300 ${debug}"
     eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
@@ -29,12 +29,12 @@ function configureFilebeat(){
     fi
 
     eval "mkdir /etc/filebeat/certs ${debug}"
-    copyCertificatesFilebeat
+    filebeat_copyCertificates
 
     logger "Filebeat post-install configuration finished."
 }
 
-function copyCertificatesFilebeat() {
+function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
@@ -52,7 +52,7 @@ function copyCertificatesFilebeat() {
 
 }
 
-function installFilebeat() {
+function filebeat_install() {
 
     logger "Starting filebeat installation."
     if [ "${sys_type}" == "zypper" ]; then

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -8,7 +8,7 @@
 
 readonly i_certs_path="/etc/wazuh-indexer/certs/"
 
-function configureIndexer() {
+function indexer_configure() {
 
     logger -d "Configuring Wazuh indexer."
     eval "export JAVA_HOME=/usr/share/wazuh-indexer/jdk/"
@@ -17,7 +17,7 @@ function configureIndexer() {
     # eval "getConfig indexer/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml ${debug}"
     # eval "rm -f /etc/wazuh-indexer/{esnode-key.pem,esnode.pem,kirk-key.pem,kirk.pem,root-ca.pem} ${debug}"
     
-    copyCertificatesIndexer
+    indexer_copyCertificates
 
     # Configure JVM options for Wazuh indexer
     ram_gb=$(free -g | awk '/^Mem:/{print $2}')
@@ -82,7 +82,7 @@ function configureIndexer() {
     logger "Wazuh indexer post-install configuration finished."
 }
 
-function copyCertificatesIndexer() {
+function indexer_copyCertificates() {
     
     eval "rm -f ${i_certs_path}/* ${debug}"
     name=${indexer_node_names[pos]}
@@ -100,7 +100,7 @@ function copyCertificatesIndexer() {
 
 }
 
-function initializeIndexer() {
+function indexer_initialize() {
 
     logger "Starting Wazuh indexer cluster."
     i=0
@@ -121,7 +121,7 @@ function initializeIndexer() {
 
 }
 
-function installIndexer() {
+function indexer_install() {
 
     logger "Starting Wazuh indexer installation."
 
@@ -144,7 +144,7 @@ function installIndexer() {
 
 }
 
-function startIndexerCluster() {
+function indexer_startCluster() {
 
     eval "export JAVA_HOME=/usr/share/wazuh-indexer/jdk/"
     eval "/usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9800 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -icl -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${indexer_node_ips[pos]} > /dev/null ${debug}"

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -6,7 +6,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-function configureWazuhCluster() {
+function manager_startCluster() {
 
     for i in "${!wazuh_servers_node_names[@]}"; do
         if [[ "${wazuh_servers_node_names[i]}" == "${winame}" ]]; then
@@ -41,7 +41,7 @@ function configureWazuhCluster() {
 
 }
 
-function installWazuh() {
+function manager_install() {
 
     logger "Starting the Wazuh manager installation."
     if [ "${sys_type}" == "zypper" ]; then

--- a/unattended_installer/install_functions/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/wazuh-passwords-tool.sh
@@ -142,15 +142,16 @@ function checkUser() {
 }
 
 function createBackUp() {
-    
+    set -x
     logger_pass -d "Creating password backup."
     eval "mkdir /usr/share/wazuh-indexer/backup ${debug_pass}"
-    eval "/usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9800 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug_pass}"
+    eval "OPENSEARCH_PATH_CONF=\"/etc/wazuh-indexer\" /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9800 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug_pass}"
     if [ "$?" != 0 ]; then
         logger_pass -e "The backup could not be created"
         exit 1;
     fi
     logger_pass -d "Password backup created"
+    set +x
 }
 
 function generateHash() {
@@ -370,7 +371,7 @@ function main() {
         done
 
         export JAVA_HOME=/usr/share/wazuh-indexer/jdk/
-        
+
         if [ -n "${verboseenabled}" ]; then
             debug_pass="2>&1 | tee -a ${logfile}"
         fi

--- a/unattended_installer/install_functions/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/wazuh-passwords-tool.sh
@@ -142,7 +142,7 @@ function checkUser() {
 }
 
 function createBackUp() {
-    set -x
+
     logger_pass -d "Creating password backup."
     eval "mkdir /usr/share/wazuh-indexer/backup ${debug_pass}"
     eval "OPENSEARCH_PATH_CONF=\"/etc/wazuh-indexer\" /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9800 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug_pass}"
@@ -151,7 +151,7 @@ function createBackUp() {
         exit 1;
     fi
     logger_pass -d "Password backup created"
-    set +x
+
 }
 
 function generateHash() {

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -406,16 +406,16 @@ function main() {
 
     if [ -n "${indexer}" ]; then
         logger "-------------------------- Wazuh Indexer --------------------------"
-        installIndexer
-        configureIndexer
+        indexer_install
+        indexer_configure
         startService "wazuh-indexer"
-        initializeIndexer
+        indexer_initialize
     fi
 
 # -------------- Start Elasticsearch cluster case  ------------------
 
     if [ -n "${start_elastic_cluster}" ]; then
-        startIndexerCluster
+        indexer_startCluster
         changePasswords
     fi
 
@@ -426,11 +426,11 @@ function main() {
 
         importFunction "dashboard.sh"
 
-        installDashboard 
-        configureDashboard
+        dashboard_install 
+        dashboard_configure
         changePasswords
         startService "wazuh-dashboard"
-        initializeDashboard
+        dashboard_initialize
 
     fi
 
@@ -442,13 +442,13 @@ function main() {
         importFunction "manager.sh"
         importFunction "filebeat.sh"
 
-        installWazuh
+        manager_install
         if [ -n "${wazuh_servers_node_types[*]}" ]; then
             configureWazuhCluster 
         fi
         startService "wazuh-manager"
-        installFilebeat
-        configureFilebeat
+        filebeat_install
+        filebeat_configure
         changePasswords
         startService "filebeat"
     fi
@@ -463,22 +463,22 @@ function main() {
         importFunction "dashboard.sh"
 
         logger "-------------------------- Wazuh Indexer --------------------------"
-        installIndexer
-        configureIndexer
+        indexer_install
+        indexer_configure
         startService "wazuh-indexer"
-        initializeIndexer
+        indexer_initialize
         logger "-------------------------------------- Wazuh Manager --------------------------------------"
-        installWazuh
+        manager_install
         startService "wazuh-manager"
-        installFilebeat
-        configureFilebeat
+        filebeat_install
+        filebeat_configure
         startService "filebeat"
         logger "------------------------------------- Wazuh Dashboard --------------------------------------"
-        installDashboard
-        configureDashboard
+        dashboard_install
+        dashboard_configure
         startService "wazuh-dashboard"
         changePasswords
-        initializeDashboardAIO
+        dashboard_initializeAIO
     fi
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: verdx <verdx@riseup.net>

|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/pull/1222|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
It changes de name of all functions of the modules to be preceded by the module name. For example, installIndexer is changed to indexer_install.
