### PR TITLE
Changed names for checks.sh and common.sh functions, adding module name 

### DIFF
--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -46,7 +46,7 @@ systemConfig() {
 preInstall() {
 
   # Disable passwords change
-  sed -i "s/changePasswords/#changePasswords/g" ${RESOURCES_PATH}/${INSTALLER}
+  sed -i "s/common_changePasswords/#common_changePasswords/g" ${RESOURCES_PATH}/${INSTALLER}
 
 }
 

--- a/tests/unattended/unit/suites/test-checks.sh
+++ b/tests/unattended/unit/suites/test-checks.sh
@@ -7,123 +7,123 @@ source "${base_dir}"/bach.sh
     @ignore logger
 }
 
-function load-checkSystem() {
-    @load_function "${base_dir}/checks.sh" checkSystem
+function load-checks_system() {
+    @load_function "${base_dir}/checks.sh" checks_system
 }
 
-test-ASSERT-FAIL-01-checkSystem-empty() {
-    load-checkSystem
+test-ASSERT-FAIL-01-checks_system-empty() {
+    load-checks_system
     @mock command -v yum === @false
     @mock command -v zypper === @false
     @mock command -v apt-get === @false
-    checkSystem
+    checks_system
 }
 
-test-02-checkSystem-yum() {
-    load-checkSystem
+test-02-checks_system-yum() {
+    load-checks_system
     @mock command -v yum === @echo /usr/bin/yum
     @mock command -v zypper === @false
     @mock command -v apt-get === @false
-    checkSystem
+    checks_system
     echo "$sys_type"
     echo "$sep"
 }
 
-test-02-checkSystem-yum-assert() {
+test-02-checks_system-yum-assert() {
     sys_type="yum"
     sep="-"
     echo "$sys_type"
     echo "$sep"
 }
 
-test-03-checkSystem-zypper() {
-    load-checkSystem
+test-03-checks_system-zypper() {
+    load-checks_system
     @mock command -v yum === @false
     @mock command -v zypper === @echo /usr/bin/zypper
     @mock command -v apt-get === @false
-    checkSystem
+    checks_system
     @echo "$sys_type"
     @echo "$sep"
 }
 
-test-03-checkSystem-zypper-assert() {
+test-03-checks_system-zypper-assert() {
     sys_type="zypper"
     sep="-"
     @echo "$sys_type"
     @echo "$sep"
 }
 
-test-04-checkSystem-apt() {
-    load-checkSystem
+test-04-checks_system-apt() {
+    load-checks_system
     @mock command -v yum === @false
     @mock command -v zypper === @false
     @mock command -v apt-get === @echo /usr/bin/apt-get
-    checkSystem
+    checks_system
     echo "$sys_type"
     echo "$sep"
 }
 
-test-04-checkSystem-apt-assert() {
+test-04-checks_system-apt-assert() {
     sys_type="apt-get"
     sep="="
     echo "$sys_type"
     echo "$sep"
 }
 
-function load-checkNames() {
-    @load_function "${base_dir}/checks.sh" checkNames
+function load-checks_names() {
+    @load_function "${base_dir}/checks.sh" checks_names
 }
 
-test-ASSERT-FAIL-05-checkNames-elastic-kibana-equals() {
-    load-checkNames
+test-ASSERT-FAIL-05-checks_names-elastic-kibana-equals() {
+    load-checks_names
     einame="node1"
     kiname="node1"
-    checkNames
+    checks_names
 }
 
-test-ASSERT-FAIL-06-checkNames-elastic-wazuh-equals() {
-    load-checkNames
+test-ASSERT-FAIL-06-checks_names-elastic-wazuh-equals() {
+    load-checks_names
     einame="node1"
     winame="node1"
-    checkNames
+    checks_names
 }
 
-test-ASSERT-FAIL-07-checkNames-kibana-wazuh-equals() {
-    load-checkNames
+test-ASSERT-FAIL-07-checks_names-kibana-wazuh-equals() {
+    load-checks_names
     kiname="node1"
     winame="node1"
-    checkNames
+    checks_names
 }
 
-test-ASSERT-FAIL-08-checkNames-wazuh-node-name-not-in-config() {
-    load-checkNames
+test-ASSERT-FAIL-08-checks_names-wazuh-node-name-not-in-config() {
+    load-checks_names
     winame="node1"
     wazuh_servers_node_names=(wazuh node10)
     @mock echo ${wazuh_servers_node_names[@]} === @out wazuh node10
     @mock grep -w $winame === @false
-    checkNames
+    checks_names
 }
 
-test-ASSERT-FAIL-09-checkNames-kibana-node-name-not-in-config() {
-    load-checkNames
+test-ASSERT-FAIL-09-checks_names-kibana-node-name-not-in-config() {
+    load-checks_names
     kiname="node1"
     kibana_node_names=(kibana node10)
     @mock echo ${kibana_node_names[@]} === @out kibana node10
     @mock grep -w $kiname === @false
-    checkNames
+    checks_names
 }
 
-test-ASSERT-FAIL-10-checkNames-elasticsearch-node-name-not-in-config() {
-    load-checkNames
+test-ASSERT-FAIL-10-checks_names-elasticsearch-node-name-not-in-config() {
+    load-checks_names
     einame="node1"
     indexer_node_names=(elasticsearch node10)
     @mock echo ${indexer_node_names[@]} === @out elasticsearch node10
     @mock grep -w $einame === @false
-    checkNames
+    checks_names
 }
 
-test-11-checkNames-all-correct-installing-elastic() {
-    load-checkNames
+test-11-checks_names-all-correct-installing-elastic() {
+    load-checks_names
     einame="elasticsearch1"
     kiname="kibana1"
     winame="wazuh1"
@@ -137,12 +137,12 @@ test-11-checkNames-all-correct-installing-elastic() {
     @mock grep -w $einame
     @mock grep -w $winame
     @mock grep -w $kiname
-    checkNames
+    checks_names
     @assert-success
 }
 
-test-12-checkNames-all-correct-installing-wazuh() {
-    load-checkNames
+test-12-checks_names-all-correct-installing-wazuh() {
+    load-checks_names
     einame="elasticsearch1"
     kiname="kibana1"
     winame="wazuh1"
@@ -156,12 +156,12 @@ test-12-checkNames-all-correct-installing-wazuh() {
     @mock grep -w $einame
     @mock grep -w $winame
     @mock grep -w $kiname
-    checkNames
+    checks_names
     @assert-success
 }
 
-test-13-checkNames-all-correct-installing-kibana() {
-    load-checkNames
+test-13-checks_names-all-correct-installing-kibana() {
+    load-checks_names
     einame="elasticsearch1"
     kiname="kibana1"
     winame="wazuh1"
@@ -175,69 +175,69 @@ test-13-checkNames-all-correct-installing-kibana() {
     @mock grep -w $einame
     @mock grep -w $winame
     @mock grep -w $kiname
-    checkNames
+    checks_names
     @assert-success
 }
 
 
-function load-checkArch() {
-    @load_function "${base_dir}/checks.sh" checkArch
+function load-checks_arch() {
+    @load_function "${base_dir}/checks.sh" checks_arch
 }
 
-test-14-checkArch-x86_64() {
+test-14-checks_arch-x86_64() {
     @mock uname -m === @out x86_64
-    load-checkArch
-    checkArch
+    load-checks_arch
+    checks_arch
     @assert-success
 }
 
-test-ASSERT-FAIL-15-checkArch-empty() {
+test-ASSERT-FAIL-15-checks_arch-empty() {
     @mock uname -m === @out
-    load-checkArch
-    checkArch
+    load-checks_arch
+    checks_arch
 }
 
-test-ASSERT-FAIL-16-checkArch-i386() {
+test-ASSERT-FAIL-16-checks_arch-i386() {
     @mock uname -m === @out i386
-    load-checkArch
-    checkArch
+    load-checks_arch
+    checks_arch
 }
 
-function load-checkArguments {
-    @load_function "${base_dir}/checks.sh" checkArguments
+function load-checks_arguments {
+    @load_function "${base_dir}/checks.sh" checks_arguments
 }
 
-test-ASSERT-FAIL-17-checkArguments-install-aio-certs-file-present() {
-    load-checkArguments
+test-ASSERT-FAIL-17-checks_arguments-install-aio-certs-file-present() {
+    load-checks_arguments
     AIO=1
     tar_file="tarfile.tar"
     @touch $tar_file
-    checkArguments
+    checks_arguments
     @rm $tar_file
 
 }
 
-test-ASSERT-FAIL-18-checkArguments-certificate-creation-certs-file-present() {
-    load-checkArguments
+test-ASSERT-FAIL-18-checks_arguments-certificate-creation-certs-file-present() {
+    load-checks_arguments
     certificates=1
     tar_file="tarfile.tar"
     @touch $tar_file
-    checkArguments
+    checks_arguments
     @rm $tar_file
 }
 
-test-ASSERT-FAIL-19-checkArguments-overwrite-with-no-component-installed() {
-    load-checkArguments
+test-ASSERT-FAIL-19-checks_arguments-overwrite-with-no-component-installed() {
+    load-checks_arguments
     overwrite=1
     AIO=
     elasticsearch=
     wazuh=
     kibana=
-    checkArguments
+    checks_arguments
 }
 
-test-20-checkArguments-uninstall-no-component-installed() {
-    load-checkArguments
+test-20-checks_arguments-uninstall-no-component-installed() {
+    load-checks_arguments
     uninstall=1
     indexerchinstalled=""
     elastic_remaining_files=""
@@ -247,456 +247,456 @@ test-20-checkArguments-uninstall-no-component-installed() {
     kibana_remaining_files=""
     filebeatinstalled=""
     filebeat_remaining_files=""
-    checkArguments
+    checks_arguments
     @assert-success
 }
 
-test-ASSERT-FAIL-21-checkArguments-uninstall-and-aio() {
-    load-checkArguments
+test-ASSERT-FAIL-21-checks_arguments-uninstall-and-aio() {
+    load-checks_arguments
     uninstall=1
     AIO=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-22-checkArguments-uninstall-and-wazuh() {
-    load-checkArguments
+test-ASSERT-FAIL-22-checks_arguments-uninstall-and-wazuh() {
+    load-checks_arguments
     uninstall=1
     wazuh=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-23-checkArguments-uninstall-and-kibana() {
-    load-checkArguments
+test-ASSERT-FAIL-23-checks_arguments-uninstall-and-kibana() {
+    load-checks_arguments
     uninstall=1
     kibana=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-24-checkArguments-uninstall-and-elasticsearch() {
-    load-checkArguments
+test-ASSERT-FAIL-24-checks_arguments-uninstall-and-elasticsearch() {
+    load-checks_arguments
     uninstall=1
     elasticsearch=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-25-checkArguments-install-aio-and-elastic () {
-    load-checkArguments
+test-ASSERT-FAIL-25-checks_arguments-install-aio-and-elastic () {
+    load-checks_arguments
     AIO=1
     elasticsearch=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-26-checkArguments-install-aio-and-wazuh () {
-    load-checkArguments
+test-ASSERT-FAIL-26-checks_arguments-install-aio-and-wazuh () {
+    load-checks_arguments
     AIO=1
     wazuh=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-27-checkArguments-install-aio-and-kibana () {
-    load-checkArguments
+test-ASSERT-FAIL-27-checks_arguments-install-aio-and-kibana () {
+    load-checks_arguments
     AIO=1
     kibana=1
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-28-checkArguments-install-aio-wazuh-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-28-checks_arguments-install-aio-wazuh-installed-no-overwrite() {
+    load-checks_arguments
     AIO=1
     wazuhinstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-29-checkArguments-install-aio-wazuh-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-29-checks_arguments-install-aio-wazuh-files-no-overwrite() {
+    load-checks_arguments
     AIO=1
     wazuh_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-30-checkArguments-install-aio-elastic-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-30-checks_arguments-install-aio-elastic-installed-no-overwrite() {
+    load-checks_arguments
     AIO=1
     indexerchinstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-31-checkArguments-install-aio-elastic-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-31-checks_arguments-install-aio-elastic-files-no-overwrite() {
+    load-checks_arguments
     AIO=1
     elastic_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-32-checkArguments-install-aio-kibana-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-32-checks_arguments-install-aio-kibana-installed-no-overwrite() {
+    load-checks_arguments
     AIO=1
     kibanainstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-33-checkArguments-install-aio-kibana-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-33-checks_arguments-install-aio-kibana-files-no-overwrite() {
+    load-checks_arguments
     AIO=1
     kibana_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-34-checkArguments-install-aio-wazuh-installed-overwrite() {
-    load-checkArguments
+test-34-checks_arguments-install-aio-wazuh-installed-overwrite() {
+    load-checks_arguments
     AIO=1
     wazuhinstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-34-checkArguments-install-aio-wazuh-installed-overwrite-assert() {
-    rollBack
+test-34-checks_arguments-install-aio-wazuh-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-35-checkArguments-install-aio-wazuh-files-overwrite() {
-    load-checkArguments
+test-35-checks_arguments-install-aio-wazuh-files-overwrite() {
+    load-checks_arguments
     AIO=1
     wazuh_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-35-checkArguments-install-aio-wazuh-files-overwrite-assert() {
-    rollBack
+test-35-checks_arguments-install-aio-wazuh-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-36-checkArguments-install-aio-elastic-installed-overwrite() {
-    load-checkArguments
+test-36-checks_arguments-install-aio-elastic-installed-overwrite() {
+    load-checks_arguments
     AIO=1
     indexerchinstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-36-checkArguments-install-aio-elastic-installed-overwrite-assert() {
-    rollBack
+test-36-checks_arguments-install-aio-elastic-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-37-checkArguments-install-aio-elastic-files-overwrite() {
-    load-checkArguments
+test-37-checks_arguments-install-aio-elastic-files-overwrite() {
+    load-checks_arguments
     AIO=1
     elastic_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-37-checkArguments-install-aio-elastic-files-overwrite-assert() {
-    rollBack
+test-37-checks_arguments-install-aio-elastic-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-38-checkArguments-install-aio-kibana-installed-overwrite() {
-    load-checkArguments
+test-38-checks_arguments-install-aio-kibana-installed-overwrite() {
+    load-checks_arguments
     AIO=1
     kibanainstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-38-checkArguments-install-aio-kibana-installed-overwrite-assert() {
-    rollBack
+test-38-checks_arguments-install-aio-kibana-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-39-checkArguments-install-aio-kibana-files-overwrite() {
-    load-checkArguments
+test-39-checks_arguments-install-aio-kibana-files-overwrite() {
+    load-checks_arguments
     AIO=1
     kibana_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-39-checkArguments-install-aio-kibana-files-overwrite-assert() {
-    rollBack
+test-39-checks_arguments-install-aio-kibana-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-ASSERT-FAIL-40-checkArguments-install-elastic-already-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-40-checks_arguments-install-elastic-already-installed-no-overwrite() {
+    load-checks_arguments
     elasticsearch=1
     indexerchinstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-41-checkArguments-install-elastic-remaining-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-41-checks_arguments-install-elastic-remaining-files-no-overwrite() {
+    load-checks_arguments
     elasticsearch=1
     elastic_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-42-checkArguments-install-elastic-already-installed-overwrite() {
-    load-checkArguments
+test-42-checks_arguments-install-elastic-already-installed-overwrite() {
+    load-checks_arguments
     elasticsearch=1
     indexerchinstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-42-checkArguments-install-elastic-already-installed-overwrite-assert() {
-    rollBack
+test-42-checks_arguments-install-elastic-already-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-43-checkArguments-install-elastic-remaining-files-overwrite() {
-    load-checkArguments
+test-43-checks_arguments-install-elastic-remaining-files-overwrite() {
+    load-checks_arguments
     elasticsearch=1
     elastic_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-43-checkArguments-install-elastic-remaining-files-overwrite-assert() {
-    rollBack
+test-43-checks_arguments-install-elastic-remaining-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-ASSERT-FAIL-44-checkArguments-install-wazuh-already-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-44-checks_arguments-install-wazuh-already-installed-no-overwrite() {
+    load-checks_arguments
     wazuh=1
     wazuhinstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-45-checkArguments-install-wazuh-remaining-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-45-checks_arguments-install-wazuh-remaining-files-no-overwrite() {
+    load-checks_arguments
     wazuh=1
     wazuh_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-46-checkArguments-install-wazuh-already-installed-overwrite() {
-    load-checkArguments
+test-46-checks_arguments-install-wazuh-already-installed-overwrite() {
+    load-checks_arguments
     wazuh=1
     wazuhinstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-46-checkArguments-install-wazuh-already-installed-overwrite-assert() {
-    rollBack
+test-46-checks_arguments-install-wazuh-already-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-47-checkArguments-install-wazuh-remaining-files-overwrite() {
-    load-checkArguments
+test-47-checks_arguments-install-wazuh-remaining-files-overwrite() {
+    load-checks_arguments
     wazuh=1
     wazuh_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-47-checkArguments-install-wazuh-remaining-files-overwrite-assert() {
-    rollBack
+test-47-checks_arguments-install-wazuh-remaining-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-ASSERT-FAIL-48-checkArguments-install-wazuh-filebeat-already-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-48-checks_arguments-install-wazuh-filebeat-already-installed-no-overwrite() {
+    load-checks_arguments
     wazuh=1
     filebeatinstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-49-checkArguments-install-wazuh-filebeat-remaining-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-49-checks_arguments-install-wazuh-filebeat-remaining-files-no-overwrite() {
+    load-checks_arguments
     wazuh=1
     filebeat_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-50-checkArguments-install-wazuh-filebeat-already-installed-overwrite() {
-    load-checkArguments
+test-50-checks_arguments-install-wazuh-filebeat-already-installed-overwrite() {
+    load-checks_arguments
     wazuh=1
     filebeatinstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-50-checkArguments-install-wazuh-filebeat-already-installed-overwrite-assert() {
-    rollBack
+test-50-checks_arguments-install-wazuh-filebeat-already-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-51-checkArguments-install-wazuh-filebeat-remaining-files-overwrite() {
-    load-checkArguments
+test-51-checks_arguments-install-wazuh-filebeat-remaining-files-overwrite() {
+    load-checks_arguments
     wazuh=1
     filebeat_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-51-checkArguments-install-wazuh-filebeat-remaining-files-overwrite-assert() {
-    rollBack
+test-51-checks_arguments-install-wazuh-filebeat-remaining-files-overwrite-assert() {
+    common_rollBack
 }
 
-test-ASSERT-FAIL-52-checkArguments-install-kibana-already-installed-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-52-checks_arguments-install-kibana-already-installed-no-overwrite() {
+    load-checks_arguments
     kibana=1
     kibanainstalled=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-ASSERT-FAIL-53-checkArguments-install-kibana-remaining-files-no-overwrite() {
-    load-checkArguments
+test-ASSERT-FAIL-53-checks_arguments-install-kibana-remaining-files-no-overwrite() {
+    load-checks_arguments
     kibana=1
     kibana_remaining_files=1
     overwrite=
-    checkArguments
+    checks_arguments
 }
 
-test-54-checkArguments-install-kibana-already-installed-overwrite() {
-    load-checkArguments
+test-54-checks_arguments-install-kibana-already-installed-overwrite() {
+    load-checks_arguments
     kibana=1
     kibanainstalled=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-54-checkArguments-install-kibana-already-installed-overwrite-assert() {
-    rollBack
+test-54-checks_arguments-install-kibana-already-installed-overwrite-assert() {
+    common_rollBack
 }
 
-test-55-checkArguments-install-kibana-remaining-files-overwrite() {
-    load-checkArguments
+test-55-checks_arguments-install-kibana-remaining-files-overwrite() {
+    load-checks_arguments
     kibana=1
     kibana_remaining_files=1
     overwrite=1
-    checkArguments
+    checks_arguments
 }
 
-test-55-checkArguments-install-kibana-remaining-files-overwrite-assert() {
-    rollBack
+test-55-checks_arguments-install-kibana-remaining-files-overwrite-assert() {
+    common_rollBack
 }
 
-function load-checkHealth() {
-    @load_function "${base_dir}/checks.sh" checkHealth
-    @mocktrue checkSpecs
+function load-checks_health() {
+    @load_function "${base_dir}/checks.sh" checks_health
+    @mocktrue checks_specifications
 }
 
-test-56-checkHealth-no-installation() {
-    load-checkHealth
-    checkHealth
+test-56-checks_health-no-installation() {
+    load-checks_health
+    checks_health
     @assert-success
 }
 
-test-ASSERT-FAIL-57-checkHealth-AIO-1-core-3700-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-57-checks_health-AIO-1-core-3700-ram() {
+    load-checks_health
     cores=1
     ram_gb=3700
     aio=1
-    checkHealth
+    checks_health
 }
 
-test-ASSERT-FAIL-58-checkHealth-AIO-2-cores-3000-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-58-checks_health-AIO-2-cores-3000-ram() {
+    load-checks_health
     cores=2
     ram_gb=3000
     aio=1
-    checkHealth
+    checks_health
 }
 
-test-59-checkHealth-AIO-2-cores-4gb() {
-    load-checkHealth
+test-59-checks_health-AIO-2-cores-4gb() {
+    load-checks_health
     cores=2
     ram_gb=3700
     aio=1
-    checkHealth
+    checks_health
     @assert-success
 }
 
-test-ASSERT-FAIL-60-checkHealth-elasticsearch-1-core-3700-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-60-checks_health-elasticsearch-1-core-3700-ram() {
+    load-checks_health
     cores=1
     ram_gb=3700
     elasticsearch=1
-    checkHealth
+    checks_health
 }
 
-test-ASSERT-FAIL-61-checkHealth-elasticsearch-2-cores-3000-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-61-checks_health-elasticsearch-2-cores-3000-ram() {
+    load-checks_health
     cores=2
     ram_gb=3000
     elasticsearch=1
-    checkHealth
+    checks_health
 }
 
-test-62-checkHealth-elasticsearch-2-cores-3700-ram() {
-    load-checkHealth
+test-62-checks_health-elasticsearch-2-cores-3700-ram() {
+    load-checks_health
     cores=2
     ram_gb=3700
     elasticsearch=1
-    checkHealth
+    checks_health
     @assert-success
 }
 
-test-ASSERT-FAIL-63-checkHealth-kibana-1-core-3700-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-63-checks_health-kibana-1-core-3700-ram() {
+    load-checks_health
     cores=1
     ram_gb=3700
     kibana=1
-    checkHealth
+    checks_health
 }
 
-test-ASSERT-FAIL-64-checkHealth-kibana-2-cores-3000-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-64-checks_health-kibana-2-cores-3000-ram() {
+    load-checks_health
     cores=2
     ram_gb=3000
     kibana=1
-    checkHealth
+    checks_health
 }
 
-test-65-checkHealth-kibana-2-cores-3700-ram() {
-    load-checkHealth
+test-65-checks_health-kibana-2-cores-3700-ram() {
+    load-checks_health
     cores=2
     ram_gb=3700
     kibana=1
-    checkHealth
+    checks_health
     @assert-success
 }
 
-test-ASSERT-FAIL-66-checkHealth-wazuh-1-core-1700-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-66-checks_health-wazuh-1-core-1700-ram() {
+    load-checks_health
     cores=1
     ram_gb=1700
     wazuh=1
-    checkHealth
+    checks_health
 }
 
-test-ASSERT-FAIL-67-checkHealth-wazuh-2-cores-1000-ram() {
-    load-checkHealth
+test-ASSERT-FAIL-67-checks_health-wazuh-2-cores-1000-ram() {
+    load-checks_health
     cores=2
     ram_gb=1000
     wazuh=1
-    checkHealth
+    checks_health
 }
 
-test-68-checkHealth-wazuh-2-cores-1700-ram() {
-    load-checkHealth
+test-68-checks_health-wazuh-2-cores-1700-ram() {
+    load-checks_health
     cores=2
     ram_gb=1700
     wazuh=1
-    checkHealth
+    checks_health
     @assert-success
 }
 
-function load-checkIfInstalled() {
-    @load_function "${base_dir}/checks.sh" checkIfInstalled
+function load-checks_installed() {
+    @load_function "${base_dir}/checks.sh" checks_installed
 }
 
-test-69-checkIfInstalled-all-installed-yum() {
-    load-checkIfInstalled
+test-69-checks_installed-all-installed-yum() {
+    load-checks_installed
     sys_type="yum"
 
     @mocktrue yum list installed
@@ -720,7 +720,7 @@ test-69-checkIfInstalled-all-installed-yum() {
     @mkdir /usr/share/kibana
     @mkdir /etc/kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
     @rmdir /var/ossec
@@ -745,7 +745,7 @@ test-69-checkIfInstalled-all-installed-yum() {
 
 }
 
-test-69-checkIfInstalled-all-installed-yum-assert() {
+test-69-checks_installed-all-installed-yum-assert() {
     @echo "wazuh-manager.x86_64 4.3.0-1 @wazuh"
     @echo 1
 
@@ -759,8 +759,8 @@ test-69-checkIfInstalled-all-installed-yum-assert() {
     @echo 1
 }
 
-test-70-checkIfInstalled-all-installed-zypper() {
-    load-checkIfInstalled
+test-70-checks_installed-all-installed-zypper() {
+    load-checks_installed
     sys_type="zypper"
 
     @mocktrue zypper packages
@@ -785,7 +785,7 @@ test-70-checkIfInstalled-all-installed-zypper() {
     @mkdir /usr/share/kibana
     @mkdir /etc/kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
     @rmdir /var/ossec
@@ -810,7 +810,7 @@ test-70-checkIfInstalled-all-installed-zypper() {
 
 }
 
-test-70-checkIfInstalled-all-installed-zypper-assert() {
+test-70-checks_installed-all-installed-zypper-assert() {
     @echo "i+ | EL-20211102 - Wazuh | wazuh-manager | 4.3.0-1 | x86_64"
     @echo 1
 
@@ -824,8 +824,8 @@ test-70-checkIfInstalled-all-installed-zypper-assert() {
     @echo 1
 }
 
-test-71-checkIfInstalled-all-installed-apt() {
-    load-checkIfInstalled
+test-71-checks_installed-all-installed-apt() {
+    load-checks_installed
     sys_type="apt-get"
 
     @mocktrue apt list --installed
@@ -849,7 +849,7 @@ test-71-checkIfInstalled-all-installed-apt() {
     @mkdir /usr/share/kibana
     @mkdir /etc/kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
     @rmdir /var/ossec
@@ -874,7 +874,7 @@ test-71-checkIfInstalled-all-installed-apt() {
 
 }
 
-test-71-checkIfInstalled-all-installed-apt-assert() {
+test-71-checks_installed-all-installed-apt-assert() {
     @echo "wazuh-manager/now 4.2.5-1 amd64 [installed,local]"
     @echo 1
 
@@ -888,8 +888,8 @@ test-71-checkIfInstalled-all-installed-apt-assert() {
     @echo 1
 }
 
-test-72-checkIfInstalled-nothing-installed-apt() {
-    load-checkIfInstalled
+test-72-checks_installed-nothing-installed-apt() {
+    load-checks_installed
     sys_type="apt-get"
 
     @mocktrue apt list --installed
@@ -903,7 +903,7 @@ test-72-checkIfInstalled-nothing-installed-apt() {
 
     @mock grep opendistroforelasticsearch-kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
 
@@ -917,7 +917,7 @@ test-72-checkIfInstalled-nothing-installed-apt() {
     @echo $kibana_remaining_files
 }
 
-test-72-checkIfInstalled-nothing-installed-apt-assert() {
+test-72-checks_installed-nothing-installed-apt-assert() {
     @echo ""
     @echo ""
 
@@ -931,8 +931,8 @@ test-72-checkIfInstalled-nothing-installed-apt-assert() {
     @echo ""
 }
 
-test-73-checkIfInstalled-nothing-installed-yum() {
-    load-checkIfInstalled
+test-73-checks_installed-nothing-installed-yum() {
+    load-checks_installed
     sys_type="yum"
 
     @mocktrue yum list installed
@@ -946,7 +946,7 @@ test-73-checkIfInstalled-nothing-installed-yum() {
 
     @mock grep opendistroforelasticsearch-kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
 
@@ -960,7 +960,7 @@ test-73-checkIfInstalled-nothing-installed-yum() {
     @echo $kibana_remaining_files
 }
 
-test-73-checkIfInstalled-nothing-installed-yum-assert() {
+test-73-checks_installed-nothing-installed-yum-assert() {
     @echo ""
     @echo ""
 
@@ -974,8 +974,8 @@ test-73-checkIfInstalled-nothing-installed-yum-assert() {
     @echo ""
 }
 
-test-74-checkIfInstalled-nothing-installed-zypper() {
-    load-checkIfInstalled
+test-74-checks_installed-nothing-installed-zypper() {
+    load-checks_installed
     sys_type="zypper"
 
     @mocktrue zypper packages
@@ -990,7 +990,7 @@ test-74-checkIfInstalled-nothing-installed-zypper() {
 
     @mock grep opendistroforelasticsearch-kibana
 
-    checkIfInstalled
+    checks_installed
     @echo $wazuhinstalled
     @echo $wazuh_remaining_files
 
@@ -1004,7 +1004,7 @@ test-74-checkIfInstalled-nothing-installed-zypper() {
     @echo $kibana_remaining_files
 }
 
-test-74-checkIfInstalled-nothing-installed-zypper-assert() {
+test-74-checks_installed-nothing-installed-zypper-assert() {
     @echo ""
     @echo ""
 
@@ -1018,57 +1018,57 @@ test-74-checkIfInstalled-nothing-installed-zypper-assert() {
     @echo ""
 }
 
-function load-checkPreviousCertificates() {
-    @load_function "${base_dir}/checks.sh" checkPreviousCertificates
+function load-checks_previousCertificate() {
+    @load_function "${base_dir}/checks.sh" checks_previousCertificate
 }
 
-test-ASSERT-FAIL-75-checkPreviousCertificates-no-tar_file() {
-    load-checkPreviousCertificates
+test-ASSERT-FAIL-75-checks_previousCertificate-no-tar_file() {
+    load-checks_previousCertificate
     tar_file=/tmp/tarfile.tar
     if [ -f $tar_file ]; then
         @rm $tar_file
     fi
-    checkPreviousCertificates
+    checks_previousCertificate
 }
 
-test-ASSERT-FAIL-76-checkPreviousCertificates-einame-not-in-tar_file() {
-    load-checkPreviousCertificates
+test-ASSERT-FAIL-76-checks_previousCertificate-einame-not-in-tar_file() {
+    load-checks_previousCertificate
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
     @mock tar -tf tarfile.tar
     einame="elastic1"
     @mockfalse grep -q elastic1.pem
     @mockfalse grep -q elastic1-key.pem
-    checkPreviousCertificates
+    checks_previousCertificate
     @rm /tmp/tarfile.tar
 }
 
-test-ASSERT-FAIL-77-checkPreviousCertificates-kiname-not-in-tar_file() {
-    load-checkPreviousCertificates
+test-ASSERT-FAIL-77-checks_previousCertificate-kiname-not-in-tar_file() {
+    load-checks_previousCertificate
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
     @mock tar -tf tarfile.tar
     kiname="kibana1"
     @mockfalse grep -q kibana1.pem
     @mockfalse grep -q kibana1-key.pem
-    checkPreviousCertificates
+    checks_previousCertificate
     @rm /tmp/tarfile.tar
 }
 
-test-ASSERT-FAIL-78-checkPreviousCertificates-winame-not-in-tar_file() {
-    load-checkPreviousCertificates
+test-ASSERT-FAIL-78-checks_previousCertificate-winame-not-in-tar_file() {
+    load-checks_previousCertificate
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
     @mock tar -tf tarfile.tar
     winame="wazuh1"
     @mockfalse grep -q wazuh1.pem
     @mockfalse grep -q wazuh1-key.pem
-    checkPreviousCertificates
+    checks_previousCertificate
     @rm /tmp/tarfile.tar
 }
 
-test-79-checkPreviousCertificates-all-correct() {
-    load-checkPreviousCertificates
+test-79-checks_previousCertificate-all-correct() {
+    load-checks_previousCertificate
     tar_file=/tmp/tarfile.tar
     @touch /tmp/tarfile.tar
     @mock tar -tf tarfile.tar
@@ -1081,7 +1081,7 @@ test-79-checkPreviousCertificates-all-correct() {
     kiname="kibana1"
     @mocktrue grep -q kibana1.pem
     @mocktrue grep -q kibana1-key.pem
-    checkPreviousCertificates
+    checks_previousCertificate
     @assert-success
     @rm /tmp/tarfile.tar
 }

--- a/tests/unattended/unit/suites/test-common.sh
+++ b/tests/unattended/unit/suites/test-common.sh
@@ -157,12 +157,12 @@ test-12-common_installPrerequisites-apt-assert() {
     apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg -y
 }
 
-function load-common_addWazuhrepo() {
-    @load_function "${base_dir}/common.sh" common_addWazuhrepo
+function load-common_addWazuhRepo() {
+    @load_function "${base_dir}/common.sh" common_addWazuhRepo
 }
 
-test-13-common_addWazuhrepo-yum() {
-    load-common_addWazuhrepo
+test-13-common_addWazuhRepo-yum() {
+    load-common_addWazuhRepo
     development=1
     sys_type="yum"
     debug=""
@@ -170,16 +170,16 @@ test-13-common_addWazuhrepo-yum() {
     releasever=""
     @mocktrue echo -e '[wazuh]\ngpgcheck=1\ngpgkey=\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=/yum/\nprotect=1'
     @mocktrue tee /etc/yum.repos.d/wazuh.repo
-    common_addWazuhrepo
+    common_addWazuhRepo
 }
 
-test-13-common_addWazuhrepo-yum-assert() {
+test-13-common_addWazuhRepo-yum-assert() {
     rm -f /etc/yum.repos.d/wazuh.repo
     rpm --import
 }
 
-test-14-common_addWazuhrepo-zypper() {
-    load-common_addWazuhrepo
+test-14-common_addWazuhRepo-zypper() {
+    load-common_addWazuhRepo
     development=1
     sys_type="zypper"
     debug=""
@@ -190,16 +190,16 @@ test-14-common_addWazuhrepo-zypper() {
     @rm /etc/apt/sources.list.d/wazuh.list
     @mocktrue echo -e '[wazuh]\ngpgcheck=1\ngpgkey=\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=/yum/\nprotect=1'
     @mocktrue tee /etc/zypp/repos.d/wazuh.repo
-    common_addWazuhrepo
+    common_addWazuhRepo
 }
 
-test-14-common_addWazuhrepo-zypper-assert() {
+test-14-common_addWazuhRepo-zypper-assert() {
     rm -f /etc/zypp/repos.d/wazuh.repo
     rpm --import
 }
 
-test-15-common_addWazuhrepo-apt() {
-    load-common_addWazuhrepo
+test-15-common_addWazuhRepo-apt() {
+    load-common_addWazuhRepo
     development=1
     sys_type="apt-get"
     debug=""
@@ -212,40 +212,40 @@ test-15-common_addWazuhrepo-apt() {
     @mocktrue apt-key add -
     @mocktrue echo "deb /apt/  main"
     @mocktrue tee /etc/apt/sources.list.d/wazuh.list
-    common_addWazuhrepo
+    common_addWazuhRepo
 }
 
-test-15-common_addWazuhrepo-apt-assert() {
+test-15-common_addWazuhRepo-apt-assert() {
     rm -f /etc/apt/sources.list.d/wazuh.list
     apt-get update -q
 }
 
-test-16-common_addWazuhrepo-apt-file-present() {
-    load-common_addWazuhrepo
+test-16-common_addWazuhRepo-apt-file-present() {
+    load-common_addWazuhRepo
     development=""
     @mkdir -p /etc/yum.repos.d
     @touch /etc/yum.repos.d/wazuh.repo
-    common_addWazuhrepo
+    common_addWazuhRepo
     @assert-success
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-17-common_addWazuhrepo-zypper-file-present() {
-    load-common_addWazuhrepo
+test-17-common_addWazuhRepo-zypper-file-present() {
+    load-common_addWazuhRepo
     development=""
     @mkdir -p /etc/zypp/repos.d/
     @touch /etc/zypp/repos.d/wazuh.repo
-    common_addWazuhrepo
+    common_addWazuhRepo
     @assert-success
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-18-common_addWazuhrepo-yum-file-present() {
-    load-common_addWazuhrepo
+test-18-common_addWazuhRepo-yum-file-present() {
+    load-common_addWazuhRepo
     development=""
     @mkdir -p /etc/apt/sources.list.d/
     @touch /etc/apt/sources.list.d/wazuh.list
-    common_addWazuhrepo
+    common_addWazuhRepo
     @assert-success
     @rm /etc/apt/sources.list.d/wazuh.list
 }

--- a/tests/unattended/unit/suites/test-common.sh
+++ b/tests/unattended/unit/suites/test-common.sh
@@ -7,162 +7,162 @@ source "${base_dir}"/bach.sh
     @ignore logger
 }
 
-function load-getConfig() {
-    @load_function "${base_dir}/common.sh" getConfig
+function load-common_getConfig() {
+    @load_function "${base_dir}/common.sh" common_getConfig
 }
 
-test-ASSERT-FAIL-01-getConfig-no-args() {
-    load-getConfig
-    getConfig
+test-ASSERT-FAIL-01-common_getConfig-no-args() {
+    load-common_getConfig
+    common_getConfig
 }
 
-test-ASSERT-FAIL-02-getConfig-one-argument() {
-    load-getConfig
-    getConfig "elasticsearch"
+test-ASSERT-FAIL-02-common_getConfig-one-argument() {
+    load-common_getConfig
+    common_getConfig "elasticsearch"
 }
 
-test-03-getConfig-local() {
-    load-getConfig
+test-03-common_getConfig-local() {
+    load-common_getConfig
     base_path="/tmp"
     config_path="example"
     local=1
-    getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
+    common_getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
 }
 
-test-03-getConfig-local-assert() {
+test-03-common_getConfig-local-assert() {
     cp /tmp/example/opensearch.yml /tmp/elasticsearch/opensearch.yml
 }
 
-test-04-getConfig-online() {
-    load-getConfig
+test-04-common_getConfig-online() {
+    load-common_getConfig
     base_path="/tmp"
     config_path="example"
     resources_config="example.com/config"
     local=
-    getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
+    common_getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
 }
 
-test-04-getConfig-online-assert() {
+test-04-common_getConfig-online-assert() {
     curl -f -so /tmp/elasticsearch/opensearch.yml example.com/config/opensearch.yml
 }
 
-test-05-getConfig-local-error() {
-    load-getConfig
+test-05-common_getConfig-local-error() {
+    load-common_getConfig
     base_path="/tmp"
     config_path="example"
     local=1
     @mockfalse cp /tmp/example/opensearch.yml /tmp/elasticsearch/opensearch.yml
-    getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
+    common_getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
 }
 
-test-05-getConfig-local-error-assert() {
-    rollBack
+test-05-common_getConfig-local-error-assert() {
+    common_rollBack
     exit 1
 }
 
-test-06-getConfig-online-error() {
-    load-getConfig
+test-06-common_getConfig-online-error() {
+    load-common_getConfig
     base_path="/tmp"
     config_path="example"
     resources_config="example.com/config"
     local=
     @mockfalse curl -f -so /tmp/elasticsearch/opensearch.yml example.com/config/opensearch.yml
-    getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
+    common_getConfig opensearch.yml /tmp/elasticsearch/opensearch.yml
 }
 
-test-06-getConfig-online-error-assert() {
-    rollBack
+test-06-common_getConfig-online-error-assert() {
+    common_rollBack
     exit 1
 }
 
-function load-installPrerequisites() {
-    @load_function "${base_dir}/common.sh" installPrerequisites
+function load-common_installPrerequisites() {
+    @load_function "${base_dir}/common.sh" common_installPrerequisites
 }
 
-test-07-installPrerequisites-yum-no-openssl() {
+test-07-common_installPrerequisites-yum-no-openssl() {
     @mock command -v openssl === @false
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="yum"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-07-installPrerequisites-yum-no-openssl-assert() {
+test-07-common_installPrerequisites-yum-no-openssl-assert() {
     yum install curl unzip wget libcap tar gnupg openssl -y
 }
 
-test-08-installPrerequisites-yum() {
+test-08-common_installPrerequisites-yum() {
     @mock command -v openssl === @echo /usr/bin/openssl
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="yum"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-08-installPrerequisites-yum-assert() {
+test-08-common_installPrerequisites-yum-assert() {
     yum install curl unzip wget libcap tar gnupg -y
 }
 
-test-09-installPrerequisites-zypper-no-openssl() {
+test-09-common_installPrerequisites-zypper-no-openssl() {
     @mock command -v openssl === @false
     @mocktrue zypper -n install libcap-progs tar gnupg
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="zypper"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-09-installPrerequisites-zypper-no-openssl-assert() {
+test-09-common_installPrerequisites-zypper-no-openssl-assert() {
     zypper -n install curl unzip wget
     zypper -n install libcap-progs tar gnupg openssl
 }
 
-test-10-installPrerequisites-zypper-no-libcap-progs() {
+test-10-common_installPrerequisites-zypper-no-libcap-progs() {
     @mock command -v openssl === @out /usr/bin/openssl
     @mockfalse zypper -n install libcap-progs tar gnupg
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="zypper"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-10-installPrerequisites-zypper-no-libcap-progs-assert() {
+test-10-common_installPrerequisites-zypper-no-libcap-progs-assert() {
     zypper -n install curl unzip wget
     zypper -n install libcap2 tar gnupg
 }
 
-test-11-installPrerequisites-apt-no-openssl() {
+test-11-common_installPrerequisites-apt-no-openssl() {
     @mock command -v openssl === @false
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="apt-get"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-11-installPrerequisites-apt-no-openssl-assert() {
+test-11-common_installPrerequisites-apt-no-openssl-assert() {
     apt-get update -q
     apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg openssl -y
 }
 
-test-12-installPrerequisites-apt() {
+test-12-common_installPrerequisites-apt() {
     @mock command -v openssl === @out /usr/bin/openssl
-    load-installPrerequisites
+    load-common_installPrerequisites
     sys_type="apt-get"
     debug=""
-    installPrerequisites
+    common_installPrerequisites
 }
 
-test-12-installPrerequisites-apt-assert() {
+test-12-common_installPrerequisites-apt-assert() {
     apt-get update -q
     apt-get install apt-transport-https curl unzip wget libcap2-bin tar gnupg -y
 }
 
-function load-addWazuhrepo() {
-    @load_function "${base_dir}/common.sh" addWazuhrepo
+function load-common_addWazuhrepo() {
+    @load_function "${base_dir}/common.sh" common_addWazuhrepo
 }
 
-test-13-addWazuhrepo-yum() {
-    load-addWazuhrepo
+test-13-common_addWazuhrepo-yum() {
+    load-common_addWazuhrepo
     development=1
     sys_type="yum"
     debug=""
@@ -170,16 +170,16 @@ test-13-addWazuhrepo-yum() {
     releasever=""
     @mocktrue echo -e '[wazuh]\ngpgcheck=1\ngpgkey=\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=/yum/\nprotect=1'
     @mocktrue tee /etc/yum.repos.d/wazuh.repo
-    addWazuhrepo
+    common_addWazuhrepo
 }
 
-test-13-addWazuhrepo-yum-assert() {
+test-13-common_addWazuhrepo-yum-assert() {
     rm -f /etc/yum.repos.d/wazuh.repo
     rpm --import
 }
 
-test-14-addWazuhrepo-zypper() {
-    load-addWazuhrepo
+test-14-common_addWazuhrepo-zypper() {
+    load-common_addWazuhrepo
     development=1
     sys_type="zypper"
     debug=""
@@ -190,16 +190,16 @@ test-14-addWazuhrepo-zypper() {
     @rm /etc/apt/sources.list.d/wazuh.list
     @mocktrue echo -e '[wazuh]\ngpgcheck=1\ngpgkey=\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=/yum/\nprotect=1'
     @mocktrue tee /etc/zypp/repos.d/wazuh.repo
-    addWazuhrepo
+    common_addWazuhrepo
 }
 
-test-14-addWazuhrepo-zypper-assert() {
+test-14-common_addWazuhrepo-zypper-assert() {
     rm -f /etc/zypp/repos.d/wazuh.repo
     rpm --import
 }
 
-test-15-addWazuhrepo-apt() {
-    load-addWazuhrepo
+test-15-common_addWazuhrepo-apt() {
+    load-common_addWazuhrepo
     development=1
     sys_type="apt-get"
     debug=""
@@ -212,164 +212,164 @@ test-15-addWazuhrepo-apt() {
     @mocktrue apt-key add -
     @mocktrue echo "deb /apt/  main"
     @mocktrue tee /etc/apt/sources.list.d/wazuh.list
-    addWazuhrepo
+    common_addWazuhrepo
 }
 
-test-15-addWazuhrepo-apt-assert() {
+test-15-common_addWazuhrepo-apt-assert() {
     rm -f /etc/apt/sources.list.d/wazuh.list
     apt-get update -q
 }
 
-test-16-addWazuhrepo-apt-file-present() {
-    load-addWazuhrepo
+test-16-common_addWazuhrepo-apt-file-present() {
+    load-common_addWazuhrepo
     development=""
     @mkdir -p /etc/yum.repos.d
     @touch /etc/yum.repos.d/wazuh.repo
-    addWazuhrepo
+    common_addWazuhrepo
     @assert-success
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-17-addWazuhrepo-zypper-file-present() {
-    load-addWazuhrepo
+test-17-common_addWazuhrepo-zypper-file-present() {
+    load-common_addWazuhrepo
     development=""
     @mkdir -p /etc/zypp/repos.d/
     @touch /etc/zypp/repos.d/wazuh.repo
-    addWazuhrepo
+    common_addWazuhrepo
     @assert-success
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-18-addWazuhrepo-yum-file-present() {
-    load-addWazuhrepo
+test-18-common_addWazuhrepo-yum-file-present() {
+    load-common_addWazuhrepo
     development=""
     @mkdir -p /etc/apt/sources.list.d/
     @touch /etc/apt/sources.list.d/wazuh.list
-    addWazuhrepo
+    common_addWazuhrepo
     @assert-success
     @rm /etc/apt/sources.list.d/wazuh.list
 }
 
-function load-restoreWazuhrepo() {
-    @load_function "${base_dir}/common.sh" restoreWazuhrepo
+function load-common_restoreWazuhrepo() {
+    @load_function "${base_dir}/common.sh" common_restoreWazuhrepo
 }
 
-test-19-restoreWazuhrepo-no-dev() {
-    load-restoreWazuhrepo
+test-19-common_restoreWazuhrepo-no-dev() {
+    load-common_restoreWazuhrepo
     development=""
-    restoreWazuhrepo
+    common_restoreWazuhrepo
     @assert-success
 }
 
-test-20-restoreWazuhrepo-yum() {
-    load-restoreWazuhrepo
+test-20-common_restoreWazuhrepo-yum() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="yum"
     @mkdir -p /etc/yum.repos.d
     @touch /etc/yum.repos.d/wazuh.repo
-    restoreWazuhrepo
+    common_restoreWazuhrepo
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-20-restoreWazuhrepo-yum-assert() {
+test-20-common_restoreWazuhrepo-yum-assert() {
     sed -i 's/-dev//g' /etc/yum.repos.d/wazuh.repo
     sed -i 's/pre-release/4.x/g' /etc/yum.repos.d/wazuh.repo
     sed -i 's/unstable/stable/g' /etc/yum.repos.d/wazuh.repo
 }
 
-test-21-restoreWazuhrepo-apt() {
-    load-restoreWazuhrepo
+test-21-common_restoreWazuhrepo-apt() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="apt-get"
     @mkdir -p /etc/apt/sources.list.d/
     @touch /etc/apt/sources.list.d/wazuh.list
-    restoreWazuhrepo
+    common_restoreWazuhrepo
     @rm /etc/apt/sources.list.d/wazuh.list
 }
 
-test-21-restoreWazuhrepo-apt-assert() {
+test-21-common_restoreWazuhrepo-apt-assert() {
     sed -i 's/-dev//g' /etc/apt/sources.list.d/wazuh.list
     sed -i 's/pre-release/4.x/g' /etc/apt/sources.list.d/wazuh.list
     sed -i 's/unstable/stable/g' /etc/apt/sources.list.d/wazuh.list
 }
 
-test-22-restoreWazuhrepo-zypper() {
-    load-restoreWazuhrepo
+test-22-common_restoreWazuhrepo-zypper() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="zypper"
     @mkdir -p /etc/zypp/repos.d/
     @touch /etc/zypp/repos.d/wazuh.repo
-    restoreWazuhrepo
+    common_restoreWazuhrepo
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-22-restoreWazuhrepo-zypper-assert() {
+test-22-common_restoreWazuhrepo-zypper-assert() {
     sed -i 's/-dev//g' /etc/zypp/repos.d/wazuh.repo
     sed -i 's/pre-release/4.x/g' /etc/zypp/repos.d/wazuh.repo
     sed -i 's/unstable/stable/g' /etc/zypp/repos.d/wazuh.repo
 }
 
-test-23-restoreWazuhrepo-yum-no-file() {
-    load-restoreWazuhrepo
+test-23-common_restoreWazuhrepo-yum-no-file() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="yum"
-    restoreWazuhrepo
+    common_restoreWazuhrepo
 }
 
-test-23-restoreWazuhrepo-yum-no-file-assert() {
+test-23-common_restoreWazuhrepo-yum-no-file-assert() {
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
     sed -i 's/unstable/stable/g'
 }
 
-test-24-restoreWazuhrepo-apt-no-file() {
-    load-restoreWazuhrepo
+test-24-common_restoreWazuhrepo-apt-no-file() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="yum"
-    restoreWazuhrepo
+    common_restoreWazuhrepo
 }
 
-test-24-restoreWazuhrepo-apt-no-file-assert() {
+test-24-common_restoreWazuhrepo-apt-no-file-assert() {
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
     sed -i 's/unstable/stable/g'
 }
 
-test-25-restoreWazuhrepo-zypper-no-file() {
-    load-restoreWazuhrepo
+test-25-common_restoreWazuhrepo-zypper-no-file() {
+    load-common_restoreWazuhrepo
     development="1"
     sys_type="yum"
-    restoreWazuhrepo
+    common_restoreWazuhrepo
 }
 
-test-25-restoreWazuhrepo-zypper-no-file-assert() {
+test-25-common_restoreWazuhrepo-zypper-no-file-assert() {
     file="/etc/zypp/repos.d/wazuh.repo"
     sed -i 's/-dev//g'
     sed -i 's/pre-release/4.x/g'
     sed -i 's/unstable/stable/g'
 }
 
-function load-createClusterKey {
-    @load_function "${base_dir}/common.sh" createClusterKey
+function load-common_createClusterKey {
+    @load_function "${base_dir}/common.sh" common_createClusterKey
 }
 
-test-26-createClusterKey() {
-    load-createClusterKey
+test-26-common_createClusterKey() {
+    load-common_createClusterKey
     base_path=/tmp
     @mkdir -p /tmp/certs
     @touch /tmp/certs/clusterkey
     @mocktrue openssl rand -hex 16
-    createClusterKey
+    common_createClusterKey
     @assert-success
     @rm /tmp/certs/clusterkey
 }
 
-function load-rollBack {
-    @load_function "${base_dir}/common.sh" rollBack
+function load-common_rollBack {
+    @load_function "${base_dir}/common.sh" common_rollBack
 }
 
-test-27-rollBack-aio-all-installed-yum() {
-    load-rollBack
+test-27-common_rollBack-aio-all-installed-yum() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -381,10 +381,10 @@ test-27-rollBack-aio-all-installed-yum() {
     sys_type="yum"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-27-rollBack-aio-all-installed-yum-assert() {
+test-27-common_rollBack-aio-all-installed-yum-assert() {
     yum remove wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -412,8 +412,8 @@ test-27-rollBack-aio-all-installed-yum-assert() {
     rm  -rf  /var/log/elasticsearch/  /var/log/filebeat/  /etc/systemd/system/elasticsearch.service.wants/  /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service  /lib/firewalld/services/kibana.xml  /lib/firewalld/services/elasticsearch.xml
 }
 
-test-28-rollBack-aio-all-installed-zypper() {
-    load-rollBack
+test-28-common_rollBack-aio-all-installed-zypper() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -425,10 +425,10 @@ test-28-rollBack-aio-all-installed-zypper() {
     sys_type="zypper"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-28-rollBack-aio-all-installed-zypper-assert() {
+test-28-common_rollBack-aio-all-installed-zypper-assert() {
     zypper -n remove wazuh-manager
     rm -f /etc/init.d/wazuh-manager
     
@@ -455,8 +455,8 @@ test-28-rollBack-aio-all-installed-zypper-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-29-rollBack-aio-all-installed-apt() {
-    load-rollBack
+test-29-common_rollBack-aio-all-installed-apt() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -468,10 +468,10 @@ test-29-rollBack-aio-all-installed-apt() {
     sys_type="apt-get"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-29-rollBack-aio-all-installed-apt-assert() {
+test-29-common_rollBack-aio-all-installed-apt-assert() {
     apt remove --purge wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -497,8 +497,8 @@ test-29-rollBack-aio-all-installed-apt-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-30-rollBack-elasticsearch-installation-all-installed-yum() {
-    load-rollBack
+test-30-common_rollBack-elasticsearch-installation-all-installed-yum() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -510,10 +510,10 @@ test-30-rollBack-elasticsearch-installation-all-installed-yum() {
     sys_type="yum"
     debug=
     elasticsearch=1
-    rollBack
+    common_rollBack
 }
 
-test-30-rollBack-elasticsearch-installation-all-installed-yum-assert() {
+test-30-common_rollBack-elasticsearch-installation-all-installed-yum-assert() {
     yum remove opendistroforelasticsearch -y
     yum remove elasticsearch* -y
     yum remove opendistro-* -y
@@ -525,8 +525,8 @@ test-30-rollBack-elasticsearch-installation-all-installed-yum-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-31-rollBack-elasticsearch-installation-all-installed-zypper() {
-    load-rollBack
+test-31-common_rollBack-elasticsearch-installation-all-installed-zypper() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -538,10 +538,10 @@ test-31-rollBack-elasticsearch-installation-all-installed-zypper() {
     sys_type="zypper"
     debug=
     elasticsearch=1
-    rollBack
+    common_rollBack
 }
 
-test-31-rollBack-elasticsearch-installation-all-installed-zypper-assert() {
+test-31-common_rollBack-elasticsearch-installation-all-installed-zypper-assert() {
     zypper -n remove opendistroforelasticsearch elasticsearch* opendistro-*
     
     rm -rf /var/lib/elasticsearch/
@@ -551,8 +551,8 @@ test-31-rollBack-elasticsearch-installation-all-installed-zypper-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-32-rollBack-elasticsearch-installation-all-installed-apt() {
-    load-rollBack
+test-32-common_rollBack-elasticsearch-installation-all-installed-apt() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -564,10 +564,10 @@ test-32-rollBack-elasticsearch-installation-all-installed-apt() {
     sys_type="apt-get"
     debug=
     elasticsearch=1
-    rollBack
+    common_rollBack
 }
 
-test-32-rollBack-elasticsearch-installation-all-installed-apt-assert() {
+test-32-common_rollBack-elasticsearch-installation-all-installed-apt-assert() {
     apt remove --purge ^elasticsearch* ^opendistro-* ^opendistroforelasticsearch -y
     
     rm -rf /var/lib/elasticsearch/
@@ -577,8 +577,8 @@ test-32-rollBack-elasticsearch-installation-all-installed-apt-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-33-rollBack-wazuh-installation-all-installed-yum() {
-    load-rollBack
+test-33-common_rollBack-wazuh-installation-all-installed-yum() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -590,10 +590,10 @@ test-33-rollBack-wazuh-installation-all-installed-yum() {
     sys_type="yum"
     debug=
     wazuh=1
-    rollBack
+    common_rollBack
 }
 
-test-33-rollBack-wazuh-installation-all-installed-yum-assert() {
+test-33-common_rollBack-wazuh-installation-all-installed-yum-assert() {
     yum remove wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -607,8 +607,8 @@ test-33-rollBack-wazuh-installation-all-installed-yum-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-34-rollBack-wazuh-installation-all-installed-zypper() {
-    load-rollBack
+test-34-common_rollBack-wazuh-installation-all-installed-zypper() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -620,10 +620,10 @@ test-34-rollBack-wazuh-installation-all-installed-zypper() {
     sys_type="zypper"
     debug=
     wazuh=1
-    rollBack
+    common_rollBack
 }
 
-test-34-rollBack-wazuh-installation-all-installed-zypper-assert() {
+test-34-common_rollBack-wazuh-installation-all-installed-zypper-assert() {
     zypper -n remove wazuh-manager
     rm -f /etc/init.d/wazuh-manager
     
@@ -638,8 +638,8 @@ test-34-rollBack-wazuh-installation-all-installed-zypper-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-35-rollBack-wazuh-installation-all-installed-apt() {
-    load-rollBack
+test-35-common_rollBack-wazuh-installation-all-installed-apt() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -651,10 +651,10 @@ test-35-rollBack-wazuh-installation-all-installed-apt() {
     sys_type="apt-get"
     debug=
     wazuh=1
-    rollBack
+    common_rollBack
 }
 
-test-35-rollBack-wazuh-installation-all-installed-apt-assert() {
+test-35-common_rollBack-wazuh-installation-all-installed-apt-assert() {
     apt remove --purge wazuh-manager -y
     
     rm -rf /var/ossec/
@@ -668,8 +668,8 @@ test-35-rollBack-wazuh-installation-all-installed-apt-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-36-rollBack-kibana-installation-all-installed-yum() {
-    load-rollBack
+test-36-common_rollBack-kibana-installation-all-installed-yum() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -681,10 +681,10 @@ test-36-rollBack-kibana-installation-all-installed-yum() {
     sys_type="yum"
     debug=
     kibana=1
-    rollBack
+    common_rollBack
 }
 
-test-36-rollBack-kibana-installation-all-installed-yum-assert() {
+test-36-common_rollBack-kibana-installation-all-installed-yum-assert() {
     yum remove opendistroforelasticsearch-kibana -y
     
     rm -rf /var/lib/kibana/
@@ -694,8 +694,8 @@ test-36-rollBack-kibana-installation-all-installed-yum-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-37-rollBack-kibana-installation-all-installed-zypper() {
-    load-rollBack
+test-37-common_rollBack-kibana-installation-all-installed-zypper() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -707,10 +707,10 @@ test-37-rollBack-kibana-installation-all-installed-zypper() {
     sys_type="zypper"
     debug=
     kibana=1
-    rollBack
+    common_rollBack
 }
 
-test-37-rollBack-kibana-installation-all-installed-zypper-assert() {
+test-37-common_rollBack-kibana-installation-all-installed-zypper-assert() {
     zypper -n remove opendistroforelasticsearch-kibana
     
     rm -rf /var/lib/kibana/
@@ -720,8 +720,8 @@ test-37-rollBack-kibana-installation-all-installed-zypper-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-38-rollBack-kibana-installation-all-installed-apt() {
-    load-rollBack
+test-38-common_rollBack-kibana-installation-all-installed-apt() {
+    load-common_rollBack
     indexerchinstalled=1
     wazuhinstalled=1
     kibanainstalled=1
@@ -733,10 +733,10 @@ test-38-rollBack-kibana-installation-all-installed-apt() {
     sys_type="apt-get"
     debug=
     kibana=1
-    rollBack
+    common_rollBack
 }
 
-test-38-rollBack-kibana-installation-all-installed-apt-assert() {
+test-38-common_rollBack-kibana-installation-all-installed-apt-assert() {
     apt remove --purge opendistroforelasticsearch-kibana -y
     
     rm -rf /var/lib/kibana/
@@ -746,8 +746,8 @@ test-38-rollBack-kibana-installation-all-installed-apt-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-39-rollBack-aio-nothing-installed() {
-    load-rollBack
+test-39-common_rollBack-aio-nothing-installed() {
+    load-common_rollBack
     indexerchinstalled=
     wazuhinstalled=
     kibanainstalled=
@@ -759,12 +759,12 @@ test-39-rollBack-aio-nothing-installed() {
     sys_type="yum"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
     @assert-success
 }
 
-test-40-rollBack-aio-all-remaining-files-yum() {
-    load-rollBack
+test-40-common_rollBack-aio-all-remaining-files-yum() {
+    load-common_rollBack
     indexerchinstalled=
     wazuhinstalled=
     kibanainstalled=
@@ -776,10 +776,10 @@ test-40-rollBack-aio-all-remaining-files-yum() {
     sys_type="yum"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-40-rollBack-aio-all-remaining-files-yum-assert() {
+test-40-common_rollBack-aio-all-remaining-files-yum-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -797,8 +797,8 @@ test-40-rollBack-aio-all-remaining-files-yum-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-41-rollBack-aio-all-remaining-files-zypper() {
-    load-rollBack
+test-41-common_rollBack-aio-all-remaining-files-zypper() {
+    load-common_rollBack
     indexerchinstalled=
     wazuhinstalled=
     kibanainstalled=
@@ -810,10 +810,10 @@ test-41-rollBack-aio-all-remaining-files-zypper() {
     sys_type="zypper"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-41-rollBack-aio-all-remaining-files-zypper-assert() {
+test-41-common_rollBack-aio-all-remaining-files-zypper-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -831,8 +831,8 @@ test-41-rollBack-aio-all-remaining-files-zypper-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-42-rollBack-aio-all-remaining-files-apt() {
-    load-rollBack
+test-42-common_rollBack-aio-all-remaining-files-apt() {
+    load-common_rollBack
     indexerchinstalled=
     wazuhinstalled=
     kibanainstalled=
@@ -844,10 +844,10 @@ test-42-rollBack-aio-all-remaining-files-apt() {
     sys_type="apt-get"
     debug=
     AIO=1
-    rollBack
+    common_rollBack
 }
 
-test-42-rollBack-aio-all-remaining-files-apt-assert() {
+test-42-common_rollBack-aio-all-remaining-files-apt-assert() {
     rm -rf /var/ossec/
     
     rm -rf /var/lib/elasticsearch/
@@ -865,73 +865,73 @@ test-42-rollBack-aio-all-remaining-files-apt-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-43-rollBack-nothing-installed-remove-yum-repo() {
-    load-rollBack
+test-43-common_rollBack-nothing-installed-remove-yum-repo() {
+    load-common_rollBack
     @mkdir -p /etc/yum.repos.d
     @touch /etc/yum.repos.d/wazuh.repo
-    rollBack
+    common_rollBack
     @rm /etc/yum.repos.d/wazuh.repo
 }
 
-test-43-rollBack-nothing-installed-remove-yum-repo-assert() {
+test-43-common_rollBack-nothing-installed-remove-yum-repo-assert() {
     rm /etc/yum.repos.d/wazuh.repo
 
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-44-rollBack-nothing-installed-remove-zypper-repo() {
-    load-rollBack
+test-44-common_rollBack-nothing-installed-remove-zypper-repo() {
+    load-common_rollBack
     @mkdir -p /etc/zypp/repos.d
     @touch /etc/zypp/repos.d/wazuh.repo
-    rollBack
+    common_rollBack
     @rm /etc/zypp/repos.d/wazuh.repo
 }
 
-test-44-rollBack-nothing-installed-remove-zypper-repo-assert() {
+test-44-common_rollBack-nothing-installed-remove-zypper-repo-assert() {
     rm /etc/zypp/repos.d/wazuh.repo
 
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-test-45-rollBack-nothing-installed-remove-apt-repo() {
-    load-rollBack
+test-45-common_rollBack-nothing-installed-remove-apt-repo() {
+    load-common_rollBack
     @mkdir -p /etc/apt/sources.list.d
     @touch /etc/apt/sources.list.d/wazuh.list
-    rollBack
+    common_rollBack
     @rm /etc/apt/sources.list.d/wazuh.list
 }
 
-test-45-rollBack-nothing-installed-remove-apt-repo-assert() {
+test-45-common_rollBack-nothing-installed-remove-apt-repo-assert() {
     rm /etc/apt/sources.list.d/wazuh.list
 
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh  /etc/systemd/system/multi-user.target.wants/wazuh-manager.service  /etc/systemd/system/multi-user.target.wants/filebeat.service  /etc/systemd/system/multi-user.target.wants/elasticsearch.service  /etc/systemd/system/multi-user.target.wants/kibana.service  /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 
 }
 
-test-46-rollBack-nothing-installed-remove-files() {
-    load-rollBack
+test-46-common_rollBack-nothing-installed-remove-files() {
+    load-common_rollBack
     @mkdir -p /var/log/elasticsearch/
-    rollBack
+    common_rollBack
     @rmdir /var/log/elasticsearch
 }
 
-test-46-rollBack-nothing-installed-remove-files-assert() {
+test-46-common_rollBack-nothing-installed-remove-files-assert() {
     rm -rf /var/log/elasticsearch/ /var/log/filebeat/ /etc/systemd/system/elasticsearch.service.wants/ /securityadmin_demo.sh /etc/systemd/system/multi-user.target.wants/wazuh-manager.service /etc/systemd/system/multi-user.target.wants/filebeat.service /etc/systemd/system/multi-user.target.wants/elasticsearch.service /etc/systemd/system/multi-user.target.wants/kibana.service /etc/systemd/system/kibana.service /lib/firewalld/services/kibana.xml /lib/firewalld/services/elasticsearch.xml
 }
 
-function load-createCertificates() {
-    @load_function "${base_dir}/common.sh" createCertificates
+function load-common_createCertificates() {
+    @load_function "${base_dir}/common.sh" common_createCertificates
 }
 
-test-47-createCertificates-aio() {
-    load-createCertificates
+test-47-common_createCertificates-aio() {
+    load-common_createCertificates
     AIO=1
     base_path=/tmp
-    createCertificates
+    common_createCertificates
 }
 
-test-47-createCertificates-aio-assert() {
-    getConfig certificate/config_aio.yml /tmp/config.yml
+test-47-common_createCertificates-aio-assert() {
+    common_getConfig certificate/config_aio.yml /tmp/config.yml
 
     readConfig
 
@@ -945,13 +945,13 @@ test-47-createCertificates-aio-assert() {
     cleanFiles
 }
 
-test-48-createCertificates-no-aio() {
-    load-createCertificates
+test-48-common_createCertificates-no-aio() {
+    load-common_createCertificates
     base_path=/tmp
-    createCertificates
+    common_createCertificates
 }
 
-test-48-createCertificates-no-aio-assert() {
+test-48-common_createCertificates-no-aio-assert() {
 
     readConfig
 
@@ -965,51 +965,51 @@ test-48-createCertificates-no-aio-assert() {
     cleanFiles
 }
 
-function load-changePasswords() {
-    @load_function "${base_dir}/common.sh" changePasswords
+function load-common_changePasswords() {
+    @load_function "${base_dir}/common.sh" common_changePasswords
 }
 
-test-ASSERT-FAIL-49-changePasswords-no-tarfile() {
-    load-changePasswords
+test-ASSERT-FAIL-49-common_changePasswords-no-tarfile() {
+    load-common_changePasswords
     tar_file=
-    changePasswords
+    common_changePasswords
 }
 
-test-50-changePasswords-with-tarfile() {
-    load-changePasswords
+test-50-common_changePasswords-with-tarfile() {
+    load-common_changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
     @touch $tar_file
     @mock tar -xf tarfile.tar -C /tmp ./password_file.yml === @touch /tmp/password_file.yml
-    changePasswords
+    common_changePasswords
     @echo $changeall
     @rm /tmp/password_file.yml
 }
 
-test-50-changePasswords-with-tarfile-assert() {
+test-50-common_changePasswords-with-tarfile-assert() {
     checkInstalledPass
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     changePassword
     rm -rf /tmp/password_file.yml
     @echo 
 }
 
-test-51-changePasswords-with-tarfile-aio() {
-    load-changePasswords
+test-51-common_changePasswords-with-tarfile-aio() {
+    load-common_changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
     AIO=1
     @touch $tar_file
     @mock tar -xf tarfile.tar -C /tmp ./password_file.yml === @touch /tmp/password_file.yml
-    changePasswords
+    common_changePasswords
     @echo $changeall
     @rm /tmp/password_file.yml
 }
 
-test-51-changePasswords-with-tarfile-aio-assert() {
+test-51-common_changePasswords-with-tarfile-aio-assert() {
     checkInstalledPass
     readUsers
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     getNetworkHost
     createBackUp
     generateHash
@@ -1019,22 +1019,22 @@ test-51-changePasswords-with-tarfile-aio-assert() {
     @echo 1
 }
 
-test-52-changePasswords-with-tarfile-start-elastic-cluster() {
-    load-changePasswords
+test-52-common_changePasswords-with-tarfile-start-elastic-cluster() {
+    load-common_changePasswords
     tar_file=tarfile.tar
     base_path=/tmp
     AIO=1
     @touch $tar_file
     @mock tar -xf tarfile.tar -C /tmp ./password_file.yml === @touch /tmp/password_file.yml
-    changePasswords
+    common_changePasswords
     @echo $changeall
     @rm /tmp/password_file.yml
 }
 
-test-52-changePasswords-with-tarfile-start-elastic-cluster-assert() {
+test-52-common_changePasswords-with-tarfile-start-elastic-cluster-assert() {
     checkInstalledPass
     readUsers
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     getNetworkHost
     createBackUp
     generateHash
@@ -1044,95 +1044,95 @@ test-52-changePasswords-with-tarfile-start-elastic-cluster-assert() {
     @echo 1
 }
 
-function load-getPass() {
-    @load_function "${base_dir}/common.sh" getPass
+function load-common_getPass() {
+    @load_function "${base_dir}/common.sh" common_getPass
 }
 
-test-53-getPass-no-args() {
-    load-getPass
+test-53-common_getPass-no-args() {
+    load-common_getPass
     users=(kibanaserver admin)
     passwords=(kibanaserver_pass admin_pass)
-    getPass
+    common_getPass
     @echo $u_pass
 }
 
-test-53-getPass-no-args-assert() {
+test-53-common_getPass-no-args-assert() {
     @echo
 }
 
-test-54-getPass-admin() {
-    load-getPass
+test-54-common_getPass-admin() {
+    load-common_getPass
     users=(kibanaserver admin)
     passwords=(kibanaserver_pass admin_pass)
-    getPass admin
+    common_getPass admin
     @echo $u_pass
 }
 
-test-54-getPass-admin-assert() {
+test-54-common_getPass-admin-assert() {
     @echo admin_pass
 }
 
-function load-startService() {
-    @load_function "${base_dir}/common.sh" startService
+function load-common_startService() {
+    @load_function "${base_dir}/common.sh" common_startService
 }
 
-test-ASSERT-FAIL-55-startService-no-args() {
-    load-startService
-    startService
+test-ASSERT-FAIL-55-common_startService-no-args() {
+    load-common_startService
+    common_startService
 }
 
-test-ASSERT-FAIL-56-startService-no-service-manager() {
-    load-startService
+test-ASSERT-FAIL-56-common_startService-no-service-manager() {
+    load-common_startService
     @mockfalse ps -e
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
     @rm /etc/init.d/wazuh
-    startService wazuh-manager
+    common_startService wazuh-manager
 }
 
-test-57-startService-systemd() {
-    load-startService
+test-57-common_startService-systemd() {
+    load-common_startService
     @mockfalse ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
-    startService wazuh-manager
+    common_startService wazuh-manager
 }
 
-test-57-startService-systemd-assert() {
+test-57-common_startService-systemd-assert() {
     systemctl daemon-reload
     systemctl enable wazuh-manager.service
     systemctl start wazuh-manager.service
 }
 
-test-58-startService-systemd-error() {
-    load-startService
+test-58-common_startService-systemd-error() {
+    load-common_startService
     @mock ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
     @mockfalse systemctl start wazuh-manager.service
-    startService wazuh-manager
+    common_startService wazuh-manager
 }
 
-test-58-startService-systemd-error-assert() {
+test-58-common_startService-systemd-error-assert() {
     systemctl daemon-reload
     systemctl enable wazuh-manager.service
-    rollBack
+    common_rollBack
     exit 1
 }
 
-test-59-startService-initd() {
-    load-startService
+test-59-common_startService-initd() {
+    load-common_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mocktrue grep -E -q "^\ *1\ .*init$"
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     @chmod +x /etc/init.d/wazuh-manager
-    startService wazuh-manager
+    common_startService wazuh-manager
     @rm /etc/init.d/wazuh-manager
 }
 
-test-59-startService-initd-assert() {
+test-59-common_startService-initd-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     chkconfig wazuh-manager on
@@ -1141,32 +1141,32 @@ test-59-startService-initd-assert() {
     @rm /etc/init.d/wazuh-manager
 }
 
-test-60-startService-initd-error() {
-    load-startService
+test-60-common_startService-initd-error() {
+    load-common_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mocktrue grep -E -q "^\ *1\ .*init$"
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     #/etc/init.d/wazuh-manager is not executable -> It will fail
-    startService wazuh-manager
+    common_startService wazuh-manager
     @rm /etc/init.d/wazuh-manager
 }
 
-test-60-startService-initd-error-assert() {
+test-60-common_startService-initd-error-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     @chmod +x /etc/init.d/wazuh-manager
     chkconfig wazuh-manager on
     service wazuh-manager start
     /etc/init.d/wazuh-manager start
-    rollBack
+    common_rollBack
     exit 1
     @rm /etc/init.d/wazuh-manager
 }
 
-test-61-startService-rc.d/init.d() {
-    load-startService
+test-61-common_startService-rc.d/init.d() {
+    load-common_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
@@ -1175,11 +1175,11 @@ test-61-startService-rc.d/init.d() {
     @touch /etc/rc.d/init.d/wazuh-manager
     @chmod +x /etc/rc.d/init.d/wazuh-manager
 
-    startService wazuh-manager
+    common_startService wazuh-manager
     @rm /etc/rc.d/init.d/wazuh-manager
 }
 
-test-61-startService-rc.d/init.d-assert() {
+test-61-common_startService-rc.d/init.d-assert() {
     @mkdir -p /etc/rc.d/init.d
     @touch /etc/rc.d/init.d/wazuh-manager
     @chmod +x /etc/rc.d/init.d/wazuh-manager
@@ -1187,19 +1187,19 @@ test-61-startService-rc.d/init.d-assert() {
     @rm /etc/rc.d/init.d/wazuh-manager
 }
 
-function load-readPasswordFileUsers() {
-    @load_function "${base_dir}/common.sh" readPasswordFileUsers
+function load-common_readPasswordFileUsers() {
+    @load_function "${base_dir}/common.sh" common_readPasswordFileUsers
 }
 
-test-ASSERT-FAIL-62-readPasswordFileUsers-file-incorrect() {
-    load-readPasswordFileUsers
+test-ASSERT-FAIL-62-common_readPasswordFileUsers-file-incorrect() {
+    load-common_readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 0
-    readPasswordFileUsers
+    common_readPasswordFileUsers
 }
 
-test-63-readPasswordFileUsers-changeall-correct() {
-    load-readPasswordFileUsers
+test-63-common_readPasswordFileUsers-changeall-correct() {
+    load-common_readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
     @mock grep name: /tmp/passfile.yml === @echo wazuh kibanaserver
@@ -1208,22 +1208,22 @@ test-63-readPasswordFileUsers-changeall-correct() {
     @mock awk '{ print substr( $2, 1, length($2) ) }'
     changeall=1
     users=( wazuh kibanaserver )
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     @echo ${fileusers[*]}
     @echo ${filepasswords[*]}
     @echo ${users[*]}
     @echo ${passwords[*]}
 }
 
-test-63-readPasswordFileUsers-changeall-correct-assert() {
+test-63-common_readPasswordFileUsers-changeall-correct-assert() {
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
 }
 
-test-64-readPasswordFileUsers-changeall-user-doesnt-exist() {
-    load-readPasswordFileUsers
+test-64-common_readPasswordFileUsers-changeall-user-doesnt-exist() {
+    load-common_readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
     @mock grep name: /tmp/passfile.yml === @out wazuh kibanaserver admin
@@ -1232,22 +1232,22 @@ test-64-readPasswordFileUsers-changeall-user-doesnt-exist() {
     @mock awk '{ print substr( $2, 1, length($2) ) }'
     changeall=1
     users=( wazuh kibanaserver )
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     @echo ${fileusers[*]}
     @echo ${filepasswords[*]}
     @echo ${users[*]}
     @echo ${passwords[*]}
 }
 
-test-64-readPasswordFileUsers-changeall-user-doesnt-exist-assert() {
+test-64-common_readPasswordFileUsers-changeall-user-doesnt-exist-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword
     @echo wazuh kibanaserver
     @echo wazuhpassword kibanaserverpassword
 }
 
-test-65-readPasswordFileUsers-no-changeall-kibana-correct() {
-    load-readPasswordFileUsers
+test-65-common_readPasswordFileUsers-no-changeall-kibana-correct() {
+    load-common_readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
     @mock grep name: /tmp/passfile.yml === @out wazuh kibanaserver admin
@@ -1257,22 +1257,22 @@ test-65-readPasswordFileUsers-no-changeall-kibana-correct() {
     changeall=
     kibanainstalled=1
     kibana=1
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     @echo ${fileusers[*]}
     @echo ${filepasswords[*]}
     @echo ${users[*]}
     @echo ${passwords[*]}
 }
 
-test-65-readPasswordFileUsers-no-changeall-kibana-correct-assert() {
+test-65-common_readPasswordFileUsers-no-changeall-kibana-correct-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword adminpassword
     @echo kibanaserver admin
     @echo kibanaserverpassword adminpassword
 }
 
-test-66-readPasswordFileUsers-no-changeall-filebeat-correct() {
-    load-readPasswordFileUsers
+test-66-common_readPasswordFileUsers-no-changeall-filebeat-correct() {
+    load-common_readPasswordFileUsers
     p_file=/tmp/passfile.yml
     @mock grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' /tmp/passfile.yml === @echo 1
     @mock grep name: /tmp/passfile.yml === @out wazuh kibanaserver admin
@@ -1282,14 +1282,14 @@ test-66-readPasswordFileUsers-no-changeall-filebeat-correct() {
     changeall=
     filebeatinstalled=1
     wazuh=1
-    readPasswordFileUsers
+    common_readPasswordFileUsers
     @echo ${fileusers[*]}
     @echo ${filepasswords[*]}
     @echo ${users[*]}
     @echo ${passwords[*]}
 }
 
-test-66-readPasswordFileUsers-no-changeall-filebeat-correct-assert() {
+test-66-common_readPasswordFileUsers-no-changeall-filebeat-correct-assert() {
     @echo wazuh kibanaserver admin
     @echo wazuhpassword kibanaserverpassword adminpassword
     @echo admin

--- a/tests/unattended/unit/suites/test-elasticsearch.sh
+++ b/tests/unattended/unit/suites/test-elasticsearch.sh
@@ -128,9 +128,9 @@ test-09-configureIndexer-dist-one-elastic-node() {
 }
 
 test-09-configureIndexer-dist-one-elastic-node-assert() {
-    getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
-    getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
-    getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
+    common_getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
+    common_getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
+    common_getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
 
     rm -f /etc/wazuh-indexer/esnode-key.pem /etc/wazuh-indexer/esnode.pem /etc/wazuh-indexer/kirk-key.pem /etc/wazuh-indexer/kirk.pem /etc/wazuh-indexer/root-ca.pem 
     copyCertificatesIndexer
@@ -138,7 +138,7 @@ test-09-configureIndexer-dist-one-elastic-node-assert() {
     sed -i "s/-Xms1g/-Xms1g/" /etc/wazuh-indexer/jvm.options
     sed -i "s/-Xmx1g/-Xmx1g/" /etc/wazuh-indexer/jvm.options
 
-    getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
+    common_getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
 
     applyLog4j2Mitigation
 
@@ -160,9 +160,9 @@ test-10-configureIndexer-dist-two-elastic-nodes() {
 }
 
 test-10-configureIndexer-dist-two-elastic-nodes-assert() {
-    getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
-    getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
-    getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
+    common_getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
+    common_getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
+    common_getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
 
     rm -f /etc/wazuh-indexer/esnode-key.pem /etc/wazuh-indexer/esnode.pem /etc/wazuh-indexer/kirk-key.pem /etc/wazuh-indexer/kirk.pem /etc/wazuh-indexer/root-ca.pem
     copyCertificatesIndexer
@@ -170,7 +170,7 @@ test-10-configureIndexer-dist-two-elastic-nodes-assert() {
     sed -i "s/-Xms1g/-Xms1g/" /etc/wazuh-indexer/jvm.options
     sed -i "s/-Xmx1g/-Xmx1g/" /etc/wazuh-indexer/jvm.options
 
-    getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
+    common_getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
 
     applyLog4j2Mitigation
 
@@ -191,9 +191,9 @@ test-11-configureIndexer-AIO() {
 }
 
 test-11-configureIndexer-AIO-assert() {
-    getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
-    getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
-    getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
+    common_getConfig elasticsearch/roles/roles.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml
+    common_getConfig elasticsearch/roles/roles_mapping.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml
+    common_getConfig elasticsearch/roles/internal_users.yml /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml
     
     export JAVA_HOME=/usr/share/wazuh-indexer/jdk/
     rm -f /etc/wazuh-indexer/esnode-key.pem /etc/wazuh-indexer/esnode.pem /etc/wazuh-indexer/kirk-key.pem /etc/wazuh-indexer/kirk.pem /etc/wazuh-indexer/root-ca.pem
@@ -203,7 +203,7 @@ test-11-configureIndexer-AIO-assert() {
     sed -i 's/-Xms1g/-Xms1g/' /etc/wazuh-indexer/jvm.options
     sed -i 's/-Xmx1g/-Xmx1g/' /etc/wazuh-indexer/jvm.options
 
-    getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
+    common_getConfig elasticsearch/elasticsearch_unattended_distributed.yml /etc/wazuh-indexer/opensearch.yml
 
     applyLog4j2Mitigation
 
@@ -227,7 +227,7 @@ test-12-initializeIndexer-one-node() {
 
 test-12-initializeIndexer-one-node-assert() {
     startIndexerCluster
-    changePasswords
+    common_changePasswords
     @echo 1
 }
 

--- a/tests/unattended/unit/suites/test-filebeat.sh
+++ b/tests/unattended/unit/suites/test-filebeat.sh
@@ -138,7 +138,7 @@ test-10-configureFilebeat-no-previous-variables() {
 test-10-configureFilebeat-no-previous-variables-assert() {
     curl -so /etc/filebeat/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
-    getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
+    common_getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     echo "output.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
     mkdir /etc/filebeat/certs
     copyCertificatesFilebeat
@@ -156,7 +156,7 @@ test-11-configureFilebeat-one-elastic-node() {
 test-11-configureFilebeat-one-elastic-node-assert() {
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
-    getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
+    common_getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     echo "output.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
     echo "  - 1.1.1.1" >> /etc/filebeat/filebeat.yml
     mkdir /etc/filebeat/certs
@@ -175,7 +175,7 @@ test-12-configureFilebeat-more-than-one-elastic-node() {
 test-12-configureFilebeat-more-than-one-elastic-node-assert() {
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
-    getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
+    common_getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml
     echo "output.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
     echo "  - 1.1.1.1" >> /etc/filebeat/filebeat.yml
     echo "  - 2.2.2.2" >> /etc/filebeat/filebeat.yml
@@ -196,7 +196,7 @@ test-13-configureFilebeat-AIO-no-previous-variables() {
 test-13-configureFilebeat-AIO-no-previous-variables-assert() {
     curl -so /etc/filebeat/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
-    getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
+    common_getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
     mkdir /etc/filebeat/certs
     copyCertificatesFilebeat
 }
@@ -212,7 +212,7 @@ test-14-configureFilebeat-AIO() {
 test-14-configureFilebeat-AIO-assert() {
     curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json --max-time 300
     chmod go+r /etc/filebeat/wazuh-template.json
-    getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
+    common_getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml
     mkdir /etc/filebeat/certs
     copyCertificatesFilebeat
 }

--- a/tests/unattended/unit/suites/test-kibana.sh
+++ b/tests/unattended/unit/suites/test-kibana.sh
@@ -133,7 +133,7 @@ test-09-configureKibana-dist-one-kibana-node-one-elastic-node-assert() {
     setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node
     echo 'server.host: "'1.1.1.1'"' >> /etc/kibana/kibana.yml
     echo "elasticsearch.hosts: https://1.1.1.1:9200" >> /etc/kibana/kibana.yml
-    getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
+    common_getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
 }
 
 test-10-configureKibana-dist-two-kibana-nodes-two-elastic-nodes() {
@@ -157,7 +157,7 @@ test-10-configureKibana-dist-two-kibana-nodes-two-elastic-nodes-assert() {
     echo "elasticsearch.hosts:" >> /etc/kibana/kibana.yml
     echo "  - https://1.1.1.1:9200" >> /etc/kibana/kibana.yml
     echo "  - https://2.2.2.2:9200" >> /etc/kibana/kibana.yml
-    getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
+    common_getConfig kibana/kibana_unattended_distributed.yml /etc/kibana/kibana.yml
 }
 
 test-ASSERT-FAIL-11-configureKibana-dist-error-downloading-plugin() {
@@ -183,7 +183,7 @@ test-12-configureKibana-AIO-assert() {
     copyKibanacerts
     modifyKibanaLogin
     setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node
-    getConfig kibana/kibana_unattended.yml /etc/kibana/kibana.yml
+    common_getConfig kibana/kibana_unattended.yml /etc/kibana/kibana.yml
 }
 
 test-ASSERT-FAIL-13-configureKibana--AIO-error-downloading-plugin() {
@@ -209,7 +209,7 @@ test-14-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct
 }
 
 test-14-initializeKibana-distributed-one-kibana-node-one-wazuh-node-curl-correct-assert() {
-    getPass "admin"
+    common_getPass "admin"
     sed -i 's,url: https://localhost,url: https://2.2.2.2,g' /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
@@ -237,7 +237,7 @@ test-16-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-corre
 }
 
 test-16-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-correct-assert() {
-    getPass "admin"
+    common_getPass "admin"
     sed -i 's,url: https://localhost,url: https://1.1.2.2,g' /usr/share/kibana/data/wazuh/config/wazuh.yml
 }
 
@@ -268,7 +268,7 @@ test-18-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error
 }
 
 test-18-initializeKibana-distributed-two-kibana-nodes-two-wazuh-nodes-curl-error-force-assert() {
-    getPass  admin
+    common_getPass  admin
     sleep  10
     sleep  10
     sleep  10
@@ -298,7 +298,7 @@ test-19-initializeKibanaAIO-curl-correct() {
 }
 
 test-19-initializeKibanaAIO-curl-correct-assert() {
-    getPass "admin"
+    common_getPass "admin"
 }
 
 
@@ -330,6 +330,6 @@ test-21-modifyKibanaLogin-assert() {
     cp -f /tmp/custom_welcome/template.js.hbs /usr/share/kibana/src/legacy/ui/ui_render/bootstrap/template.js.hbs
     rm -f /tmp/custom_welcome/*
     rmdir /tmp/custom_welcome
-    getConfig kibana/customWelcomeKibana.css /tmp/customWelcomeKibana.css
+    common_getConfig kibana/customWelcomeKibana.css /tmp/customWelcomeKibana.css
     rm -f /tmp/customWelcomeKibana.css
 }

--- a/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
+++ b/tests/unattended/unit/suites/test-wazuh-passwords-tool.sh
@@ -127,9 +127,9 @@ test-05-changePassword-changeall-all-users-all-installed-assert() {
     awk -v new=22 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/wazuh-indexer/backup/internal_users.yml
     mv -f internal_users.yml_tmp /usr/share/wazuh-indexer/backup/internal_users.yml
     echo "admin_configuration_string"
-    restartService "filebeat"
+    recommon_startService "filebeat"
     echo "kibanaserver_configuration_string"
-    restartService "kibana"
+    recommon_startService "kibana"
 }
 
 test-06-changePassword-nuser-kibanaserver-kibana-installed() {
@@ -154,7 +154,7 @@ test-06-changePassword-nuser-kibanaserver-kibana-installed-assert() {
     awk -v new="11" 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/wazuh-indexer/backup/internal_users.yml
     mv -f internal_users.yml_tmp /usr/share/wazuh-indexer/backup/internal_users.yml
     echo "kibanaserver_configuration_string"
-    restartService "kibana"
+    recommon_startService "kibana"
 }
 
 test-07-changePassword-nuser-kibanaserver-kibana-not-installed() {
@@ -203,7 +203,7 @@ test-08-changePassword-nuser-admin-filebeat-installed-assert() {
     awk -v new=11 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /usr/share/wazuh-indexer/backup/internal_users.yml
     mv -f internal_users.yml_tmp /usr/share/wazuh-indexer/backup/internal_users.yml
     echo "admin_configuration_string"
-    restartService "filebeat"
+    recommon_startService "filebeat"
 }
 
 test-09-changePassword-nuser-admin-filebeat-not-installed() {
@@ -631,97 +631,97 @@ test-28-readUsers-assert() {
     @echo "kibanaserver admin"
 }
 
-function load-restartService() {
-    @load_function "${base_dir}/wazuh-passwords-tool.sh" restartService
+function load-recommon_startService() {
+    @load_function "${base_dir}/wazuh-passwords-tool.sh" recommon_startService
 }
 
-test-ASSERT-FAIL-29-restartService-no-args() {
-    load-restartService
-    restartService
+test-ASSERT-FAIL-29-recommon_startService-no-args() {
+    load-recommon_startService
+    recommon_startService
 }
 
-test-ASSERT-FAIL-30-restartService-no-service-manager() {
-    load-restartService
+test-ASSERT-FAIL-30-recommon_startService-no-service-manager() {
+    load-recommon_startService
     @mockfalse ps -e
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
     @rm /etc/init.d/wazuh
-    restartService wazuh-manager
+    recommon_startService wazuh-manager
 }
 
-test-31-restartService-systemd() {
-    load-restartService
+test-31-recommon_startService-systemd() {
+    load-recommon_startService
     @mockfalse ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
-    restartService wazuh-manager
+    recommon_startService wazuh-manager
 }
 
-test-31-restartService-systemd-assert() {
+test-31-recommon_startService-systemd-assert() {
     systemctl daemon-reload
     systemctl restart wazuh-manager.service
 }
 
-test-32-restartService-systemd-error() {
-    load-restartService
+test-32-recommon_startService-systemd-error() {
+    load-recommon_startService
     @mock ps -e === @out 
     @mocktrue grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
     @mockfalse systemctl restart wazuh-manager.service
-    @mock type -t rollBack === @out "function"
-    restartService wazuh-manager
+    @mock type -t common_rollBack === @out "function"
+    recommon_startService wazuh-manager
 }
 
-test-32-restartService-systemd-error-assert() {
+test-32-recommon_startService-systemd-error-assert() {
     systemctl daemon-reload
-    rollBack
+    common_rollBack
     exit 1
 }
 
-test-33-restartService-initd() {
-    load-restartService
+test-33-recommon_startService-initd() {
+    load-recommon_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mocktrue grep -E -q "^\ *1\ .*init$"
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     @chmod +x /etc/init.d/wazuh-manager
-    restartService wazuh-manager
+    recommon_startService wazuh-manager
     @rm /etc/init.d/wazuh-manager
 }
 
-test-33-restartService-initd-assert() {
+test-33-recommon_startService-initd-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     /etc/init.d/wazuh-manager restart
     @rm /etc/init.d/wazuh-manager
 }
 
-test-34-restartService-initd-error() {
-    load-restartService
+test-34-recommon_startService-initd-error() {
+    load-recommon_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mocktrue grep -E -q "^\ *1\ .*init$"
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     #/etc/init.d/wazuh-manager is not executable -> It will fail
-    @mock type -t rollBack === @out "function"
-    restartService wazuh-manager
+    @mock type -t common_rollBack === @out "function"
+    recommon_startService wazuh-manager
     @rm /etc/init.d/wazuh-manager
 }
 
-test-34-restartService-initd-error-assert() {
+test-34-recommon_startService-initd-error-assert() {
     @mkdir -p /etc/init.d
     @touch /etc/init.d/wazuh-manager
     @chmod +x /etc/init.d/wazuh-manager
     /etc/init.d/wazuh-manager restart
-    rollBack
+    common_rollBack
     exit 1
     @rm /etc/init.d/wazuh-manager
 }
 
-test-35-restartService-rc.d/init.d() {
-    load-restartService
+test-35-recommon_startService-rc.d/init.d() {
+    load-recommon_startService
     @mock ps -e === @out 
     @mockfalse grep -E -q "^\ *1\ .*systemd$"
     @mockfalse grep -E -q "^\ *1\ .*init$"
@@ -730,11 +730,11 @@ test-35-restartService-rc.d/init.d() {
     @touch /etc/rc.d/init.d/wazuh-manager
     @chmod +x /etc/rc.d/init.d/wazuh-manager
 
-    restartService wazuh-manager
+    recommon_startService wazuh-manager
     @rm /etc/rc.d/init.d/wazuh-manager
 }
 
-test-35-restartService-rc.d/init.d-assert() {
+test-35-recommon_startService-rc.d/init.d-assert() {
     @mkdir -p /etc/rc.d/init.d
     @touch /etc/rc.d/init.d/wazuh-manager
     @chmod +x /etc/rc.d/init.d/wazuh-manager

--- a/tests/unattended/unit/suites/test-wazuh.sh
+++ b/tests/unattended/unit/suites/test-wazuh.sh
@@ -21,7 +21,7 @@ test-01-installWazuh-zypper-error() {
 }
 
 test-01-installWazuh-zypper-error-assert() {
-    rollBack
+    common_rollBack
     exit 1
 }
 
@@ -36,7 +36,7 @@ test-02-installWazuh-apt-error() {
 }
 
 test-02-installWazuh-apt-error-assert() {
-    rollBack
+    common_rollBack
     exit 1
 }
 
@@ -51,7 +51,7 @@ test-03-installWazuh-yum-error() {
 }
 
 test-03-installWazuh-yum-error-assert() {
-    rollBack
+    common_rollBack
     exit 1
 }
 

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -6,7 +6,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-function checkArch() {
+function checks_arch() {
 
     arch=$(uname -m)
 
@@ -16,7 +16,7 @@ function checkArch() {
     fi
 }
 
-function checkArguments() {
+function checks_arguments() {
 
     # -------------- Configurations ---------------------------------
 
@@ -147,9 +147,9 @@ function checkArguments() {
 
 }
 
-function checkHealth() {
+function checks_health() {
 
-    checkSpecs
+    checks_specifications
     if [ -n "${indexer}" ]; then
         if [ "${cores}" -lt 2 ] || [ "${ram_gb}" -lt 3700 ]; then
             logger -e "Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements."
@@ -188,7 +188,7 @@ function checkHealth() {
 
 }
 
-function checkIfInstalled() {
+function checks_installed() {
 
     if [ "${sys_type}" == "yum" ]; then
         wazuhinstalled=$(yum list installed 2>/dev/null | grep wazuh-manager)
@@ -241,7 +241,7 @@ function checkIfInstalled() {
 }
 
 # This function ensures different names in the config.yml file.
-function checkNames() {
+function checks_names() {
 
     if [ -n "${indxname}" ] && [ -n "${dashname}" ] && [ "${indxname}" == "${dashname}" ]; then
         logger -e "The node names for Elastisearch and Kibana must be different."
@@ -276,7 +276,7 @@ function checkNames() {
 }
 
 # This function checks if the target certificates are created before to start the installation.
-function checkPreviousCertificates() {
+function checks_previousCertificate() {
 
     if [ ! -f "${tar_file}" ]; then
         logger -e "No certificates file found (${tar_file}). Run the script with the option -c|--certificates to create automatically or copy them from the node where they were created."
@@ -306,14 +306,14 @@ function checkPreviousCertificates() {
 
 }
 
-function checkSpecs() {
+function checks_specifications() {
 
     cores=$(cat /proc/cpuinfo | grep -c processor )
     ram_gb=$(free -m | awk '/^Mem:/{print $2}')
 
 }
 
-function checkSystem() {
+function checks_system() {
 
     if [ -n "$(command -v yum)" ]; then
         sys_type="yum"

--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -19,7 +19,7 @@ fi
 readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"
 readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.1.tar.gz"
 
-function common_addWazuhrepo() {
+function common_addWazuhRepo() {
 
     logger -d "Adding the Wazuh repository."
 

--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -7,19 +7,19 @@
 # Foundation.
 
 if [ -n "${development}" ]; then
-    repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
-    repobaseurl="https://packages-dev.wazuh.com/pre-release"
-    reporelease="unstable"
+    readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"
+    readonly repobaseurl="https://packages-dev.wazuh.com/pre-release"
+    readonly reporelease="unstable"
 else
-    repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
-    repobaseurl="https://packages.wazuh.com/4.x"
-    reporelease="stable"
+    readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"
+    readonly repobaseurl="https://packages.wazuh.com/4.x"
+    readonly reporelease="stable"
 fi
 
-filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"
-filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.1.tar.gz"
+readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"
+readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.1.tar.gz"
 
-function addWazuhrepo() {
+function common_addWazuhrepo() {
 
     logger -d "Adding the Wazuh repository."
 
@@ -52,10 +52,10 @@ function addWazuhrepo() {
 
 }
 
-function createCertificates() {
+function common_createCertificates() {
 
     if [ -n "${AIO}" ]; then
-        eval "getConfig certificate/config_aio.yml ${base_path}/config.yml ${debug}"
+        eval "common_getConfig certificate/config_aio.yml ${base_path}/config.yml ${debug}"
     fi
 
     readConfig
@@ -71,13 +71,13 @@ function createCertificates() {
 
 }
 
-function createClusterKey() {
+function common_createClusterKey() {
 
     openssl rand -hex 16 >> "${base_path}/certs/clusterkey"
 
 }
 
-function changePasswords() {
+function common_changePasswords() {
 
     logger -d "Setting passwords."
     if [ -f "${tar_file}" ]; then
@@ -88,7 +88,7 @@ function changePasswords() {
             changeall=1
             readUsers
         fi
-        readPasswordFileUsers
+        common_readPasswordFileUsers
     else
         logger -e "Cannot find passwords-file. Exiting"
         exit 1
@@ -108,7 +108,7 @@ function changePasswords() {
 
 }
 
-function extractConfig() {
+function common_extractConfig() {
 
     if ! $(tar -tf "${tar_file}" | grep -q config.yml); then
         logger -e "There is no config.yml file in ${tar_file}."
@@ -118,10 +118,10 @@ function extractConfig() {
 
 }
 
-function getConfig() {
+function common_getConfig() {
 
     if [ "$#" -ne 2 ]; then
-        logger -e "getConfig should be called with two arguments"
+        logger -e "common_getConfig should be called with two arguments"
         exit 1
     fi
 
@@ -132,13 +132,13 @@ function getConfig() {
     fi
     if [ "$?" != 0 ]; then
         logger -e "Unable to find configuration file ${1}. Exiting."
-        rollBack
+        common_rollBack
         exit 1
     fi
 
 }
 
-function getPass() {
+function common_getPass() {
 
     for i in "${!users[@]}"; do
         if [ "${users[i]}" == "${1}" ]; then
@@ -148,7 +148,7 @@ function getPass() {
 
 }
 
-function installPrerequisites() {
+function common_installPrerequisites() {
 
     logger "Starting the installation of dependencies."
 
@@ -176,7 +176,7 @@ function installPrerequisites() {
 
 }
 
-function readPasswordFileUsers() {
+function common_readPasswordFileUsers() {
 
     filecorrect=$(grep -Pzc '\A(User:\s*name:\s*\w+\s*password:\s*[A-Za-z0-9_\-]+\s*)+\Z' "${p_file}")
     if [ "${filecorrect}" -ne 1 ]; then
@@ -251,7 +251,7 @@ User:
 
 }
 
-function restoreWazuhrepo() {
+function common_restoreWazuhrepo() {
 
     if [ -n "${development}" ]; then
         if [ "${sys_type}" == "yum" ] && [ -f "/etc/yum.repos.d/wazuh.repo" ]; then
@@ -271,7 +271,7 @@ function restoreWazuhrepo() {
 
 }
 
-function rollBack() {
+function common_rollBack() {
 
     if [ -z "${uninstall}" ]; then
         logger "Cleaning the installation."
@@ -368,7 +368,7 @@ function rollBack() {
     eval "rm -rf ${elements_to_remove[*]}"
 
     if [ -z "${uninstall}" ]; then
-        if [ -n "${rollback_conf}" ] || [ -n "${overwrite}" ]; then
+        if [ -n "${srollback_conf}" ] || [ -n "${overwrite}" ]; then
             logger "Installation cleaned."
         else
             logger "Installation cleaned. Check the ${logfile} file to learn more about the issue."
@@ -377,10 +377,10 @@ function rollBack() {
 
 }
 
-function startService() {
+function common_startService() {
 
     if [ "$#" -ne 1 ]; then
-        logger -e "startService must be called with 1 argument."
+        logger -e "common_startService must be called with 1 argument."
         exit 1
     fi
 
@@ -392,7 +392,7 @@ function startService() {
         eval "systemctl start ${1}.service ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
-            rollBack
+            common_rollBack
             exit 1
         else
             logger "${1^} service started."
@@ -403,7 +403,7 @@ function startService() {
         eval "/etc/init.d/${1} start ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
-            rollBack
+            common_rollBack
             exit 1
         else
             logger "${1^} service started."
@@ -412,7 +412,7 @@ function startService() {
         eval "/etc/rc.d/init.d/${1} start ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
-            rollBack
+            common_rollBack
             exit 1
         else
             logger "${1^} service started."

--- a/unattended_installer/install_functions/dashboards.sh
+++ b/unattended_installer/install_functions/dashboards.sh
@@ -13,9 +13,9 @@ function dashboards_configure() {
     dashboards_copyCertificates
 
     if [ -n "${AIO}" ]; then
-        eval "getConfig dashboards/dashboards_unattended.yml /etc/wazuh-dashboards/dashboards.yml ${debug}"
+        eval "common_getConfig dashboards/dashboards_unattended.yml /etc/wazuh-dashboards/dashboards.yml ${debug}"
     else
-        eval "getConfig dashboards/dashboards_unattended_distributed.yml /etc/wazuh-dashboards/dashboards.yml ${debug}"
+        eval "common_getConfig dashboards/dashboards_unattended_distributed.yml /etc/wazuh-dashboards/dashboards.yml ${debug}"
         if [ "${#dashboards_node_names[@]}" -eq 1 ]; then
             pos=0
             ip=${dashboards_node_ips[0]}
@@ -68,7 +68,7 @@ function dashboards_copyCertificates() {
 function dashboards_initialize() {
 
     logger "Starting Wazuh dashboards  (this may take a while)."
-    getPass "admin"
+    common_getPass "admin"
     j=0
 
     if [ "${#dashboards_node_names[@]}" -eq 1 ]; then
@@ -116,7 +116,7 @@ function dashboards_initialize() {
         logger "${flag}" "Failed to connect with ${failed_nodes[*]}. Connection refused."
         if [ -z "${force}" ]; then
             logger "If want to install Wazuh dashboards without waiting for the Wazuh indexer cluster, use the -F option"
-            rollBack
+            common_rollBack
             exit 1
         else
             logger "When Wazuh dashboards is able to connect to your Elasticsearch cluster, you can access the web interface https://${nodes_dashboards_ip}. The credentials are admin:${u_pass}"
@@ -130,14 +130,14 @@ function dashboards_initialize() {
 function dashboards_initializeAIO() {
 
     logger "Starting Wazuh dashboards (this may take a while)."
-    getPass "admin"
+    common_getPass "admin"
     until [ "$(curl -XGET https://localhost/status -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)" -eq "200" ] || [ "${i}" -eq 12 ]; do
         sleep 10
         i=$((i+1))
     done
     if [ ${i} -eq 12 ]; then
         logger -e "Cannot connect to Wazuh dashboards."
-        rollBack
+        common_rollBack
         exit 1
     fi
     logger "Wazuh dashboards started."
@@ -155,7 +155,7 @@ function dashboards_install() {
     fi
     if [  "$?" != 0  ]; then
         logger -e "Wazuh dashboards installation failed"
-        rollBack
+        common_rollBack
         exit 1
     else
         dashboardsinstalled="1"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -14,9 +14,9 @@ function filebeat_configure(){
     eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
     eval "curl -s ${filebeat_wazuh_module} --max-time 300 | tar -xvz -C /usr/share/filebeat/module ${debug}"
     if [ -n "${AIO}" ]; then
-        eval "getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml ${debug}"
+        eval "common_getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml ${debug}"
     else
-        eval "getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml ${debug}"
+        eval "common_getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml ${debug}"
         if [ ${#indexer_node_names[@]} -eq 1 ]; then
             echo -e "\noutput.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
             echo "  - ${indexer_node_ips[0]}:9700" >> /etc/filebeat/filebeat.yml

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -51,7 +51,7 @@ function manager_install() {
     fi
     if [  "$?" != 0  ]; then
         logger -e "Wazuh installation failed"
-        rollBack
+        common_rollBack
         exit 1
     else
         wazuhinstalled="1"

--- a/unattended_installer/install_functions/wazuh-cert-tool.sh
+++ b/unattended_installer/install_functions/wazuh-cert-tool.sh
@@ -9,12 +9,12 @@
 # Foundation.
 
 if [ -z "${base_path}" ]; then
-    base_path="$(dirname "$(readlink -f "$0")")"
-    config_file="${base_path}/config.yml"
+    readonly base_path="$(dirname "$(readlink -f "$0")")"
+    readonly config_file="${base_path}/config.yml"
 fi
 
 if [[ -z "${logfile}" ]]; then
-    logfile="/var/log/wazuh-cert-tool.log"
+    readonly logfile="/var/log/wazuh-cert-tool.log"
 fi
 
 debug_cert=">> ${logfile} 2>&1"

--- a/unattended_installer/install_functions/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/wazuh-passwords-tool.sh
@@ -13,11 +13,11 @@ if [[ -z "${logfile}" ]]; then
 fi
 debug_pass=">> ${logfile} 2>&1"
 if [ -n "$(command -v yum)" ]; then
-    readonly sys_type="yum"
+    sys_type="yum"
 elif [ -n "$(command -v zypper)" ]; then
-    readonly sys_type="zypper"
+    sys_type="zypper"
 elif [ -n "$(command -v apt-get)" ]; then
-    readonly sys_type="apt-get"
+    sys_type="apt-get"
 fi
 
 function changePassword() {

--- a/unattended_installer/install_functions/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/wazuh-passwords-tool.sh
@@ -9,15 +9,15 @@
 # Foundation.
 
 if [[ -z "${logfile}" ]]; then
-    logfile="/var/log/wazuh-password-tool.log"
+    readonly logfile="/var/log/wazuh-password-tool.log"
 fi
 debug_pass=">> ${logfile} 2>&1"
 if [ -n "$(command -v yum)" ]; then
-    sys_type="yum"
+    readonly sys_type="yum"
 elif [ -n "$(command -v zypper)" ]; then
-    sys_type="zypper"
+    readonly sys_type="zypper"
 elif [ -n "$(command -v apt-get)" ]; then
-    sys_type="apt-get"
+    readonly sys_type="apt-get"
 fi
 
 function changePassword() {
@@ -557,8 +557,8 @@ function restartService() {
         eval "systemctl restart ${1}.service ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
-            if [[ $(type -t rollBack) == "function" ]]; then
-                rollBack
+            if [[ $(type -t common_rollBack) == "function" ]]; then
+                common_rollBack
             fi
             exit 1;
         else
@@ -568,8 +568,8 @@ function restartService() {
         eval "/etc/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
-            if [[ $(type -t rollBack) == "function" ]]; then
-                rollBack
+            if [[ $(type -t common_rollBack) == "function" ]]; then
+                common_rollBack
             fi
             exit 1;
         else
@@ -579,16 +579,16 @@ function restartService() {
         eval "/etc/rc.d/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
-            if [[ $(type -t rollBack) == "function" ]]; then
-                rollBack
+            if [[ $(type -t common_rollBack) == "function" ]]; then
+                common_rollBack
             fi
             exit 1;
         else
             logger_pass -d "${1^} started"
         fi
     else
-        if [[ $(type -t rollBack) == "function" ]]; then
-            rollBack
+        if [[ $(type -t common_rollBack) == "function" ]]; then
+            common_rollBack
         fi
         logger_pass -e "${1^} could not start. No service manager found on the system."
         exit 1;

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -394,7 +394,7 @@ function main() {
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboards}" ] || [ -n "${wazuh}" ]; then
         logger "------------------------------------ Dependencies -------------------------------------"
         common_installPrerequisites
-        common_addWazuhrepo
+        common_addWazuhRepo
     fi
 # -------------- Elasticsearch or Start Elasticsearch cluster case---
 


### PR DESCRIPTION
|Related issue|
|---|
| #1231  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Changed the names of all functions in checks.sh and common.sh to be preceded by the module name. For example `addWazuhrepo` to `common_addWazuhRepo`

