### PR TITLE
Added journalctl output to log when starting or restarting service fails

### DIFF
--- a/unattended_installer/install_functions/common.sh
+++ b/unattended_installer/install_functions/common.sh
@@ -392,6 +392,9 @@ function common_startService() {
         eval "systemctl start ${1}.service ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             common_rollBack
             exit 1
         else
@@ -403,6 +406,9 @@ function common_startService() {
         eval "/etc/init.d/${1} start ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             common_rollBack
             exit 1
         else
@@ -412,6 +418,9 @@ function common_startService() {
         eval "/etc/rc.d/init.d/${1} start ${debug}"
         if [  "$?" != 0  ]; then
             logger -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             common_rollBack
             exit 1
         else

--- a/unattended_installer/install_functions/wazuh-passwords-tool.sh
+++ b/unattended_installer/install_functions/wazuh-passwords-tool.sh
@@ -557,6 +557,9 @@ function restartService() {
         eval "systemctl restart ${1}.service ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             if [[ $(type -t common_rollBack) == "function" ]]; then
                 common_rollBack
             fi
@@ -568,6 +571,9 @@ function restartService() {
         eval "/etc/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             if [[ $(type -t common_rollBack) == "function" ]]; then
                 common_rollBack
             fi
@@ -579,6 +585,9 @@ function restartService() {
         eval "/etc/rc.d/init.d/${1} restart ${debug_pass}"
         if [  "$?" != 0  ]; then
             logger_pass -e "${1^} could not be started."
+            if [ -n "$(command -v journalctl)" ]; then
+                eval "journalctl -r -u ${1} >> ${logfile}"
+            fi
             if [[ $(type -t common_rollBack) == "function" ]]; then
                 common_rollBack
             fi


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Added the output of journalctl -u -r to the logfile when the script fails to start or restart a service.
<!--
Add a clear description of how the problem has been solved.
-->
