### PR TITLE
Add new shared library, to avoid memory fragmentation

### DIFF
--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -663,6 +663,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/librsync.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
+%attr(750, root, wazuh) %{_localstatedir}/lib/libjemalloc.so.2
 %{_localstatedir}/lib/libpython3.9.so.1.0
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
 %attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#10107|

# Description
This pr is intended to add a new library for packaging in the manager only.

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [X] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [X] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [X] Build the package for aarch64
  - [X] Package install/remove/install
  - [X] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
