### PR TITLE
Merge Wazuh Dashboard v3 

### DIFF
--- a/stack/dashboard/base/files/etc/http_service.js
+++ b/stack/dashboard/base/files/etc/http_service.js
@@ -167,11 +167,11 @@ class HttpService {
       path: '/{p*}',
       method: '*',
       handler: (req, responseToolkit) => {
-        this.log.debug(`Wazuh Dashboard server is not ready yet ${req.method}:${req.url.href}.`); // If server is not ready yet, because plugins or core can perform
+        this.log.debug(`Wazuh dashboard server is not ready yet ${req.method}:${req.url.href}.`); // If server is not ready yet, because plugins or core can perform
         // long running tasks (build assets, saved objects migrations etc.)
         // we should let client know that and ask to retry after 30 seconds.
 
-        return responseToolkit.response('Wazuh Dashboard server is not ready yet').code(503).header('Retry-After', '30');
+        return responseToolkit.response('Wazuh dashboard server is not ready yet').code(503).header('Retry-After', '30');
       }
     });
     await this.notReadyServer.start();

--- a/stack/dashboard/base/files/etc/http_service.js
+++ b/stack/dashboard/base/files/etc/http_service.js
@@ -1,0 +1,182 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.HttpService = void 0;
+
+var _rxjs = require("rxjs");
+
+var _operators = require("rxjs/operators");
+
+var _std = require("@osd/std");
+
+var _csp = require("../csp");
+
+var _router = require("./router");
+
+var _http_config = require("./http_config");
+
+var _http_server = require("./http_server");
+
+var _https_redirect_server = require("./https_redirect_server");
+
+var _lifecycle_handlers = require("./lifecycle_handlers");
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/** @internal */
+class HttpService {
+  constructor(coreContext) {
+    this.coreContext = coreContext;
+
+    _defineProperty(this, "httpServer", void 0);
+
+    _defineProperty(this, "httpsRedirectServer", void 0);
+
+    _defineProperty(this, "config$", void 0);
+
+    _defineProperty(this, "configSubscription", void 0);
+
+    _defineProperty(this, "logger", void 0);
+
+    _defineProperty(this, "log", void 0);
+
+    _defineProperty(this, "env", void 0);
+
+    _defineProperty(this, "notReadyServer", void 0);
+
+    _defineProperty(this, "internalSetup", void 0);
+
+    _defineProperty(this, "requestHandlerContext", void 0);
+
+    const {
+      logger,
+      configService,
+      env
+    } = coreContext;
+    this.logger = logger;
+    this.env = env;
+    this.log = logger.get('http');
+    this.config$ = (0, _rxjs.combineLatest)([configService.atPath(_http_config.config.path), configService.atPath(_csp.config.path)]).pipe((0, _operators.map)(([http, csp]) => new _http_config.HttpConfig(http, csp)));
+    this.httpServer = new _http_server.HttpServer(logger, 'OpenSearchDashboards');
+    this.httpsRedirectServer = new _https_redirect_server.HttpsRedirectServer(logger.get('http', 'redirect', 'server'));
+  }
+
+  async setup(deps) {
+    this.requestHandlerContext = deps.context.createContextContainer();
+    this.configSubscription = this.config$.subscribe(() => {
+      if (this.httpServer.isListening()) {
+        // If the server is already running we can't make any config changes
+        // to it, so we warn and don't allow the config to pass through.
+        this.log.warn('Received new HTTP config after server was started. Config will **not** be applied.');
+      }
+    });
+    const config = await this.config$.pipe((0, _operators.first)()).toPromise();
+
+    if (this.shouldListen(config)) {
+      await this.runNotReadyServer(config);
+    }
+
+    const {
+      registerRouter,
+      ...serverContract
+    } = await this.httpServer.setup(config);
+    (0, _lifecycle_handlers.registerCoreHandlers)(serverContract, config, this.env);
+    this.internalSetup = { ...serverContract,
+      createRouter: (path, pluginId = this.coreContext.coreId) => {
+        const enhanceHandler = this.requestHandlerContext.createHandler.bind(null, pluginId);
+        const router = new _router.Router(path, this.log, enhanceHandler);
+        registerRouter(router);
+        return router;
+      },
+      registerRouteHandlerContext: (pluginOpaqueId, contextName, provider) => this.requestHandlerContext.registerContext(pluginOpaqueId, contextName, provider)
+    };
+    return this.internalSetup;
+  } // this method exists because we need the start contract to create the `CoreStart` used to start
+  // the `plugin` and `legacy` services.
+
+
+  getStartContract() {
+    return { ...(0, _std.pick)(this.internalSetup, ['auth', 'basePath', 'getServerInfo']),
+      isListening: () => this.httpServer.isListening()
+    };
+  }
+
+  async start() {
+    const config = await this.config$.pipe((0, _operators.first)()).toPromise();
+
+    if (this.shouldListen(config)) {
+      if (this.notReadyServer) {
+        this.log.debug('stopping NotReady server');
+        await this.notReadyServer.stop();
+        this.notReadyServer = undefined;
+      } // If a redirect port is specified, we start an HTTP server at this port and
+      // redirect all requests to the SSL port.
+
+
+      if (config.ssl.enabled && config.ssl.redirectHttpFromPort !== undefined) {
+        await this.httpsRedirectServer.start(config);
+      }
+
+      await this.httpServer.start();
+    }
+
+    return this.getStartContract();
+  }
+  /**
+   * Indicates if http server has configured to start listening on a configured port.
+   * We shouldn't start http service in two cases:
+   * 1. If `server.autoListen` is explicitly set to `false`.
+   * 2. When the process is run as dev cluster master in which case cluster manager
+   * will fork a dedicated process where http service will be set up instead.
+   * @internal
+   * */
+
+
+  shouldListen(config) {
+    return !this.coreContext.env.isDevClusterMaster && config.autoListen;
+  }
+
+  async stop() {
+    if (this.configSubscription === undefined) {
+      return;
+    }
+
+    this.configSubscription.unsubscribe();
+    this.configSubscription = undefined;
+
+    if (this.notReadyServer) {
+      await this.notReadyServer.stop();
+    }
+
+    await this.httpServer.stop();
+    await this.httpsRedirectServer.stop();
+  }
+
+  async runNotReadyServer(config) {
+    this.log.debug('starting NotReady server');
+    const httpServer = new _http_server.HttpServer(this.logger, 'NotReady');
+    const {
+      server
+    } = await httpServer.setup(config);
+    this.notReadyServer = server; // use hapi server while OpenSearchDashboardsResponseFactory doesn't allow specifying custom headers
+    // https://github.com/elastic/kibana/issues/33779
+
+    this.notReadyServer.route({
+      path: '/{p*}',
+      method: '*',
+      handler: (req, responseToolkit) => {
+        this.log.debug(`Wazuh Dashboard server is not ready yet ${req.method}:${req.url.href}.`); // If server is not ready yet, because plugins or core can perform
+        // long running tasks (build assets, saved objects migrations etc.)
+        // we should let client know that and ask to retry after 30 seconds.
+
+        return responseToolkit.response('Wazuh Dashboard server is not ready yet').code(503).header('Retry-After', '30');
+      }
+    });
+    await this.notReadyServer.start();
+  }
+
+}
+
+exports.HttpService = HttpService;

--- a/stack/dashboard/deb/debian/postinst
+++ b/stack/dashboard/deb/debian/postinst
@@ -35,11 +35,11 @@ case "$1" in
                 service wazuh-dashboard restart > /dev/null 2>&1
             fi
         fi
-
-        runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create"
-        runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin"
-        runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin"
-
+        if [ ! -f "${INSTALLATION_DIR}"/config/opensearch_dashboards.keystore ]; then
+            runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
+            runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
+            runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+        fi
     ;;
 
 

--- a/stack/dashboard/deb/debian/preinst
+++ b/stack/dashboard/deb/debian/preinst
@@ -29,7 +29,6 @@ case "$1" in
         # environment configuration
         mkdir -p "${CONFIG_DIR}"
         mkdir -p "${INSTALLATION_DIR}"
-        mkdir -p "${LOG_DIR}"
 
         
         # Create wazuh-dashboard group if not existing
@@ -51,6 +50,12 @@ case "$1" in
                     "${NAME}"
             echo " OK"
         fi  
+
+        if [ -d "${LOG_DIR}" ]; then
+            chown -R "${NAME}":"${NAME}" "${LOG_DIR}" 
+        else
+            mkdir -p "${LOG_DIR}"
+        fi
     
     ;;
     upgrade)

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -115,7 +115,7 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION).zip" 
+	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION).zip" 
 
 	find $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/wazuh/ -exec chown $(USER):$(GROUP) {} \;
 

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -32,7 +32,6 @@ export LOG_DIR=/var/log/${NAME}
 export USER=${NAME}
 export GROUP=${NAME}
 export DASHBOARD_FILE=wazuh-dashboard-base-$(BASE_VERSION)-linux-x64.tar.xz
-export OD_VERSION=1.2.0
 
 # -----------------------------------------------------------------------------
 
@@ -116,7 +115,7 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-$(OD_VERSION).zip" 
+	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION).zip" 
 
 	find $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/wazuh/ -exec chown $(USER):$(GROUP) {} \;
 

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -98,7 +98,7 @@ override_dh_install:
 
 	rm -rf $(TARGET_DIR)$(INSTALLATION_DIR)/etc
 
-	curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
+	curl -O https://packages-dev.wazuh.com/stack/demo-certs.tar.gz
 
 	tar -xf demo-certs.tar.gz
 

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -32,6 +32,7 @@ export LOG_DIR=/var/log/${NAME}
 export USER=${NAME}
 export GROUP=${NAME}
 export DASHBOARD_FILE=wazuh-dashboard-base-$(BASE_VERSION)-linux-x64.tar.xz
+export OD_VERSION=1.2.0
 
 # -----------------------------------------------------------------------------
 
@@ -83,6 +84,7 @@ override_dh_install:
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/custom_welcome/Assets/Favicons/* $(TARGET_DIR)$(INSTALLATION_DIR)/src/core/server/core_app/assets/favicons/
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/custom_welcome/Assets/Favicons/favicon-32x32.png $(TARGET_DIR)$(INSTALLATION_DIR)/src/core/server/core_app/assets/favicons/favicon.ico
 	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/opensearch_dashboards_config.js $(TARGET_DIR)$(INSTALLATION_DIR)/src/core/server/opensearch_dashboards_config.js
+	cp $(TARGET_DIR)$(INSTALLATION_DIR)/etc/http_service.js $(TARGET_DIR)$(INSTALLATION_DIR)/src/core/server/http/http_service.js
 
 
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/config
@@ -114,7 +116,7 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://s3.amazonaws.com/warehouse.wazuh.com/stack/dashboard/wazuh-1.2.0.zip" 
+	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-$(OD_VERSION).zip" 
 
 	find $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/wazuh/ -exec chown $(USER):$(GROUP) {} \;
 

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -54,7 +54,7 @@ override_dh_auto_install:
 
 override_dh_install:
 	if [ "$(BASE)" = "s3" ]; then \
-		curl -kOL https://s3.amazonaws.com/warehouse.wazuh.com/stack/dashboard/$(DASHBOARD_FILE) ;\
+		curl -kOL https://packages-dev.wazuh.com/stack/dashboard/base/$(DASHBOARD_FILE) ;\
 	else \
 		cp /root/output/wazuh-dashboard-base-$(BASE_VERSION)-linux-x64.tar.xz ./ ;\
 	fi

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -136,6 +136,12 @@ if [ $1 = 1 ]; then
   if ! id -u %{USER} > /dev/null 2>&1; then
     useradd -g %{GROUP} -G %{USER} -d %{INSTALL_DIR}/ -r -s /sbin/nologin wazuh-dashboard
   fi
+  if [ -d %{LOG_DIR} ]; then
+      chown -R %{USER}:%{GROUP} %{LOG_DIR}
+  else
+      mkdir -p %{LOG_DIR}
+      chown %{USER}:%{GROUP} %{LOG_DIR}
+  fi
 fi
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
@@ -202,10 +208,6 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
-if [ ! -d %{LOG_DIR} ]; then
-    mkdir -p %{LOG_DIR}
-    chown %{USER}:%{GROUP} %{LOG_DIR}
-fi
 if [ ! -d %{PID_DIR} ]; then
     mkdir -p %{PID_DIR}
     chown %{USER}:%{GROUP} %{PID_DIR}

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -47,7 +47,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 
 # Set up required files
 if [ "%{_base}" = "s3" ];then
-    curl -kOL https://s3.amazonaws.com/warehouse.wazuh.com/stack/dashboard/%{DASHBOARD_FILE}
+    curl -kOL https://packages-dev.wazuh.com/stack/dashboard/base/%{DASHBOARD_FILE}
 else
     cp /root/output/wazuh-dashboard-base-%{version}-linux-x64.tar.xz ./
 fi

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -32,7 +32,6 @@ ExclusiveOS: linux
 %global PID_DIR /run/%{name}
 %global INSTALL_DIR /usr/share/%{name}
 %global DASHBOARD_FILE wazuh-dashboard-base-%{version}-linux-x64.tar.xz
-%global OD_VERSION 1.2.0
 
 # -----------------------------------------------------------------------------
 
@@ -120,7 +119,7 @@ chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
 
 
-runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{OD_VERSION}.zip" 
+runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}.zip" 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -32,6 +32,7 @@ ExclusiveOS: linux
 %global PID_DIR /run/%{name}
 %global INSTALL_DIR /usr/share/%{name}
 %global DASHBOARD_FILE wazuh-dashboard-base-%{version}-linux-x64.tar.xz
+%global OD_VERSION 1.2.0
 
 # -----------------------------------------------------------------------------
 
@@ -86,6 +87,7 @@ cp %{buildroot}%{INSTALL_DIR}/etc/custom_welcome/Assets/default_branding/wazuh_m
 cp %{buildroot}%{INSTALL_DIR}/etc/custom_welcome/Assets/Favicons/* %{buildroot}%{INSTALL_DIR}/src/core/server/core_app/assets/favicons/
 cp %{buildroot}%{INSTALL_DIR}/etc/custom_welcome/Assets/Favicons/favicon-32x32.png %{buildroot}%{INSTALL_DIR}/src/core/server/core_app/assets/favicons/favicon.ico
 cp %{buildroot}%{INSTALL_DIR}/etc/opensearch_dashboards_config.js %{buildroot}%{INSTALL_DIR}/src/core/server/opensearch_dashboards_config.js
+cp %{buildroot}%{INSTALL_DIR}/etc/http_service.js %{buildroot}%{INSTALL_DIR}/src/core/server/http/http_service.js
 
 mkdir -p %{buildroot}%{INSTALL_DIR}/config
 
@@ -118,7 +120,7 @@ chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
 
 
-runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://s3.amazonaws.com/warehouse.wazuh.com/stack/dashboard/wazuh-1.2.0.zip" 
+runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{OD_VERSION}.zip" 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -98,7 +98,7 @@ chmod 640 %{buildroot}/etc/init.d/wazuh-dashboard
 chmod 640 %{buildroot}/etc/systemd/system/wazuh-dashboard.service 
 chmod 640 %{buildroot}/etc/default/wazuh-dashboard
 
-curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
+curl -O https://packages-dev.wazuh.com/stack/demo-certs.tar.gz
 
 tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -119,7 +119,7 @@ chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
 
 
-runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}.zip" 
+runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}.zip" 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -155,10 +155,11 @@ fi
 %post
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
 
-runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
-runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
-runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
-
+if [ ! -f %{INSTALLATION_DIR}/config/opensearch_dashboards.keystore ]; then
+  runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
+  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
+  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+fi
 # -----------------------------------------------------------------------------
 
 %preun

--- a/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
+++ b/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
@@ -2,8 +2,8 @@ network.host: "0.0.0.0"
 node.name: "node-1"
 cluster.initial_master_nodes:
 - "node-1"
-- "node-2"
-- "node-3"
+#- "node-2"
+#- "node-3"
 cluster.name: "wazuh-cluster"
 #discovery.seed_hosts:
 #  - "node-1-ip"
@@ -35,13 +35,13 @@ plugins.security.ssl.transport.resolve_hostname: false
 
 plugins.security.audit.type: internal_opensearch
 plugins.security.authcz.admin_dn:
-- "CN=admin,OU=Docu,O=Wazuh,L=California,C=US"
+- "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-- "CN=node-1,OU=Docu,O=Wazuh,L=California,C=US"
-#- "CN=node-2,OU=Docu,O=Wazuh,L=California,C=US"
-#- "CN=node-3,OU=Docu,O=Wazuh,L=California,C=US"
+- "CN=node-1,OU=Wazuh,O=Wazuh,L=California,C=US"
+#- "CN=node-2,OU=Wazuh,O=Wazuh,L=California,C=US"
+#- "CN=node-3,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"

--- a/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
+++ b/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
@@ -2,8 +2,13 @@ network.host: "0.0.0.0"
 node.name: "node-1"
 cluster.initial_master_nodes:
 - "node-1"
+- "node-2"
+- "node-3"
 cluster.name: "wazuh-cluster"
-
+#discovery.seed_hosts:
+#  - "node-1-ip"
+#  - "node-2-ip"
+#  - "node-3-ip"
 http.port: 9700-9799
 transport.tcp.port: 9800-9899
 node.max_local_storage_nodes: "3"
@@ -34,7 +39,9 @@ plugins.security.authcz.admin_dn:
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-- "CN=demo-indexer,OU=Docu,O=Wazuh,L=California,C=US"
+- "CN=node-1,OU=Docu,O=Wazuh,L=California,C=US"
+#- "CN=node-2,OU=Docu,O=Wazuh,L=California,C=US"
+#- "CN=node-3,OU=Docu,O=Wazuh,L=California,C=US"
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -93,7 +93,7 @@ override_dh_install:
 	cp -pr $(BASE_DIR)/* $(TARGET_DIR)$(INSTALLATION_DIR)
 
 	# Download demo certificates
-	curl -kOL https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
+	curl -kOL https://packages-dev.wazuh.com/stack/demo-certs.tar.gz
 	tar xzvf demo-certs.tar.gz && rm -f demo-certs.tar.gz
 	mkdir -p $(TARGET_DIR)$(CONFIG_DIR)/certs/
 	cp certs/admin.pem $(TARGET_DIR)$(CONFIG_DIR)/certs/

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -84,7 +84,7 @@ rm -rf wazuh-indexer-*/usr
 cp -pr wazuh-indexer-*/* ${RPM_BUILD_ROOT}%{INSTALL_DIR}/
 
 # Download demo certificates
-curl -kOL https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
+curl -kOL https://packages-dev.wazuh.com/stack/demo-certs.tar.gz
 tar xzf demo-certs.tar.gz && rm -f demo-certs.tar.gz
 chown -R %{USER}:%{GROUP} certs
 mkdir -p ${RPM_BUILD_ROOT}%{CONFIG_DIR}/certs/


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1258|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
- Wazuh plugin download path updated
- Changed error message from "Opensearch Dashboards server is not ready yet" to "Wazuh Dashboard server is not ready yet"
- A validation is added so that, in case of an upgrade, the Keystore is not replaced

## Logs example

<!--
Paste here related logs
-->
```
{"type":"response","@timestamp":"2022-02-15T12:24:30Z","tags":[],"pid":18232,"method":"get","statusCode":200,"req":{"url":"/ui/wazuh_wazuh_bg.svg","method":"get","headers":{"host":"192.168.56.252","connection":"keep-alive","user-agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.87 Safari/537.36","accept":"image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8","sec-gpc":"1","sec-fetch-site":"same-origin","sec-fetch-mode":"no-cors","sec-fetch-dest":"image","referer":"https://192.168.56.252/ui/legacy_light_theme.css","accept-encoding":"gzip, deflate, br","accept-language":"en-US,en;q=0.9"},"remoteAddress":"192.168.56.1","userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.87 Safari/537.36","referer":"https://192.168.56.252/ui/legacy_light_theme.css"},"res":{"statusCode":200,"responseTime":5,"contentLength":9},"message":"GET /ui/wazuh_wazuh_bg.svg 200 5ms - 9.0B"}
{"type":"log","@timestamp":"2022-02-15T12:37:24Z","tags":["info","plugins-system"],"pid":18232,"message":"Stopping all plugins."}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["info","plugins-service"],"pid":18398,"message":"Plugin \"visTypeXy\" is disabled."}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["info","plugins-system"],"pid":18398,"message":"Setting up [45] plugins: [alertingDashboards,usageCollection,opensearchDashboardsUsageCollection,opensearchDashboardsLegacy,mapsLegacy,share,opensearchUiShared,embeddable,legacyExport,expressions,data,home,console,apmOss,management,indexPatternManagement,advancedSettings,savedObjects,securityDashboards,indexManagementDashboards,anomalyDetectionDashboards,dashboard,notebooksDashboards,visualizations,visTypeTable,visTypeVega,visTypeTimeline,timeline,visTypeMarkdown,tileMap,regionMap,inputControlVis,visualize,ganttChartDashboards,queryWorkbenchDashboards,traceAnalyticsDashboards,reportsDashboards,charts,visTypeVislib,visTypeTimeseries,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]"}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["info","savedobjects-service"],"pid":18398,"message":"Waiting until all OpenSearch nodes are compatible with OpenSearch Dashboards before starting saved objects migrations..."}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["info","savedobjects-service"],"pid":18398,"message":"Starting saved objects migrations"}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["info","plugins-system"],"pid":18398,"message":"Starting [45] plugins: [alertingDashboards,usageCollection,opensearchDashboardsUsageCollection,opensearchDashboardsLegacy,mapsLegacy,share,opensearchUiShared,embeddable,legacyExport,expressions,data,home,console,apmOss,management,indexPatternManagement,advancedSettings,savedObjects,securityDashboards,indexManagementDashboards,anomalyDetectionDashboards,dashboard,notebooksDashboards,visualizations,visTypeTable,visTypeVega,visTypeTimeline,timeline,visTypeMarkdown,tileMap,regionMap,inputControlVis,visualize,ganttChartDashboards,queryWorkbenchDashboards,traceAnalyticsDashboards,reportsDashboards,charts,visTypeVislib,visTypeTimeseries,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]"}
{"type":"log","@timestamp":"2022-02-15T12:37:57Z","tags":["listening","info"],"pid":18398,"message":"Server running at https://0.0.0.0:443"}
{"type":"log","@timestamp":"2022-02-15T12:37:58Z","tags":["info","http","server","OpenSearchDashboards"],"pid":18398,"message":"http server running at https://0.0.0.0:443"}


```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
