### PR TITLE
Change wazuh_servers tag in config.yml

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -51,7 +51,7 @@ def get_indexer_ip():
         dictionary = yaml.safe_load(stream)
     return (dictionary.get('network.host'))
 
-def api_call_elasticsearch(host,query,address,api_protocol,api_user,api_pass,api_port):
+def api_call_indexer(host,query,address,api_protocol,api_user,api_pass,api_port):
 
     if (query == ""):   # Calling ES API without query
         if (api_user != "" and api_pass != ""): # If credentials provided
@@ -74,7 +74,7 @@ def api_call_elasticsearch(host,query,address,api_protocol,api_user,api_pass,api
     response = resp.json()
     return response
 
-def get_elasticsearch_cluster_status():
+def get_indexer_cluster_status():
     ip = get_indexer_ip()
     resp = requests.get('https://'+ip+':9700/_cluster/health',
                         auth=("admin",
@@ -162,7 +162,7 @@ def test_check_filebeat_process():
     assert check_call("ps -xa | grep \"/usr/share/filebeat/bin/filebeat\" | grep -v grep", shell=True) != ""
 
 @pytest.mark.indexer
-def test_check_elasticsearch_process():
+def test_check_indexer_process():
     assert check_call("ps -xa | grep \"/usr/share/wazuh-indexer/jdk/bin/java\" | grep -v grep | cut -d \" \" -f15", shell=True) != ""
 
 @pytest.mark.dashboard
@@ -170,12 +170,12 @@ def test_check_dashboard_process():
     assert check_call("ps -xa | grep \"/usr/share/wazuh-dashboard/bin/../node/bin/node\" | grep -v grep", shell=True) != ""
 
 @pytest.mark.indexer
-def test_check_elasticsearch_cluster_status_not_red():
-    assert get_elasticsearch_cluster_status() != "red"
+def test_check_indexer_cluster_status_not_red():
+    assert get_indexer_cluster_status() != "red"
 
 @pytest.mark.indexer_cluster
-def test_check_elasticsearch_cluster_status_not_yellow():
-    assert get_elasticsearch_cluster_status() != "yellow"
+def test_check_indexer_cluster_status_not_yellow():
+    assert get_indexer_cluster_status() != "yellow"
 
 @pytest.mark.dashboard
 def test_check_dashboard_status():
@@ -252,7 +252,7 @@ def test_check_alerts():
         }
     }
 
-    response = api_call_elasticsearch(get_indexer_ip(),query,get_indexer_ip(),'https',"admin",get_password("admin"),'9700')
+    response = api_call_indexer(get_indexer_ip(),query,get_indexer_ip(),'https',"admin",get_password("admin"),'9700')
 
     print(response)
 

--- a/unattended_installer/config/certificate/config.yml
+++ b/unattended_installer/config/certificate/config.yml
@@ -4,9 +4,9 @@ nodes:
     name: node-1
     ip: <indexer-node-ip>
     # name: node-2
-    # ip: <elasticsearch-node-ip>
+    # ip: <indexer-node-ip>
     # name: node-3
-    # ip: <elasticsearch-node-ip>
+    # ip: <indexer-node-ip>
 
   # Wazuh server nodes
   # Use node_type only with more than one Wazuh manager

--- a/unattended_installer/config/certificate/config.yml
+++ b/unattended_installer/config/certificate/config.yml
@@ -10,7 +10,7 @@ nodes:
 
   # Wazuh server nodes
   # Use node_type only with more than one Wazuh manager
-  wazuh_servers:
+  server:
     name: wazuh-1
     ip: <wazuh-manager-ip>
     # node_type: master

--- a/unattended_installer/config/certificate/config_aio.yml
+++ b/unattended_installer/config/certificate/config_aio.yml
@@ -2,8 +2,8 @@ nodes:
   indexer:
     name: indexer
     ip: 127.0.0.1
-  wazuh_servers:
-    name: filebeat
+  server:
+    name: server
     ip: 127.0.0.1
   dashboard:
     name: dashboard

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -258,7 +258,7 @@ function checks_names() {
         exit 1
     fi
 
-    if [ -n "${winame}" ] && [ -z "$(echo "${wazuh_servers_node_names[@]}" | grep -w "${winame}")" ]; then
+    if [ -n "${winame}" ] && [ -z "$(echo "${server_node_names[@]}" | grep -w "${winame}")" ]; then
         logger -e "The Wazuh server node name ${winame} does not appear on the configuration file."
         exit 1
     fi

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -86,12 +86,12 @@ function dashboard_initialize() {
         j=$((j+1))
     done
 
-    if [ "${#wazuh_servers_node_names[@]}" -eq 1 ]; then
-        wazuh_api_address=${wazuh_servers_node_ips[0]}
+    if [ "${#server_node_names[@]}" -eq 1 ]; then
+        wazuh_api_address=${server_node_ips[0]}
     else
-        for i in "${!wazuh_servers_node_types[@]}"; do
-            if [[ "${wazuh_servers_node_types[i]}" == "master" ]]; then
-                wazuh_api_address=${wazuh_servers_node_ips[i]}
+        for i in "${!server_node_types[@]}"; do
+            if [[ "${server_node_types[i]}" == "master" ]]; then
+                wazuh_api_address=${server_node_ips[i]}
             fi
         done
     fi

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -8,15 +8,15 @@
 
 function manager_startCluster() {
 
-    for i in "${!wazuh_servers_node_names[@]}"; do
-        if [[ "${wazuh_servers_node_names[i]}" == "${winame}" ]]; then
+    for i in "${!server_node_names[@]}"; do
+        if [[ "${server_node_names[i]}" == "${winame}" ]]; then
             pos="${i}";
         fi
     done
 
-    for i in "${!wazuh_servers_node_types[@]}"; do
-        if [[ "${wazuh_servers_node_types[i],,}" == "master" ]]; then
-            master_address=${wazuh_servers_node_ips[i]}
+    for i in "${!server_node_types[@]}"; do
+        if [[ "${server_node_types[i],,}" == "master" ]]; then
+            master_address=${server_node_ips[i]}
         fi
     done
 
@@ -30,7 +30,7 @@ function manager_startCluster() {
 
     eval 'sed -i -e "${lstart},${lend}s/<name>.*<\/name>/<name>wazuh_cluster<\/name>/" \
         -e "${lstart},${lend}s/<node_name>.*<\/node_name>/<node_name>${winame}<\/node_name>/" \
-        -e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${wazuh_servers_node_types[pos],,}<\/node_type>/" \
+        -e "${lstart},${lend}s/<node_type>.*<\/node_type>/<node_type>${server_node_types[pos],,}<\/node_type>/" \
         -e "${lstart},${lend}s/<key>.*<\/key>/<key>${key}<\/key>/" \
         -e "${lstart},${lend}s/<port>.*<\/port>/<port>${port}<\/port>/" \
         -e "${lstart},${lend}s/<bind_addr>.*<\/bind_addr>/<bind_addr>${bind_address}<\/bind_addr>/" \

--- a/unattended_installer/install_functions/wazuh-cert-tool.sh
+++ b/unattended_installer/install_functions/wazuh-cert-tool.sh
@@ -144,13 +144,13 @@ function generateIndexercertificates() {
 
 function generateFilebeatcertificates() {
 
-    if [ ${#wazuh_servers_node_names[@]} -gt 0 ]; then
+    if [ ${#server_node_names[@]} -gt 0 ]; then
         logger_cert -d "Creating the Wazuh server certificates."
 
-        for i in "${!wazuh_servers_node_names[@]}"; do
-            generateCertificateconfiguration "${wazuh_servers_node_names[i]}" "${wazuh_servers_node_ips[i]}"
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/${wazuh_servers_node_names[i]}-key.pem -out ${base_path}/certs/${wazuh_servers_node_names[i]}.csr -config ${base_path}/certs/${wazuh_servers_node_names[i]}.conf -days 3650 ${debug_cert}"
-            eval "openssl x509 -req -in ${base_path}/certs/${wazuh_servers_node_names[i]}.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -out ${base_path}/certs/${wazuh_servers_node_names[i]}.pem -extfile ${base_path}/certs/${wazuh_servers_node_names[i]}.conf -extensions v3_req -days 3650 ${debug_cert}"
+        for i in "${!server_node_names[@]}"; do
+            generateCertificateconfiguration "${server_node_names[i]}" "${server_node_ips[i]}"
+            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${base_path}/certs/${server_node_names[i]}-key.pem -out ${base_path}/certs/${server_node_names[i]}.csr -config ${base_path}/certs/${server_node_names[i]}.conf -days 3650 ${debug_cert}"
+            eval "openssl x509 -req -in ${base_path}/certs/${server_node_names[i]}.csr -CA ${base_path}/certs/root-ca.pem -CAkey ${base_path}/certs/root-ca.key -CAcreateserial -out ${base_path}/certs/${server_node_names[i]}.pem -extfile ${base_path}/certs/${server_node_names[i]}.conf -extensions v3_req -days 3650 ${debug_cert}"
         done
     fi
 
@@ -336,14 +336,14 @@ function readConfig() {
         fi
         eval "$(parse_yaml "${config_file}")"
         eval "indexer_node_names=( $(parse_yaml "${config_file}" | grep nodes_indexer_name | sed 's/nodes_indexer_name=//') )"
-        eval "wazuh_servers_node_names=( $(parse_yaml "${config_file}" | grep nodes_wazuh_servers_name | sed 's/nodes_wazuh_servers_name=//') )"
+        eval "server_node_names=( $(parse_yaml "${config_file}" | grep nodes_server_name | sed 's/nodes_server_name=//') )"
         eval "dashboard_node_names=( $(parse_yaml "${config_file}" | grep nodes_dashboard_name | sed 's/nodes_dashboard_name=//') )"
 
         eval "indexer_node_ips=( $(parse_yaml "${config_file}" | grep nodes_indexer_ip | sed 's/nodes_indexer_ip=//') )"
-        eval "wazuh_servers_node_ips=( $(parse_yaml "${config_file}" | grep nodes_wazuh_servers_ip | sed 's/nodes_wazuh_servers_ip=//') )"
+        eval "server_node_ips=( $(parse_yaml "${config_file}" | grep nodes_server_ip | sed 's/nodes_server_ip=//') )"
         eval "dashboard_node_ips=( $(parse_yaml "${config_file}" | grep nodes_dashboard_ip | sed 's/nodes_dashboard_ip=//') )"
 
-        eval "wazuh_servers_node_types=( $(parse_yaml "${config_file}" | grep nodes_wazuh_servers_node_type | sed 's/nodes_wazuh_servers_node_type=//') )"
+        eval "server_node_types=( $(parse_yaml "${config_file}" | grep nodes_server_node_type | sed 's/nodes_server_node_type=//') )"
 
         unique_names=($(echo "${indexer_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_names[@]}" -ne "${#indexer_node_names[@]}" ]; then 
@@ -357,14 +357,14 @@ function readConfig() {
             exit 1
         fi
 
-        unique_names=($(echo "${wazuh_servers_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-        if [ "${#unique_names[@]}" -ne "${#wazuh_servers_node_names[@]}" ]; then 
+        unique_names=($(echo "${server_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_names[@]}" -ne "${#server_node_names[@]}" ]; then 
             logger_cert -e "Duplicated Wazuh server node names."
             exit 1
         fi
 
-        unique_ips=($(echo "${wazuh_servers_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-        if [ "${#unique_ips[@]}" -ne "${#wazuh_servers_node_ips[@]}" ]; then 
+        unique_ips=($(echo "${server_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+        if [ "${#unique_ips[@]}" -ne "${#server_node_ips[@]}" ]; then 
             logger_cert -e "Duplicated Wazuh server node ips."
             exit 1
         fi
@@ -381,33 +381,33 @@ function readConfig() {
             exit 1
         fi
 
-        if [ "${#wazuh_servers_node_names[@]}" -ne "${#wazuh_servers_node_ips[@]}" ]; then 
+        if [ "${#server_node_names[@]}" -ne "${#server_node_ips[@]}" ]; then 
             logger_cert -e "Different number of Wazuh server node names and IPs."
             exit 1
         fi
 
-        for i in "${wazuh_servers_node_types[@]}"; do
+        for i in "${server_node_types[@]}"; do
             if ! echo "$i" | grep -ioq master && ! echo "$i" | grep -ioq worker; then
                 logger_cert -e "Incorrect node_type $i must be master or worker"
                 exit 1
             fi
         done
 
-        if [ "${#wazuh_servers_node_names[@]}" -le 1 ]; then
-            if [ "${#wazuh_servers_node_types[@]}" -ne 0 ]; then
+        if [ "${#server_node_names[@]}" -le 1 ]; then
+            if [ "${#server_node_types[@]}" -ne 0 ]; then
                 logger_cert -e "The tag node_type can only be used with more than one Wazuh server."
                 exit 1
             fi
-        elif [ "${#wazuh_servers_node_names[@]}" -gt "${#wazuh_servers_node_types[@]}" ]; then
+        elif [ "${#server_node_names[@]}" -gt "${#server_node_types[@]}" ]; then
             logger_cert -e "The tag node_type needs to be specified for all Wazuh server nodes."
             exit 1
-        elif [ "${#wazuh_servers_node_names[@]}" -lt "${#wazuh_servers_node_types[@]}" ]; then
+        elif [ "${#server_node_names[@]}" -lt "${#server_node_types[@]}" ]; then
             logger_cert -e "Found extra node_type tags."
             exit 1
-        elif [ $(grep -io master <<< ${wazuh_servers_node_types[*]} | wc -l) -ne 1 ]; then
+        elif [ $(grep -io master <<< ${server_node_types[*]} | wc -l) -ne 1 ]; then
             logger_cert -e "Wazuh cluster needs a single master node."
             exit 1
-        elif [ $(grep -io worker <<< ${wazuh_servers_node_types[*]} | wc -l) -ne $(( ${#wazuh_servers_node_types[@]} - 1 )) ]; then
+        elif [ $(grep -io worker <<< ${server_node_types[*]} | wc -l) -ne $(( ${#server_node_types[@]} - 1 )) ]; then
             logger_cert -e "Incorrect number of workers."
             exit 1
         fi

--- a/unattended_installer/wazuh_install.sh
+++ b/unattended_installer/wazuh_install.sh
@@ -367,7 +367,7 @@ function main() {
             checkOpenSSL
         fi
         common_createCertificates
-        if [ -n "${wazuh_servers_node_types[*]}" ]; then
+        if [ -n "${server_node_types[*]}" ]; then
             common_createClusterKey
         fi
         gen_file="${base_path}/certs/password_file.yml"
@@ -443,7 +443,7 @@ function main() {
         importFunction "filebeat.sh"
 
         manager_install
-        if [ -n "${wazuh_servers_node_types[*]}" ]; then
+        if [ -n "${server_node_types[*]}" ]; then
             manager_startCluster
         fi
         common_startService "wazuh-manager"


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR modifies the tags in `config.yml` substituting `wazuh_servers` with `server`.

### New template
```
nodes:
  # Wazuh indexer server nodes
  indexer:
    name: node-1
    ip: <indexer-node-ip>
    # name: node-2
    # ip: <elasticsearch-node-ip>
    # name: node-3
    # ip: <elasticsearch-node-ip>

  # Wazuh server nodes
  # Use node_type only with more than one Wazuh manager
  server:
    name: wazuh-1
    ip: <wazuh-manager-ip>
    # node_type: master
    # name: wazuh-2
    # ip: <wazuh-manager-ip>
    # node_type: worker

  # Wazuh dashboard node
  dashboard:
    name: dashboard
    ip: <dashboard-node-ip>

```

Also, we have replaced elasticsearch with indexer in the install test function names.

## Logs example

```
[root@centos repo]# ./wazuh_install.sh -a -l
16/02/2022 15:39:23 INFO: Starting Wazuh unattended installer. Wazuh version: 4.3.0. Wazuh installer version: 0.1
16/02/2022 15:39:24 INFO: Check recommended minimum hardware requirements for AIO done.
16/02/2022 15:39:24 INFO: --------------------------------- Configuration files ---------------------------------
16/02/2022 15:39:25 INFO: Configuration files created: /home/vagrant/repo/configurations.tar
16/02/2022 15:39:25 INFO: ------------------------------------ Dependencies -------------------------------------
16/02/2022 15:39:25 INFO: Starting the installation of dependencies.
16/02/2022 15:39:25 INFO: Installation of dependencies finished.
16/02/2022 15:39:26 INFO: ------------------------------------ Wazuh indexer ------------------------------------
16/02/2022 15:39:26 INFO: Starting Wazuh indexer installation.
16/02/2022 15:40:41 INFO: Wazuh indexer installation finished.
16/02/2022 15:40:41 INFO: Wazuh indexer post-install configuration finished.
16/02/2022 15:40:41 INFO: Starting service wazuh-indexer.
16/02/2022 15:40:49 INFO: Wazuh-indexer service started.
16/02/2022 15:40:49 INFO: Starting Wazuh indexer cluster.
16/02/2022 15:40:54 INFO: Wazuh indexer cluster started.
16/02/2022 15:40:54 INFO: ------------------------------------- Wazuh server ------------------------------------
16/02/2022 15:40:54 INFO: Starting the Wazuh manager installation.
16/02/2022 15:41:39 INFO: Wazuh manager installation finished.
16/02/2022 15:41:39 INFO: Starting service wazuh-manager.
16/02/2022 15:41:46 INFO: Wazuh-manager service started.
16/02/2022 15:41:46 INFO: Starting filebeat installation.
16/02/2022 15:41:52 INFO: Filebeat installation finished.
16/02/2022 15:41:53 INFO: Filebeat post-install configuration finished.
16/02/2022 15:41:53 INFO: Starting service filebeat.
16/02/2022 15:41:53 INFO: Filebeat service started.
16/02/2022 15:41:53 INFO: ---------------------------------- Wazuh dashboard -----------------------------------
16/02/2022 15:41:53 INFO: Starting Wazuh dashboard installation.
16/02/2022 15:43:02 INFO: Wazuh dashboard installation finished.
16/02/2022 15:43:02 INFO: Wazuh dashboard post-install configuration finished.
16/02/2022 15:43:02 INFO: Starting service wazuh-dashboard.
16/02/2022 15:43:02 INFO: Wazuh-dashboard service started.
16/02/2022 15:43:16 INFO: Starting Wazuh dashboard (this may take a while).
16/02/2022 15:43:28 INFO: Wazuh dashboard started.
16/02/2022 15:43:28 INFO: You can access the web interface https://<wazuh-dashboard-host-ip>. The credentials are admin:F3LwSGDqoEIqD0u2mpieX8MaS349AgKU
16/02/2022 15:43:28 INFO: Installation finished. You can find in /home/vagrant/repo/configurations.tar all the certificates created, as well as password_file.yml, with the passwords for all users and config.yml, with the nodes of all of the components and their ips.
```
