### PR TITLE
Wazuh Passwords tool prints password when all are changed

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -351,6 +351,9 @@ function passwords_runSecurityAdmin() {
 
     if [ -n "${changeall}" ]; then
         if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_elastic_cluster}" ]; then
+            for i in "${!users[@]}"; do
+                common_logger $'The password for user '${users[i]}' is '${passwords[i]}''
+            done
             common_logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/dashboard.yml if necessary and restart the services."
         else
             common_logger -d "Passwords changed."


### PR DESCRIPTION
|Related issue|
|---|
| closes #1268 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
`wazuh-passwords-tool` now prints the changed passwords when used with option `-a`

## Logs example

<!--
Paste here related logs
-->
```
root@debian-9:/vagrant/wazuh-packages/unattended_installer# bash wazuh-passwords-tool.sh -a
18/02/2022 14:46:51 INFO: The password for user admin is 1GKbzPf7RXxjZIJaLuJqVwjqlPu7jrUO
18/02/2022 14:46:51 INFO: The password for user kibanaserver is BAuiLidnjhinezBfsX3q88jvsmeBOyWI
18/02/2022 14:46:51 INFO: The password for user kibanaro is 5MiEfxnu2jvA827W0Om2l1aGTamLe2Ha
18/02/2022 14:46:51 INFO: The password for user logstash is sgjxbXYMc3fsBVniAZ4sBaKZ36msFLJG
18/02/2022 14:46:51 INFO: The password for user readall is muSvhPim62nDvHH5CfcnFIEtOrFc78wC
18/02/2022 14:46:51 INFO: The password for user snapshotrestore is XfKYiATVq3PSR7CGMo5J9Td4BIy48x1h
18/02/2022 14:46:51 INFO: The password for user wazuh_admin is Cw98dzZvMFrbcdIemyi2DXSCNMXSZfrd
18/02/2022 14:46:51 INFO: The password for user wazuh_user is 1JdeEj1SV5jckgcuRHdHTfm1fJhOThgN
18/02/2022 14:46:51 WARNING: Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/dashboard.yml if necessary and restart the services.
root@debian-9:/vagrant/wazuh-packages/unattended_installer# 
```