### PR TITLE
Add com.apple.system-task-ports.read entitlement for listing processes accurately 

### DIFF
--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -18,5 +18,7 @@
     <true/>
     <key>com.apple.security.assets.movies.read-only</key>
     <true/>
+    <key>com.apple.system-task-ports.read</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
|Related issue|
|---|
|#11855|


## Description

This PR adds the `com.apple.system-task-ports.read` entitlement to our binaries. This is needed to be able to run functions such as `task_for_pid` and others which are needed to determine the state of a process. Without this entitlement, we can only get the process info for the calling process.

