### PR TITLE
Fix partition size in AIX package generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Fix AIX partition size [#1274](https://github.com/wazuh/wazuh-packages/pull/1274)
 - Fix Solaris 11 upgrade from previous packages [#1147](https://github.com/wazuh/wazuh-packages/pull/1147)
 - Add new GCloud integration files to Solaris 11 [#1126](https://github.com/wazuh/wazuh-packages/pull/1126)
 - Update SPECS [#689](https://github.com/wazuh/wazuh-packages/pull/689)

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -60,7 +60,7 @@ build_perl() {
 }
 
 build_cmake() {
-  mv /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h.bkp 
+  mv /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h.bkp
   curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz
   gtar -zxf cmake-3.12.4.tar.gz && cd cmake-3.12.4
   ./bootstrap
@@ -77,9 +77,9 @@ build_environment() {
   if grep 'www.siteox.com' /etc/motd > /dev/null 2>&1; then
     for partition in "/home" "/opt"; do
       partition_size=$(df -m | grep $partition | awk -F' ' '{print $2}' | cut -d'.' -f1)
-      if [[ ${partition_size} -lt "3584" ]]; then
-        echo "Resizing $partition partition to 3.5GB"
-        chfs -a size=3584M $partition > /dev/null 2>&1
+      if [[ ${partition_size} -lt "2048" ]]; then
+        echo "Resizing $partition partition to 2GB"
+        chfs -a size=2048M $partition > /dev/null 2>&1
       fi
     done
   fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/12201#issuecomment-1050268381|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR aims to fix the AIX package generation, since the partition is not resized correctly

## Logs example and Tests

Failed: https://ci.wazuh.info/view/Packages/job/Packages_builder_special/408/

```
18:28:09  installing package perl-5.28.0-1 needs 117Mb on the /opt filesystem
18:28:09  installing package gcc-6.3.0-1 needs 87Mb on the /opt filesystem
18:28:09  installing package libstdc++-6.3.0-1 needs 66Mb on the /opt filesystem
18:28:09  ./Configure[3118]: gcc:  not found
```

Success: https://ci.wazuh.info/view/Packages/job/Packages_builder_special/409/



<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] AIX
- [x] Package installation
- [x] Package upgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

Check related issue with testing

<!-- Depending on the affected OS -->
- Tests for IBM AIX
  - [x] `%files` section is correctly updated if necessary (not necessary)
  - [x] Check the changes from IBM AIX 5 to 7 (testing in aix 6.1)
