### PR TITLE
Change FIM database management using DBSync and RSync

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -20,7 +20,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64:${LD_LIBRARY_PATH}"

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -23,7 +23,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -24,7 +24,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
         --with-fpu=vfpv3-d16 --with-float=hard --enable-languages=c,c++ \
        --disable-multilib --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -23,7 +23,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib:${LD_LIBRARY_PATH}"

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -20,7 +20,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64:${LD_LIBRARY_PATH}"

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -66,11 +66,9 @@ build_environment() {
     /usr/local/bin/depothelper $fpt_connection -f libtool
     /usr/local/bin/depothelper $fpt_connection -f coreutils
     /usr/local/bin/depothelper $fpt_connection -f gdb
-    /usr/local/bin/depothelper $fpt_connection -f perl-5.10.1
+    /usr/local/bin/depothelper $fpt_connection -f perl
     /usr/local/bin/depothelper $fpt_connection -f regex
     /usr/local/bin/depothelper $fpt_connection -f python
-    cp /usr/bin/perl /tmp/perl
-    cp /usr/local/bin/perl5.10.1 /usr/bin/perl
 
     # Install GCC 9.4
     mkdir ${build_tools_path}

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -141,6 +141,12 @@ compile() {
     gmake deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
     gmake TARGET=agent USE_SELINUX=no
     bash ${source_directory}/install.sh
+    # Install std libs needed to run the agent
+    cp -f ${build_tools_path}/bootstrap-gcc/gcc94_prefix/lib/libstdc++.so.6.28 ${install_path}/lib
+    cp -f ${build_tools_path}/bootstrap-gcc/gcc94_prefix/lib/libgcc_s.so.0 ${install_path}/lib
+    ln -s ${install_path}/lib/libstdc++.so.6.28 ${install_path}/lib/libstdc++.so.6
+    ln -s ${install_path}/lib/libstdc++.so.6.28 ${install_path}/lib/libstdc++.so
+    ln -s ${install_path}/lib/libgcc_s.so.0 ${install_path}/lib/libgcc_s.so
     cd $current_path
 }
 

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -75,7 +75,7 @@ build_environment() {
     cd ${build_tools_path}
     mkdir bootstrap-gcc
     cd ${build_tools_path}/bootstrap-gcc
-    curl -k -SO https://packages.wazuh.com/utils/gcc/gcc_9.4_HPUX_build.tar.gz
+    curl -k -SO http://packages.wazuh.com/utils/gcc/gcc_9.4_HPUX_build.tar.gz
     gunzip gcc_9.4_HPUX_build.tar.gz
     tar -xf gcc_9.4_HPUX_build.tar
     rm -f gcc_9.4_HPUX_build.tar
@@ -83,7 +83,7 @@ build_environment() {
 
     # Install cmake 3.22.2
     cd ${build_tools_path}
-    curl -k -SO https://packages.wazuh.com/utils/cmake/cmake_3.22.2_HPUX_build.tar.gz
+    curl -k -SO http://packages.wazuh.com/utils/cmake/cmake_3.22.2_HPUX_build.tar.gz
     gunzip cmake_3.22.2_HPUX_build.tar.gz
     tar -xf cmake_3.22.2_HPUX_build.tar
     rm -f cmake_3.22.2_HPUX_build.tar

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -21,7 +21,8 @@ control_binary=""
 # Needed variables to build Wazuh with custom GCC and cmake
 PATH=${build_tools_path}/bootstrap-gcc/gcc94_prefix/bin:${build_tools_path}/cmake_prefix_install/bin:$PATH:/usr/local/bin
 LD_LIBRARY_PATH=${build_tools_path}/bootstrap-gcc/gcc94_prefix/lib
-CXX=/home/okkam/bootstrap-gcc/gcc94_prefix/bin/g++
+export LD_LIBRARY_PATH
+CXX=${build_tools_path}/bootstrap-gcc/gcc94_prefix/bin/g++
 
 build_environment() {
 

--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -8,15 +8,20 @@
 
 install_path="/var/ossec"
 current_path=`pwd`
+build_tools_path="/home/okkam"
 source_directory=${current_path}/wazuh-sources
 configuration_file="${source_directory}/etc/preloaded-vars.conf"
-PATH=$PATH:/usr/local/bin
 target_dir="${current_path}/output"
 checksum_dir=""
 wazuh_version=""
 wazuh_revision="1"
 depot_path=""
 control_binary=""
+
+# Needed variables to build Wazuh with custom GCC and cmake
+PATH=${build_tools_path}/bootstrap-gcc/gcc94_prefix/bin:${build_tools_path}/cmake_prefix_install/bin:$PATH:/usr/local/bin
+LD_LIBRARY_PATH=${build_tools_path}/bootstrap-gcc/gcc94_prefix/lib
+CXX=/home/okkam/bootstrap-gcc/gcc94_prefix/bin/g++
 
 build_environment() {
 
@@ -53,7 +58,6 @@ build_environment() {
     swinstall -s $depot \*
     /usr/local/bin/depothelper $fpt_connection -f curl
     /usr/local/bin/depothelper $fpt_connection -f unzip
-    /usr/local/bin/depothelper $fpt_connection -f gcc
     /usr/local/bin/depothelper $fpt_connection -f make
     /usr/local/bin/depothelper $fpt_connection -f bash
     /usr/local/bin/depothelper $fpt_connection -f gzip
@@ -62,9 +66,29 @@ build_environment() {
     /usr/local/bin/depothelper $fpt_connection -f libtool
     /usr/local/bin/depothelper $fpt_connection -f coreutils
     /usr/local/bin/depothelper $fpt_connection -f gdb
-    /usr/local/bin/depothelper $fpt_connection -f perl
+    /usr/local/bin/depothelper $fpt_connection -f perl-5.10.1
     /usr/local/bin/depothelper $fpt_connection -f regex
     /usr/local/bin/depothelper $fpt_connection -f python
+    cp /usr/bin/perl /tmp/perl
+    cp /usr/local/bin/perl5.10.1 /usr/bin/perl
+
+    # Install GCC 9.4
+    mkdir ${build_tools_path}
+    cd ${build_tools_path}
+    mkdir bootstrap-gcc
+    cd ${build_tools_path}/bootstrap-gcc
+    curl -k -SO https://packages.wazuh.com/utils/gcc/gcc_9.4_HPUX_build.tar.gz
+    gunzip gcc_9.4_HPUX_build.tar.gz
+    tar -xf gcc_9.4_HPUX_build.tar
+    rm -f gcc_9.4_HPUX_build.tar
+    cp -f ${build_tools_path}/bootstrap-gcc/gcc94_prefix/bin/gcc ${build_tools_path}/bootstrap-gcc/gcc94_prefix/bin/cc
+
+    # Install cmake 3.22.2
+    cd ${build_tools_path}
+    curl -k -SO https://packages.wazuh.com/utils/cmake/cmake_3.22.2_HPUX_build.tar.gz
+    gunzip cmake_3.22.2_HPUX_build.tar.gz
+    tar -xf cmake_3.22.2_HPUX_build.tar
+    rm -f cmake_3.22.2_HPUX_build.tar
 }
 
 config() {
@@ -171,6 +195,8 @@ clean() {
     find /sbin -name "*wazuh-agent*" -exec rm {} \;
     userdel wazuh
     groupdel wazuh
+
+    rm -rf ${build_tools_path}
 
     exit ${exit_code}
 }

--- a/rpms/CentOS/5/i386/Dockerfile
+++ b/rpms/CentOS/5/i386/Dockerfile
@@ -31,7 +31,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     linux32 ./contrib/download_prerequisites && \
     linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib --disable-libsanitizer && \
     linux32 make -j2 && linux32 make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"

--- a/rpms/CentOS/5/x86_64/Dockerfile
+++ b/rpms/CentOS/5/x86_64/Dockerfile
@@ -35,7 +35,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     make -j2 && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"

--- a/rpms/CentOS/6/i386/Dockerfile
+++ b/rpms/CentOS/6/i386/Dockerfile
@@ -46,7 +46,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"

--- a/rpms/CentOS/6/x86_64/Dockerfile
+++ b/rpms/CentOS/6/x86_64/Dockerfile
@@ -46,7 +46,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"

--- a/rpms/CentOS/7/aarch64/Dockerfile
+++ b/rpms/CentOS/7/aarch64/Dockerfile
@@ -30,7 +30,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer --disable-bootstrap && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"

--- a/rpms/CentOS/7/armv7hl/Dockerfile
+++ b/rpms/CentOS/7/armv7hl/Dockerfile
@@ -10,7 +10,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
         --with-float=hard --with-fpu=vfpv3-d16 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"

--- a/rpms/CentOS/7/ppc64le/Dockerfile
+++ b/rpms/CentOS/7/ppc64le/Dockerfile
@@ -27,7 +27,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -549,6 +549,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libstdc++.so.6
 %attr(750, root, wazuh) %{_localstatedir}/lib/libgcc_s.so.1
+%attr(750, root, wazuh) %{_localstatedir}/lib/libfimdb.so
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -675,6 +675,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/libjemalloc.so.2
 %attr(750, root, wazuh) %{_localstatedir}/lib/libstdc++.so.6
 %attr(750, root, wazuh) %{_localstatedir}/lib/libgcc_s.so.1
+%attr(750, root, wazuh) %{_localstatedir}/lib/libfimdb.so
 %{_localstatedir}/lib/libpython3.9.so.1.0
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
 %attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log

--- a/solaris/solaris11/SPECS/template_agent.json
+++ b/solaris/solaris11/SPECS/template_agent.json
@@ -679,6 +679,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/lib/libfimdb.so": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/lib/libsysinfo.so": {
         "class": "static",
         "group": "wazuh",

--- a/wpk/linux/x86_64/Dockerfile
+++ b/wpk/linux/x86_64/Dockerfile
@@ -25,7 +25,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ \
         --disable-multilib --disable-libsanitizer && \
     make -j$(nproc) && make install && \
-    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
 
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"


### PR DESCRIPTION
|Related issue|Component|
|---|---|
| https://github.com/wazuh/wazuh/issues/9103 | FIM |

## Description

This pull request adds the following changes related to the FIM rework to support DBSync, and RSync.

- RPM specs have been updated to include the new library for FIM `libfimdb.so`
- Solaris specs have been updated to include the new library
- The script to generate the package for HP-UX has been updated to:
  - Download and deploy the needed compiler GCC 9.4 and CMake 3.22.2
  - GCC is no longer downloaded from the depothelper
  - Standard libraries needed to run the agent are added to the installation directory

After the need to include two new libraries in the agent installation, the footprint of the package grows.
- `libstdc++.so`: 27MB
-  `libgcc_s.so`: 0.4MB
- Agent package: 55MB

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Windows
  - [x] macOS
  - [x] Solaris
  - [x] AIX
  - [x] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
