### PR TITLE
Check if group exists before removing

### DIFF
--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postinst
@@ -152,9 +152,11 @@ case "$1" in
             find ${DIR} -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecr > /dev/null 2>&1
         fi
-        delgroup ossec > /dev/null 2>&1
+        if getent group ossec > /dev/null 2>&1; then 
+            delgroup ossec > /dev/null 2>&1
+        fi
     fi
-    
+
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postinst
@@ -245,7 +245,9 @@ case "$1" in
             find ${DIR} -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
             deluser ossecr > /dev/null 2>&1
         fi
-        delgroup ossec > /dev/null 2>&1
+        if getent group ossec > /dev/null 2>&1; then 
+            delgroup ossec > /dev/null 2>&1
+        fi
     fi
 
     if [ ! -z "$2" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1276|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error where in some Debian systems the ossec group was deleted once all the users had been deleted causing the post install script to fail when upgrading.

## Logs example

<!--
Paste here related logs
-->
```
root@ubuntu20LTS:/home/vagrant# apt install ./wazuh-agent_4.1.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.1.0-1_amd64.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/5310 kB of archives.
After this operation, 16.8 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_4.1.0-1_amd64.deb wazuh-agent amd64 4.1.0-1 [5310 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 63261 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.1.0-1_amd64.deb ...
Unpacking wazuh-agent (4.1.0-1) ...
Setting up wazuh-agent (4.1.0-1) ...
Processing triggers for systemd (245.4-4ubuntu3.15) ...
root@ubuntu20LTS:/home/vagrant# apt install ./wazuh-agent_4.3.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.3.0-1_amd64.deb'
The following packages will be upgraded:
  wazuh-agent
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/8241 kB of archives.
After this operation, 9736 kB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_4.3.0-1_amd64.deb wazuh-agent amd64 4.3.0-1 [8241 kB]
Preconfiguring packages ...
(Reading database ... 63579 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.3.0-1_amd64.deb ...
Unpacking wazuh-agent (4.3.0-1) over (4.1.0-1) ...
Setting up wazuh-agent (4.3.0-1) ...
Installing new version of config file /etc/systemd/system/wazuh-agent.service ...
Installing new version of config file /etc/init.d/wazuh-agent ...
Processing triggers for systemd (245.4-4ubuntu3.15) ...

```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
