### PR TITLE
Fix Wazuh not stopping after uninstalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Fix error where Wazuh could continue running after uninstalling [#1280](https://github.com/wazuh/wazuh-packages/pull/1280)
 - Fix AIX partition size [#1274](https://github.com/wazuh/wazuh-packages/pull/1274)
 - Fix Solaris 11 upgrade from previous packages [#1147](https://github.com/wazuh/wazuh-packages/pull/1147)
 - Add new GCloud integration files to Solaris 11 [#1126](https://github.com/wazuh/wazuh-packages/pull/1126)

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/prerm
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/prerm
@@ -19,9 +19,8 @@ case "$1" in
       # Check for SysV
       elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
           service wazuh-agent stop > /dev/null 2>&1
-      else
-          ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
+      ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
       # Save the conffiles
       mkdir -p ${DIR}/tmp/conffiles

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/prerm
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/prerm
@@ -17,9 +17,8 @@ case "$1" in
       # Check for SysV
       elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
           service wazuh-manager stop > /dev/null 2>&1
-      else
-          ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
       fi
+      ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
       # Purging files
       rm -rf ${DIR}/stats/*

--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -382,11 +382,10 @@ if [ $1 = 0 ]; then
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
     systemctl stop wazuh-agent.service > /dev/null 2>&1
   # Check for SysV
-  elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+  elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     service wazuh-agent stop > /dev/null 2>&1
-  else # Anything else
-    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
   fi
+  %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
 
   # Check for systemd
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
@@ -464,7 +463,7 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 ; then
     systemctl daemon-reload > /dev/null 2>&1
     systemctl restart wazuh-agent.service > /dev/null 2>&1
-  elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+  elif command -v service > /dev/null 2>&1; then
     service wazuh-agent restart > /dev/null 2>&1
   else
     %{_localstatedir}/bin/wazuh-control restart > /dev/null 2>&1

--- a/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
@@ -186,12 +186,12 @@ fi
 if [ $1 = 2 ]; then
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then
     systemctl stop wazuh-manager.service > /dev/null 2>&1
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1 || %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
   # Check for SysV
   elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     service wazuh-manager stop > /dev/null 2>&1
-    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1 || %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
+    %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
   elif %{_localstatedir}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     touch %{_localstatedir}/tmp/wazuh.restart
@@ -461,11 +461,10 @@ if [ $1 = 0 ]; then
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then
     systemctl stop wazuh-manager.service > /dev/null 2>&1
   # Check for SysV
-  elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+  elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
     service wazuh-manager stop > /dev/null 2>&1
-  else # Anything else
-    %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
   fi
+  %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
 
   # Check for systemd
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1279|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a behavior where Wazuh could continue running after uninstallation if the systemctl service was mishandled.
## Logs example

<!--
Paste here related logs
-->
https://github.com/wazuh/wazuh-packages/issues/1279#issuecomment-1055599620
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
