### PR TITLE
Change indexer port and rename dashboard configuration file

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -76,7 +76,7 @@ def api_call_indexer(host,query,address,api_protocol,api_user,api_pass,api_port)
 
 def get_indexer_cluster_status():
     ip = get_indexer_ip()
-    resp = requests.get('https://'+ip+':9700/_cluster/health',
+    resp = requests.get('https://'+ip+':9200/_cluster/health',
                         auth=("admin",
                         get_password("admin")),
                         verify=False)
@@ -252,7 +252,7 @@ def test_check_alerts():
         }
     }
 
-    response = api_call_indexer(get_indexer_ip(),query,get_indexer_ip(),'https',"admin",get_password("admin"),'9700')
+    response = api_call_indexer(get_indexer_ip(),query,get_indexer_ip(),'https',"admin",get_password("admin"),'9200')
 
     print(response)
 

--- a/tests/unattended/unit/suites/test-dashboard.sh
+++ b/tests/unattended/unit/suites/test-dashboard.sh
@@ -133,7 +133,7 @@ test-09-dashboard_configure-dist-one-kibana-node-one-elastic-node() {
 
 test-09-dashboard_configure-dist-one-kibana-node-one-elastic-node-assert() {
     dashboard_copyCertificates
-    installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/dashboard.yml
+    installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/opensearch_dashboards.yml
 }
 
 test-10-dashboard_configure-dist-two-kibana-nodes-two-elastic-nodes() {
@@ -148,7 +148,7 @@ test-10-dashboard_configure-dist-two-kibana-nodes-two-elastic-nodes() {
 
 test-10-dashboard_configure-dist-two-kibana-nodes-two-elastic-nodes-assert() {
     dashboard_copyCertificates
-    installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/dashboard.yml
+    installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/opensearch_dashboards.yml
 }
 
 test-11-dashboard_configure-AIO() {
@@ -163,7 +163,7 @@ test-11-dashboard_configure-AIO() {
 
 test-11-dashboard_configure-AIO-assert() {
     dashboard_copyCertificates
-    installCommon_getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/dashboard.yml
+    installCommon_getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/opensearch_dashboards.yml
 }
 
 function load-dashboard_initialize() {

--- a/tests/unattended/unit/suites/test-indexer.sh
+++ b/tests/unattended/unit/suites/test-indexer.sh
@@ -192,7 +192,7 @@ test-12-indexer_initialize-one-node() {
     indexer_node_names=("elastic1")
     indexer_node_ips=("1.1.1.1")
     pos=0
-    @mocktrue curl -XGET https://1.1.1.1:9700/ -uadmin:admin -k --max-time 120 --silent --output /dev/null
+    @mocktrue curl -XGET https://1.1.1.1:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null
     indexer_initialize
 }
 
@@ -215,6 +215,6 @@ test-ASSERT-FAIL-14-indexer_initialize-error-connecting() {
     indexer_node_names=("elastic1")
     indexer_node_ips=("1.1.1.1")
     pos=0
-    @mockfalse curl -XGET https://1.1.1.1:9700/ -uadmin:admin -k --max-time 120 --silent --output /dev/null
+    @mockfalse curl -XGET https://1.1.1.1:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null
     indexer_initialize
 }

--- a/unattended_installer/config/dashboard/dashboard.yml
+++ b/unattended_installer/config/dashboard/dashboard.yml
@@ -1,5 +1,5 @@
 server.host: "<kibana-ip>"
-opensearch.hosts: https://<elasticsearch-ip>:9700
+opensearch.hosts: https://<elasticsearch-ip>:9200
 server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver

--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -1,6 +1,6 @@
 server.host: 0.0.0.0
 server.port: 443
-opensearch.hosts: https://localhost:9700
+opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -1,5 +1,5 @@
 server.host: 0.0.0.0
-opensearch.hosts: https://127.0.0.1:9700
+opensearch.hosts: https://127.0.0.1:9200
 server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver

--- a/unattended_installer/config/filebeat/filebeat.yml
+++ b/unattended_installer/config/filebeat/filebeat.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch:
-  hosts: ["<elasticsearch_ip>:9700"]
+  hosts: ["<elasticsearch_ip>:9200"]
   protocol: https
   username: ${username}
   password: ${password}

--- a/unattended_installer/config/filebeat/filebeat_all_in_one.yml
+++ b/unattended_installer/config/filebeat/filebeat_all_in_one.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch:
-  hosts: ["127.0.0.1:9700"]
+  hosts: ["127.0.0.1:9200"]
   protocol: https
   username: ${username}
   password: ${password}

--- a/unattended_installer/config/filebeat/filebeat_elastic_cluster.yml
+++ b/unattended_installer/config/filebeat/filebeat_elastic_cluster.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch:
-  hosts: ["<elasticsearch_ip_node_1>:9700", "<elasticsearch_ip_node_2>:9700", "<elasticsearch_ip_node_3>:9700"]
+  hosts: ["<elasticsearch_ip_node_1>:9200", "<elasticsearch_ip_node_2>:9200", "<elasticsearch_ip_node_3>:9200"]
   protocol: https
   username: ${username}
   password: ${password}

--- a/unattended_installer/config/filebeat/filebeat_unattended.yml
+++ b/unattended_installer/config/filebeat/filebeat_unattended.yml
@@ -1,8 +1,8 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch.hosts:
-        - 127.0.0.1:9700
-#        - <elasticsearch_ip_node_2>:9700 
-#        - <elasticsearch_ip_node_3>:9700
+        - 127.0.0.1:9200
+#        - <elasticsearch_ip_node_2>:9200 
+#        - <elasticsearch_ip_node_3>:9200
 
 output.elasticsearch:
   protocol: https

--- a/unattended_installer/config/indexer/indexer_all_in_one.yml
+++ b/unattended_installer/config/indexer/indexer_all_in_one.yml
@@ -4,8 +4,6 @@ cluster.initial_master_nodes:
 - "node-1"
 cluster.name: "wazuh-cluster"
 
-http.port: 9700-9799
-transport.tcp.port: 9800-9899
 node.max_local_storage_nodes: "3"
 path.data: /var/lib/wazuh-indexer
 path.logs: /var/log/wazuh-indexer

--- a/unattended_installer/config/indexer/indexer_unattended_distributed.yml
+++ b/unattended_installer/config/indexer/indexer_unattended_distributed.yml
@@ -5,8 +5,6 @@ node.ingest: true
 cluster.name: wazuh-indexer-cluster
 cluster.routing.allocation.disk.threshold_enabled: false
 
-http.port: 9700-9799
-transport.tcp.port: 9800-9899
 node.max_local_storage_nodes: "3"
 path.data: /var/lib/wazuh-indexer
 path.logs: /var/log/wazuh-indexer

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -11,9 +11,9 @@ function dashboard_configure() {
     dashboard_copyCertificates
 
     if [ -n "${AIO}" ]; then
-        eval "installCommon_getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/dashboard.yml ${debug}"
+        eval "installCommon_getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
     else
-        eval "installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/dashboard.yml ${debug}"
+        eval "installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
         if [ "${#dashboard_node_names[@]}" -eq 1 ]; then
             pos=0
             ip=${dashboard_node_ips[0]}
@@ -26,14 +26,14 @@ function dashboard_configure() {
             ip=${dashboard_node_ips[pos]}
         fi
 
-        echo 'server.host: "'${ip}'"' >> /etc/wazuh-dashboard/dashboard.yml
+        echo 'server.host: "'${ip}'"' >> /etc/wazuh-dashboard/opensearch_dashboards.yml
 
         if [ "${#indexer_node_names[@]}" -eq 1 ]; then
-            echo "opensearch.hosts: https://"${indexer_node_ips[0]}":9700" >> /etc/wazuh-dashboard/dashboard.yml
+            echo "opensearch.hosts: https://"${indexer_node_ips[0]}":9200" >> /etc/wazuh-dashboard/opensearch_dashboards.yml
         else
-            echo "opensearch.hosts:" >> /etc/wazuh-dashboard/dashboard.yml
+            echo "opensearch.hosts:" >> /etc/wazuh-dashboard/opensearch_dashboards.yml
             for i in "${indexer_node_ips[@]}"; do
-                    echo "  - https://${i}:9700" >> /etc/wazuh-dashboard/dashboard.yml
+                    echo "  - https://${i}:9200" >> /etc/wazuh-dashboard/opensearch_dashboards.yml
             done
         fi
     fi
@@ -104,7 +104,7 @@ function dashboard_initialize() {
         common_logger "${flag}" "Cannot connect to Wazuh dashboard."
 
         for i in "${!indexer_node_ips[@]}"; do
-            curl=$(curl -XGET https://${indexer_node_ips[i]}:9700/ -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)
+            curl=$(curl -XGET https://${indexer_node_ips[i]}:9200/ -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)
             exit_code=$?
             if [[ "${exit_code}" -eq "7" ]]; then
                 failed_connect=1

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -17,11 +17,11 @@ function filebeat_configure(){
         eval "installCommon_getConfig filebeat/filebeat_distributed.yml /etc/filebeat/filebeat.yml ${debug}"
         if [ ${#indexer_node_names[@]} -eq 1 ]; then
             echo -e "\noutput.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
-            echo "  - ${indexer_node_ips[0]}:9700" >> /etc/filebeat/filebeat.yml
+            echo "  - ${indexer_node_ips[0]}:9200" >> /etc/filebeat/filebeat.yml
         else
             echo -e "\noutput.elasticsearch.hosts:" >> /etc/filebeat/filebeat.yml
             for i in "${indexer_node_ips[@]}"; do
-                echo "  - ${i}:9700" >> /etc/filebeat/filebeat.yml
+                echo "  - ${i}:9200" >> /etc/filebeat/filebeat.yml
             done
         fi
     fi

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -97,7 +97,7 @@ function indexer_initialize() {
 
     common_logger "Initializing Wazuh indexer cluster security settings."
     i=0
-    until curl -XGET https://${indexer_node_ips[pos]}:9700/ -uadmin:admin -k --max-time 120 --silent --output /dev/null || [ "${i}" -eq 12 ]; do
+    until curl -XGET https://${indexer_node_ips[pos]}:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null || [ "${i}" -eq 12 ]; do
         sleep 10
         i=$((i+1))
     done
@@ -108,7 +108,7 @@ function indexer_initialize() {
     fi
 
     if [ -n "${AIO}" ]; then
-        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9800 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}root-ca.pem -cert ${indexer_cert_path}admin.pem -key ${indexer_cert_path}admin-key.pem -h 127.0.0.1 ${debug}"
+        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}root-ca.pem -cert ${indexer_cert_path}admin.pem -key ${indexer_cert_path}admin-key.pem -h 127.0.0.1 ${debug}"
     fi
 
     if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then
@@ -147,7 +147,7 @@ function indexer_install() {
 function indexer_startCluster() {
 
     eval "wazuh_indexer_ip=( $(cat /etc/wazuh-indexer/opensearch.yml | grep network.host | sed 's/network.host:\s//') )"
-    eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9800 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -icl -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${wazuh_indexer_ip} ${debug}"
+    eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -icl -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${wazuh_indexer_ip} ${debug}"
     if [  "$?" != 0  ]; then
         common_logger -e "The Wazuh indexer cluster security configuration could not be initialized."
         installCommon_rollBack
@@ -155,7 +155,7 @@ function indexer_startCluster() {
     else
         common_logger "Wazuh indexer cluster security configuration initialized."
     fi
-    eval "curl --silent ${filebeat_wazuh_template} | curl -X PUT 'https://${indexer_node_ips[pos]}:9700/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent ${debug}"
+    eval "curl --silent ${filebeat_wazuh_template} | curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent ${debug}"
     if [  "$?" != 0  ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."
         installCommon_rollBack

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -89,7 +89,7 @@ function passwords_createBackUp() {
 
     common_logger -d "Creating password backup."
     eval "mkdir /usr/share/wazuh-indexer/backup ${debug}"
-    eval "JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -icl -p 9800 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug}"
+    eval "JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -icl -p 9300 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug}"
     if [ "$?" != 0 ]; then
         common_logger -e "The backup could not be created"
         exit 1;
@@ -344,7 +344,7 @@ function passwords_runSecurityAdmin() {
 
     common_logger -d "Loading new passwords changes."
     eval "cp /usr/share/wazuh-indexer/backup/* /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ ${debug}"
-    eval "OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9800 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug}"
+    eval "OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug}"
     if [  "$?" != 0  ]; then
         common_logger -e "Could not load the changes."
         exit 1;
@@ -357,7 +357,7 @@ function passwords_runSecurityAdmin() {
     fi
 
     if [[ -n "${nuser}" ]] && [[ -z ${autopass} ]]; then
-        common_logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/dashboard.yml if necessary and restart the services."
+        common_logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/opensearch_dashboards.yml if necessary and restart the services."
     fi
 
     if [ -n "${changeall}" ]; then
@@ -365,7 +365,7 @@ function passwords_runSecurityAdmin() {
             for i in "${!users[@]}"; do
                 common_logger $'The password for user '${users[i]}' is '${passwords[i]}''
             done
-            common_logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/dashboard.yml if necessary and restart the services."
+            common_logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/opensearch_dashboards.yml if necessary and restart the services."
         else
             common_logger -d "Passwords changed."
         fi


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1287|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR changes the ports used by wazuh-indexer to 9200 and 9300 and renames the wazuh-dashboard configuration file.

## Logs example

<!--
Paste here related logs
-->
```
root@debian:/home/vagrant/repo# bash wazuh-install.sh -a
04/03/2022 14:18:09 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
04/03/2022 14:18:10 INFO: --- Configuration files ---
04/03/2022 14:18:10 INFO: Generating configuration files.
04/03/2022 14:18:10 INFO: Created /home/vagrant/repo/wazuh-install-files.tar. Contains Wazuh cluster key, certificates, and passwords necessary for installation.
04/03/2022 14:18:16 INFO: --- Wazuh indexer ---
04/03/2022 14:18:16 INFO: Initializing Wazuh indexer cluster security settings.
04/03/2022 14:19:25 INFO: Wazuh indexer installation finished.
04/03/2022 14:19:25 INFO: Wazuh indexer post-install configuration finished.
04/03/2022 14:19:25 INFO: Starting service wazuh-indexer.
04/03/2022 14:19:34 INFO: Wazuh-indexer service started.
04/03/2022 14:19:34 INFO: Initializing Wazuh indexer cluster security settings.
04/03/2022 14:19:40 INFO: Wazuh indexer cluster started.
04/03/2022 14:19:40 INFO: --- Wazuh server ---
04/03/2022 14:19:40 INFO: Starting the Wazuh manager installation.
04/03/2022 14:20:26 INFO: Wazuh manager installation finished.
04/03/2022 14:20:26 INFO: Starting service wazuh-manager.
04/03/2022 14:20:42 INFO: Wazuh-manager service started.
04/03/2022 14:20:42 INFO: Starting Filebeat installation.
04/03/2022 14:20:48 INFO: Filebeat installation finished.
04/03/2022 14:20:49 INFO: Filebeat post-install configuration finished.
04/03/2022 14:20:49 INFO: Starting service filebeat.
04/03/2022 14:20:50 INFO: Filebeat service started.
04/03/2022 14:20:50 INFO: --- Wazuh dashboard ---
04/03/2022 14:20:50 INFO: Starting Wazuh dashboard installation.
04/03/2022 14:21:39 INFO: Wazuh dashboard installation finished.
04/03/2022 14:21:39 INFO: Wazuh dashboard post-install configuration finished.
04/03/2022 14:21:39 INFO: Starting service wazuh-dashboard.
04/03/2022 14:21:39 INFO: Wazuh-dashboard service started.
04/03/2022 14:21:55 INFO: Starting Wazuh dashboard.
04/03/2022 14:22:06 INFO: Wazuh dashboard started.
04/03/2022 14:22:06 INFO: --- Summary ---
04/03/2022 14:22:06 INFO: You can access the web interface https://<wazuh-dashboard-host-ip>.
    User: admin
    Password: bUM71FU1EwPdNm2ag3X8k1CeDONYwhxX
04/03/2022 14:22:06 INFO: Installation finished.
04/03/2022 14:22:06 INFO: The certificates and passwords used are stored in /home/vagrant/repo/wazuh-install-files.tar.
```

