### PR TITLE
Add centos8 vault repository due to EOL 4.2

### DIFF
--- a/wazuhapp/Docker/Dockerfile
+++ b/wazuhapp/Docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8
 
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+
 # Install dependencies
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centostesting && \
     curl -sL https://rpm.nodesource.com/setup_10.x | bash - && \


### PR DESCRIPTION
|Related issue|
|---|
|-|

## Description

Due to Centos 8 EOL, it is necessary to update the Wazuh app generation Dockerfile to use the Centos vault

## Logs example

```
 info running @kbn/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
 │ warn worker stderr npx browserslist@latest --update-db
 │ succ 1 bundles compiled successfully after 134.3 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [wazuh-7.10.2.zip]
Done in 144.41s.
+ find /tmp/source/plugins/wazuh/build -name '*.zip' -exec mv '{}' /wazuh_app/wazuh_kibana-4.2.5_7.10.2-1.zip ';'
+ '[' no = yes ']'
+ exit 0
# ls /wazuh-app 
wazuh_kibana-4.2.5_7.10.2-1.zip

```

## Tests

- Build the package in any supported platform
  - [x] Linux


