### PR TITLE
Add centos8 vault repository due to EOL master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.4.0]
 
+- Add centos8 vault repository due to EOL [#1308](https://github.com/wazuh/wazuh-packages/pull/1308)
 - Update SPECS [#1014](https://github.com/wazuh/wazuh-packages/pull/1014)
 - Add Azure integration files to Solaris 11 and RPM SPECS [#1167](https://github.com/wazuh/wazuh-packages/pull/1167)
 
 ## [v4.3.0]
 
+- Add centos8 vault repository due to EOL [#1307](https://github.com/wazuh/wazuh-packages/pull/1307)
+- Fix user deletion warning RPM manager [#1302](https://github.com/wazuh/wazuh-packages/pull/1302)
+- Fix issue where Solaris 11 was not executed in clean installations [#1292](https://github.com/wazuh/wazuh-packages/pull/1292)
+- Fix error where Wazuh could continue running after uninstalling [#1280](https://github.com/wazuh/wazuh-packages/pull/1280)
+- Fix AIX partition size [#1274](https://github.com/wazuh/wazuh-packages/pull/1274)
 - Fix Solaris 11 upgrade from previous packages [#1147](https://github.com/wazuh/wazuh-packages/pull/1147)
 - Add new GCloud integration files to Solaris 11 [#1126](https://github.com/wazuh/wazuh-packages/pull/1126)
 - Update SPECS [#689](https://github.com/wazuh/wazuh-packages/pull/689)
@@ -16,6 +22,26 @@ All notable changes to this project will be documented in this file.
 - Add new SCA files to Solaris 11 [#944](https://github.com/wazuh/wazuh-packages/pull/944)
 - Improved support for ppc64le on CentOS and Debian [#915](https://github.com/wazuh/wazuh-packages/pull/975)
 - Fix error with wazuh user in Debian packages [#1005](https://github.com/wazuh/wazuh-packages/pull/1005)
+- Add ossec user and group during compilation [#1023](https://github.com/wazuh/wazuh-packages/pull/1023)
+- Merge Wazuh Dashboard v3 [#1261](https://github.com/wazuh/wazuh-packages/pull/1261)
+- Fix certs permissions in RPM [#1256](https://github.com/wazuh/wazuh-packages/pull/1256)
+- [Kibana app] Support pluginPlatform.version property in the app manifest [#1208](https://github.com/wazuh/wazuh-packages/pull/1208)
+- Fix certificates creation using parameters 4.3 [#1162](https://github.com/wazuh/wazuh-packages/pull/1162)
+- Fix archlinux package generation parameters 4.3 [#1193](https://github.com/wazuh/wazuh-packages/pull/1193)
+- Add new 2.17.1 log4j mitigation version 4.3 [#1132](https://github.com/wazuh/wazuh-packages/pull/1132)
+- Fix client keys Ownership for 3.7.x and previous versions [#1123](https://github.com/wazuh/wazuh-packages/pull/1123)
+- Added new log4j remediation 4.3 [#1106](https://github.com/wazuh/wazuh-packages/pull/1106)
+- Fix linux wpk generation 4.3 [#1112](https://github.com/wazuh/wazuh-packages/pull/1112)
+- Add log4j mitigation 4.3 [#1096](https://github.com/wazuh/wazuh-packages/pull/1096)
+- Increase admin.pem cert expiration date 4.3 [#1086](https://github.com/wazuh/wazuh-packages/pull/1086)
+- Remove wazuh user from unattended/OVA/AMI 4.3 [#1078](https://github.com/wazuh/wazuh-packages/pull/1078)
+- Fix groupdel ossec error in upgrade to 4.3.0 [#1074](https://github.com/wazuh/wazuh-packages/pull/1074)
+- Fix curl kibana.yml 4.3 [#1067](https://github.com/wazuh/wazuh-packages/pull/1067)
+- Remove restore-permissions.sh from Debian Packages [#1060](https://github.com/wazuh/wazuh-packages/pull/1060)
+- Bump unattended 4.3.0 [#1048](https://github.com/wazuh/wazuh-packages/pull/1048)
+- Removed cd usages in unattended installer and fixed uninstaller 4.3 [#1012](https://github.com/wazuh/wazuh-packages/pull/1012)
+- Add ossec user and group during compilation [#1023](https://github.com/wazuh/wazuh-packages/pull/1023)
+- Removed warning and added text in wazuh-passwords-tool.sh final message 4.3 [#1020](https://github.com/wazuh/wazuh-packages/pull/1020)
 
 ## [v4.2.5]
 

--- a/wazuhapp/Docker/Dockerfile
+++ b/wazuhapp/Docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8
 
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+
 # Install dependencies
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centostesting && \
     curl -sL https://rpm.nodesource.com/setup_10.x | bash - && \


### PR DESCRIPTION
|Related issue|
|---|
|-|

## Description

Due to Centos 8 EOL, it is necessary to update the APP generation Dockerfile to use the Centos vault

## Logs example

```
 info running @kbn/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ warn worker stderr Browserslist: caniuse-lite is outdated. Please run:
 │ warn worker stderr npx browserslist@latest --update-db
 │ succ 1 bundles compiled successfully after 134.3 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [wazuh-7.10.2.zip]
Done in 144.41s.
+ find /tmp/source/plugins/wazuh/build -name '*.zip' -exec mv '{}' /wazuh_app/wazuh_kibana-4.2.5_7.10.2-1.zip ';'
+ '[' no = yes ']'
+ exit 0
# ls /wazuh-app 
wazuh_kibana-4.2.5_7.10.2-1.zip

```

## Tests

- Build the package in any supported platform
  - [x] Linux
- [x] Change added to CHANGELOG.md
