### PR TITLE
Fix unattended certificate permissions

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -54,7 +54,7 @@ function dashboard_copyCertificates() {
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} ./root-ca.pem ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
-        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"
+        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}*"
         common_logger -d "Wazuh dashboard certificate setup finished."
     else
         common_logger -e "No certificates found. Wazuh dashboard  could not be initialized."

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -48,7 +48,7 @@ function filebeat_copyCertificates() {
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./${winame}-key.pem && mv ${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./root-ca.pem ${debug}"
         fi
-        eval "chown root:root ${indexer_cert_path}/*"
+        eval "chown root:root ${filebeat_cert_path}*"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
         exit 1;

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -85,7 +85,7 @@ function indexer_copyCertificates() {
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./root-ca.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./admin.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./admin-key.pem  ${debug}"
-        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
+        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"
         exit 1;


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error with the permissions of the wazuh-indexer when using the wazuh-install.sh script.

## Logs example

<!--
Paste here related logs
-->
```
[root@centos repo]# bash wazuh-install.sh -a -o
09/03/2022 11:52:22 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
09/03/2022 11:52:23 INFO: --- Removing existing Wazuh installation ---
09/03/2022 11:52:23 INFO: Removing Wazuh manager.
09/03/2022 11:52:39 INFO: Wazuh manager removed.
09/03/2022 11:52:39 INFO: Removing Wazuh indexer.
09/03/2022 11:52:40 INFO: Wazuh indexer removed.
09/03/2022 11:52:40 INFO: Removing Filebeat.
09/03/2022 11:52:40 INFO: Filebeat removed.
09/03/2022 11:52:40 INFO: Removing Wazuh dashboard.
09/03/2022 11:52:45 INFO: Wazuh dashboard removed.
09/03/2022 11:52:45 INFO: Installation cleaned.
09/03/2022 11:52:45 INFO: --- Configuration files ---
09/03/2022 11:52:45 INFO: Generating configuration files.
09/03/2022 11:52:45 INFO: Created /home/vagrant/repo/wazuh-install-files.tar. Contains Wazuh cluster key, certificates, and passwords necessary for installation.
09/03/2022 11:52:48 INFO: --- Wazuh indexer ---
09/03/2022 11:52:48 INFO: Starting Wazuh indexer installation.
09/03/2022 11:54:11 INFO: Wazuh indexer installation finished.
09/03/2022 11:54:11 INFO: Wazuh indexer post-install configuration finished.
09/03/2022 11:54:11 INFO: Starting service wazuh-indexer.
09/03/2022 11:54:19 INFO: Wazuh-indexer service started.
09/03/2022 11:54:19 INFO: Initializing Wazuh indexer cluster security settings.
09/03/2022 11:54:24 INFO: Wazuh indexer cluster initialized.
09/03/2022 11:54:24 INFO: --- Wazuh server ---
09/03/2022 11:54:24 INFO: Starting the Wazuh manager installation.
09/03/2022 11:55:07 INFO: Wazuh manager installation finished.
09/03/2022 11:55:07 INFO: Starting service wazuh-manager.
09/03/2022 11:55:17 INFO: Wazuh-manager service started.
09/03/2022 11:55:17 INFO: Starting Filebeat installation.
09/03/2022 11:55:22 INFO: Filebeat installation finished.
09/03/2022 11:55:24 INFO: Filebeat post-install configuration finished.
09/03/2022 11:55:24 INFO: Starting service filebeat.
09/03/2022 11:55:24 INFO: Filebeat service started.
09/03/2022 11:55:24 INFO: --- Wazuh dashboard ---
09/03/2022 11:55:24 INFO: Starting Wazuh dashboard installation.
09/03/2022 11:56:37 INFO: Wazuh dashboard installation finished.
09/03/2022 11:56:37 INFO: Wazuh dashboard post-install configuration finished.
09/03/2022 11:56:37 INFO: Starting service wazuh-dashboard.
09/03/2022 11:56:37 INFO: Wazuh-dashboard service started.
09/03/2022 11:56:52 INFO: Starting Wazuh dashboard.
09/03/2022 11:57:03 INFO: Wazuh dashboard started.
09/03/2022 11:57:03 INFO: --- Summary ---
09/03/2022 11:57:03 INFO: You can access the web interface https://<wazuh-dashboard-ip>.
    User: admin
    Password: hggCuOaLQqLeBFIfkwaU3DjHaoDu298K
09/03/2022 11:57:03 INFO: Installation finished.
09/03/2022 11:57:03 INFO: The certificates and passwords used are stored in /home/vagrant/repo/wazuh-install-files.tar.
[root@centos repo]# ls -la /etc/wazuh-indexer/certs/
total 24
drwxr-x---. 2 wazuh-indexer wazuh-indexer  100 mar  9 11:54 .
drwxr-x---. 6 wazuh-indexer wazuh-indexer 4096 mar  9 11:54 ..
-rw-------. 1 wazuh-indexer wazuh-indexer 1704 mar  9 11:52 admin-key.pem
-rw-------. 1 wazuh-indexer wazuh-indexer 1107 mar  9 11:52 admin.pem
-rw-------. 1 wazuh-indexer wazuh-indexer 1704 mar  9 11:52 indexer-key.pem
-rw-------. 1 wazuh-indexer wazuh-indexer 1220 mar  9 11:52 indexer.pem
-rw-------. 1 wazuh-indexer wazuh-indexer 1184 mar  9 11:52 root-ca.pem
[root@centos repo]# ls -la /etc/wazuh-dashboard/certs/
total 12
dr-x------. 2 wazuh-dashboard wazuh-dashboard   68 mar  9 11:56 .
drwxr-xr-x. 3 wazuh-dashboard wazuh-dashboard   69 mar  9 11:55 ..
-r-x------. 1 wazuh-dashboard wazuh-dashboard 1708 mar  9 11:52 dashboard-key.pem
-r-x------. 1 wazuh-dashboard wazuh-dashboard 1224 mar  9 11:52 dashboard.pem
-r-x------. 1 wazuh-dashboard wazuh-dashboard 1184 mar  9 11:52 root-ca.pem
[root@centos repo]# ls -la /etc/filebeat/certs/
total 16
drw-------. 2 root root   66 mar  9 11:55 .
drwxr-xr-x. 4 root root 4096 mar  9 11:55 ..
-rw-------. 1 root root 1708 mar  9 11:52 filebeat-key.pem
-rw-------. 1 root root 1220 mar  9 11:52 filebeat.pem
-rw-------. 1 root root 1184 mar  9 11:52 root-ca.pem

```