### PR TITLE
Adapt test unattended to comments in password_file

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -35,9 +35,9 @@ def get_password(username):
 
     with open("./password_file.yml", 'r') as pass_file:
         while pass_dict["User"]["name"] != username:
-            for i in range(3):
+            for i in range(4):
                 tmp_yaml+=pass_file.readline()
-                pass_dict=yaml.safe_load(tmp_yaml)
+            pass_dict=yaml.safe_load(tmp_yaml)
     return pass_dict["User"]["password"]
 
 def get_wazuh_version():


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-jenkins/issues/3321|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error where the `get_password` function in `test_unattended.py` could not correctly read the password file.

This was caused by the inclusion of comments in the file.

## Tests
https://devel.ci.wazuh.info/job/Test_unattended/451/

