### PR TITLE
Check recommended OS in wazuh installation assistant

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -15,6 +15,7 @@ readonly resources_config="${base_path}/config"
 readonly resources_certs="${base_path}/cert_tool"
 readonly resources_passwords="${base_path}/passwords_tool"
 readonly resources_common="${base_path}/common_functions"
+readonly source_branch="4.3"
 
 function getHelp() {
 
@@ -99,6 +100,11 @@ function buildInstaller() {
         sed -n '/^function [a-zA-Z_]\(\)/,/^}/p' ${install_modules[$i]} >> "${output_script_path}"
         echo >> "${output_script_path}"
     done
+
+    ## dist-detect.sh
+    echo "function dist_detect() {" >> "${output_script_path}"
+    curl -s "https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh" | sed '/^#/d' >> "${output_script_path}"
+    echo "}" >> "${output_script_path}"
 
     ## Common functions
     sed -n '/^function [a-zA-Z_]\(\)/,/^}/p' "${resources_common}/common.sh" >> "${output_script_path}"

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -175,6 +175,29 @@ function checks_arguments() {
 
 }
 
+function check_dist() {
+    dist_detect
+    if [ "${DIST_NAME}" != "centos" ] && [ "${DIST_NAME}" != "rhel" ] && [ "${DIST_NAME}" != "amzn" ] && [ "${DIST_NAME}" != "Ubuntu" ]; then
+        notsupported=1
+    fi
+    if ([ "${DIST_NAME}" == "centos" ] || [ "${DIST_NAME}" == "rhel" ]) && ([ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ]); then
+        notsupported=1
+    fi
+    if ([ "${DIST_NAME}" == "amzn" ]) && ([ "${DIST_VER}" -ne "2" ]); then
+        notsupported=1
+    fi
+    if ([ "${DIST_NAME}" == "ubuntu" ]) && ([ "${DIST_VER}" -ne "16" ] && [ "${DIST_VER}" -ne "18" ] && [ "${DIST_VER}" -ne "20" ]); then
+        notsupported=1
+    fi
+    if ([ "${DIST_NAME}" == "ubuntu" ]) && ([ "${DIST_VER}" -eq "16" ] || [ "${DIST_VER}" -eq "18" ] || [ "${DIST_VER}" -eq "20" ]) &&  ([ "${DIST_SUBVER}" != "04" ]); then
+        notsupported=1
+    fi
+    if [ -n "${notsupported}" ] && [ -z "${ignore}" ]; then
+        common_logger -e "The system is not supported, supported systems are: Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04"
+        exit 1
+    fi
+}
+
 function checks_health() {
 
     logger "Verifying that your system meets the recommended minimum hardware requirements."

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -34,8 +34,8 @@ function getHelp() {
     echo -e "        -h,  --help"
     echo -e "                Display this help and exit."
     echo -e ""
-    echo -e "        -i,  --ignore-hardware-check"
-    echo -e "                Ignore check for minimum hardware requirements."
+    echo -e "        -i,  --ignore-check"
+    echo -e "                Ignore check for system compatibility and minimum hardware requirements."
     echo -e ""
     echo -e "        -o,  --overwrite"
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
@@ -110,7 +110,7 @@ function main() {
             "-h"|"--help")
                 getHelp
                 ;;
-            "-i"|"--ignore-hardware-check")
+            "-i"|"--ignore-check")
                 ignore=1
                 shift 1
                 ;;
@@ -198,6 +198,7 @@ function main() {
 
 # -------------- Uninstall case  ------------------------------------
 
+    check_dist
     common_checkSystem
     common_checkInstalled
     checks_arguments


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1228 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds the dist-detect.sh script as a function to the unattended script and uses it to check if the system is compatible. This can be ignored by using the -i flag

## Logs example

<!--
Paste here related logs
-->
### Not supported system
```
opensuse:/home/vagrant/repo # bash wazuh-install.sh -a -o
09/03/2022 16:28:24 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
09/03/2022 16:28:24 ERROR: The system is not supported, supported systems are: Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04
```

### Supported system
```
[root@centos repo]# ./wazuh-install.sh -a -o
09/03/2022 16:29:13 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
09/03/2022 16:29:14 INFO: --- Removing existing Wazuh installation ---
09/03/2022 16:29:14 INFO: Installation cleaned.
09/03/2022 16:29:14 INFO: --- Configuration files ---
09/03/2022 16:29:14 INFO: Generating configuration files.
09/03/2022 16:29:14 INFO: Created /home/vagrant/repo/wazuh-install-files.tar. Contains Wazuh cluster key, certificates, and passwords necessary for installation.
09/03/2022 16:29:17 INFO: --- Wazuh indexer ---
09/03/2022 16:29:17 INFO: Initializing Wazuh indexer cluster security settings.
09/03/2022 16:30:51 INFO: Wazuh indexer installation finished.
09/03/2022 16:30:51 INFO: Wazuh indexer post-install configuration finished.
09/03/2022 16:30:51 INFO: Starting service wazuh-indexer.
09/03/2022 16:30:59 INFO: Wazuh-indexer service started.
09/03/2022 16:30:59 INFO: Initializing Wazuh indexer cluster security settings.
09/03/2022 16:31:04 INFO: Wazuh indexer cluster initialized.
09/03/2022 16:31:04 INFO: --- Wazuh server ---
09/03/2022 16:31:04 INFO: Starting the Wazuh manager installation.
09/03/2022 16:31:51 INFO: Wazuh manager installation finished.
09/03/2022 16:31:51 INFO: Starting service wazuh-manager.
09/03/2022 16:32:01 INFO: Wazuh-manager service started.
09/03/2022 16:32:01 INFO: Starting Filebeat installation.
09/03/2022 16:32:05 INFO: Filebeat installation finished.
09/03/2022 16:32:07 INFO: Filebeat post-install configuration finished.
09/03/2022 16:32:07 INFO: Starting service filebeat.
09/03/2022 16:32:07 INFO: Filebeat service started.
09/03/2022 16:32:07 INFO: --- Wazuh dashboard ---
09/03/2022 16:32:07 INFO: Starting Wazuh dashboard installation.
09/03/2022 16:33:25 INFO: Wazuh dashboard installation finished.
09/03/2022 16:33:25 INFO: Wazuh dashboard post-install configuration finished.
09/03/2022 16:33:25 INFO: Starting service wazuh-dashboard.
09/03/2022 16:33:25 INFO: Wazuh-dashboard service started.
./wazuh-install.sh: línea 2727: restartService: no se encontró la orden
./wazuh-install.sh: línea 2742: restartService: no se encontró la orden
09/03/2022 16:33:39 INFO: Starting Wazuh dashboard.
09/03/2022 16:33:41 INFO: Wazuh dashboard started.
09/03/2022 16:33:41 INFO: --- Summary ---
09/03/2022 16:33:41 INFO: You can access the web interface https://<wazuh-dashboard-ip>.
    User: admin
    Password: hFQOHQsJQb2ZsW9Tifcsf1HF60uMej83
09/03/2022 16:33:41 INFO: Installation finished.
09/03/2022 16:33:41 INFO: The certificates and passwords used are stored in /home/vagrant/repo/wazuh-install-files.tar.
```