### PR TITLE
Folder for tar file in Unnattended installer

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -31,9 +31,9 @@ def get_password(username):
     tmp_yaml=""
 
     with tarfile.open("../../../unattended_installer/wazuh-install-files.tar") as configurations:
-        configurations.extract("./password_file.yml")
+        configurations.extract("./wazuh-install-files/password_file.yml")
 
-    with open("./password_file.yml", 'r') as pass_file:
+    with open("./wazuh-install-files/password_file.yml", 'r') as pass_file:
         while pass_dict["User"]["name"] != username:
             for i in range(4):
                 tmp_yaml+=pass_file.readline()

--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -31,9 +31,9 @@ def get_password(username):
     tmp_yaml=""
 
     with tarfile.open("../../../unattended_installer/wazuh-install-files.tar") as configurations:
-        configurations.extract("./wazuh-install-files/password_file.yml")
+        configurations.extract("wazuh-install-files/password_file.yml")
 
-    with open("./wazuh-install-files/password_file.yml", 'r') as pass_file:
+    with open("wazuh-install-files/password_file.yml", 'r') as pass_file:
         while pass_dict["User"]["name"] != username:
             for i in range(4):
                 tmp_yaml+=pass_file.readline()
@@ -56,9 +56,9 @@ def api_call_indexer(host,query,address,api_protocol,api_user,api_pass,api_port)
     if (query == ""):   # Calling ES API without query
         if (api_user != "" and api_pass != ""): # If credentials provided
             resp = requests.get(api_protocol + '://' + address + ':' + api_port,
-                   auth=(api_user,
-                   api_pass),
-                   verify=False)
+                    auth=(api_user,
+                    api_pass),
+                    verify=False)
         else:
             resp = requests.get(api_protocol + '://' + address + ':' + api_port, verify=False)
 

--- a/unattended_installer/cert_tool/certVariables.sh
+++ b/unattended_installer/cert_tool/certVariables.sh
@@ -7,6 +7,6 @@
 # Foundation.
 
 readonly base_path="$(dirname "$(readlink -f "$0")")"
-readonly config_file="${base_path}/wazuh-install-files/config.yml"
+readonly config_file="${base_path}/config.yml"
 readonly logfile="/var/log/wazuh-cert-tool.log"
 debug=">> ${logfile} 2>&1"

--- a/unattended_installer/cert_tool/certVariables.sh
+++ b/unattended_installer/cert_tool/certVariables.sh
@@ -7,6 +7,6 @@
 # Foundation.
 
 readonly base_path="$(dirname "$(readlink -f "$0")")"
-readonly config_file="${base_path}/config.yml"
+readonly config_file="${base_path}/wazuh-install-files/config.yml"
 readonly logfile="/var/log/wazuh-cert-tool.log"
 debug=">> ${logfile} 2>&1"

--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -12,4 +12,3 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/kibana-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/kibana.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -12,4 +12,3 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"

--- a/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
@@ -10,5 +10,4 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"
 

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,10 +49,10 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}config_dir/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}config_dir/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem && mv ${dashboard_cert_path}config_dir/root-ca.pem ${dashboard_cert_path}root-ca.pem ${debug}"
-        eval "rm -rf ${dashboard_cert_path}config_dir/"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}wazuh-install-files/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}wazuh-install-files/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}wazuh-install-files/root-ca.pem ${dashboard_cert_path}root-ca.pem ${debug}"
+        eval "rm -rf ${dashboard_cert_path}wazuh-install-files/"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}*"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,8 +49,8 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv config_dir/${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv config_dir/{dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -51,8 +51,8 @@ function dashboard_copyCertificates() {
 
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}config_dir/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}config_dir/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem && mv ${dashboard_cert_path}config_dir/root-ca.pem ${dashboard_cert_path} ${debug}"
-        eval "rm -rf ${indexer_cert_path}config_dir/"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem && mv ${dashboard_cert_path}config_dir/root-ca.pem ${dashboard_cert_path}root-ca.pem ${debug}"
+        eval "rm -rf ${dashboard_cert_path}config_dir/"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,12 +49,12 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}.pem ${dashboard_cert_path}/dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}-key.pem ${dashboard_cert_path}/dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}/wazuh-install-files/root-ca.pem ${dashboard_cert_path}/root-ca.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}.pem ${dashboard_cert_path}/dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}-key.pem ${dashboard_cert_path}/dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}/wazuh-install-files/root-ca.pem ${dashboard_cert_path}/root-ca.pem ${debug}"
         eval "rm -rf ${dashboard_cert_path}/wazuh-install-files/"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
-        eval "chmod -R 500 ${dashboard_cert_path}/ ${debug}"
+        eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"
         common_logger -d "Wazuh dashboard certificate setup finished."
     else

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,8 +49,8 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv config_dir/${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv config_dir/{dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv config_dir${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv config_dir${dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -44,18 +44,18 @@ function dashboard_configure() {
 
 function dashboard_copyCertificates() {
 
-    eval "rm -f ${dashboard_cert_path}* ${debug}"
+    eval "rm -f ${dashboard_cert_path}/* ${debug}"
     if [ -f "${tar_file}" ]; then
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}wazuh-install-files/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}wazuh-install-files/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}wazuh-install-files/root-ca.pem ${dashboard_cert_path}root-ca.pem ${debug}"
-        eval "rm -rf ${dashboard_cert_path}wazuh-install-files/"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}.pem ${dashboard_cert_path}/dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}-key.pem ${dashboard_cert_path}/dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path}/ wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}/wazuh-install-files/root-ca.pem ${dashboard_cert_path}/root-ca.pem ${debug}"
+        eval "rm -rf ${dashboard_cert_path}/wazuh-install-files/"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
-        eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
-        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}*"
+        eval "chmod -R 500 ${dashboard_cert_path}/ ${debug}"
+        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"
         common_logger -d "Wazuh dashboard certificate setup finished."
     else
         common_logger -e "No certificates found. Wazuh dashboard  could not be initialized."

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -51,7 +51,8 @@ function dashboard_copyCertificates() {
 
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}config_dir/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}config_dir/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem && mv ${dashboard_cert_path}config_dir/root-ca.pem ${dashboard_cert_path} ${debug}"
+        eval "rm -rf ${indexer_cert_path}config_dir/"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,9 +49,9 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} ./${name}.pem  && mv ${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} ./${name}-key.pem  && mv ${dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} ./root-ca.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -49,8 +49,8 @@ function dashboard_copyCertificates() {
 
         name=${dashboard_node_names[pos]}
 
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv config_dir${dashboard_cert_path}${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv config_dir${dashboard_cert_path}${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}.pem  && mv ${dashboard_cert_path}config_dir/${name}.pem ${dashboard_cert_path}dashboard.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/${name}-key.pem  && mv ${dashboard_cert_path}config_dir/${name}-key.pem ${dashboard_cert_path}dashboard-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} config_dir/root-ca.pem ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,13 +40,13 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards ./${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards ./${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./root-ca.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./${winame}.pem && mv ${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./${winame}-key.pem && mv ${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} ./root-ca.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         fi
         eval "chown root:root ${indexer_cert_path}/*"
     else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -42,15 +42,15 @@ function filebeat_copyCertificates() {
         if [ -n "${AIO}" ]; then
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
-            eval "rm -rf ${indexer_cert_path}config_dir/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}config_dir/"
         else
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}config_dir/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}config_dir/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path} ${debug}"
-            eval "rm -rf ${indexer_cert_path}config_dir/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}config_dir/"
         fi
-        eval "chown root:root ${indexer_cert_path}/*"
+        eval "chown root:root ${filebeat_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
         exit 1;

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,17 +40,17 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}\wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}\filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}\wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}\filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}\wazuh-install-files/root-ca.pem ${filebeat_cert_path}\root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}\wazuh-install-files/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}/wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}/filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}/wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}/filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}/wazuh-install-files/root-ca.pem ${filebeat_cert_path}/root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}\wazuh-install-files/${winame}.pem ${filebeat_cert_path}\filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}\wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}\filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}\wazuh-install-files/root-ca.pem ${filebeat_cert_path}\root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}\wazuh-install-files/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}/wazuh-install-files/${winame}.pem ${filebeat_cert_path}/filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}/wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}/filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}/wazuh-install-files/root-ca.pem ${filebeat_cert_path}/root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
         fi
-        eval "chown root:root ${filebeat_cert_path}\*"
+        eval "chown root:root ${filebeat_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
         exit 1;

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -43,10 +43,12 @@ function filebeat_copyCertificates() {
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
+            eval "rm -rf ${indexer_cert_path}config_dir/"
         else
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}config_dir/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}config_dir/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path} ${debug}"
+            eval "rm -rf ${indexer_cert_path}config_dir/"
         fi
         eval "chown root:root ${indexer_cert_path}/*"
     else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,12 +40,12 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv config_dir/${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv config_dir/${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv config_dir${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv config_dir${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv config_dir/${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv config_dir/${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv config_dir${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv config_dir${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         fi
         eval "chown root:root ${indexer_cert_path}/*"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,17 +40,17 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}wazuh-install-files/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}wazuh-install-files/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}\wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}\filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}\wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}\filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}\wazuh-install-files/root-ca.pem ${filebeat_cert_path}\root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}\wazuh-install-files/"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}wazuh-install-files/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}wazuh-install-files/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}wazuh-install-files/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}\wazuh-install-files/${winame}.pem ${filebeat_cert_path}\filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}\wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}\filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path}\ wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}\wazuh-install-files/root-ca.pem ${filebeat_cert_path}\root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}\wazuh-install-files/"
         fi
-        eval "chown root:root ${filebeat_cert_path}*"
+        eval "chown root:root ${filebeat_cert_path}\*"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
         exit 1;

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,12 +40,12 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv config_dir${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv config_dir${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv config_dir${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv config_dir${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}config_dir/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}config_dir/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         fi
         eval "chown root:root ${indexer_cert_path}/*"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,15 +40,15 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}config_dir/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}config_dir/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}wazuh-install-files/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}wazuh-install-files/"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}config_dir/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}config_dir/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem && mv ${filebeat_cert_path}config_dir/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
-            eval "rm -rf ${filebeat_cert_path}config_dir/"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}wazuh-install-files/${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}wazuh-install-files/root-ca.pem ${filebeat_cert_path}root-ca.pem ${debug}"
+            eval "rm -rf ${filebeat_cert_path}wazuh-install-files/"
         fi
         eval "chown root:root ${filebeat_cert_path}*"
     else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,12 +40,12 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}.pem ${debug} && mv config_dir/${filebeat_cert_path}${server_node_names[0]}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards config_dir/${server_node_names[0]}-key.pem ${debug} && mv config_dir/${filebeat_cert_path}${server_node_names[0]}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv ${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv ${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}.pem && mv config_dir/${filebeat_cert_path}${winame}.pem ${filebeat_cert_path}filebeat.pem ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/${winame}-key.pem && mv config_dir/${filebeat_cert_path}${winame}-key.pem ${filebeat_cert_path}filebeat-key.pem ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} config_dir/root-ca.pem ${debug}"
         fi
         eval "chown root:root ${indexer_cert_path}/*"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,12 +80,12 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv ${indexer_cert_path}config_dir/${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv ${indexer_cert_path}config_dir/${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem && mv ${indexer_cert_path}config_dir/root-ca.pem ${indexer_cert_path} ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem && mv ${indexer_cert_path}config_dir/admin.pem ${indexer_cert_path} ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem && mv ${indexer_cert_path}config_dir/admin-key.pem ${indexer_cert_path} ${debug}"
-        eval "rm -rf ${indexer_cert_path}config_dir/"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}wazuh-install-files/${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}wazuh-install-files/${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}wazuh-install-files/root-ca.pem ${indexer_cert_path} ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem && mv ${indexer_cert_path}wazuh-install-files/admin.pem ${indexer_cert_path} ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}wazuh-install-files/admin-key.pem ${indexer_cert_path} ${debug}"
+        eval "rm -rf ${indexer_cert_path}wazuh-install-files/"
         eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,8 +80,8 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv config_dir/${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv config_dir/${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv config_dir${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv config_dir${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem  ${debug}"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,8 +80,8 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv config_dir${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv config_dir${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv ${indexer_cert_path}config_dir/${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv ${indexer_cert_path}config_dir/${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem  ${debug}"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,11 +80,11 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./${name}.pem  && mv ${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./${name}-key.pem  && mv ${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./root-ca.pem  ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./admin.pem  ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} ./admin-key.pem  ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv ${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv ${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem  ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem  ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem  ${debug}"
         eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -76,17 +76,17 @@ function indexer_configure() {
 
 function indexer_copyCertificates() {
 
-    eval "rm -f ${indexer_cert_path}* ${debug}"
+    eval "rm -f ${indexer_cert_path}\* ${debug}"
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}wazuh-install-files/${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}wazuh-install-files/${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}wazuh-install-files/root-ca.pem ${indexer_cert_path} ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem && mv ${indexer_cert_path}wazuh-install-files/admin.pem ${indexer_cert_path} ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}wazuh-install-files/admin-key.pem ${indexer_cert_path} ${debug}"
-        eval "rm -rf ${indexer_cert_path}wazuh-install-files/"
-        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}\wazuh-install-files/${name}.pem ${indexer_cert_path}\indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}\wazuh-install-files/${name}-key.pem ${indexer_cert_path}\indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}\wazuh-install-files/root-ca.pem ${indexer_cert_path}\ ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/admin.pem && mv ${indexer_cert_path}\wazuh-install-files/admin.pem ${indexer_cert_path}\ ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}\wazuh-install-files/admin-key.pem ${indexer_cert_path}\ ${debug}"
+        eval "rm -rf ${indexer_cert_path}\wazuh-install-files/"
+        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}\/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"
         exit 1;
@@ -109,7 +109,7 @@ function indexer_initialize() {
     fi
 
     if [ -n "${AIO}" ]; then
-        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}root-ca.pem -cert ${indexer_cert_path}admin.pem -key ${indexer_cert_path}admin-key.pem -h 127.0.0.1 ${debug}"
+        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}\root-ca.pem -cert ${indexer_cert_path}\admin.pem -key ${indexer_cert_path}\admin-key.pem -h 127.0.0.1 ${debug}"
     fi
 
     if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -76,17 +76,17 @@ function indexer_configure() {
 
 function indexer_copyCertificates() {
 
-    eval "rm -f ${indexer_cert_path}\* ${debug}"
+    eval "rm -f ${indexer_cert_path}/* ${debug}"
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}\wazuh-install-files/${name}.pem ${indexer_cert_path}\indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}\wazuh-install-files/${name}-key.pem ${indexer_cert_path}\indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}\wazuh-install-files/root-ca.pem ${indexer_cert_path}\ ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/admin.pem && mv ${indexer_cert_path}\wazuh-install-files/admin.pem ${indexer_cert_path}\ ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path}\ wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}\wazuh-install-files/admin-key.pem ${indexer_cert_path}\ ${debug}"
-        eval "rm -rf ${indexer_cert_path}\wazuh-install-files/"
-        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}\/*"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}/wazuh-install-files/${name}.pem ${indexer_cert_path}/indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}/wazuh-install-files/${name}-key.pem ${indexer_cert_path}/indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}/wazuh-install-files/root-ca.pem ${indexer_cert_path}/ ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem && mv ${indexer_cert_path}/wazuh-install-files/admin.pem ${indexer_cert_path}/ ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}/wazuh-install-files/admin-key.pem ${indexer_cert_path}/ ${debug}"
+        eval "rm -rf ${indexer_cert_path}/wazuh-install-files/"
+        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"
         exit 1;
@@ -109,7 +109,7 @@ function indexer_initialize() {
     fi
 
     if [ -n "${AIO}" ]; then
-        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}\root-ca.pem -cert ${indexer_cert_path}\admin.pem -key ${indexer_cert_path}\admin-key.pem -h 127.0.0.1 ${debug}"
+        eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
     fi
 
     if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,8 +80,8 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv ${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv ${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv config_dir/${indexer_cert_path}${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv config_dir/${indexer_cert_path}${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem  ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem  ${debug}"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -82,9 +82,10 @@ function indexer_copyCertificates() {
     if [ -f "${tar_file}" ]; then
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}.pem  && mv ${indexer_cert_path}config_dir/${name}.pem ${indexer_cert_path}indexer.pem ${debug}"
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/${name}-key.pem  && mv ${indexer_cert_path}config_dir/${name}-key.pem ${indexer_cert_path}indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem  ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem  ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem  ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/root-ca.pem && mv ${indexer_cert_path}config_dir/root-ca.pem ${indexer_cert_path} ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin.pem && mv ${indexer_cert_path}config_dir/admin.pem ${indexer_cert_path} ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} config_dir/admin-key.pem && mv ${indexer_cert_path}config_dir/admin-key.pem ${indexer_cert_path} ${debug}"
+        eval "rm -rf ${indexer_cert_path}config_dir/"
         eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -79,7 +79,6 @@ function installCommon_addWazuhRepo() {
 function installCommon_createCertificates() {
 
     if [ -n "${AIO}" ]; then
-        mkdir -p "${base_path}/wazuh-install-files"
         eval "installCommon_getConfig certificate/config_aio.yml ${config_file} ${debug}"
     fi
 
@@ -139,8 +138,8 @@ function installCommon_extractConfig() {
         common_logger -e "There is no config.yml file in ${tar_file}."
         exit 1
     fi
-    mkdir -p ${base_path}/wazuh-install-files
     eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/config.yml ${debug}"
+    eval "mv ${base_path}/wazuh-install-files/config.yml ${base_path}/config.yml"
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -79,7 +79,7 @@ function installCommon_addWazuhRepo() {
 function installCommon_createCertificates() {
 
     if [ -n "${AIO}" ]; then
-        mkdir "${base_path}/wazuh-install-files"
+        mkdir -p "${base_path}/wazuh-install-files"
         eval "installCommon_getConfig certificate/config_aio.yml ${config_file} ${debug}"
     fi
 
@@ -139,6 +139,7 @@ function installCommon_extractConfig() {
         common_logger -e "There is no config.yml file in ${tar_file}."
         exit 1
     fi
+    mkdir -p ${base_path}/wazuh-install-files
     eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/config.yml ${debug}"
 
 }

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -105,8 +105,8 @@ function installCommon_changePasswords() {
 
     common_logger -d "Setting passwords."
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${base_path} config_dir/password_file.yml ${debug}"
-        p_file="${base_path}/config_dir/password_file.yml"
+        eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/password_file.yml ${debug}"
+        p_file="${base_path}/wazuh-install-files/password_file.yml"
         common_checkInstalled
         if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
             changeall=1
@@ -134,11 +134,11 @@ function installCommon_changePasswords() {
 
 function installCommon_extractConfig() {
 
-    if ! $(tar -tf "${tar_file}" | grep -q config_dir/config.yml); then
+    if ! $(tar -tf "${tar_file}" | grep -q wazuh-install-files/config.yml); then
         common_logger -e "There is no config.yml file in ${tar_file}."
         exit 1
     fi
-    eval "tar -xf ${tar_file} -C ${base_path} config_dir/config.yml ${debug}"
+    eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/config.yml ${debug}"
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -79,6 +79,7 @@ function installCommon_addWazuhRepo() {
 function installCommon_createCertificates() {
 
     if [ -n "${AIO}" ]; then
+        mkdir "${base_path}/wazuh-install-files"
         eval "installCommon_getConfig certificate/config_aio.yml ${config_file} ${debug}"
     fi
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -105,7 +105,7 @@ function installCommon_changePasswords() {
 
     common_logger -d "Setting passwords."
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${base_path} ./password_file.yml ${debug}"
+        eval "tar -xf ${tar_file} -C ${base_path} config_dir/password_file.yml ${debug}"
         p_file="${base_path}/password_file.yml"
         common_checkInstalled
         if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
@@ -134,11 +134,11 @@ function installCommon_changePasswords() {
 
 function installCommon_extractConfig() {
 
-    if ! $(tar -tf "${tar_file}" | grep -q config.yml); then
+    if ! $(tar -tf "${tar_file}" | grep -q config_dir/config.yml); then
         common_logger -e "There is no config.yml file in ${tar_file}."
         exit 1
     fi
-    eval "tar -xf ${tar_file} -C ${base_path} ./config.yml ${debug}"
+    eval "tar -xf ${tar_file} -C ${base_path} config_dir/config.yml ${debug}"
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -106,7 +106,7 @@ function installCommon_changePasswords() {
     common_logger -d "Setting passwords."
     if [ -f "${tar_file}" ]; then
         eval "tar -xf ${tar_file} -C ${base_path} config_dir/password_file.yml ${debug}"
-        p_file="${base_path}/password_file.yml"
+        p_file="${base_path}/config_dir/password_file.yml"
         common_checkInstalled
         if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
             changeall=1

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -238,9 +238,10 @@ function main() {
         passwords_generatePasswordFile
         # Using cat instead of simple cp because OpenSUSE unknown error.
         eval "cat '${config_file}' > '${base_path}/certs/config.yml'"
-        eval "chown root:root ${base_path}/certs/*"
-        eval "tar -zcf '${tar_file}' -C '${base_path}/certs/' . ${debug}"
-        eval "rm -rf '${base_path}/certs' ${debug}"
+        eval "mv ${base_path}/certs/ ${base_path}/config_dir/"
+        eval "chown root:root ${base_path}/config_dir/*"
+        eval "tar -zcf '${tar_file}' -C '${base_path}/' config_dir/ ${debug}"
+        eval "rm -rf '${base_path}/config_dir' ${debug}"
         common_logger "Created ${tar_file}. Contains Wazuh cluster key, certificates, and passwords necessary for installation."
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -238,10 +238,10 @@ function main() {
         passwords_generatePasswordFile
         # Using cat instead of simple cp because OpenSUSE unknown error.
         eval "cat '${config_file}' > '${base_path}/certs/config.yml'"
-        eval "mv ${base_path}/certs/ ${base_path}/config_dir/"
-        eval "chown root:root ${base_path}/config_dir/*"
-        eval "tar -zcf '${tar_file}' -C '${base_path}/' config_dir/ ${debug}"
-        eval "rm -rf '${base_path}/config_dir' ${debug}"
+        eval "mv ${base_path}/certs/ ${base_path}/wazuh-install-files/"
+        eval "chown root:root ${base_path}/wazuh-install-files/*"
+        eval "tar -zcf '${tar_file}' -C '${base_path}/' wazuh-install-files/ ${debug}"
+        eval "rm -rf '${base_path}/wazuh-install-files' ${debug}"
         common_logger "Created ${tar_file}. Contains Wazuh cluster key, certificates, and passwords necessary for installation."
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -234,10 +234,9 @@ function main() {
         if [ -n "${server_node_types[*]}" ]; then
             installCommon_createClusterKey
         fi
-        gen_file="${base_path}/certs/password_file.yml"
+        gen_file="${base_path}/wazuh-install-files/password_file.yml"
         passwords_generatePasswordFile
         # Using cat instead of simple cp because OpenSUSE unknown error.
-        eval "cat '${config_file}' > '${base_path}/certs/config.yml'"
         eval "mv ${base_path}/certs/ ${base_path}/wazuh-install-files/"
         eval "chown root:root ${base_path}/wazuh-install-files/*"
         eval "tar -zcf '${tar_file}' -C '${base_path}/' wazuh-install-files/ ${debug}"
@@ -248,7 +247,6 @@ function main() {
     if [ -z "${configurations}" ]; then
         installCommon_extractConfig
         cert_readConfig
-        rm -f "${config_file}"
     fi
 
     # Distributed architecture: node names must be different

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -91,7 +91,7 @@ function main() {
                 ;;
             "-c"|"--configfile")
                 if [ -z "${2}" ]; then
-                    common_logger -e "Error on arguments. Probably missing <path-to-config-yml> after -f|--fileconfig"
+                    common_logger -e "Error on arguments. Probably missing <path-to-config-yml> after -c|--configfile"
                     getHelp
                     exit 1
                 fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -241,6 +241,7 @@ function main() {
         eval "chown root:root ${base_path}/wazuh-install-files/*"
         eval "tar -zcf '${tar_file}' -C '${base_path}/' wazuh-install-files/ ${debug}"
         eval "rm -rf '${base_path}/wazuh-install-files' ${debug}"
+        eval "rm -rf '${base_path}/certs' ${debug}"
         common_logger "Created ${tar_file}. Contains Wazuh cluster key, certificates, and passwords necessary for installation."
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -234,14 +234,14 @@ function main() {
         if [ -n "${server_node_types[*]}" ]; then
             installCommon_createClusterKey
         fi
-        gen_file="${base_path}/wazuh-install-files/password_file.yml"
+        gen_file="${base_path}/certs/password_file.yml"
         passwords_generatePasswordFile
         # Using cat instead of simple cp because OpenSUSE unknown error.
-        eval "mv ${base_path}/certs/* ${base_path}/wazuh-install-files/"
+        eval "cat '${config_file}' > '${base_path}/certs/config.yml'"
+        eval "mv ${base_path}/certs/ ${base_path}/wazuh-install-files/"
         eval "chown root:root ${base_path}/wazuh-install-files/*"
         eval "tar -zcf '${tar_file}' -C '${base_path}/' wazuh-install-files/ ${debug}"
         eval "rm -rf '${base_path}/wazuh-install-files' ${debug}"
-        eval "rm -rf '${base_path}/certs' ${debug}"
         common_logger "Created ${tar_file}. Contains Wazuh cluster key, certificates, and passwords necessary for installation."
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -237,7 +237,7 @@ function main() {
         gen_file="${base_path}/wazuh-install-files/password_file.yml"
         passwords_generatePasswordFile
         # Using cat instead of simple cp because OpenSUSE unknown error.
-        eval "mv ${base_path}/certs/ ${base_path}/wazuh-install-files/"
+        eval "mv ${base_path}/certs/* ${base_path}/wazuh-install-files/"
         eval "chown root:root ${base_path}/wazuh-install-files/*"
         eval "tar -zcf '${tar_file}' -C '${base_path}/' wazuh-install-files/ ${debug}"
         eval "rm -rf '${base_path}/wazuh-install-files' ${debug}"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -16,7 +16,7 @@ readonly wazuh_install_vesion="0.1"
 ## Links and paths to resources
 readonly resources="https://packages-dev.wazuh.com/resources/${wazuh_major}"
 readonly base_path="$(dirname $(readlink -f "$0"))"
-config_file="${base_path}/config.yml"
+config_file="${base_path}/wazuh-install-files/config.yml"
 tar_file="${base_path}/wazuh-install-files.tar"
 
 readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -21,9 +21,9 @@ tar_file="${base_path}/wazuh-install-files.tar"
 
 readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"
 
-readonly dashboard_cert_path="/etc/wazuh-dashboard/certs/"
-readonly filebeat_cert_path="/etc/filebeat/certs/"
-readonly indexer_cert_path="/etc/wazuh-indexer/certs/"
+readonly dashboard_cert_path="/etc/wazuh-dashboard/certs"
+readonly filebeat_cert_path="/etc/filebeat/certs"
+readonly indexer_cert_path="/etc/wazuh-indexer/certs"
 
 readonly logfile="/var/log/wazuh-install.log"
 debug=">> ${logfile} 2>&1"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -16,7 +16,7 @@ readonly wazuh_install_vesion="0.1"
 ## Links and paths to resources
 readonly resources="https://packages-dev.wazuh.com/resources/${wazuh_major}"
 readonly base_path="$(dirname $(readlink -f "$0"))"
-config_file="${base_path}/wazuh-install-files/config.yml"
+config_file="${base_path}/config.yml"
 tar_file="${base_path}/wazuh-install-files.tar"
 
 readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -20,7 +20,7 @@ function manager_startCluster() {
         fi
     done
 
-    key=$(tar -axf "${tar_file}" ./clusterkey -O)
+    key=$(tar -axf "${tar_file}" config_dir/clusterkey -O)
     bind_address="0.0.0.0"
     port="1516"
     hidden="no"

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -20,7 +20,7 @@ function manager_startCluster() {
         fi
     done
 
-    key=$(tar -axf "${tar_file}" config_dir/clusterkey -O)
+    key=$(tar -axf "${tar_file}" wazuh-install-files/clusterkey -O)
     bind_address="0.0.0.0"
     port="1516"
     hidden="no"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1300|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
A subdirectory is created inside the tar named wazuh-install-files.
it is tested on Centos 7 and Ubuntu 20.04 on both systems it works ok.

### Centos 7

```
09/03/2022 20:33:56 INFO: --- Wazuh dashboard ---
09/03/2022 20:33:56 INFO: Starting Wazuh dashboard installation.
09/03/2022 20:35:17 INFO: Wazuh dashboard installation finished.
09/03/2022 20:35:17 INFO: Wazuh dashboard post-install configuration finished.
09/03/2022 20:35:17 INFO: Starting service wazuh-dashboard.
09/03/2022 20:35:17 INFO: Wazuh-dashboard service started.
09/03/2022 20:35:33 INFO: Starting Wazuh dashboard.
09/03/2022 20:35:45 INFO: Wazuh dashboard started.
09/03/2022 20:35:45 INFO: --- Summary ---
09/03/2022 20:35:45 INFO: You can access the web interface https://<wazuh-dashboard-ip>.
    User: admin
    Password: un7SByIujIPtZaftRdA6loeFHWrjHSE2
09/03/2022 20:35:45 INFO: Installation finished.
09/03/2022 20:35:45 INFO: The certificates and passwords used are stored in /root/wazuh-packages/unattended_installer/wazuh-install-files.tar.

```
![Screenshot_20220309_174020](https://user-images.githubusercontent.com/64099752/157531999-fdc5644a-a298-4f8f-8c5e-30d7f94d0723.png)

```
[root@centos7-1 unattended_installer]# curl -X GET -k -u admin:un7SByIujIPtZaftRdA6loeFHWrjHSE2 https://localhost:9200/_cat/health
1646858508 20:41:48 wazuh-cluster yellow 1 1 true 9 9 0 0 1 0 - 90.0%

```

### Ubuntu 20.04
```
09/03/2022 20:36:49 INFO: --- Wazuh dashboard ---
09/03/2022 20:36:49 INFO: Starting Wazuh dashboard installation.
09/03/2022 20:37:30 INFO: Wazuh dashboard installation finished.
09/03/2022 20:37:30 INFO: Wazuh dashboard post-install configuration finished.
09/03/2022 20:37:30 INFO: Starting service wazuh-dashboard.
09/03/2022 20:37:30 INFO: Wazuh-dashboard service started.
09/03/2022 20:37:44 INFO: Starting Wazuh dashboard.
09/03/2022 20:37:56 INFO: Wazuh dashboard started.
09/03/2022 20:37:56 INFO: --- Summary ---
09/03/2022 20:37:56 INFO: You can access the web interface https://<wazuh-dashboard-ip>.
    User: admin
    Password: xBtf9QiWidAf6h6FgSsw2v5bxF1cesLt
09/03/2022 20:37:56 INFO: Installation finished.
09/03/2022 20:37:56 INFO: The certificates and passwords used are stored in /root/wazuh-packages/unattended_installer/wazuh-install-files.tar.
root@ubuntu20:~/wazuh-packages/unattended_installer# 

```
![Screenshot_20220309_174316](https://user-images.githubusercontent.com/64099752/157532462-4dc5fdba-3432-4c17-8758-9a8326d0c330.png)

```
root@ubuntu20:~/wazuh-packages/unattended_installer# curl -X GET -k -u admin:xBtf9QiWidAf6h6FgSsw2v5bxF1cesLt https://localhost:9200/_cat/health
1646858632 20:43:52 wazuh-cluster yellow 1 1 true 7 7 0 0 1 0 - 87.5%

```

```
[root@centos7-1 unattended_installer]# tar tf wazuh-install-files.tar 
wazuh-install-files/
wazuh-install-files/root-ca.key
wazuh-install-files/root-ca.pem
wazuh-install-files/admin-key.pem
wazuh-install-files/admin.pem
wazuh-install-files/indexer-key.pem
wazuh-install-files/indexer.pem
wazuh-install-files/server-key.pem
wazuh-install-files/server.pem
wazuh-install-files/dashboard-key.pem
wazuh-install-files/dashboard.pem
wazuh-install-files/password_file.yml
wazuh-install-files/config.yml
```

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
