### PR TITLE
Remove wazuh-dashboard log from configuration files

### DIFF
--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -12,4 +12,3 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/kibana-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/kibana.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -12,4 +12,3 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"

--- a/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
@@ -10,5 +10,4 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
-logging.dest: "/var/log/wazuh-dashboard/wazuh-dashboard.log"
 


### PR DESCRIPTION
|Related issue|
|---|
|#1321|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The changes made for the issue #1321 caused the unattended script to fail with the following error:
```
[root@centos vagrant]# systemctl status wazuh-dashboard -l
● wazuh-dashboard.service - wazuh-dashboard
   Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since lun 2022-03-14 08:23:01 UTC; 731ms ago
  Process: 29624 ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards -c /etc/wazuh-dashboard/opensearch_dashboards.yml (code=exited, status=1/FAILURE)
 Main PID: 29624 (code=exited, status=1/FAILURE)

mar 14 08:23:00 centos systemd[1]: Started wazuh-dashboard.
mar 14 08:23:00 centos systemd[1]: Starting wazuh-dashboard...
mar 14 08:23:01 centos opensearch-dashboards[29624]: Error: ENOENT: no such file or directory, open '/var/log/wazuh-dashboard/wazuh-dashboard.log'
mar 14 08:23:01 centos systemd[1]: wazuh-dashboard.service: main process exited, code=exited, status=1/FAILURE
mar 14 08:23:01 centos systemd[1]: Unit wazuh-dashboard.service entered failed state.
mar 14 08:23:01 centos systemd[1]: wazuh-dashboard.service failed.
```
This PR fixes that error by removing the log file from the configuration.

