### PR TITLE
Remove unused svc from solaris 11 package generation

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -180,7 +180,6 @@ create_package() {
 
 
     # Package generation process
-    svcbundle -o wazuh-agent.xml -s service-name=application/wazuh-agent -s start-method="${install_path}/bin/${control_binary} start" -s stop-method="${install_path}/bin/${control_binary} stop"
     pkgsend generate ${install_path} | pkgfmt > wazuh-agent.p5m.1
     sed "s|<INSTALL_PATH>|${install_path}|" ${current_path}/postinstall.sh > ${current_path}/postinstall.sh.new
     mv ${current_path}/postinstall.sh.new ${current_path}/postinstall.sh
@@ -193,7 +192,6 @@ create_package() {
         mv wazuh-agent.p5m.1.aux_sed wazuh-agent.p5m.1
     done
     # Add service files
-    echo "file wazuh-agent.xml path=lib/svc/manifest/site/wazuh-agent.xml owner=root group=sys mode=0744 restart_fmri=svc:/system/manifest-import:default" >> wazuh-agent.p5m.1
     echo "file smf_manifest.xml path=lib/svc/manifest/site/post-install.xml owner=root group=sys mode=0744 restart_fmri=svc:/system/manifest-import:default" >> wazuh-agent.p5m.1
     echo "dir  path=var/ossec/installation_scripts owner=root group=bin mode=0755" >> wazuh-agent.p5m.1
     echo "file postinstall.sh path=var/ossec/installation_scripts/postinstall.sh owner=root group=bin mode=0744" >> wazuh-agent.p5m.1


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR removes the wazuh-agent.xml svc  from the Solaris 11 package this svc was not used and made the agent to try to start after installation, causing error to appear in the log.

## Logs example
### Error log
```
root@solaris11:/export/home/vagrant# svcs -Lv svc:/application/wazuh-agent:default
svc:/application/wazuh-agent:default
[ Mar 15 11:09:48 Enabled. ]
[ Mar 15 11:09:48 Rereading configuration. ]
[ Mar 15 11:09:48 Executing start method ("/var/ossec/bin/wazuh-control start"). ]
2022/03/15 11:09:49 wazuh-agentd: ERROR: (4112): Invalid server address found: 'MANAGER_IP'
2022/03/15 11:09:49 wazuh-agentd: CRITICAL: (1215): No client configured. Exiting.
wazuh-agentd: Configuration error. Exiting
[ Mar 15 11:09:49 Method "start" exited with status 1. ]
[ Mar 15 11:09:49 Executing start method ("/var/ossec/bin/wazuh-control start"). ]
2022/03/15 11:09:49 wazuh-agentd: ERROR: (4112): Invalid server address found: 'MANAGER_IP'
2022/03/15 11:09:49 wazuh-agentd: CRITICAL: (1215): No client configured. Exiting.
wazuh-agentd: Configuration error. Exiting
[ Mar 15 11:09:49 Method "start" exited with status 1. ]
[ Mar 15 11:09:49 Executing start method ("/var/ossec/bin/wazuh-control start"). ]
2022/03/15 11:09:49 wazuh-agentd: ERROR: (4112): Invalid server address found: 'MANAGER_IP'
2022/03/15 11:09:49 wazuh-agentd: CRITICAL: (1215): No client configured. Exiting.
wazuh-agentd: Configuration error. Exiting
[ Mar 15 11:09:49 Method "start" exited with status 1. ]
```
<!--
Paste here related logs
-->

## Tests
https://ci.wazuh.info/job/Test_install/86007/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
