### PR TITLE
Admin cert creation fixed

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -25,6 +25,10 @@ function cert_checkOpenSSL() {
 
 function cert_generateAdmincertificate() {
 
+    if [ ! -f ${base_path}/certs/root-ca.pem ]; then
+        cert_generateRootCAcertificate
+    fi
+
     eval "openssl genrsa -out ${base_path}/certs/admin-key-temp.pem 2048 ${debug}"
     eval "openssl pkcs8 -inform PEM -outform PEM -in ${base_path}/certs/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${base_path}/certs/admin-key.pem ${debug}"
     eval "openssl req -new -key ${base_path}/certs/admin-key.pem -out ${base_path}/certs/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin' ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1340|

```
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-packages/unattended_installer$ sudo ./wazuh-certs-tool.sh -a
16/03/2022 14:53:27 INFO: Admin certificates created.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-packages/unattended_installer$ sudo ls -la certs/
total 36
drw------- 2 root    root    4096 mar 16 14:53 .
drwxrwxr-x 9 cbordon cbordon 4096 mar 16 14:53 ..
-rw------- 1 root    root     976 mar 16 14:53 admin.csr
-rw------- 1 root    root    1704 mar 16 14:53 admin-key.pem
-rw------- 1 root    root    1675 mar 16 14:53 admin-key-temp.pem
-rw------- 1 root    root    1119 mar 16 14:53 admin.pem
-rw------- 1 root    root    1704 mar 16 14:53 root-ca.key
-rw------- 1 root    root    1204 mar 16 14:53 root-ca.pem
-rw------- 1 root    root      41 mar 16 14:53 root-ca.srl
```