### PR TITLE
Sign windows dll files.

### DIFF
--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -76,6 +76,12 @@ function BuildWazuhMsi(){
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\*.exe"
         Write-Host "Signing .vbs files..."
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\InstallerScripts.vbs"
+        Write-Host "Signing .dll files..."
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\*.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\data_provider\build\bin\sysinfo.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
     }
 
     Write-Host "Building MSI installer..."


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/12751|

## Description
This issue aims to sign the dynamic libraries, so that they can have a better evaluation, under different malware scanners, from third party vendors.

Many times calls to operating system libraries, or some intrusion to obtain information relevant to the need of the product may seem strange for a third party software, when this software tries to help security.

### Actual
![image](https://user-images.githubusercontent.com/14300208/158714797-1ad473f5-89f0-494e-bd58-8b4dab879759.png)

### Expected
Dll files signed.

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
