### PR TITLE
Generate wazuh-certs-tool.sh and wazuh-passwords-tool.sh scripts instead of copying them from repository

### DIFF
--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -102,10 +102,16 @@ override_dh_install:
 	cp certs/demo-indexer-key.pem $(TARGET_DIR)$(CONFIG_DIR)/certs/
 	cp certs/root-ca.pem $(TARGET_DIR)$(CONFIG_DIR)/certs/
 
+	# Build wazuh-certs-tool
+	$(REPO_DIR)/builder.sh -c
+
+	# Build wazuh-passwords-tool
+	$(REPO_DIR)/builder.sh -p
+
 	# Copy the security tools
-	cp $(REPO_DIR)/install_functions/wazuh-cert-tool.sh $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/
-	cp $(REPO_DIR)/install_functions/wazuh-passwords-tool.sh $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/
-	cp $(REPO_DIR)/config/certificate/config.yml $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/config.yml
+	cp $(REPO_DIR)/wazuh-certs-tool.sh $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/
+	cp $(REPO_DIR)/wazuh-passwords-tool.sh $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/
+	cp /root/documentation-templates/wazuh/config.yml $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/config.yml
 
 	# Copy Wazuh's config files for the security plugin
 	cp -pr $(REPO_DIR)/config/indexer/roles/roles_mapping.yml $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/securityconfig/
@@ -520,7 +526,7 @@ override_dh_fixperms:
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/hash.sh
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/securityadmin.sh
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/audit_config_migrater.sh
-	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/wazuh-cert-tool.sh
+	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/wazuh-certs-tool.sh
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/wazuh-passwords-tool.sh
 	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/jakarta.xml.ws-api-2.3.3.jar
 	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/xmlschema-core-2.2.5.jar

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -94,9 +94,15 @@ cp certs/demo-indexer.pem ${RPM_BUILD_ROOT}%{CONFIG_DIR}/certs/
 cp certs/demo-indexer-key.pem ${RPM_BUILD_ROOT}%{CONFIG_DIR}/certs/
 cp certs/root-ca.pem ${RPM_BUILD_ROOT}%{CONFIG_DIR}/certs/
 
-cp %{REPO_DIR}/install_functions/wazuh-cert-tool.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/
-cp %{REPO_DIR}/install_functions/wazuh-passwords-tool.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/
-cp %{REPO_DIR}/config/certificate/config.yml ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/config.yml
+# Build wazuh-certs-tool
+%{REPO_DIR}/builder.sh -c
+
+# Build wazuh-passwords-tool
+%{REPO_DIR}/builder.sh -p
+
+cp %{REPO_DIR}/wazuh-certs-tool.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/
+cp %{REPO_DIR}/wazuh-passwords-tool.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/
+cp /root/documentation-templates/wazuh/config.yml ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/config.yml
 
 cp %{REPO_DIR}/config/indexer/roles/internal_users.yml ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/securityconfig/
 cp %{REPO_DIR}/config/indexer/roles/roles.yml ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/securityconfig/
@@ -675,7 +681,7 @@ rm -fr %{buildroot}
 %attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/hash.sh
 %attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/securityadmin.sh
 %attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/audit_config_migrater.sh
-%attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/wazuh-cert-tool.sh
+%attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/wazuh-certs-tool.sh
 %attr(740, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/tools/wazuh-passwords-tool.sh
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/jakarta.xml.ws-api-2.3.3.jar
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/plugins/opensearch-security/xmlschema-core-2.2.5.jar

--- a/unattended_installer/config/indexer/roles/internal_users.yml
+++ b/unattended_installer/config/indexer/roles/internal_users.yml
@@ -61,7 +61,7 @@ wazuh_admin:
   hidden: false
   backend_roles: []
   attributes: {}
-  opensearch_security_roles: []
+  opendistro_security_roles: []
   static: false
   
 wazuh_user:
@@ -70,5 +70,5 @@ wazuh_user:
   hidden: false
   backend_roles: []
   attributes: {}
-  opensearch_security_roles: []
+  opendistro_security_roles: []
   static: false  


### PR DESCRIPTION
|Related issue|
|---|
|#1344|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Modify the build of the wazuh indexer package, so that it generates the wazuh-certs-tool.sh, and wazuh-passwords-tool.sh scripts, instead of copying them from the current repository where the package is being built.
To generate the scripts, the builder.sh was used with the -c and -p parameters, respectively.

## Tests

```
$ sudo ./build_package.sh -s /tmp
...
# Build wazuh-certs-tool
/root/unattended_installer/builder.sh -c
# Build wazuh-passwords-tool
/root/unattended_installer/builder.sh -p
# Copy the security tools
cp /root/unattended_installer/wazuh-certs-tool.sh /build/wazuh-indexer/wazuh-indexer-4.3.0/debian/wazuh-indexer/usr/share/wazuh-indexer/plugins/opensearch-security/tools/
cp /root/unattended_installer/wazuh-passwords-tool.sh /build/wazuh-indexer/wazuh-indexer-4.3.0/debian/wazuh-indexer/usr/share/wazuh-indexer/plugins/opensearch-security/tools/
cp /root/documentation-templates/wazuh/config.yml /build/wazuh-indexer/wazuh-indexer-4.3.0/debian/wazuh-indexer/usr/share/wazuh-indexer/plugins/opensearch-security/tools/ config.yml
```

```
$ sudo ./build_package.sh -s /tmp
...
+ /root/unattended_installer/builder.sh -c
+ /root/unattended_installer/builder.sh -p
+ cp /root/unattended_installer/wazuh-certs-tool.sh /build/rpmbuild/BUILDROOT/wazuh-indexer-4.3.0-1.x86_64/usr/share/wazuh-indexer/plugins/opensearch-security/tools/
+ cp /root/unattended_installer/wazuh-passwords-tool.sh /build/rpmbuild/BUILDROOT/wazuh-indexer-4.3.0-1.x86_64/usr/share/wazuh-indexer/plugins/opensearch-security/tools/
+ cp /root/documentation-templates/wazuh/config.yml /build/rpmbuild/BUILDROOT/wazuh-indexer-4.3.0-1.x86_64/usr/share/wazuh-indexer/plugins/opensearch-security/tools/config .yml
```