### PR TITLE
Fixed builder.sh generated permissions

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -237,16 +237,18 @@ function builder_main() {
 
     if [ -n "${installer}" ]; then
         buildInstaller
+        chmod 500 ${output_script_path}
     fi
 
     if [ -n "${passwordsTool}" ]; then
         buildPasswordsTool
+        chmod 500 ${output_script_path}
     fi
 
     if [ -n "${certTool}" ]; then
         buildCertsTool
+        chmod 500 ${output_script_path}
     fi
-    chmod 500 ${output_script_path}
 }
 
 builder_main "$@"


### PR DESCRIPTION
|Related issue|
|---|
|#1348|

## Description
- The permissions were only set once in the builder_main function, so it would only gave permission to the first parameter
- I've added the same command so every time a new script is generated it sets the right permissions.

## Logs example

![2022-03-21_10-16](https://user-images.githubusercontent.com/61159728/159239885-72e59ac7-7503-472b-8091-f34685eff936.png)
As we can see, only the first parameter has the right permissions
## Tests
### Execute builder.sh
After the change, every new generated script has read and execution permission
![2022-03-21_10-36](https://user-images.githubusercontent.com/61159728/159240145-0827ec9f-0ef1-433a-8e15-b0139ec99431.png)
