### PR TITLE
Added new information at beginning of the run

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -207,6 +207,7 @@ function main() {
     fi
 
     common_logger "Starting Wazuh installation assistant. Wazuh version: ${wazuh_version}"
+    common_logger "The verbose logging will be redirected to the file: ${logfile}"
 
 # -------------- Uninstall case  ------------------------------------
 


### PR DESCRIPTION
This PR aims to add a new line describing where the logs can be found at the beginning of the script run. 

Example: 
```
[vagrant@centos7 ~]$ sudo bash wazuh-install.sh -a
22/03/2022 16:49:20 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
22/03/2022 16:49:20 INFO: The verbose logging will be redirected to the file: /var/log/wazuh-install.log
22/03/2022 16:49:22 INFO: --- Configuration files ---
22/03/2022 16:49:22 INFO: Generating configuration files.
22/03/2022 16:49:23 INFO: Created /home/vagrant/wazuh-install-files.tar. Contains Wazuh cluster key, certificates, and passwords necessary for installation.
22/03/2022 16:49:28 INFO: --- Wazuh indexer ---
22/03/2022 16:49:28 INFO: Starting Wazuh indexer installation.
22/03/2022 16:50:20 INFO: Wazuh indexer installation finished.
```