### PR TITLE
Change dependencies installation order

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -235,6 +235,12 @@ function main() {
         rm -f "${tar_file}"
     fi
 
+# -------------- Prerequisites and Wazuh repo  ----------------------
+    if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
+        installCommon_installPrerequisites
+        installCommon_addWazuhRepo
+    fi
+
 # -------------- Configuration creation case  -----------------------
 
     # Creation certificate case: Only AIO and -g option can create certificates.
@@ -267,12 +273,6 @@ function main() {
     # Distributed architecture: node names must be different
     if [[ -z "${AIO}" && -z "${download}" && ( -n "${indexer}"  || -n "${dashboard}" || -n "${wazuh}" )]]; then
         checks_names
-    fi
-
-# -------------- Prerequisites and Wazuh repo  ----------------------
-    if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
-        installCommon_installPrerequisites
-        installCommon_addWazuhRepo
     fi
 
 # -------------- Wazuh Indexer case -------------------------------


### PR DESCRIPTION
This PR aims to change the dependencies installation run prior to configuration files creation. 

```
22/03/2022 17:54:54 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
22/03/2022 17:54:54 INFO: The verbose logging will be redirected to the file: /var/log/wazuh-install.log
22/03/2022 17:55:00 INFO: --- Dependencies ---
22/03/2022 17:55:00 INFO: Installing unzip.
22/03/2022 17:55:01 INFO: Installing wget.
22/03/2022 17:55:04 INFO: --- Configuration files ---
22/03/2022 17:55:04 INFO: Generating configuration files.
22/03/2022 17:55:05 INFO: Created wazuh-install-files.tar. It contains Wazuh cluster key, certificates, and passwords necessary for installation.
22/03/2022 17:55:05 INFO: --- Wazuh indexer ---
```