### PR TITLE
Rename certificates in configuration files

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -48,14 +48,14 @@ function dashboard_copyCertificates() {
     name=${dashboard_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "sed -i s/dashboard.pem/${name}.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml" 
-        eval "sed -i s/dashboard-key.pem/${name}-key.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
+        eval "sed -i s/dashboard.pem/${name}.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}" 
+        eval "sed -i s/dashboard-key.pem/${name}-key.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
-        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"
+        eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/* ${debug}"
         common_logger -d "Wazuh dashboard certificate setup finished."
     else
         common_logger -e "No certificates found. Wazuh dashboard  could not be initialized."

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -45,14 +45,14 @@ function dashboard_configure() {
 function dashboard_copyCertificates() {
 
     eval "rm -f ${dashboard_cert_path}/* ${debug}"
+    name=${dashboard_node_names[pos]}
+
     if [ -f "${tar_file}" ]; then
-
-        name=${dashboard_node_names[pos]}
-
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}.pem ${dashboard_cert_path}/dashboard.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem  && mv ${dashboard_cert_path}/wazuh-install-files/${name}-key.pem ${dashboard_cert_path}/dashboard-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem && mv ${dashboard_cert_path}/wazuh-install-files/root-ca.pem ${dashboard_cert_path}/root-ca.pem ${debug}"
-        eval "rm -rf ${dashboard_cert_path}/wazuh-install-files/"
+        eval "sed -i s/dashboard.pem/${name}.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml" 
+        eval "sed -i s/dashboard-key.pem/${name}-key.pem/ /etc/wazuh-dashboard/opensearch_dashboards.yml"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
         eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/*"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -8,12 +8,12 @@
 
 function dashboard_configure() {
 
-    dashboard_copyCertificates
-
     if [ -n "${AIO}" ]; then
         eval "installCommon_getConfig dashboard/dashboard_unattended.yml /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
+        dashboard_copyCertificates
     else
         eval "installCommon_getConfig dashboard/dashboard_unattended_distributed.yml /etc/wazuh-dashboard/opensearch_dashboards.yml ${debug}"
+        dashboard_copyCertificates
         if [ "${#dashboard_node_names[@]}" -eq 1 ]; then
             pos=0
             ip=${dashboard_node_ips[0]}

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,14 +40,18 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} && mv ${filebeat_cert_path}/wazuh-install-files/${server_node_names[0]}.pem ${filebeat_cert_path}/filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} && mv ${filebeat_cert_path}/wazuh-install-files/${server_node_names[0]}-key.pem ${filebeat_cert_path}/filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}/wazuh-install-files/root-ca.pem ${filebeat_cert_path}/root-ca.pem ${debug}"
+            eval "sed -i s/filebeat.pem/${name}.pem/ /etc/filebeat/filebeat.yml" 
+            eval "sed -i s/filebeat-key.pem/${name}-key.pem/ /etc/filebeat/filebeat.yml"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} --strip-components 1"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} --strip-components 1"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
             eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
         else
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem && mv ${filebeat_cert_path}/wazuh-install-files/${winame}.pem ${filebeat_cert_path}/filebeat.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem && mv ${filebeat_cert_path}/wazuh-install-files/${winame}-key.pem ${filebeat_cert_path}/filebeat-key.pem ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem && mv ${filebeat_cert_path}/wazuh-install-files/root-ca.pem ${filebeat_cert_path}/root-ca.pem ${debug}"
+            eval "sed -i s/filebeat.pem/${winame}.pem/ /etc/filebeat/filebeat.yml" 
+            eval "sed -i s/filebeat-key.pem/${winame}-key.pem/ /etc/filebeat/filebeat.yml"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem --strip-components 1"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem --strip-components 1"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
             eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
         fi
         eval "chown root:root ${filebeat_cert_path}/*"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,8 +40,8 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "sed -i s/filebeat.pem/${name}.pem/ /etc/filebeat/filebeat.yml" 
-            eval "sed -i s/filebeat-key.pem/${name}-key.pem/ /etc/filebeat/filebeat.yml"
+            eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /etc/filebeat/filebeat.yml" 
+            eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /etc/filebeat/filebeat.yml"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} --strip-components 1"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} --strip-components 1"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -42,8 +42,8 @@ function filebeat_copyCertificates() {
         if [ -n "${AIO}" ]; then
             eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /etc/filebeat/filebeat.yml ${debug}" 
             eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /etc/filebeat/filebeat.yml ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} --strip-components 1 ${debug}"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem --strip-components 1 ${debug}"
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
             eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/ ${debug}"
         else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -40,21 +40,21 @@ function filebeat_copyCertificates() {
 
     if [ -f "${tar_file}" ]; then
         if [ -n "${AIO}" ]; then
-            eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /etc/filebeat/filebeat.yml" 
-            eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /etc/filebeat/filebeat.yml"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} --strip-components 1"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} --strip-components 1"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
-            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
+            eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /etc/filebeat/filebeat.yml ${debug}" 
+            eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /etc/filebeat/filebeat.yml ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}.pem ${debug} --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} --wildcards wazuh-install-files/${server_node_names[0]}-key.pem ${debug} --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
+            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/ ${debug}"
         else
-            eval "sed -i s/filebeat.pem/${winame}.pem/ /etc/filebeat/filebeat.yml" 
-            eval "sed -i s/filebeat-key.pem/${winame}-key.pem/ /etc/filebeat/filebeat.yml"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem --strip-components 1"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem --strip-components 1"
-            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
-            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/"
+            eval "sed -i s/filebeat.pem/${winame}.pem/ /etc/filebeat/filebeat.yml ${debug}" 
+            eval "sed -i s/filebeat-key.pem/${winame}-key.pem/ /etc/filebeat/filebeat.yml ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}.pem --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/${winame}-key.pem --strip-components 1 ${debug}"
+            eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
+            eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/ ${debug}"
         fi
-        eval "chown root:root ${filebeat_cert_path}/*"
+        eval "chown root:root ${filebeat_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
         exit 1;

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,14 +80,14 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "sed -i s/indexer.pem/${name}.pem/ /etc/wazuh-indexer/opensearch.yml" 
-        eval "sed -i s/indexer-key.pem/${name}-key.pem/ /etc/wazuh-indexer/opensearch.yml"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem --strip-components 1"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem --strip-components 1"
-        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
+        eval "sed -i s/indexer.pem/${name}.pem/ /etc/wazuh-indexer/opensearch.yml ${debug}"
+        eval "sed -i s/indexer-key.pem/${name}-key.pem/ /etc/wazuh-indexer/opensearch.yml ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem --strip-components 1 ${debug}"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem --strip-components 1 ${debug}"
+        eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"
         exit 1;

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -80,12 +80,13 @@ function indexer_copyCertificates() {
     name=${indexer_node_names[pos]}
 
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem  && mv ${indexer_cert_path}/wazuh-install-files/${name}.pem ${indexer_cert_path}/indexer.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem  && mv ${indexer_cert_path}/wazuh-install-files/${name}-key.pem ${indexer_cert_path}/indexer-key.pem ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem && mv ${indexer_cert_path}/wazuh-install-files/root-ca.pem ${indexer_cert_path}/ ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem && mv ${indexer_cert_path}/wazuh-install-files/admin.pem ${indexer_cert_path}/ ${debug}"
-        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem && mv ${indexer_cert_path}/wazuh-install-files/admin-key.pem ${indexer_cert_path}/ ${debug}"
-        eval "rm -rf ${indexer_cert_path}/wazuh-install-files/"
+        eval "sed -i s/indexer.pem/${name}.pem/ /etc/wazuh-indexer/opensearch.yml" 
+        eval "sed -i s/indexer-key.pem/${name}-key.pem/ /etc/wazuh-indexer/opensearch.yml"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/root-ca.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin.pem --strip-components 1"
+        eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem --strip-components 1"
         eval "chown wazuh-indexer:wazuh-indexer ${indexer_cert_path}/*"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -148,8 +148,8 @@ function installCommon_changePasswords() {
 
     common_logger -d "Setting passwords."
     if [ -f "${tar_file}" ]; then
-        eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/passwords.wazuh ${debug}"
-        p_file="${base_path}/wazuh-install-files/passwords.wazuh"
+        eval "tar -xf ${tar_file} -C /tmp wazuh-install-files/passwords.wazuh ${debug}"
+        p_file="/tmp/wazuh-install-files/passwords.wazuh"
         common_checkInstalled
         if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
             changeall=1
@@ -171,7 +171,6 @@ function installCommon_changePasswords() {
     if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
         passwords_runSecurityAdmin
     fi
-    rm -rf "${base_path}/wazuh-install-files"
 
 }
 
@@ -181,8 +180,7 @@ function installCommon_extractConfig() {
         common_logger -e "There is no config.yml file in ${tar_file}."
         exit 1
     fi
-    eval "tar -xf ${tar_file} -C ${base_path} wazuh-install-files/config.yml ${debug}"
-    eval "mv ${base_path}/wazuh-install-files/config.yml ${base_path}/config.yml"
+    eval "tar -xf ${tar_file} -C /tmp wazuh-install-files/config.yml ${debug}"
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -95,7 +95,7 @@ function installCommon_createCertificates() {
     if [ -d /tmp/wazuh-certificates/ ]; then
         eval "rm -rf /tmp/wazuh-certificates/ ${debug}"
     fi        
-    mkdir "/tmp/wazuh-certificates/ ${debug}"
+    eval "mkdir /tmp/wazuh-certificates/ ${debug}"
     
 
     cert_generateRootCAcertificate
@@ -120,8 +120,8 @@ function installCommon_createInstallFiles() {
     if [ -d /tmp/wazuh-install-files ]; then
         eval "rm -rf /tmp/wazuh-install-files ${debug}"
     fi 
-    
-    if mkdir /tmp/wazuh-install-files > /dev/null 2>&1; then
+
+    if eval "mkdir /tmp/wazuh-install-files ${debug}"; then
         common_logger "Generating configuration files."
         if [ -n "${configurations}" ]; then
             cert_checkOpenSSL

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -92,7 +92,11 @@ function installCommon_createCertificates() {
 
     cert_readConfig
 
-    mkdir "/tmp/wazuh-certificates/"
+    if [ -d /tmp/wazuh-certificates/ ]; then
+        eval "rm -rf /tmp/wazuh-certificates/ ${debug}"
+    fi        
+    mkdir "/tmp/wazuh-certificates/ ${debug}"
+    
 
     cert_generateRootCAcertificate
     cert_generateAdmincertificate
@@ -100,7 +104,8 @@ function installCommon_createCertificates() {
     cert_generateFilebeatcertificates
     cert_generateDashboardcertificates
     cert_cleanFiles
-    mv /tmp/wazuh-certificates/* /tmp/wazuh-install-files
+    eval "mv /tmp/wazuh-certificates/* /tmp/wazuh-install-files ${debug}"
+    eval "rm -rf /tmp/wazuh-certificates/ ${debug}"
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -452,9 +452,7 @@ function installCommon_rollBack() {
                             "/etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service"
                             "/etc/systemd/system/wazuh-dashboard.service"
                             "/lib/firewalld/services/dashboard.xml"
-                            "/lib/firewalld/services/opensearch.xml"
-                            "${base_path}/wazuh-install-files"
-                            "${base_path}/wazuh-install-files.tar" )
+                            "/lib/firewalld/services/opensearch.xml" )
 
     eval "rm -rf ${elements_to_remove[*]}"
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -117,6 +117,10 @@ function installCommon_createClusterKey() {
 
 function installCommon_createInstallFiles() {
     
+    if [ -d /tmp/wazuh-install-files ]; then
+        eval "rm -rf /tmp/wazuh-install-files ${debug}"
+    fi 
+    
     if mkdir /tmp/wazuh-install-files > /dev/null 2>&1; then
         common_logger "Generating configuration files."
         if [ -n "${configurations}" ]; then

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -203,7 +203,7 @@ function main() {
     if [ -z "${disableSpinner}" ]; then
         installCommon_spin &
         spin_pid=$!
-        trap "kill -9 ${spin_pid} ${debug}" EXIT
+        trap "kill -9 ${spin_pid} > /dev/null 2>&1" EXIT
     fi
 
     common_logger "Starting Wazuh installation assistant. Wazuh version: ${wazuh_version}"

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -251,8 +251,8 @@ function main() {
 
     if [ -z "${configurations}" ] && [ -z "${download}" ]; then
         installCommon_extractConfig
+        config_file="/tmp/wazuh-install-files/config.yml"
         cert_readConfig
-        eval "rm -f ${config_file}"
     fi
 
     # Distributed architecture: node names must be different

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -255,7 +255,7 @@ function main() {
     fi
 
     # Distributed architecture: node names must be different
-    if [[ -z "${AIO}" && -z "${download}" && ( -n "${indexer}"  || -n "${dashboard}" || -n "${wazuh}" )]]; then
+    if [[ -z "${AIO}" && -z "${download}" && ( -n "${indexer}"  || -n "${dashboard}" || -n "${wazuh}" ) ]]; then
         checks_names
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -252,6 +252,7 @@ function main() {
     if [ -z "${configurations}" ] && [ -z "${download}" ]; then
         installCommon_extractConfig
         cert_readConfig
+        eval "rm -f ${config_file}"
     fi
 
     # Distributed architecture: node names must be different
@@ -343,6 +344,7 @@ function main() {
     fi
 
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
+        eval "rm -rf /tmp/wazuh-install-files ${debug}"
         common_logger "Installation finished."
     elif [ -n "${start_elastic_cluster}" ]; then
         common_logger "Elasticsearch cluster started."


### PR DESCRIPTION
|Related issue|
|---|
|#1336|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR modifies the way we use the certificates in the configuration files during in the installation assistant.

## Automated tests:
CentOS 7: https://ci.wazuh.info/view/Tests/job/Test_unattended/47/
Ubuntu bionic: https://ci.wazuh.info/view/Tests/job/Test_unattended/48/
Distributed: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/380/

## Logs example

<!--
Paste here related logs
-->

