### PR TITLE
Add rm to wazuh-install-files in rollBack function

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -411,17 +411,11 @@ function installCommon_rollBack() {
                             "/etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service"
                             "/etc/systemd/system/wazuh-dashboard.service"
                             "/lib/firewalld/services/dashboard.xml"
-                            "/lib/firewalld/services/opensearch.xml" )
+                            "/lib/firewalld/services/opensearch.xml"
+                            "${base_path}/wazuh-install-files"
+                            "${base_path}/wazuh-install-files.tar" )
 
     eval "rm -rf ${elements_to_remove[*]}"
-    
-    if [[ -d ${base_path}/wazuh-install-files ]]; then
-        eval "rm -rf ${base_path}/wazuh-install-files"
-    fi
-    
-    if [[ -f ${base_path}/wazuh-install-files.tar ]]; then
-        eval "rm -rf ${base_path}/wazuh-install-files.tar"
-    fi
 
     if [ -z "${uninstall}" ]; then
         if [ -n "${rollback_conf}" ] || [ -n "${overwrite}" ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -414,6 +414,14 @@ function installCommon_rollBack() {
                             "/lib/firewalld/services/opensearch.xml" )
 
     eval "rm -rf ${elements_to_remove[*]}"
+    
+    if [[ -d ${base_path}/wazuh-install-files ]]; then
+        eval "rm -rf ${base_path}/wazuh-install-files"
+    fi
+    
+    if [[ -f ${base_path}/wazuh-install-files.tar ]]; then
+        eval "rm -rf ${base_path}/wazuh-install-files.tar"
+    fi
 
     if [ -z "${uninstall}" ]; then
         if [ -n "${rollback_conf}" ] || [ -n "${overwrite}" ]; then


### PR DESCRIPTION
|Related issue|
|---|
| closes https://github.com/wazuh/wazuh-packages/issues/1373|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Wazuh-install-files and wazuh-install-files.tar removal is added to the RollBack function

## Logs example

<!--
Paste here related logs
-->

## Tests

Centos 7: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/480/console
Ubuntu Bionic: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/481/console

Distributed: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/364/console

