### PR TITLE
Update Filebeat configuration template

### DIFF
--- a/documentation-templates/wazuh/filebeat/filebeat.yml
+++ b/documentation-templates/wazuh/filebeat/filebeat.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch:
-  hosts: ["<elasticsearch_ip>:9200"]
+  hosts: ["127.0.0.1:9200"]
   protocol: https
   username: ${username}
   password: ${password}
@@ -20,3 +20,11 @@ filebeat.modules:
       enabled: true
     archives:
       enabled: false
+
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644


### PR DESCRIPTION

## Description

This PR sets the default Elasticsearch host as localhost, to be consistent with the Wazuh indexer and Wazuh dashboard default configuration files. This simplifies the installation instructions for all-in-one deployments.  

It also enables and configures the Filebeat logging system. 


