### PR TITLE
Certificates permissions updated for unattended installer

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -61,7 +61,7 @@ function cert_generateAdmincertificate() {
     eval "openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-certificates/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-certificates/admin-key.pem ${debug}"
     eval "openssl req -new -key /tmp/wazuh-certificates/admin-key.pem -out /tmp/wazuh-certificates/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin' ${debug}"
     eval "openssl x509 -days 3650 -req -in /tmp/wazuh-certificates/admin.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -sha256 -out /tmp/wazuh-certificates/admin.pem ${debug}"
-    cert_setpermisions
+
 }
 
 function cert_generateCertificateconfiguration() {
@@ -122,7 +122,6 @@ function cert_generateIndexercertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${indexer_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -config /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${indexer_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
-        cert_setpermisions
     fi
 
 }
@@ -137,7 +136,6 @@ function cert_generateFilebeatcertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${server_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${server_node_names[i]}.csr -config /tmp/wazuh-certificates/${server_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${server_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${server_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${server_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
-        cert_setpermisions
     fi
 
 }
@@ -153,7 +151,6 @@ function cert_generateDashboardcertificates() {
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${dashboard_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${dashboard_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${dashboard_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
 
         done
-        cert_setpermisions
     fi
 
 }
@@ -163,7 +160,7 @@ function cert_generateRootCAcertificate() {
     common_logger -d "Creating the root certificate."
 
     eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/root-ca.key -out /tmp/wazuh-certificates/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650 ${debug}"
-    cert_setpermisions
+
 }
 
 function cert_parseYaml() {

--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -61,7 +61,7 @@ function cert_generateAdmincertificate() {
     eval "openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-certificates/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-certificates/admin-key.pem ${debug}"
     eval "openssl req -new -key /tmp/wazuh-certificates/admin-key.pem -out /tmp/wazuh-certificates/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin' ${debug}"
     eval "openssl x509 -days 3650 -req -in /tmp/wazuh-certificates/admin.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -sha256 -out /tmp/wazuh-certificates/admin.pem ${debug}"
-
+    set_permisions
 }
 
 function cert_generateCertificateconfiguration() {
@@ -122,6 +122,7 @@ function cert_generateIndexercertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${indexer_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -config /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${indexer_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
+        set_permisions
     fi
 
 }
@@ -136,6 +137,7 @@ function cert_generateFilebeatcertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${server_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${server_node_names[i]}.csr -config /tmp/wazuh-certificates/${server_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${server_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${server_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${server_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
+        set_permisions
     fi
 
 }
@@ -151,6 +153,7 @@ function cert_generateDashboardcertificates() {
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${dashboard_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${dashboard_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${dashboard_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
 
         done
+        set_permisions
     fi
 
 }
@@ -160,7 +163,7 @@ function cert_generateRootCAcertificate() {
     common_logger -d "Creating the root certificate."
 
     eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/root-ca.key -out /tmp/wazuh-certificates/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650 ${debug}"
-
+    set_permisions
 }
 
 function cert_parseYaml() {
@@ -279,4 +282,9 @@ function cert_readConfig() {
         exit 1
     fi
 
+}
+
+function cert_setpermisions() {
+    eval "chmod 500 /tmp/wazuh-certificates ${debug}"
+    eval "chmod 400 /tmp/wazuh-certificates/* ${debug}"
 }

--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -61,7 +61,7 @@ function cert_generateAdmincertificate() {
     eval "openssl pkcs8 -inform PEM -outform PEM -in /tmp/wazuh-certificates/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out /tmp/wazuh-certificates/admin-key.pem ${debug}"
     eval "openssl req -new -key /tmp/wazuh-certificates/admin-key.pem -out /tmp/wazuh-certificates/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin' ${debug}"
     eval "openssl x509 -days 3650 -req -in /tmp/wazuh-certificates/admin.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -sha256 -out /tmp/wazuh-certificates/admin.pem ${debug}"
-    set_permisions
+    cert_setpermisions
 }
 
 function cert_generateCertificateconfiguration() {
@@ -122,7 +122,7 @@ function cert_generateIndexercertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${indexer_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -config /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${indexer_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${indexer_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${indexer_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
-        set_permisions
+        cert_setpermisions
     fi
 
 }
@@ -137,7 +137,7 @@ function cert_generateFilebeatcertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/${server_node_names[i]}-key.pem -out /tmp/wazuh-certificates/${server_node_names[i]}.csr -config /tmp/wazuh-certificates/${server_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${server_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${server_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${server_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
-        set_permisions
+        cert_setpermisions
     fi
 
 }
@@ -153,7 +153,7 @@ function cert_generateDashboardcertificates() {
             eval "openssl x509 -req -in /tmp/wazuh-certificates/${dashboard_node_names[i]}.csr -CA /tmp/wazuh-certificates/root-ca.pem -CAkey /tmp/wazuh-certificates/root-ca.key -CAcreateserial -out /tmp/wazuh-certificates/${dashboard_node_names[i]}.pem -extfile /tmp/wazuh-certificates/${dashboard_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
 
         done
-        set_permisions
+        cert_setpermisions
     fi
 
 }
@@ -163,7 +163,7 @@ function cert_generateRootCAcertificate() {
     common_logger -d "Creating the root certificate."
 
     eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout /tmp/wazuh-certificates/root-ca.key -out /tmp/wazuh-certificates/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650 ${debug}"
-    set_permisions
+    cert_setpermisions
 }
 
 function cert_parseYaml() {

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -161,6 +161,7 @@ function main() {
             cert_generateAdmincertificate
             common_logger "Admin certificates created."
             cert_cleanFiles
+            cert_setpermisions
             eval "mv /tmp/wazuh-certificates ${base_path}/wazuh-certificates ${debug}"
         fi
 
@@ -175,6 +176,7 @@ function main() {
             cert_generateDashboardcertificates
             common_logger "Wazuh dashboard certificates created."
             cert_cleanFiles
+            cert_setpermisions
             eval "mv /tmp/wazuh-certificates ${base_path}/wazuh-certificates ${debug}"
         fi
 
@@ -190,6 +192,7 @@ function main() {
             cert_generateIndexercertificates
             common_logger "Wazuh indexer certificates created."
             cert_cleanFiles
+            cert_setpermisions
             eval "mv /tmp/wazuh-certificates ${base_path}/wazuh-certificates ${debug}"
         fi
 
@@ -198,6 +201,7 @@ function main() {
             cert_generateFilebeatcertificates
             common_logger "Wazuh server certificates created."
             cert_cleanFiles
+            cert_setpermisions
             eval "mv /tmp/wazuh-certificates ${base_path}/wazuh-certificates ${debug}"
         fi
 
@@ -206,6 +210,7 @@ function main() {
             cert_generateDashboardcertificates
             common_logger "Wazuh dashboard certificates created."
             cert_cleanFiles
+            cert_setpermisions
             eval "mv /tmp/wazuh-certificates ${base_path}/wazuh-certificates ${debug}"
         fi
 

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -145,8 +145,10 @@ function main() {
                 exit 1
             fi
         fi
-
-        mkdir "/tmp/wazuh-certificates"
+        
+        if [[ ! -d "/tmp/wazuh-certificates" ]]; then
+            mkdir "/tmp/wazuh-certificates"
+        fi
 
         cert_readConfig
 

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -55,7 +55,8 @@ function dashboard_copyCertificates() {
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/${name}-key.pem --strip-components 1 ${debug}"
         eval "tar -xf ${tar_file} -C ${dashboard_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
         eval "chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/ ${debug}"
-        eval "chmod -R 500 ${dashboard_cert_path} ${debug}"
+        eval "chmod 500 ${dashboard_cert_path} ${debug}"
+        eval "chmod 400 ${dashboard_cert_path}/* ${debug}"
         eval "chown wazuh-dashboard:wazuh-dashboard ${dashboard_cert_path}/* ${debug}"
         common_logger -d "Wazuh dashboard certificate setup finished."
     else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -54,8 +54,8 @@ function filebeat_copyCertificates() {
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
             eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/ ${debug}"
         fi
-        eval "chmod 500 ${dashboard_cert_path} ${debug}"
-        eval "chmod 400 ${dashboard_cert_path}/* ${debug}"
+        eval "chmod 500 ${filebeat_cert_path} ${debug}"
+        eval "chmod 400 ${filebeat_cert_path}/* ${debug}"
         eval "chown root:root ${filebeat_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -54,6 +54,8 @@ function filebeat_copyCertificates() {
             eval "tar -xf ${tar_file} -C ${filebeat_cert_path} wazuh-install-files/root-ca.pem --strip-components 1 ${debug}"
             eval "rm -rf ${filebeat_cert_path}/wazuh-install-files/ ${debug}"
         fi
+        eval "chmod 500 ${dashboard_cert_path} ${debug}"
+        eval "chmod 400 ${dashboard_cert_path}/* ${debug}"
         eval "chown root:root ${filebeat_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -90,8 +90,8 @@ function indexer_copyCertificates() {
         eval "tar -xf ${tar_file} -C ${indexer_cert_path} wazuh-install-files/admin-key.pem --strip-components 1 ${debug}"
         eval "rm -rf ${indexer_cert_path}/wazuh-install-files/"
         eval "chown -R wazuh-indexer:wazuh-indexer ${indexer_cert_path} ${debug}"
-        eval "chmod 750 ${indexer_cert_path} ${debug}"
-        eval "chmod 600 ${indexer_cert_path}/* ${debug}"
+        eval "chmod 500 ${indexer_cert_path} ${debug}"
+        eval "chmod 400 ${indexer_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Wazuh indexer"
         exit 1;

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -123,6 +123,7 @@ function installCommon_createCertificates() {
     cert_generateFilebeatcertificates
     cert_generateDashboardcertificates
     cert_cleanFiles
+    cert_setpermisions
     eval "mv /tmp/wazuh-certificates/* /tmp/wazuh-install-files ${debug}"
     eval "rm -rf /tmp/wazuh-certificates/ ${debug}"
 


### PR DESCRIPTION
|Related issue|
|---|
|This PR closes #1402|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The certificate containing the folder should change the permissions to 500, and the certificates created by the script should have 400. The Wazuh installation assistant and Wazuh certs tool assign those permissions accordingly.

## Logs example

<!--
Paste here related logs
-->

## Tests
[centos8_unattende](https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/497)
[ubuntu-xenial_unattended](https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/496)
[Unattended Distributed](https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/390)

Before changes:
![image](https://user-images.githubusercontent.com/89791732/161119414-caf3cf78-afdb-47dd-891c-575797e69a08.png)

After changes:
![image](https://user-images.githubusercontent.com/89791732/161136116-d7ba9a49-8cc7-4fff-be07-d8560c1ecc39.png)

On the other hand, validation was added that if the temporary directory, used for the creation of the certificates, exists, it will not be created.
This is because if the same dir existed, it threw an error.