### PR TITLE
Strange characters deleted for ova logo

### DIFF
--- a/ova/assets/custom/messages.sh
+++ b/ova/assets/custom/messages.sh
@@ -20,18 +20,18 @@ EOF
 cat > /etc/motd <<EOF
 
 
-        WWWWWW            WWWWWW           WWWWWW
-         WWWWWW          WWWWWWWW          WWWWWW
-          WWWWWW        WWWWWWWWWW        WWWWWW
-          &WWWWW       WWWWW WWWWW       WWWWWW
-           WWWWWW     WWWWWW  WWWWW     WWWWWW
-            WWWWWW    WWWWW    WWWWW    WWWWW
+       WWWWWW             WWWWWW             WWWWWW
+        WWWWWW           WWWWWWWW           WWWWWW
+         WWWWWW         WWWWWWWWWW         WWWWWW
+          WWWWWW       WWWWW  WWWWW       WWWWWW
+           WWWWWW     WWWWWW  WWWWWW     WWWWWW
+            WWWWWW    WWWWW    WWWWW    WWWWWW
              WWWWWW  WWWWW      WWWWW  WWWWWW
-             /WWWWW,WWWWW       WWWWW WWWWWW
+              WWWWW WWWWW       WWWWW WWWWWW
               WWWWWWWWWW         WWWWWWWWWW         WWWWW
-               WWWWWWWW.          WWWWWWWW        WWWWWWWWW
-                WWWWWWW            WWWWWW&        WWWWWWWWW
-                 WWWWW              WWWWW          .WWWWW%
+               WWWWWWWW           WWWWWWWW        WWWWWWWWW
+                WWWWWWW           WWWWWWW         WWWWWWWWW
+                 WWWWW             WWWWW            WWWWW
 
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#1404|

## Description

The logo created when installing an ova image had some strange characters.

I've deleted this characters and try to make it as symmetrical and perfect as I could.


## Logs example

![2022-04-01_13-06](https://user-images.githubusercontent.com/61159728/161268047-5fa59d03-4701-4b68-bf49-3c1118cbd94a.png)

## Tests
After deleting the characters
![2022-04-01_14-45](https://user-images.githubusercontent.com/61159728/161268061-923db6ad-76e2-4a72-9e0d-c01057267b95.png)

