### PR TITLE
Fix APT lock detection and retry inside installCommon function in unattended installer

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -94,11 +94,15 @@ function installCommon_aptInstall() {
     fi
     eval "DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q ${debug}"
     install_result="$?"
-    while [ "${install_result}" -eq 100 ] && [ "${i}" -lt 12 ]; do
+    eval "tail -n 2 ${logfile} | grep 'Could not get lock'"
+    grep_result="$?"
+    while [ "${grep_result}" -eq 0 ] && [ "${i}" -lt 12 ]; do
         sleep 10
         i=$((i+1))
         eval "DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q ${debug}"
         install_result="$?"
+        eval "tail -n 2 ${logfile} | grep 'Could not get lock'"
+        grep_result="$?"
     done
     
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1412 |


## Description
Hello team we have solved the problem related with APT locked during unattended installation


https://user-images.githubusercontent.com/10661307/161295066-9b8f4d44-6c24-4aac-82bf-18242ad9b4e9.mp4


## Logs example
```
01/04/2022 15:22:11 INFO: --- Wazuh indexer ---
01/04/2022 15:22:11 INFO: Starting Wazuh indexer installation.
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4535 (apt)
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4535 (apt)
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4535 (apt)
01/04/2022 15:23:27 INFO: Wazuh indexer installation finished.
01/04/2022 15:23:27 INFO: Wazuh indexer post-install configuration finished.
```
