### PR TITLE
Generation of .tar.gz file with all symbols for macOS on the package generation.

### DIFF
--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -165,6 +165,7 @@ function build_package() {
             mkdir -p ${CHECKSUMDIR}
             cd ${DESTINATION} && shasum -a512 "${pkg_name}" > "${CHECKSUMDIR}/${pkg_name}.sha512"
         fi
+        tar -C ${WAZUH_PATH}/src/symbols -czf ${DESTINATION}wazuh-agent-macos-amd64-debug-info-${VERSION}-${REVISION}.tar.gz .
         clean_and_exit 0
     else
         echo "ERROR: something went wrong while building the package."


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1328 |

# Description
Enable the creation of macOS symbols compressed tar.gz file.

OUTPUT FILE NAME: wazuh-[agent/manager]-[os]-[architecture]-debug-info-${version}-{revision}.tar.gz

## DoD
- [x] Generate a new tar.gz file with all debug symbols information, on generate packages process.
- [x] Manual tests.