### PR TITLE
Fix dependencies for AIX package building

### DIFF
--- a/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
+++ b/aix/SPECS/4.3.0/wazuh-agent-4.3.0-aix.spec
@@ -56,7 +56,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.ssh
 # Copy the files into RPM_BUILD_ROOT directory
 sed "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/ossec-hids-aix.init > src/init/templates/ossec-hids-aix.init.tmp
 mv src/init/templates/ossec-hids-aix.init.tmp src/init/templates/ossec-hids-aix.init
-install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
+/opt/freeware/bin/install -m 0750 src/init/templates/ossec-hids-aix.init ${RPM_BUILD_ROOT}%{_init_scripts}/wazuh-agent
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
 
 # Add configuration scripts

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/ksh
 
 # Script to build Wazuh RPM package for AIX
-# Copyright (C) 2015, Wazuh Inc.
+# Copyright (C) 2015-2020, Wazuh Inc.
 #
 # This program is a free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -9,6 +9,7 @@
 # Foundation.
 
 # Script configuration variables
+
 current_path="$( cd $(dirname $0) ; pwd -P )"
 install_path="/var/ossec"
 reference="master"
@@ -28,7 +29,7 @@ aix_version=$(oslevel)
 aix_major=$(echo ${aix_version} | cut -d'.' -f 1)
 aix_minor=$(echo ${aix_version} | cut -d'.' -f 2)
 
-export PATH=/opt/freeware/bin:$PATH
+export PATH=$PATH:/opt/freeware/bin
 
 show_help() {
   echo
@@ -48,9 +49,9 @@ show_help() {
 # Function to install perl 5.10 on AIX
 build_perl() {
 
-  wget http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz
-  gunzip perl-5.10.1.tar.gz && tar -xvf perl-5.10.1.tar
-  cd perl-5.10.1 && ./Configure -des -Dcc='gcc'
+  curl -LO http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz -k -s
+  gunzip perl-5.10.1.tar.gz && tar -xf perl-5.10.1.tar
+  cd perl-5.10.1 &&   
   make && make install
   ln -fs /usr/local/bin/perl /bin/perl
   ln -fs /usr/local/bin/perl /opt/freeware/bin/perl
@@ -60,9 +61,11 @@ build_perl() {
 }
 
 build_cmake() {
-  mv /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h.bkp
-  curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz
-  gtar -zxf cmake-3.12.4.tar.gz && cd cmake-3.12.4
+  socket_lib=$(find /opt/freeware/lib/gcc/*/6.3.0/include-fixed/sys/ -name socket.h)
+  mv ${socket_lib} ${socket_lib}.bkp 
+  curl -LO http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz -k -s
+  ln -s /usr/bin/make /usr/bin/gmake
+  gunzip cmake-3.12.4.tar.gz && tar -xf cmake-3.12.4.tar && cd cmake-3.12.4
   ./bootstrap
   sed ' 1 s/.*/&-Wl,-bbigtoc/' Source/CMakeFiles/ctest.dir/link.txt | tee Source/CMakeFiles/ctest.dir/link.txt
   sed ' 1 s/.*/&-Wl,-bbigtoc/' Source/CMakeFiles/cpack.dir/link.txt | tee Source/CMakeFiles/cpack.dir/link.txt
@@ -86,82 +89,82 @@ build_environment() {
 
   rpm="rpm -Uvh --nodeps"
 
-  $rpm http://www.oss4aix.org/download/RPMS/autoconf/autoconf-2.69-2.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/automake/automake-1.16.1-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/bash/bash-4.4-4.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/bzip2/bzip2-1.0.6-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/coreutils/coreutils-64bit-8.28-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/expat/expat-2.2.5-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/expat/expat-devel-2.2.5-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/gettext/gettext-0.17-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/glib2/glib2-2.38.2-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/glib/glib-devel-1.2.10-3.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/gmp/gmp-6.1.2-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/gmp/gmp-devel-6.1.2-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/grep/grep-3.1-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/gzip/gzip-1.8-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/info/info-6.4-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/libffi/libffi-3.2.1-2.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/libiconv/libiconv-1.15-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/libidn/libidn-1.33-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/libsigsegv/libsigsegv-2.12-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/libtool/libtool-2.4.6-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/m4/m4-1.4.18-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/make/make-4.2.1-1.aix5.3.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/openldap/openldap-2.4.44-0.1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/openssl/openssl-1.0.2u-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/openssl/openssl-devel-1.0.2u-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/pcre/pcre-8.41-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/pkg-config/pkg-config-0.29.1-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/readline/readline-7.0-3.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/sed/sed-4.5-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/wget/wget-1.19.2-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/zlib/zlib-1.2.11-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/python/python-2.7.13-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/python/python-libs-2.7.13-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/popt/popt-1.16-2.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/rsync/rsync-3.1.3-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/nano/nano-2.5.3-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/curl/curl-7.72.0-1.aix5.1.ppc.rpm || true
-  $rpm http://www.oss4aix.org/download/RPMS/tar/tar-1.32-1.aix5.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/libiconv-1.14-22.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/autoconf-2.71-1.aix6.1.noarch.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/automake-1.16.2-1.aix6.1.noarch.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/bash-4.4-4.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/bzip2-1.0.6-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/coreutils-8.25-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/expat-2.2.6-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/expat-devel-2.2.6-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/gettext-0.17-1.aix5.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/glib2-2.33.2-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/glib2-devel-2.33.2-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/gmp-6.1.1-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/gmp-devel-6.1.1-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/grep-3.0-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/gzip-1.8-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/info-6.4-1.aix5.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/libffi-3.2.1-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/libidn-1.33-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/libsigsegv-2.10-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/libtool-2.4.6-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/m4-1.4.18-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/make-4.3-1.aix5.3.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/openldap-2.4.44-6.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/openssl-1.0.2g-3.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/openssl-devel-1.0.2g-3.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/pcre-8.42-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/pkg-config-0.29.1-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/readline-7.0-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/sed-4.7-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/wget-1.19-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/zlib-1.2.11-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/python-2.6-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/popt-1.16-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/rsync-3.1.2-3.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/tar-1.32-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/curl-7.72.0-1.aix5.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/readline-devel-7.0-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/guile-1.8.8-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/unixODBC-2.3.1-1.aix6.1.ppc.rpm || true
+
 
   if [[ "${aix_major}" = "6" ]] || [[ "${aix_major}" = "7" ]]; then
-    $rpm http://www.oss4aix.org/download/RPMS/isl/isl-0.18-1.aix5.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/mpfr/mpfr-3.1.6-1.aix5.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/libmpc/libmpc-1.0.3-1.aix5.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/file/file-5.32-1.aix5.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/file/file-libs-5.32-1.aix5.1.ppc.rpm || true
-    $rpm http://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/perl/perl-5.28.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/mpfr-3.1.4-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libmpc-1.0.3-2.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/file-5.32-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/file-libs-5.32-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/perl-5.30.3-2.aix6.1.ppc.rpm || true
   fi
 
   if [[ "${aix_major}" = "6" ]]; then
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-6.3.0-1.aix6.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-cpp-6.3.0-1.aix6.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libgcc-6.3.0-1.aix6.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-6.3.0-1.aix6.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-devel-6.3.0-1.aix6.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-c++-6.3.0-1.aix6.1.ppc.rpm || true
-
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-6.3.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-cpp-6.3.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libgcc-6.3.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-6.3.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-devel-6.3.0-1.aix6.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-c%2B%2B-6.3.0-1.aix6.1.ppc.rpm || true
   fi
 
   if [[ "${aix_major}" = "7" ]] && [[ "${aix_minor}" = "1" ]]; then
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-6.3.0-1.aix7.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-cpp-6.3.0-1.aix7.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libgcc-6.3.0-1.aix7.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-6.3.0-1.aix7.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-devel-6.3.0-1.aix7.1.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-c++-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-cpp-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libgcc-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-devel-6.3.0-1.aix7.1.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-c%2B%2B-6.3.0-1.aix7.1.ppc.rpm || true
   fi
 
   if [[ "${aix_major}" = "7" ]] && [[ "${aix_minor}" = "2" ]]; then
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-6.3.0-1.aix7.2.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-cpp-6.3.0-1.aix7.2.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libgcc-6.3.0-1.aix7.2.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-6.3.0-1.aix7.2.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/libstdc++-devel-6.3.0-1.aix7.2.ppc.rpm || true
-    $rpm http://www.oss4aix.org/download/RPMS/gcc/gcc-c++-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-cpp-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libgcc-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-devel-6.3.0-1.aix7.2.ppc.rpm || true
+    $rpm http://packages-dev.wazuh.com/deps/aix/gcc-c%2B%2B-6.3.0-1.aix7.2.ppc.rpm || true
   fi
-
+  
   build_perl
 
   if [[ "${aix_major}" = "6" ]] || [[ "${aix_major}" = "7" ]]; then
@@ -172,9 +175,9 @@ build_environment() {
 
 build_package() {
 
-  source_code="https://api.github.com/repos/wazuh/wazuh/tarball/${reference}"
+  source_code="http://api.github.com/repos/wazuh/wazuh/tarball/${reference}"
 
-  rm -f wazuh.tar.gz && wget -O wazuh.tar.gz --no-check-certificate ${source_code}
+  rm -f wazuh.tar.gz && curl -L ${source_code} -k -o wazuh.tar.gz -s
   rm -rf wazuh-wazuh-* wazuh-agent-*
   extracted_directory=$(gunzip -c wazuh.tar.gz | tar -xvf - | tail -n 1 | cut -d' ' -f2 | cut -d'/' -f1)
   wazuh_version=$(cat ${extracted_directory}/src/VERSION | cut -d'v' -f2)
@@ -194,9 +197,10 @@ build_package() {
 
   cp ${current_path}/SPECS/${wazuh_version}/wazuh-agent-${wazuh_version}-aix.spec ${rpm_build_dir}/SPECS
 
-  if [[ ${aix_major} = "6" ]] && [[ -f /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h ]]; then
-    ignored_lib=/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.1.0/6.3.0/include-fixed/sys/socket.h
-    mv ${ignored_lib} ${ignored_lib}.backup
+  socket_lib=$(find /opt/freeware/lib/gcc/*/6.3.0/include-fixed/sys/ -name socket.h)
+
+  if [[ ${aix_major} = "6" ]] && [[ -f ${socket_lib} ]]; then
+    mv ${socket_lib} ${socket_lib}.backup
   fi
 
   init_scripts="/etc/rc.d/init.d"

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -206,7 +206,7 @@ build_package() {
   init_scripts="/etc/rc.d/init.d"
   sysconfdir="/etc"
 
-  rpm --define '_tmppath /tmp' --define "_topdir ${rpm_build_dir}" --define "_localstatedir ${install_path}" \
+  rpmbuild --define '_tmppath /tmp' --define "_topdir ${rpm_build_dir}" --define "_localstatedir ${install_path}" \
   --define "_init_scripts ${init_scripts}" --define "_sysconfdir ${sysconfdir}" \
   -bb ${rpm_build_dir}/SPECS/${package_name}-aix.spec
 

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -51,7 +51,7 @@ build_perl() {
 
   curl -LO http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz -k -s
   gunzip perl-5.10.1.tar.gz && tar -xf perl-5.10.1.tar
-  cd perl-5.10.1 &&   
+  cd perl-5.10.1 && ./Configure -des -Dcc='gcc'
   make && make install
   ln -fs /usr/local/bin/perl /bin/perl
   ln -fs /usr/local/bin/perl /opt/freeware/bin/perl

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -1,7 +1,7 @@
-#!/bin/ksh
+#!/bin/bash
 
-# Script to build Wazuh RPM package for AIX
-# Copyright (C) 2015-2020, Wazuh Inc.
+# Wazuh package generator
+# Copyright (C) 2015, Wazuh Inc.
 #
 # This program is a free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -120,7 +120,6 @@ build_environment() {
   $rpm http://packages-dev.wazuh.com/deps/aix/sed-4.7-2.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/wget-1.19-1.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/zlib-1.2.11-1.aix6.1.ppc.rpm || true
-  $rpm http://packages-dev.wazuh.com/deps/aix/python-2.6-1.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/popt-1.16-2.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/rsync-3.1.2-3.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/tar-1.32-1.aix6.1.ppc.rpm || true
@@ -128,6 +127,13 @@ build_environment() {
   $rpm http://packages-dev.wazuh.com/deps/aix/readline-devel-7.0-1.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/guile-1.8.8-2.aix6.1.ppc.rpm || true
   $rpm http://packages-dev.wazuh.com/deps/aix/unixODBC-2.3.1-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/db-4.8.24-4.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/gdbm-1.10-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/ncurses-6.2-2.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/sqlite-3.33.0-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/sqlite-libs-3.33.0-1.aix6.1.ppc.rpm || true
+  $rpm http://packages-dev.wazuh.com/deps/aix/python-2.7.15-1.aix6.1.ppc.rpm || true
+
 
 
   if [[ "${aix_major}" = "6" ]] || [[ "${aix_major}" = "7" ]]; then
@@ -206,7 +212,7 @@ build_package() {
   init_scripts="/etc/rc.d/init.d"
   sysconfdir="/etc"
 
-  rpmbuild --define '_tmppath /tmp' --define "_topdir ${rpm_build_dir}" --define "_localstatedir ${install_path}" \
+  rpm --define '_tmppath /tmp' --define "_topdir ${rpm_build_dir}" --define "_localstatedir ${install_path}" \
   --define "_init_scripts ${init_scripts}" --define "_sysconfdir ${sysconfdir}" \
   -bb ${rpm_build_dir}/SPECS/${package_name}-aix.spec
 


### PR DESCRIPTION
|Related issue|
|---|
|#1387|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR replaces the dependencies used for building the AIX package and sets the links pointing to our own s3 repository.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [x] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [x] `%files` section is correctly updated if necessary
  - [x] Check the changes from IBM AIX 6 to 7
