### PR TITLE
Fix error compilation for CentOS 5 and 7, and building docker images CentOS 5 for i386

### DIFF
--- a/rpms/CentOS/5/i386/CentOS-Base.repo
+++ b/rpms/CentOS/5/i386/CentOS-Base.repo
@@ -1,0 +1,67 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#released updates
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#additional packages that may be useful
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#additional packages that extend functionality of existing packages
+
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#contrib - packages by Centos Users
+
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/contrib/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+[cr]
+name=CentOS-$releasever - CR
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/cr/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+[addons]
+name=CentOS-$releasever - CR
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/addons/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+[fasttrack]
+name=CentOS-$releasever - CR
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/fasttrack/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/rpms/CentOS/5/i386/Dockerfile
+++ b/rpms/CentOS/5/i386/Dockerfile
@@ -3,6 +3,9 @@ FROM scratch
 # Add the tar.gz with all the files needed
 ADD centos-5-i386.tar.gz /
 
+RUN rm /etc/yum.repos.d/* && echo "exactarch=1" >> /etc/yum.conf
+COPY CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+
 RUN linux32 yum install -y gcc-c++
 
 # Install Perl 5.10
@@ -38,6 +41,8 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz && \
     tar -zxvf cmake-3.12.4.tar.gz && cd cmake-3.12.4 && \
     linux32 ./bootstrap && linux32 make -j2 && linux32 make install && \
     cd / && rm -rf cmake-*
+
+RUN ln -fs $(which gcc) $(which cc)
 
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package

--- a/rpms/CentOS/5/x86_64/Dockerfile
+++ b/rpms/CentOS/5/x86_64/Dockerfile
@@ -45,6 +45,8 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz && \
     tar -zxvf cmake-3.12.4.tar.gz && cd cmake-3.12.4 && \
     ./bootstrap && make -j2 && make install && cd / && rm -rf cmake-*
 
+RUN ln -fs $(which gcc) $(which cc)
+
 # Add the scripts to build the RPM package
 ADD build.sh /usr/local/bin/build_package
 RUN chmod +x /usr/local/bin/build_package

--- a/rpms/CentOS/7/armv7hl/Dockerfile
+++ b/rpms/CentOS/7/armv7hl/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \
     linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --with-arch=armv7-a \
-        --with-float=hard --enable-languages=c,c++ --disable-multilib \
+        --with-float=hard --with-fpu=vfpv3-d16 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     linux32 make -j$(nproc) && linux32 make install && \
     ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && cd / && rm -rf gcc-*


### PR DESCRIPTION
|Related issue|
|---|
|#1424|

## Description

Hi Team

This PR aims to fix the issue of building docker images for CentOS 5 on i386 architecture, resolve the error compilation in the Wazuh project for CentOS 5 on x86_64 and i386 architecture, and the FPU related error compilation in CentOS 7 for armv7vl architecture.

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
