### PR TITLE
Removed extra spaces in name servers and ips

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -193,15 +193,15 @@ function cert_readConfig() {
         fi
         eval "$(cert_convertCRLFtoLF "${config_file}")"
         eval "$(cert_parseYaml "${config_file}")"
-        eval "indexer_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_indexer_name | sed 's/nodes_indexer_name=//') )"
-        eval "server_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_server_name | sed 's/nodes_server_name=//') )"
-        eval "dashboard_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_dashboard_name | sed 's/nodes_dashboard_name=//') )"
+        eval "indexer_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_indexer_name | sed 's/nodes_indexer_name=//' | sed -r 's/\s+//g') )"
+        eval "server_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_server_name | sed 's/nodes_server_name=//' | sed -r 's/\s+//g') )"
+        eval "dashboard_node_names=( $(cert_parseYaml "${config_file}" | grep nodes_dashboard_name | sed 's/nodes_dashboard_name=//' | sed -r 's/\s+//g') )"
 
-        eval "indexer_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_indexer_ip | sed 's/nodes_indexer_ip=//') )"
-        eval "server_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_server_ip | sed 's/nodes_server_ip=//') )"
-        eval "dashboard_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_dashboard_ip | sed 's/nodes_dashboard_ip=//') )"
+        eval "indexer_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_indexer_ip | sed 's/nodes_indexer_ip=//' | sed -r 's/\s+//g') )"
+        eval "server_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_server_ip | sed 's/nodes_server_ip=//' | sed -r 's/\s+//g') )"
+        eval "dashboard_node_ips=( $(cert_parseYaml "${config_file}" | grep nodes_dashboard_ip | sed 's/nodes_dashboard_ip=//' | sed -r 's/\s+//g') )"
 
-        eval "server_node_types=( $(cert_parseYaml "${config_file}" | grep nodes_server_node_type | sed 's/nodes_server_node_type=//') )"
+        eval "server_node_types=( $(cert_parseYaml "${config_file}" | grep nodes_server_node_type | sed 's/nodes_server_node_type=//' | sed -r 's/\s+//g') )"
 
         unique_names=($(echo "${indexer_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_names[@]}" -ne "${#indexer_node_names[@]}" ]; then 


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1205|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Added a sed to the end of the search for each server name and ip, which removes any extra space in it

## Logs example

<!--
Paste here related logs
-->
![Screenshot_20220405_123357](https://user-images.githubusercontent.com/64099752/161807722-e315f315-7c48-46e3-9aee-916d4a9111c7.png)
![Screenshot_20220405_135352](https://user-images.githubusercontent.com/64099752/161807898-40b079c0-f6dc-4fb8-9e09-cec4bae7e8de.png)
![Screenshot_20220405_135406](https://user-images.githubusercontent.com/64099752/161807972-26a913c6-aa0d-4ceb-bae8-3e1c947336ee.png)


## Tests

Centos: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/506/console
Ubuntu: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/507/console
Distributted: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/396/console

