### PR TITLE
Remove quotes into cert_parseYaml tools

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -178,7 +178,7 @@ function cert_parseYaml() {
         for (i in vname) {if (i > indent) {delete vname[i]}}
         if (length($3) > 0) {
             vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-            printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+            printf("%s%s%s=%s\n", "'$prefix'",vn, $2, $3);
         }
     }'
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #1437|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Modify certFunctions.sh to remove quotes in output of cert_parseYaml function. To use it on docker cert generations.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->
```
fcaffieri@Fede:~/repos/wazuh-packages/unattended_installer$ ./builder.sh -c
fcaffieri@Fede:~/repos/wazuh-packages/unattended_installer$ ls -la
total 76
drwxrwxr-x  7 fcaffieri fcaffieri  4096 abr  6 12:42 .
drwxrwxr-x 20 fcaffieri fcaffieri  4096 abr  6 12:38 ..
-rwxrwxr-x  1 fcaffieri fcaffieri  9345 mar 31 09:33 builder.sh
drwxrwxr-x  2 fcaffieri fcaffieri  4096 abr  6 12:38 cert_tool
drwxrwxr-x  2 fcaffieri fcaffieri  4096 mar 30 15:07 common_functions
drwxrwxr-x  6 fcaffieri fcaffieri  4096 mar 21 14:55 config
-rw-------  1 root      root        150 abr  4 09:35 config.yml
-rw-rw-r--  1 fcaffieri fcaffieri  2397 mar 21 14:55 Development-guide.md
drwxrwxr-x  2 fcaffieri fcaffieri  4096 abr  6 12:38 install_functions
drwxrwxr-x  2 fcaffieri fcaffieri  4096 mar 30 15:07 passwords_tool
-r-x------  1 fcaffieri fcaffieri 24807 abr  6 12:42 wazuh-certs-tool.sh

fcaffieri@Fede:~/repos/wazuh-packages/unattended_installer$ sudo ./wazuh-certs-tool.sh -A
06/04/2022 12:42:35 INFO: Admin certificates created.
06/04/2022 12:42:36 INFO: Wazuh indexer certificates created.
06/04/2022 12:42:36 INFO: Wazuh server certificates created.
06/04/2022 12:42:36 INFO: Wazuh dashboard certificates created.

fcaffieri@Fede:~/repos/wazuh-packages/unattended_installer$ ls -la
total 80
drwxrwxr-x  8 fcaffieri fcaffieri  4096 abr  6 12:42 .
drwxrwxr-x 20 fcaffieri fcaffieri  4096 abr  6 12:38 ..
-rwxrwxr-x  1 fcaffieri fcaffieri  9345 mar 31 09:33 builder.sh
drwxrwxr-x  2 fcaffieri fcaffieri  4096 abr  6 12:38 cert_tool
drwxrwxr-x  2 fcaffieri fcaffieri  4096 mar 30 15:07 common_functions
drwxrwxr-x  6 fcaffieri fcaffieri  4096 mar 21 14:55 config
-rw-------  1 root      root        150 abr  6 12:42 config.yml
-rw-rw-r--  1 fcaffieri fcaffieri  2397 mar 21 14:55 Development-guide.md
drwxrwxr-x  2 fcaffieri fcaffieri  4096 abr  6 12:38 install_functions
drwxrwxr-x  2 fcaffieri fcaffieri  4096 mar 30 15:07 passwords_tool
dr-x------  2 root      root       4096 abr  6 12:42 wazuh-certificates
-r-x------  1 fcaffieri fcaffieri 24807 abr  6 12:42 wazuh-certs-tool.sh

fcaffieri@Fede:~/repos/wazuh-packages/unattended_installer$ sudo ls -la wazuh-certificates/
total 48
dr-x------ 2 root      root      4096 abr  6 12:42 .
drwxrwxr-x 8 fcaffieri fcaffieri 4096 abr  6 12:42 ..
-r-------- 1 root      root      1704 abr  6 12:42 admin-key.pem
-r-------- 1 root      root      1119 abr  6 12:42 admin.pem
-r-------- 1 root      root      1704 abr  6 12:42 dashboard-key.pem
-r-------- 1 root      root      1237 abr  6 12:42 dashboard.pem
-r-------- 1 root      root      1704 abr  6 12:42 indexer-key.pem
-r-------- 1 root      root      1237 abr  6 12:42 indexer.pem
-r-------- 1 root      root      1704 abr  6 12:42 root-ca.key
-r-------- 1 root      root      1204 abr  6 12:42 root-ca.pem
-r-------- 1 root      root      1704 abr  6 12:42 server-key.pem
-r-------- 1 root      root      1233 abr  6 12:42 server.pem

```

## Tests

https://devel.ci.wazuh.info/job/Test_unattended/513
https://devel.ci.wazuh.info/job/Test_unattended/514
https://devel.ci.wazuh.info/job/Test_unattended_distributed/429