### PR TITLE
Check if Indexer is listening on Port 9300 after install

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -30,7 +30,7 @@ function checks_arguments() {
         fi
     fi
 
-    if [[ -n "${configurations}" && ( -n "${AIO}" || -n "${indexer}" || -n "${dashboard}" || -n "${wazuh}" || -n "${overwrite}" || -n "${start_elastic_cluster}" || -n "${tar_conf}" || -n "${uninstall}" ) ]]; then
+    if [[ -n "${configurations}" && ( -n "${AIO}" || -n "${indexer}" || -n "${dashboard}" || -n "${wazuh}" || -n "${overwrite}" || -n "${start_indexer_cluster}" || -n "${tar_conf}" || -n "${uninstall}" ) ]]; then
         common_logger -e "The argument -g|--generate-configurations can't be used with -a|--all-in-one, -o|--overwrite, -s|--start-cluster, -t|--tar, -u|--uninstall, -wd|--wazuh-dashboard, -wi|--wazuh-indexer, or -ws|--wazuh-server."
         exit 1
     fi
@@ -156,14 +156,14 @@ function checks_arguments() {
 
     # -------------- Cluster start ----------------------------------
 
-    if [[ -n "${start_elastic_cluster}" && ( -n "${AIO}" || -n "${indexer}" || -n "${dashboard}" || -n "${wazuh}" || -n "${overwrite}" || -n "${configurations}" || -n "${tar_conf}" || -n "${uninstall}") ]]; then
+    if [[ -n "${start_indexer_cluster}" && ( -n "${AIO}" || -n "${indexer}" || -n "${dashboard}" || -n "${wazuh}" || -n "${overwrite}" || -n "${configurations}" || -n "${tar_conf}" || -n "${uninstall}") ]]; then
         common_logger -e "The argument -s|--start-cluster can't be used with -a|--all-in-one, -g|--generate-configurations,-o|--overwrite , -u|--uninstall, -wi|--wazuh-indexer, -wd|--wazuh-dashboard, -s|--start-cluster, -ws|--wazuh-server."
         exit 1
     fi
 
     # -------------- Global -----------------------------------------
 
-    if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_elastic_cluster}" ] && [ -z "${configurations}" ] && [ -z "${uninstall}" ] && [ -z "${download}" ]; then
+    if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ] && [ -z "${configurations}" ] && [ -z "${uninstall}" ] && [ -z "${download}" ]; then
         common_logger -e "At least one of these arguments is necessary -a|--all-in-one, -g|--generate-configurations, -wi|--wazuh-indexer, -wd|--wazuh-dashboard, -s|--start-cluster, -ws|--wazuh-server, -u|--uninstall, -dw|--download-wazuh."
         exit 1
     fi

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -121,7 +121,7 @@ function dashboard_initialize() {
             exit 1
         else
             common_logger "--- Summary ---"
-            common_logger "When Wazuh dashboard is able to connect to your Elasticsearch cluster, you can access the web interface https://${nodes_dashboard_ip}.\n    User: admin\n    Password: ${u_pass}"
+            common_logger "When Wazuh dashboard is able to connect to your Wazuh indexer cluster, you can access the web interface https://${nodes_dashboard_ip}.\n    User: admin\n    Password: ${u_pass}"
         fi
     else
         common_logger "Wazuh dashboard web application initialized."

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -112,7 +112,7 @@ function indexer_initialize() {
         installCommon_rollBack
         exit 1
     fi
-    
+
     if [ -n "${AIO}" ]; then
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
     fi
@@ -153,7 +153,7 @@ function indexer_install() {
 }
 
 function indexer_startCluster() {
-    
+
     f=0    
     for r in "${indexer_node_ips[@]}"; do
         until eval "nc -z ${r} 9300" || [ "${f}" -eq 12 ]; do
@@ -184,5 +184,5 @@ function indexer_startCluster() {
     else
         common_logger -d "Inserted wazuh-alerts template into the Wazuh indexer cluster."
     fi
-    
+
 }

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -161,8 +161,7 @@ function indexer_startCluster() {
             retries=$((retries+1))
         done
         if [ ${retries} -eq 12 ]; then
-            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${ip_to_test} on port 9300. Review your firewall/network configuration before and try again."
-            installCommon_rollBack
+            common_logger -e "Connectivity check failed on node ${ip_to_test} port 9300. Possible causes: Wazuh indexer not installed on the node, the Wazuh indexer service is not running or you have connectivity issues with that node. Please check this before trying again."
             exit 1
         fi
     done

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -112,7 +112,21 @@ function indexer_initialize() {
         installCommon_rollBack
         exit 1
     fi
-
+    f=0
+    
+    for r in "${indexer_node_ips[@]}"; do
+        nc -z ${r} 9300   
+        until $? -eq 1 || [ "${f}" -eq 12 ]; do
+            sleep 10
+            f=$((i+1))
+        done
+        if [ ${f} -eq 12 ]; then
+            common_logger -e "Cannot initialize Wazuh indexer cluster."
+            installCommon_rollBack
+            exit 1
+        fi
+    done
+    
     if [ -n "${AIO}" ]; then
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
     fi

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -154,14 +154,14 @@ function indexer_install() {
 
 function indexer_startCluster() {
 
-    f=0    
-    for r in "${indexer_node_ips[@]}"; do
-        until eval "nc -z ${r} 9300" || [ "${f}" -eq 12 ]; do
+    retries=0    
+    for ip_to_test in "${indexer_node_ips[@]}"; do
+        until eval "nc -z ${ip_to_test} 9300" || [ "${retries}" -eq 12 ]; do
             sleep 10
-            f=$((f+1))
+            retries=$((retries+1))
         done
-        if [ ${f} -eq 12 ]; then
-            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${r} on port 9300."
+        if [ ${retries} -eq 12 ]; then
+            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${ip_to_test} on port 9300."
             installCommon_rollBack
             exit 1
         fi

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -112,13 +112,12 @@ function indexer_initialize() {
         installCommon_rollBack
         exit 1
     fi
-    f=0
-    
+    f=0    
     for r in "${indexer_node_ips[@]}"; do
-        nc -z ${r} 9300   
-        until $? -eq 1 || [ "${f}" -eq 12 ]; do
+        nc -z "${r}" 9300
+        until [ "$?" -eq 0 ] || [ "${f}" -eq 12 ]; do
             sleep 10
-            f=$((i+1))
+            f=$((f+1))
         done
         if [ ${f} -eq 12 ]; then
             common_logger -e "Cannot initialize Wazuh indexer cluster."

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -161,7 +161,7 @@ function indexer_startCluster() {
             retries=$((retries+1))
         done
         if [ ${retries} -eq 12 ]; then
-            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${ip_to_test} on port 9300."
+            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${ip_to_test} on port 9300. Review your firewall/network configuration before and try again."
             installCommon_rollBack
             exit 1
         fi

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -112,19 +112,6 @@ function indexer_initialize() {
         installCommon_rollBack
         exit 1
     fi
-    f=0    
-    for r in "${indexer_node_ips[@]}"; do
-        nc -z "${r}" 9300
-        until [ "$?" -eq 0 ] || [ "${f}" -eq 12 ]; do
-            sleep 10
-            f=$((f+1))
-        done
-        if [ ${f} -eq 12 ]; then
-            common_logger -e "Cannot initialize Wazuh indexer cluster."
-            installCommon_rollBack
-            exit 1
-        fi
-    done
     
     if [ -n "${AIO}" ]; then
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -icl -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
@@ -166,6 +153,19 @@ function indexer_install() {
 }
 
 function indexer_startCluster() {
+    
+    f=0    
+    for r in "${indexer_node_ips[@]}"; do
+        until eval "nc -z ${r} 9300" || [ "${f}" -eq 12 ]; do
+            sleep 10
+            f=$((f+1))
+        done
+        if [ ${f} -eq 12 ]; then
+            common_logger -e "Cannot initialize Wazuh indexer cluster. Unable to connect to node ${r} on port 9300."
+            installCommon_rollBack
+            exit 1
+        fi
+    done
 
     eval "wazuh_indexer_ip=( $(cat /etc/wazuh-indexer/opensearch.yml | grep network.host | sed 's/network.host:\s//') )"
     eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -icl -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${wazuh_indexer_ip} ${debug}"
@@ -184,5 +184,5 @@ function indexer_startCluster() {
     else
         common_logger -d "Inserted wazuh-alerts template into the Wazuh indexer cluster."
     fi
-
+    
 }

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -237,7 +237,7 @@ function installCommon_getPass() {
 function installCommon_installPrerequisites() {
 
     if [ "${sys_type}" == "yum" ]; then
-        dependencies=( curl unzip wget libcap tar gnupg openssl )
+        dependencies=( curl unzip wget libcap tar gnupg openssl nmap-ncat )
         not_installed=()
         for dep in "${dependencies[@]}"; do
             if [ -z "$(yum list installed 2>/dev/null | grep ${dep})" ];then
@@ -259,7 +259,7 @@ function installCommon_installPrerequisites() {
 
     elif [ "${sys_type}" == "apt-get" ]; then
         eval "apt update -q ${debug}"
-        dependencies=( apt-transport-https curl unzip wget libcap2-bin tar software-properties-common gnupg openssl )
+        dependencies=( apt-transport-https curl unzip wget libcap2-bin tar software-properties-common gnupg openssl netcat )
         not_installed=()
 
         for dep in "${dependencies[@]}"; do

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -491,7 +491,7 @@ function installCommon_rollBack() {
 }
 
 function installCommon_startService() {
-    
+
     if [ "$#" -ne 1 ]; then
         common_logger -e "installCommon_startService must be called with 1 argument."
         exit 1
@@ -543,5 +543,5 @@ function installCommon_startService() {
         common_logger -e "${1^} could not start. No service manager found on the system."
         exit 1
     fi
-    
+
 }

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -175,7 +175,7 @@ function installCommon_changePasswords() {
         eval "tar -xf ${tar_file} -C /tmp wazuh-install-files/passwords.wazuh ${debug}"
         p_file="/tmp/wazuh-install-files/passwords.wazuh"
         common_checkInstalled
-        if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
+        if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
             changeall=1
             passwords_readUsers
         fi
@@ -184,7 +184,7 @@ function installCommon_changePasswords() {
         common_logger -e "Cannot find passwords file. Exiting"
         exit 1
     fi
-    if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
+    if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
         passwords_getNetworkHost
         passwords_createBackUp
         passwords_generateHash
@@ -192,7 +192,7 @@ function installCommon_changePasswords() {
 
     passwords_changePassword
 
-    if [ -n "${start_elastic_cluster}" ] || [ -n "${AIO}" ]; then
+    if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
         passwords_runSecurityAdmin
     fi
 
@@ -491,7 +491,7 @@ function installCommon_rollBack() {
 }
 
 function installCommon_startService() {
-
+    
     if [ "$#" -ne 1 ]; then
         common_logger -e "installCommon_startService must be called with 1 argument."
         exit 1
@@ -543,5 +543,5 @@ function installCommon_startService() {
         common_logger -e "${1^} could not start. No service manager found on the system."
         exit 1
     fi
-
+    
 }

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -270,7 +270,7 @@ function main() {
         indexer_initialize
     fi
 
-# -------------- Start Elasticsearch cluster case  ------------------
+# -------------- Start Wazuh Indexer cluster case  ------------------
 
     if [ -n "${start_indexer_cluster}" ]; then
         indexer_startCluster

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -121,7 +121,7 @@ function main() {
                 shift 1
                 ;;
             "-s"|"--start-cluster")
-                start_elastic_cluster=1
+                start_indexer_cluster=1
                 shift 1
                 ;;
             "-t"|"--tar")
@@ -272,7 +272,7 @@ function main() {
 
 # -------------- Start Elasticsearch cluster case  ------------------
 
-    if [ -n "${start_elastic_cluster}" ]; then
+    if [ -n "${start_indexer_cluster}" ]; then
         indexer_startCluster
         installCommon_changePasswords
     fi
@@ -346,8 +346,8 @@ function main() {
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
         eval "rm -rf /tmp/wazuh-install-files ${debug}"
         common_logger "Installation finished."
-    elif [ -n "${start_elastic_cluster}" ]; then
-        common_logger "Elasticsearch cluster started."
+    elif [ -n "${start_indexer_cluster}" ]; then
+        common_logger "Wazuh indexer cluster started."
     fi
 
 }

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -374,7 +374,7 @@ function passwords_runSecurityAdmin() {
     fi
 
     if [ -n "${changeall}" ]; then
-        if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_elastic_cluster}" ]; then
+        if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
             for i in "${!users[@]}"; do
                 common_logger $'The password for user '${users[i]}' is '${passwords[i]}''
             done


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1411|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
A validation is added so that before starting the Wazuh Indexer cluster it is verified that the nodes are listening on port 9300, a delay and a retry of 12 times are added to give time if it is due to some delay in the process of install

## Logs example

<!--
Paste here related logs
-->
Example of an install where all nodes are listening on port 9300

![Screenshot_20220406_124137](https://user-images.githubusercontent.com/64099752/162017451-362ec5cd-f613-48ff-a803-c275960d79f5.png)

Example with a node with port 9300 blocked by firewall-cmd

![Screenshot_20220406_125253](https://user-images.githubusercontent.com/64099752/162017678-38350089-38a3-4228-a9c0-72d7bc9ec926.png)
![Screenshot_20220406_125138](https://user-images.githubusercontent.com/64099752/162017709-69f8872d-df13-4a45-baea-848acc80d68f.png)


## Tests

Centos: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/515/console
Ubuntu: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/516/console
Distributted: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/403/parameters/


