### PR TITLE
Add support for RPM/DEB debuginfo packages

### DIFF
--- a/debs/SPECS/4.4.0/wazuh-agent/debian/control
+++ b/debs/SPECS/4.4.0/wazuh-agent/debian/control
@@ -12,3 +12,12 @@ Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-agent-dbg
+Architecture: any
+Section: devel
+Depends: wazuh-agent (= ${binary:Version})
+Replaces: wazuh-agent-dbg
+Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
+ .
+ This package contains files necessary for debugging the wazuh-agent with gdb.

--- a/debs/SPECS/4.4.0/wazuh-agent/debian/control
+++ b/debs/SPECS/4.4.0/wazuh-agent/debian/control
@@ -16,7 +16,7 @@ Description: Wazuh helps you to gain security visibility into your infrastructur
 Package: wazuh-agent-dbg
 Architecture: any
 Section: devel
-Depends: wazuh-agent (= ${binary:Version})
+Conflicts: wazuh-agent (<< ${binary:Version}), wazuh-agent (>> ${binary:Version})
 Replaces: wazuh-agent-dbg
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
  .

--- a/debs/SPECS/4.4.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-agent/debian/rules
@@ -145,8 +145,8 @@ override_dh_install:
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
 	# Add debug symbols
-	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
-	cp src/symbols/* ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}
+	mv ${TARGET_DIR}/${INSTALLATION_DIR}/.symbols ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
 
 override_dh_auto_clean:
 	$(MAKE) -j$(JOBS) -C src clean

--- a/debs/SPECS/4.4.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-agent/debian/rules
@@ -17,6 +17,7 @@ export DH_VERBOSE=1
 export DH_OPTIONS
 
 export TARGET_DIR=${CURDIR}/debian/wazuh-agent
+export TARGET_DIR_SYMS=${CURDIR}/debian/wazuh-agent-dbg
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
@@ -40,7 +41,7 @@ override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
 
 	# Build the binaries
-	make -C src deps TARGET=agent
+	make -j$(JOBS) -C src deps TARGET=agent
 	make -j$(JOBS) -C src/ TARGET=agent USE_SELINUX=yes DEBUG=$(DEBUG_ENABLED)
 
 	USER_LANGUAGE="en" \
@@ -143,11 +144,14 @@ override_dh_install:
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
+	# Add debug symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+	cp src/symbols/* ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+
 override_dh_auto_clean:
-	$(MAKE) -C src clean
+	$(MAKE) -j$(JOBS) -C src clean
 
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure

--- a/debs/SPECS/4.4.0/wazuh-manager/debian/control
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/control
@@ -17,7 +17,7 @@ Description: Wazuh helps you to gain security visibility into your infrastructur
 Package: wazuh-manager-dbg
 Architecture: any
 Section: devel
-Depends: wazuh-manager (= ${binary:Version})
+Conflicts: wazuh-manager (<< ${binary:Version}), wazuh-manager (>> ${binary:Version})
 Replaces: wazuh-manager-dbg
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
  .

--- a/debs/SPECS/4.4.0/wazuh-manager/debian/control
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/control
@@ -13,3 +13,12 @@ Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-manager-dbg
+Architecture: any
+Section: devel
+Depends: wazuh-manager (= ${binary:Version})
+Replaces: wazuh-manager-dbg
+Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
+ .
+ This package contains files necessary for debugging the wazuh-manager with gdb.

--- a/debs/SPECS/4.4.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/rules
@@ -16,8 +16,10 @@ export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 export PKG_DIR=debian/wazuh-manager
+export DBG_DIR=debian/wazuh-manager-dbg
 
 export TARGET_DIR=${CURDIR}/${PKG_DIR}
+export TARGET_DIR_SYMS=${CURDIR}/${DBG_DIR}
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
@@ -190,6 +192,10 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/18/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/18/04
 	cp etc/templates/config/ubuntu/20/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/20/04
 
+	# Add debug symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+	cp src/symbols/* ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions
@@ -204,6 +210,5 @@ override_dh_auto_clean:
 	$(MAKE) -C src clean
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure override_dh_fixperms

--- a/debs/SPECS/4.4.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/rules
@@ -193,8 +193,8 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/20/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/20/04
 
 	# Add debug symbols
-	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
-	cp src/symbols/* ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}
+	mv ${TARGET_DIR}/${INSTALLATION_DIR}/.symbols ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
 
 override_dh_fixperms:
 	dh_fixperms

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -96,10 +96,6 @@ if [ "${build_target}" == "api" ]; then
     fi
 fi
 
-if [[ "${debug}" == "yes" ]]; then
-    sed -i "s:dh_strip --no-automatic-dbgsym::g" ${sources_dir}/debian/rules
-fi
-
 # Installing build dependencies
 cd ${sources_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
@@ -115,10 +111,13 @@ else
 fi
 
 deb_file="wazuh-${build_target}_${wazuh_version}-${package_release}"
+dbg_file="wazuh-${build_target}-dbg_${wazuh_version}-${package_release}"
 if [[ "${architecture_target}" == "ppc64le" ]]; then
   deb_file="${deb_file}_ppc64el.deb"
+  dbg_file="${dbg_file}_ppc64el.deb"
 else
   deb_file="${deb_file}_${architecture_target}.deb"
+  dbg_file="${dbg_file}_${architecture_target}.deb"
 fi
 pkg_path="${build_dir}/${build_target}"
 
@@ -126,3 +125,5 @@ if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${deb_file} > /var/local/checksum/${deb_file}.sha512
 fi
 mv ${pkg_path}/${deb_file} /var/local/wazuh
+mv ${pkg_path}/${dbg_file} /var/local/wazuh
+

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -79,7 +79,7 @@ build_deb() {
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
         ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
-    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 2) added to ${OUTDIR}."
 
     return 0
 }

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -149,7 +149,7 @@ help() {
     echo "    -r, --revision <rev>       [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    -p, --path <path>          [Optional] Installation path for the package. By default: /var/ossec."
-    echo "    -d, --debug                [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -d, --debug                [Optional] Build the binaries without optimizations. By default: no."
     echo "    -c, --checksum <path>      [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>           [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -29,6 +29,14 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+%package -n wazuh-agent-debuginfo
+Summary: Debug info for Wazuh
+Group: Development/Libraries
+Requires: wazuh-agent(%{_arch}) = %{version}-%{release}
+
+%description -n wazuh-agent-debuginfo
+This package contains files necessary for debugging the wazuh-agent with gdb.
+
 %prep
 %setup -q
 
@@ -40,14 +48,14 @@ pushd src
 make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
-    make deps TARGET=agent
+    make -j%{_threads} deps TARGET=agent
     make -j%{_threads} TARGET=agent USE_SELINUX=yes DEBUG=%{_debugenabled}
 %else
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
     %endif
     deps_version=`cat Makefile | grep "DEPS_VERSION =" | cut -d " " -f 3`
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
+    make -j%{_threads} deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no DEBUG=%{_debugenabled} ${MSGPACK}
 
 %endif
@@ -168,9 +176,10 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 
-if [ %{_debugenabled} = "yes" ]; then
-  %{_rpmconfigdir}/find-debuginfo.sh
-fi
+# Add debug symbols
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+cp src/symbols/* ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+
 exit 0
 
 %pre
@@ -609,11 +618,9 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
-%if %{_debugenabled} == "yes"
-/usr/lib/debug/%{_localstatedir}/*
-/usr/src/debug/%{name}-%{version}/*
-%endif
-
+%files -n wazuh-agent-debuginfo
+%dir %attr(750, root, root) %{_localstatedir}/.symbols
+%attr(660, root, root) %{_localstatedir}/.symbols/*
 
 %changelog
 * Sat Dec 25 2021 support <info@wazuh.com> - 4.4.0

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -32,7 +32,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %package -n wazuh-agent-debuginfo
 Summary: Debug info for Wazuh
 Group: Development/Libraries
-Requires: wazuh-agent(%{_arch}) = %{version}-%{release}
+Requires: wazuh-agent = %{version}-%{release}
 
 %description -n wazuh-agent-debuginfo
 This package contains files necessary for debugging the wazuh-agent with gdb.
@@ -620,7 +620,7 @@ rm -fr %{buildroot}
 
 %files -n wazuh-agent-debuginfo
 %dir %attr(750, root, root) %{_localstatedir}/.symbols
-%attr(660, root, root) %{_localstatedir}/.symbols/*
+%attr(640, root, root) %{_localstatedir}/.symbols/*
 
 %changelog
 * Sat Dec 25 2021 support <info@wazuh.com> - 4.4.0

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -832,7 +832,7 @@ rm -fr %{buildroot}
 
 %files -n wazuh-agent-debuginfo
 %dir %attr(750, root, root) %{_localstatedir}/.symbols
-%attr(660, root, root) %{_localstatedir}/.symbols/*
+%attr(640, root, root) %{_localstatedir}/.symbols/*
 
 
 %changelog

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -26,7 +26,7 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
-%package -n wazuh-agent-debuginfo
+%package -n wazuh-manager-debuginfo
 Summary: Debug info for Wazuh
 Group: Development/Libraries
 Requires: wazuh-manager = %{version}-%{release}
@@ -830,7 +830,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
-%files -n wazuh-agent-debuginfo
+%files -n wazuh-manager-debuginfo
 %dir %attr(750, root, root) %{_localstatedir}/.symbols
 %attr(640, root, root) %{_localstatedir}/.symbols/*
 

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -26,6 +26,14 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+%package -n wazuh-agent-debuginfo
+Summary: Debug info for Wazuh
+Group: Development/Libraries
+Requires: wazuh-manager = %{version}-%{release}
+
+%description -n wazuh-manager-debuginfo
+This package contains files necessary for debugging the wazuh-manager with gdb.
+
 %prep
 %setup -q
 
@@ -37,7 +45,7 @@ pushd src
 make clean
 
 # Build Wazuh sources
-make deps TARGET=server
+make -j%{_threads} deps TARGET=server
 make -j%{_threads} TARGET=server USE_SELINUX=yes DEBUG=%{_debugenabled}
 
 popd
@@ -163,9 +171,10 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 
-if [ %{_debugenabled} = "yes" ]; then
-  %{_rpmconfigdir}/find-debuginfo.sh
-fi
+# Add debug symbols
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+cp src/symbols/* ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+
 exit 0
 
 %pre
@@ -821,10 +830,9 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
-%if %{_debugenabled} == "yes"
-/usr/lib/debug/%{_localstatedir}/*
-/usr/src/debug/%{name}-%{version}/*
-%endif
+%files -n wazuh-agent-debuginfo
+%dir %attr(750, root, root) %{_localstatedir}/.symbols
+%attr(660, root, root) %{_localstatedir}/.symbols/*
 
 
 %changelog

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -53,6 +53,7 @@ fi
 build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+dbg_file="wazuh-${build_target}-debuginfo-${wazuh_version}-${package_release}"
 rpm_file="${file_name}.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
 pkg_path="${rpm_build_dir}/RPMS/${architecture_target}"
@@ -132,3 +133,4 @@ if [[ "${src}" == "yes" ]]; then
 fi
 
 find ${extract_path} -maxdepth 3 -type f -name "${file_name}*" -exec mv {} /var/local/wazuh \;
+find ${extract_path} -maxdepth 3 -type f -name "${dbg_file}*" -exec mv {} /var/local/wazuh \;

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -80,6 +80,7 @@ if [[ "${future}" == "yes" ]]; then
     MINOR=$(echo $base_version | cut -d. -f2)
     wazuh_version="${MAJOR}.30.0"
     file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+    dbg_file="wazuh-${build_target}-debuginfo-${wazuh_version}-${package_release}"
     old_name="wazuh-${build_target}-${base_version}-${package_release}"
     package_name=wazuh-${build_target}-${wazuh_version}
     old_package_name=wazuh-${build_target}-${base_version}

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -98,7 +98,7 @@ build_rpm() {
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
         ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
-    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 2) added to ${OUTDIR}."
 
     return 0
 }

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -177,7 +177,7 @@ help() {
     echo "    -s, --store <path>           [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    -j, --jobs <number>          [Optional] Number of parallel jobs when compiling."
     echo "    -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec."
-    echo "    -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
+    echo "    -d, --debug                  [Optional] Build the binaries without optimizations. By default: no."
     echo "    -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
     echo "    --dont-build-docker          [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."


### PR DESCRIPTION
|Related issue|
|---|
|Closes #1310|
## Description

This PR aims to add RPM/DEB debuginfo packages

Defacto debuginfo packages names
- RPM: `<package_name>-debuginfo` Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/developer_guide/intro.debuginfo
- DEB: `<package_name>-dbg` -> Ref: https://wiki.debian.org/DebugPackage

Packages constraints
- debuginfo package version (major,minor,release) and arch must exactly match with wazuh-<target> counterpart

## Steps
- Generate agent/manager packages
```sh
./generate_rpm_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t agent
./generate_rpm_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t manager
./generate_debian_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t agent
./generate_debian_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t manager
```
- Generate future agent/manager packages (for upgrade scenarios and deps between debuginfo and binary packages)
```sh
./generate_rpm_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t agent --future
./generate_rpm_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t manager --future 
./generate_debian_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t agent --future
./generate_debian_package.sh --packages-branch "1310-rpm-dev-debuginfo-packages" -b "dev-debug-symbols" -t manager --future
```
## Querying packages
- RPM
```sh
[root@centos7 vagrant]# rpm -qip wazuh-agent-debuginfo-4.4.0-1.x86_64.rpm 
Name        : wazuh-agent-debuginfo
Version     : 4.4.0
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Development/Libraries
Size        : 9730917
License     : GPL
Signature   : (none)
Source RPM  : wazuh-agent-4.4.0-1.src.rpm
Build Date  : Thu 07 Apr 2022 12:44:47 PM UTC
Build Host  : 3e5a3ab74969
Relocations : (not relocatable)
Packager    : Wazuh, Inc <info@wazuh.com>
Vendor      : Wazuh, Inc <info@wazuh.com>
URL         : https://www.wazuh.com/
Summary     : Debug info for Wazuh
Description :
This package contains files necessary for debugging the wazuh-agent with gdb.
[root@centos7 vagrant]# rpm -qlp wazuh-agent-debuginfo-4.4.0-1.x86_64.rpm 
/usr/lib/.build-id
/usr/lib/.build-id/04/0a80dd7ce98fec694899291d702b052015718e.1
/usr/lib/.build-id/07/72a435bdf99a65df2041d98410c0eed6192f22.1
/usr/lib/.build-id/10/b70daa7364669f475ad79822320ecc20d5c902.1
/usr/lib/.build-id/21/a26409d52eb1fe990aa8e89c9f561266788100.1
/usr/lib/.build-id/28/d7b49369bda47d2035853f1438464a040c2848.1
/usr/lib/.build-id/2c/c6266acef0c721d0f636305516328f5c3cc963.2
/usr/lib/.build-id/3b/dbda499fa480a2c62150057619de6430036ec8.1
/usr/lib/.build-id/47/a12e5097b8a2a71d3a7289d6940880feef1bc0.1
/usr/lib/.build-id/53/430c36baa25d6ffda9c6ab23a1d9aeec9a2284.1
/usr/lib/.build-id/61/be5bd5dda2fd6e4535b5d0c9034c9eaef04052.1
/usr/lib/.build-id/69/98f588fa6c7337164839bbf7aca437975f61f2.1
/usr/lib/.build-id/71/bfc7c718bd3437ab36032a25278603064e76aa.1
/usr/lib/.build-id/82/5e5cb764708ee0dc718550143a9acc0b70c47f.1
/usr/lib/.build-id/95/f02fa1845f6ebf9acaca5bd1e6a7942dc0175a.1
/usr/lib/.build-id/96/3bb9de642a86532fdf2f5db1ffbfa5be2e786d.1
/usr/lib/.build-id/a7/112ce807e8aa8a09eb04ed44d158451be07342.1
/usr/lib/.build-id/ac/58ee85e1b234ecda532b2b80e5541349b55e30.1
/usr/lib/.build-id/af/1902c4445193c60e98088771d6fc4a88f1ad6e.1
/usr/lib/.build-id/c5/44a6e18a17bc557147d24128dcae7af528d1b0.1
/usr/lib/.build-id/d4/e87403b6064822af9ecbe628ed8da951156ed9.1
/usr/lib/.build-id/e9/2d8d43851c069ec3c14427bec2806c12db0479.1
/var/ossec/.symbols
/var/ossec/.symbols/agent-auth.debug
/var/ossec/.symbols/default-firewall-drop.debug
/var/ossec/.symbols/disable-account.debug
/var/ossec/.symbols/firewalld-drop.debug
/var/ossec/.symbols/host-deny.debug
/var/ossec/.symbols/ip-customblock.debug
/var/ossec/.symbols/ipfw.debug
/var/ossec/.symbols/kaspersky.debug
/var/ossec/.symbols/libdbsync.debug
/var/ossec/.symbols/librsync.debug
/var/ossec/.symbols/libsyscollector.debug
/var/ossec/.symbols/libsysinfo.debug
/var/ossec/.symbols/libwazuhext.debug
/var/ossec/.symbols/libwazuhshared.debug
/var/ossec/.symbols/manage_agents.debug
/var/ossec/.symbols/npf.debug
/var/ossec/.symbols/pf.debug
/var/ossec/.symbols/restart-wazuh.debug
/var/ossec/.symbols/route-null.debug
/var/ossec/.symbols/wazuh-agentd.debug
/var/ossec/.symbols/wazuh-execd.debug
/var/ossec/.symbols/wazuh-logcollector.debug
/var/ossec/.symbols/wazuh-modulesd.debug
/var/ossec/.symbols/wazuh-slack.debug
/var/ossec/.symbols/wazuh-syscheckd.debug

```
- DEB
```sh
# dpkg-deb -I wazuh-agent-dbg_4.4.0-1_amd64.deb  
 new Debian package, version 2.0.
 size 4662738 bytes: control archive=1404 bytes.
     636 bytes,    14 lines      control              
    1943 bytes,    27 lines      md5sums              
 Package: wazuh-agent-dbg
 Source: wazuh-agent
 Version: 4.4.0-1
 Architecture: amd64
 Maintainer: Wazuh, Inc <info@wazuh.com>
 Installed-Size: 14416
 Depends: wazuh-agent (= 4.4.0-1)
 Replaces: wazuh-agent-dbg
 Section: devel
 Priority: extra
 Homepage: https://www.wazuh.com
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
  .
  This package contains files necessary for debugging the wazuh-agent with gdb.
# dpkg-deb -c wazuh-agent-dbg_4.4.0-1_amd64.deb                                                                                                               2 ↵
drwxr-xr-x root/root         0 2022-04-07 16:03 ./
drwxr-xr-x root/root         0 2022-04-07 16:03 ./var/
drwxr-xr-x root/root         0 2022-04-07 16:03 ./var/ossec/
drwxr-xr-x root/root         0 2022-04-07 16:03 ./var/ossec/.symbols/
-rwxr-xr-x root/root      2784 2022-04-07 16:03 ./var/ossec/.symbols/libwazuhext.debug
-rwxr-xr-x root/root     40594 2022-04-07 16:03 ./var/ossec/.symbols/ipfw.debug
-rwxr-xr-x root/root     40682 2022-04-07 16:03 ./var/ossec/.symbols/npf.debug
-rwxr-xr-x root/root    655514 2022-04-07 16:03 ./var/ossec/.symbols/manage_agents.debug
-rwxr-xr-x root/root     41515 2022-04-07 16:03 ./var/ossec/.symbols/pf.debug
-rwxr-xr-x root/root     41789 2022-04-07 16:03 ./var/ossec/.symbols/disable-account.debug
-rwxr-xr-x root/root      2408 2022-04-07 16:03 ./var/ossec/.symbols/librsync.debug
-rwxr-xr-x root/root    410628 2022-04-07 16:03 ./var/ossec/.symbols/libwazuhshared.debug
-rwxr-xr-x root/root     45071 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-slack.debug
-rwxr-xr-x root/root   3075076 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-syscheckd.debug
-rwxr-xr-x root/root     46608 2022-04-07 16:03 ./var/ossec/.symbols/default-firewall-drop.debug
-rwxr-xr-x root/root    643881 2022-04-07 16:03 ./var/ossec/.symbols/agent-auth.debug
-rwxr-xr-x root/root     41609 2022-04-07 16:03 ./var/ossec/.symbols/firewalld-drop.debug
-rwxr-xr-x root/root     37310 2022-04-07 16:03 ./var/ossec/.symbols/restart-wazuh.debug
-rwxr-xr-x root/root      2256 2022-04-07 16:03 ./var/ossec/.symbols/libsyscollector.debug
-rwxr-xr-x root/root   2298373 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-execd.debug
-rwxr-xr-x root/root   2425183 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-agentd.debug
-rwxr-xr-x root/root   2215293 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-modulesd.debug
-rwxr-xr-x root/root     39504 2022-04-07 16:03 ./var/ossec/.symbols/route-null.debug
-rwxr-xr-x root/root     39410 2022-04-07 16:03 ./var/ossec/.symbols/kaspersky.debug
-rwxr-xr-x root/root      2384 2022-04-07 16:03 ./var/ossec/.symbols/libdbsync.debug
-rwxr-xr-x root/root   2488280 2022-04-07 16:03 ./var/ossec/.symbols/wazuh-logcollector.debug
-rwxr-xr-x root/root     39239 2022-04-07 16:03 ./var/ossec/.symbols/ip-customblock.debug
-rwxr-xr-x root/root     43063 2022-04-07 16:03 ./var/ossec/.symbols/host-deny.debug
-rwxr-xr-x root/root      2408 2022-04-07 16:03 ./var/ossec/.symbols/libsysinfo.debug
drwxr-xr-x root/root         0 2022-04-07 16:03 ./usr/
drwxr-xr-x root/root         0 2022-04-07 16:03 ./usr/share/
drwxr-xr-x root/root         0 2022-04-07 16:03 ./usr/share/doc/
drwxr-xr-x root/root         0 2022-04-07 16:03 ./usr/share/doc/wazuh-agent-dbg/
-rw-r--r-- root/root      3144 2022-04-07 16:01 ./usr/share/doc/wazuh-agent-dbg/changelog.Debian.gz
-rw-r--r-- root/root       791 2022-01-31 14:15 ./usr/share/doc/wazuh-agent-dbg/copyright
```

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
