### PR TITLE
Changed CONFIG_DIR var in opensearch-dashboards script

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -56,6 +56,9 @@ cp ./etc/custom_welcome/Assets/Favicons/* ./src/core/server/core_app/assets/favi
 cp ./etc/custom_welcome/Assets/Favicons/favicon-32x32.png ./src/core/server/core_app/assets/favicons/favicon.ico
 cp ./etc/opensearch_dashboards_config.js ./src/core/server/opensearch_dashboards_config.js
 cp ./etc/http_service.js ./src/core/server/http/http_service.js
+cp ./etc/opensearch-dashboards ./bin/opensearch-dashboards
+cp ./etc/opensearch-dashboards-keystore ./bin/opensearch-dashboards-keystore
+cp ./etc/opensearch-dashboards-plugin ./bin/opensearch-dashboards-plugin
 # Replace the redirection to `home` in the header logo
 sed -i "s'/app/home'/app/wazuh'g" ./src/core/target/public/core.entry.js
 # Replace others redirections to `home`

--- a/stack/dashboard/base/files/etc/opensearch-dashboards
+++ b/stack/dashboard/base/files/etc/opensearch-dashboards
@@ -1,0 +1,34 @@
+#!/bin/sh
+SCRIPT=$0
+
+# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
+while [ -h "$SCRIPT" ] ; do
+  ls=$(ls -ld "$SCRIPT")
+  # Drop everything prior to ->
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=$(dirname "$SCRIPT")/"$link"
+  fi
+done
+
+DIR="$(dirname "${SCRIPT}")/.."
+CONFIG_DIR=${OSD_PATH_CONF:-"/etc/wazuh-dashboard"}
+
+if [ -x "${DIR}/node/bin/node" ]; then
+  NODE="${DIR}/node/bin/node"
+else
+  NODE="$(which node)"
+fi
+
+if [ ! -x "$NODE" ]; then
+  echo "unable to find usable node.js executable."
+  exit 1
+fi
+
+if [ -f "${CONFIG_DIR}/node.options" ]; then
+  OSD_NODE_OPTS="$(grep -v ^# < ${CONFIG_DIR}/node.options | xargs)"
+fi
+
+NODE_OPTIONS="--no-warnings --max-http-header-size=65536 $OSD_NODE_OPTS $NODE_OPTIONS" NODE_ENV=production exec "${NODE}" "${DIR}/src/cli/dist" ${@}

--- a/stack/dashboard/base/files/etc/opensearch-dashboards-keystore
+++ b/stack/dashboard/base/files/etc/opensearch-dashboards-keystore
@@ -1,0 +1,29 @@
+#!/bin/sh
+SCRIPT=$0
+
+# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
+while [ -h "$SCRIPT" ] ; do
+  ls=$(ls -ld "$SCRIPT")
+  # Drop everything prior to ->
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=$(dirname "$SCRIPT")/"$link"
+  fi
+done
+
+DIR="$(dirname "${SCRIPT}")/.."
+CONFIG_DIR=${OSD_PATH_CONF:-"/etc/wazuh-dashboard"}
+NODE="${DIR}/node/bin/node"
+test -x "$NODE"
+if [ ! -x "$NODE" ]; then
+  echo "unable to find usable node.js executable."
+  exit 1
+fi
+
+if [ -f "${CONFIG_DIR}/node.options" ]; then
+  OSD_NODE_OPTS="$(grep -v ^# < ${CONFIG_DIR}/node.options | xargs)"
+fi
+
+NODE_OPTIONS="$OSD_NODE_OPTS $NODE_OPTIONS" "${NODE}" "${DIR}/src/cli_keystore/dist" "$@"

--- a/stack/dashboard/base/files/etc/opensearch-dashboards-plugin
+++ b/stack/dashboard/base/files/etc/opensearch-dashboards-plugin
@@ -1,0 +1,29 @@
+#!/bin/sh
+SCRIPT=$0
+
+# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
+while [ -h "$SCRIPT" ] ; do
+  ls=$(ls -ld "$SCRIPT")
+  # Drop everything prior to ->
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=$(dirname "$SCRIPT")/"$link"
+  fi
+done
+
+DIR="$(dirname "${SCRIPT}")/.."
+CONFIG_DIR=${OSD_PATH_CONF:-"/etc/wazuh-dashboard"}
+NODE="${DIR}/node/bin/node"
+test -x "$NODE"
+if [ ! -x "$NODE" ]; then
+  echo "unable to find usable node.js executable."
+  exit 1
+fi
+
+if [ -f "${CONFIG_DIR}/node.options" ]; then
+  OSD_NODE_OPTS="$(grep -v ^# < ${CONFIG_DIR}/node.options | xargs)"
+fi
+
+NODE_OPTIONS="--no-warnings $OSD_NODE_OPTS $NODE_OPTIONS" NODE_ENV=production exec "${NODE}" "${DIR}/src/cli_plugin/dist" "$@"


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1447|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The CONFIG_DIR variable of the opensearch scripts is modified

## Logs example

<!--
Paste here related logs
-->

## Tests
build:

- rpm: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7495/console
- deb: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7496/console

Install:

- centos: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/441/console
- debian: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/442/console

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
