### PR TITLE
Download cv2pdb, generate zip file with debug symbols for winagent

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -3,7 +3,19 @@ FROM ubuntu:20.04
 # Installing necessary packages
 RUN apt-get update && \
     apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
-    curl perl binutils zip libssl1.1 libssl-dev
+    curl perl binutils zip libssl1.1 libssl-dev lsb-release gnupg
+
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt -y install tzdata
+RUN dpkg --add-architecture i386
+RUN wget -qO - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+RUN echo "deb https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" >> /etc/apt/sources.list
+
+RUN apt update
+RUN apt install -y --install-recommends winehq-stable
+RUN apt install -y winbind
+
+ENV WINEPATH="/usr/i686-w64-mingw32/lib;/path/to/wazuh/src"
+ENV WINEARCH=win32
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && \

--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -6,6 +6,7 @@ BRANCH=$1
 JOBS=$2
 DEBUG=$3
 REVISION=$4
+DEBUG_SYMBOLS_PATH=$5
 ZIP_NAME="windows_agent_${REVISION}.zip"
 
 URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
@@ -15,15 +16,31 @@ wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip
 
 # Compile the wazuh agent for Windows
 FLAGS="-j ${JOBS} "
+VERSION=$(cat wazuh-*/src/VERSION)
+ZIP_SYMBOLS_NAME="wazuh-agent-windows-x86_64-debug-info-${VERSION}-${REVISION}.zip"
 
 if [[ "${DEBUG}" = "yes" ]]; then
     FLAGS+="-d "
 fi
 
+rm /wazuh-*/src/symbols/.gitignore
+
 make -C /wazuh-*/src deps TARGET=winagent ${FLAGS}
-make -C /wazuh-*/src TARGET=winagent ${FLAGS}
+
+if [ ! -z "${DEBUG_SYMBOLS_PATH}" ]; then
+    make -C /wazuh-*/src TARGET=winagent ${FLAGS} WIN_STRIP_TOOL_PATH=/tools
+else
+    make -C /wazuh-*/src TARGET=winagent ${FLAGS}
+fi
+
+if [ "$(ls -A /wazuh-*/src/symbols)" ]; then
+    cd /wazuh-*/src/symbols && zip -r ${ZIP_SYMBOLS_NAME} .
+    cd /wazuh-*/src/symbols && mv ${ZIP_SYMBOLS_NAME} /shared
+    cd /
+fi
 
 rm -rf /wazuh-*/src/external
+rm -rf /wazuh-*/src/symbols
 
 # Zip the compiled agent and move it to the shared folder
 zip -r ${ZIP_NAME} wazuh-*

--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -6,7 +6,6 @@ BRANCH=$1
 JOBS=$2
 DEBUG=$3
 REVISION=$4
-DEBUG_SYMBOLS_PATH=$5
 ZIP_NAME="windows_agent_${REVISION}.zip"
 
 URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
@@ -16,7 +15,7 @@ wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip
 
 # Compile the wazuh agent for Windows
 FLAGS="-j ${JOBS} "
-VERSION=$(cat wazuh-*/src/VERSION)
+VERSION=$(cat wazuh-*/src/VERSION | cut -dv -f2)
 ZIP_SYMBOLS_NAME="wazuh-agent-windows-x86_64-debug-info-${VERSION}-${REVISION}.zip"
 
 if [[ "${DEBUG}" = "yes" ]]; then
@@ -27,7 +26,7 @@ rm /wazuh-*/src/symbols/.gitignore
 
 make -C /wazuh-*/src deps TARGET=winagent ${FLAGS}
 
-if [ ! -z "${DEBUG_SYMBOLS_PATH}" ]; then
+if [ ! -z "/tools" ]; then
     make -C /wazuh-*/src TARGET=winagent ${FLAGS} WIN_STRIP_TOOL_PATH=/tools
 else
     make -C /wazuh-*/src TARGET=winagent ${FLAGS}

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -39,7 +39,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -cv, --cv2pdb-tool <path> [Optional] Path where the dll libraries and the cv2pdb executable to build debug symbols are located."
+    echo "    -c, --cv2pdb-tool <path>  [Optional] Path where the dll libraries and the cv2pdb executable to build debug symbols are located. Path must be absolute, if you use relative path won't work"
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -63,7 +63,7 @@ main() {
         "-h"|"--help")
             help 0
             ;;
-        "-cv"|"--cv2pdb-tool")
+        "-c"|"--cv2pdb-tool")
             if [ -n "$2" ]; then
                 CV2PDB_TOOLS_PATH="$2"
                 shift 2

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -14,9 +14,7 @@ TAG=$1
 
 
 generate_compiled_win_agent() {
-
-    if [ ! -d "${OUTDIR}" ]; then
-        echo "Creating building directory at ${OUTDIR}"
+if [ ! -d "${OUTDIR}" ]; then echo "Creating building directory at ${OUTDIR}"
         mkdir -p ${OUTDIR}
     fi
 
@@ -39,7 +37,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -c, --cv2pdb-tool <path>  [Optional] Path where the dll libraries and the cv2pdb executable to build debug symbols are located. Path must be absolute, if you use relative path won't work"
+    echo "    -c, --cv2pdb-tool <path>  [Optional] Absolute path where cv2pdb tools to build debug symbols are located."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -37,7 +37,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -c, --cv2pdb-tool <path>  [Optional] Absolute path where cv2pdb tools to build debug symbols are located."
+    echo "    -c, --cv2pdb-tool <path>  [Optional] Absolute path where cv2pdb tools to extract debug symbols are located."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -34,12 +34,12 @@ help() {
     echo
     echo "Usage: $0 [OPTIONS]"
     echo
-    echo "    -b, --branch <branch>         [Required] Select Git branch [${BRANCH}]. By default: master."
-    echo "    -j, --jobs <number>           [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4."
-    echo "    -r, --revision <rev>          [Optional] Package revision. By default: 1."
-    echo "    -s, --store <path>            [Optional] Set the directory where the package will be stored. By default the current path."
-    echo "    -d, --debug                   [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -ds, --debug-symbols <path>   [Optional] Directy where there are the library and cv2pdb executables."
+    echo "    -b, --branch <branch>     [Required] Select Git branch [${BRANCH}]. By default: master."
+    echo "    -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4."
+    echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
+    echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
+    echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -cv, --cv2pdb-path <path> [Optional] Directory where there are the ddl library and cv2pdb executables."
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -63,7 +63,7 @@ main() {
         "-h"|"--help")
             help 0
             ;;
-        "-ds"|"--debug-symbols")
+        "-cv"|"--cv2pdb-path")
             if [ -n "$2" ]; then
                 DEBUG_SYMBOLS_PATH="$2"
                 shift 2

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -14,7 +14,9 @@ TAG=$1
 
 
 generate_compiled_win_agent() {
-if [ ! -d "${OUTDIR}" ]; then echo "Creating building directory at ${OUTDIR}"
+
+    if [ ! -d "${OUTDIR}" ]; then
+        echo "Creating building directory at ${OUTDIR}"
         mkdir -p ${OUTDIR}
     fi
 

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -6,7 +6,7 @@ REVISION="1"
 DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
-DEBUG_SYMBOLS_PATH=""
+CV2PDB_TOOLS_PATH=""
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -21,8 +21,8 @@ generate_compiled_win_agent() {
     fi
 
     docker build -t ${DOCKER_IMAGE_NAME} ./ || exit 1
-    if [ ! -z "{DEBUG_SYMBOLS_PATH}" ]; then
-        docker run --rm -v ${OUTDIR}:/shared -v ${DEBUG_SYMBOLS_PATH}:/tools ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} ${DEBUG_SYMBOLS_PATH} || exit 1
+    if [ ! -z "{CV2PDB_TOOLS_PATH}" ]; then
+        docker run --rm -v ${OUTDIR}:/shared -v ${CV2PDB_TOOLS_PATH}:/tools ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
     else
         docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
     fi
@@ -39,7 +39,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -cv, --cv2pdb-path <path> [Optional] Directory where there are the ddl library and cv2pdb executables."
+    echo "    -cv, --cv2pdb-tool <path> [Optional] Path where the dll libraries and the cv2pdb executable to build debug symbols are located."
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -63,9 +63,9 @@ main() {
         "-h"|"--help")
             help 0
             ;;
-        "-cv"|"--cv2pdb-path")
+        "-cv"|"--cv2pdb-tool")
             if [ -n "$2" ]; then
-                DEBUG_SYMBOLS_PATH="$2"
+                CV2PDB_TOOLS_PATH="$2"
                 shift 2
             else
                 help 1


### PR DESCRIPTION
|Related issue|
|---|
|#1332|

## Description

Hi team

This PR aims to build the zip with the debug symbols. The file should be built when we want to create a Windows package. After some testing, I was able to reach the following results.

- Generation and compression of debug symbols in a zip file
 
![image](https://user-images.githubusercontent.com/58960358/163855675-b6192a20-8a89-461b-94b3-2f04f967387b.png)

- Output then ran the script `sudo ./generate_compiled_windows_agent.sh -b dev-debug-symbols -c /home/hanes/wazuh-tools/utils/cv2pdb`

![image](https://user-images.githubusercontent.com/58960358/163855372-7b010749-fbd6-4f46-b11c-ded0ef498744.png)

- Debug symbols compressed

![image](https://user-images.githubusercontent.com/58960358/163855464-cdc1b51a-26ed-4d8e-9819-434c5296e9ac.png)


Hanes

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
