### PR TITLE
Add orm.py to Solaris 11 SPEC file

### DIFF
--- a/solaris/solaris11/SPECS/template_agent_v4.4.0.json
+++ b/solaris/solaris11/SPECS/template_agent_v4.4.0.json
@@ -1855,6 +1855,14 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/azure/orm.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/docker": {
         "class": "static",
         "group": "wazuh",


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1407 |


## Description

In this PR we update the Solaris 11 files to include the new `orm.py` file for the Azure module added in https://github.com/wazuh/wazuh/issues/11940.

No changes were necessary for RPM spec files as the entire `Azure` folder, including this new file, is copied during the installation.


## Tests

We tested the modified packages by creating a Solaris11 and a RPM agent packages and installing them in a Solaris11 and a Centos 7 machine respectively. Everything worked as expected. After the installation, the following files were present in `/var/ossec/wodles/azure/`:
```
root@solaris11:/tmp# ls -l /var/ossec/wodles/azure/
total 87
-rwxr-x---   1 root     wazuh      35994 abr 13 10:13 azure-logs
-rwxr-x---   1 root     wazuh       7007 abr 13 10:13 orm.py
```

The module was able to run without any issues.


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
