### PR TITLE
Fix permissions of .opensearch.keystore.initial_md5sum

### DIFF
--- a/stack/indexer/deb/debian/postinst
+++ b/stack/indexer/deb/debian/postinst
@@ -109,6 +109,8 @@ case "$1" in
             chown "${USER}:${GROUP}" "${CONFIG_DIR}"/opensearch.keystore
             chmod 660 "${CONFIG_DIR}"/opensearch.keystore
             md5sum "${CONFIG_DIR}"/opensearch.keystore > "${CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
+            chown "${USER}:${GROUP}" "${CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
+            chmod 600 "${CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
         else
             chown "${USER}:${GROUP}" "${CONFIG_DIR}"/opensearch.keystore
             chmod 660 "${CONFIG_DIR}"/opensearch.keystore

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -260,6 +260,8 @@ if [ ! -f "%{CONFIG_DIR}"/opensearch.keystore ]; then
     chown %{USER}:%{GROUP} "%{CONFIG_DIR}"/opensearch.keystore
     chmod 660 "%{CONFIG_DIR}"/opensearch.keystore
     md5sum "%{CONFIG_DIR}"/opensearch.keystore > "%{CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
+    chown %{USER}:%{GROUP} "%{CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
+    chmod 600 "%{CONFIG_DIR}"/.opensearch.keystore.initial_md5sum
 else
     chown %{USER}:%{GROUP} "%{CONFIG_DIR}"/opensearch.keystore
     chmod 660 "%{CONFIG_DIR}"/opensearch.keystore


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1454|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests
Build:
rpm: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7511/console
deb: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7512/console

Install:
Centos: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/447/console
Debian: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/448/console

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
