### PR TITLE
Fixed filebeat template URL using unattended assistant

### DIFF
--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -16,7 +16,7 @@ readonly bucket="packages-dev.wazuh.com"
 readonly repository="pre-release" #use 4.x for production
 
 ## Links and paths to resources
-readonly resources="https://${bucket}/resources/${wazuh_major}"
+readonly resources="https://${bucket}/${wazuh_major}"
 readonly BASE_URL="https://${bucket}/${repository}"
 readonly base_path="$(dirname $(readlink -f "$0"))"
 config_file="${base_path}/config.yml"

--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -84,7 +84,7 @@ function offline_download() {
 
   curl -so ${DEST_PATH}/GPG-KEY-WAZUH https://packages.wazuh.com/key/GPG-KEY-WAZUH
 
-  curl -so ${DEST_PATH}/filebeat.yml ${resources}/open-distro/filebeat/7.x/filebeat_all_in_one.yml
+  curl -so ${DEST_PATH}/filebeat.yml ${resources}/tpl/wazuh/filebeat/filebeat.yml
 
   curl -so ${DEST_PATH}/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json
 


### PR DESCRIPTION
This PR fixes the filebeat template URL to be downloaded in offline mode. 