### PR TITLE
Remove quotation marks from host, port and certificate path

### DIFF
--- a/stack/indexer/indexer-security-init.sh
+++ b/stack/indexer/indexer-security-init.sh
@@ -31,7 +31,7 @@ fi
 
 HOST=""
 OPTIONS="-icl -nhnv"
-WAZUH_INDEXER_ROOT_CA="$(cat ${CONFIG_FILE} 2>&1 | grep http.pemtrustedcas | sed 's/.*: //')"
+WAZUH_INDEXER_ROOT_CA="$(cat ${CONFIG_FILE} 2>&1 | grep http.pemtrustedcas | sed 's/.*: //' | tr -d "[\"\']")"
 WAZUH_INDEXER_ADMIN_PATH="$(dirname "${WAZUH_INDEXER_ROOT_CA}" 2>&1)"
 SECURITY_PATH="${INSTALL_PATH}/plugins/opensearch-security"
 
@@ -43,7 +43,7 @@ getNetworkHost() {
     HOST=$(grep -hr "network.host:" "${CONFIG_FILE}" 2>&1)
     NH="network.host: "
     HOST="${HOST//$NH}"
-    HOST="${HOST//\"}"
+    HOST=$(echo "${HOST}" | tr -d "[\"\']")
 
     # Allow to find ip with an interface
     PATTERN="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"
@@ -67,6 +67,7 @@ getPort() {
     else
         PORT="9300"
     fi
+    PORT=$(echo "${PORT}" | tr -d "[\"\']")
 
 }
 # -----------------------------------------------------------------------------
@@ -117,6 +118,7 @@ main() {
         "-ho"|"--host")
             if [ -n "$2" ]; then
                 HOST="$2"
+                HOST=$(echo "${HOST}" | tr -d "[\"\']")
                 isIP=$(echo "${2}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
                 isDNS=$(echo "${2}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$")
                 if [[ -z "${isIP}" ]] &&  [[ -z "${isDNS}" ]]; then
@@ -131,6 +133,7 @@ main() {
         "-p"|"--port")
             if [ -n "$2" ]; then
                 PORT="$2"
+                PORT=$(echo "${PORT}" | tr -d "[\"\']")
                 if [[ -z $(echo "${2}" | grep -P "^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$") ]]; then
                     echo "The given information does not match with a valid PORT number."
                     exit 1


### PR DESCRIPTION
|Related issue|
|---|
|-|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR improves the parsing of quotes of the values obtained from the opensearch.yml file allowing to add more encapsulation characters, it also takes into account not only double quotes but single quotes, the path of the root certificate and the port to use

## Tests

- opensearch.yml file accept the following variations
 ```
 - network.host: ip
  - plugins.security.ssl.http.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem
  - transport.tcp.port: 9800
```
  ```
- network.host: "ip"
  - plugins.security.ssl.http.pemtrustedcas_filepath: "/etc/wazuh-indexer/certs/root-ca.pem"
  - transport.tcp.port: "9800"
```
```
  - network.host: 'ip'
  - plugins.security.ssl.http.pemtrustedcas_filepath: '/etc/wazuh-indexer/certs/root-ca.pem'
  - transport.tcp.port: '9800'
```

- opensearch.yml file will not accept the following variations (service restart failed) (multiple encapsulation)

```
  - network.host: ""ip""
  - plugins.security.ssl.http.pemtrustedcas_filepath: ""/etc/wazuh-indexer/certs/root-ca.pem""
  - transport.tcp.port: ""9800""
```
```
  - network.host: ''ip''
  - plugins.security.ssl.http.pemtrustedcas_filepath: ''/etc/wazuh-indexer/certs/root-ca.pem''
  - transport.tcp.port: ''9800''
```

This variations will be parsed as:

```
[root@centos7 vagrant]# /usr/share/wazuh-indexer/bin/indexer-security-init.sh
/etc/wazuh-indexer/certs/root-ca.pem
192.168.57.102
9800
Security Admin v7
Will connect to 192.168.57.102:9800 ... done
```

- The HOST and PORT parameter will be parsed too in case the user tries to put extra quotes, but this is usually detected as wrong parameter and the help message will appear