### PR TITLE
Added ssl verification mode to filebeat Elastic basic

### DIFF
--- a/documentation-templates/elastic-basic/filebeat.yml
+++ b/documentation-templates/elastic-basic/filebeat.yml
@@ -19,4 +19,5 @@ output.elasticsearch.protocol: https
 output.elasticsearch.ssl.certificate: /etc/filebeat/certs/filebeat.crt
 output.elasticsearch.ssl.key: /etc/filebeat/certs/filebeat.key
 output.elasticsearch.ssl.certificate_authorities: /etc/filebeat/certs/ca/ca.crt
+output.elasticsearch.ssl.verification_mode: strict
 output.elasticsearch.username: elastic

--- a/documentation-templates/elastic-basic/filebeat_all_in_one.yml
+++ b/documentation-templates/elastic-basic/filebeat_all_in_one.yml
@@ -19,4 +19,5 @@ output.elasticsearch.protocol: https
 output.elasticsearch.ssl.certificate: /etc/elasticsearch/certs/elasticsearch.crt
 output.elasticsearch.ssl.key: /etc/elasticsearch/certs/elasticsearch.key
 output.elasticsearch.ssl.certificate_authorities: /etc/elasticsearch/certs/ca/ca.crt
+output.elasticsearch.ssl.verification_mode: strict
 output.elasticsearch.username: elastic


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-packages/issues/1049 |

This PR aims to add a new setting to avoid the annoying warning of "server's certificate chain verification is disabled" described in https://github.com/wazuh/wazuh-packages/issues/1049 