### PR TITLE
Fix dashboardinstalled variable

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -84,7 +84,7 @@ function passwords_checkUser() {
 
 function passwords_createBackUp() {
 
-    if [ -z "${indexer_installed}" ] && [ -z "${dashboardinstalled}" ] && [ -z "${filebeat_installed}" ]; then
+    if [ -z "${indexer_installed}" ] && [ -z "${dashboard_installed}" ] && [ -z "${filebeat_installed}" ]; then
         common_logger -e "Cannot find Wazuh indexer, Wazuh dashboard or Filebeat on the system."
         exit 1;
     else


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1466|

the variable is renamed

Centos: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/527/console
Ubuntu: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/528/console
Distributed: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/444/console