### PR TITLE
Disabled multitenancy by default in dashboard, changed the app default route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Disabled multitenancy by default in dashboard and changed the app default route [#1471](https://github.com/wazuh/wazuh-packages/pull/1471)
 - Set as warning the unhandled promises in wazuh dashboard [#1434](https://github.com/wazuh/wazuh-packages/pull/1434/)
 - Remove ip message from OVA [#1395](https://github.com/wazuh/wazuh-packages/pull/1395)
 - Remove demo certificates from indexer and dashboard packages [#1390](https://github.com/wazuh/wazuh-packages/pull/1390)

--- a/stack/dashboard/base/files/etc/opensearch_dashboards.yml
+++ b/stack/dashboard/base/files/etc/opensearch_dashboards.yml
@@ -5,11 +5,11 @@ opensearch.ssl.verificationMode: certificate
 #opensearch.username:
 #opensearch.password:
 opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
-opensearch_security.multitenancy.enabled: true
+opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-uiSettings.overrides.defaultRoute: /app/wazuh?security_tenant=global
+uiSettings.overrides.defaultRoute: /app/wazuh
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1470 |

## Description
Hello!
We have disabled multitenancy option inside wazuh-dashboard default configuration. This option will disable the login pop-up that ask for select the dashboard tenant.
We have also changed the default UI route to remove tenant parameter.

## Tests
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Change added to CHANGELOG.md

![image](https://user-images.githubusercontent.com/10661307/164223106-663ff3f1-3c84-4fde-8261-f5a50326d60b.png)
Pop-up shown when switch tenant button is pressed:
![image](https://user-images.githubusercontent.com/10661307/164223176-e60e82ae-d112-46f6-be73-77b9edd50090.png)
