### PR TITLE
Added ctrl-c handler

### DIFF
--- a/stack/indexer/indexer-security-init.sh
+++ b/stack/indexer/indexer-security-init.sh
@@ -35,6 +35,24 @@ WAZUH_INDEXER_ROOT_CA="$(cat ${CONFIG_FILE} 2>&1 | grep http.pemtrustedcas | sed
 WAZUH_INDEXER_ADMIN_PATH="$(dirname "${WAZUH_INDEXER_ROOT_CA}" 2>&1)"
 SECURITY_PATH="${INSTALL_PATH}/plugins/opensearch-security"
 
+# -----------------------------------------------------------------------------
+
+trap ctrl_c INT
+
+clean(){
+
+    exit_code=$1
+    indexer_process_id=$(pgrep -f wazuh-indexer -c)
+    if [ "${indexer_process_id}" -gt 1 ]; then
+        pkill -n -f wazuh-indexer
+    fi
+    exit "${exit_code}"
+    
+}
+
+ctrl_c() {
+    clean 1
+}
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
|Related issue|
|---|
|#1409|

## Description

- Pressing ctrl+c did not end the execution of the securityadmin.sh
- This was happening because when indexer-security-index was executed it created 3 new processes and it did not exist a trap for ctrl-c
- The added code checks if there is more than one process with the name wazuh-indexer, if so, it deletes the newly created ones

## Logs example
Ctrl-c did not stop the execution
![2022-04-19_10-49](https://user-images.githubusercontent.com/61159728/164403255-e8a54648-665b-4d6b-bc91-4d194ee46d42.png)

## Tests

![2022-04-21_09-12](https://user-images.githubusercontent.com/61159728/164403892-f71bd992-5d79-4f17-b864-c9c12fdf2dd3.png)


Even if it's press when it's almost finished, it does not kill the other wazuh-indexer process

![2022-04-21_09-39](https://user-images.githubusercontent.com/61159728/164404162-8e7ef3d2-d859-43e4-ac1a-bc5c85aec787.png)

