### PR TITLE
Remove plugins.security.audit.type from opensearch.yml

### DIFF
--- a/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
+++ b/stack/indexer/base/files/etc/wazuh-indexer/opensearch.yml
@@ -23,7 +23,6 @@ plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
 plugins.security.ssl.transport.resolve_hostname: false
 
-plugins.security.audit.type: internal_opensearch
 plugins.security.authcz.admin_dn:
 - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.check_snapshot_restore_write_privileges: true

--- a/unattended_installer/config/indexer/indexer.yml
+++ b/unattended_installer/config/indexer/indexer.yml
@@ -16,7 +16,6 @@ plugins.security.nodes_dn:
 plugins.security.authcz.admin_dn:
 - CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
 
-plugins.security.audit.type: internal_elasticsearch
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]

--- a/unattended_installer/config/indexer/indexer_all_in_one.yml
+++ b/unattended_installer/config/indexer/indexer_all_in_one.yml
@@ -18,7 +18,6 @@ plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
 plugins.security.ssl.transport.resolve_hostname: false
 
-plugins.security.audit.type: internal_opensearch
 plugins.security.authcz.admin_dn:
 - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.check_snapshot_restore_write_privileges: true

--- a/unattended_installer/config/indexer/indexer_unattended_distributed.yml
+++ b/unattended_installer/config/indexer/indexer_unattended_distributed.yml
@@ -20,7 +20,6 @@ plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
 plugins.security.ssl.transport.resolve_hostname: false
 
-plugins.security.audit.type: internal_opensearch
 plugins.security.authcz.admin_dn:
 - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.check_snapshot_restore_write_privileges: true


### PR DESCRIPTION
|Related issue|
|---|
|#1469|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR removes the setting `plugins.security.audit.type: internal_opensearch` from the indexer configuration files.
