### PR TITLE
Added -q in grep to hide apt lock error message

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -78,14 +78,14 @@ function installCommon_aptInstall() {
     fi
     eval "DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q ${debug}"
     install_result="$?"
-    eval "tail -n 2 ${logfile} | grep 'Could not get lock'"
+    eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
     grep_result="$?"
     while [ "${grep_result}" -eq 0 ] && [ "${i}" -lt 12 ]; do
         sleep 10
         i=$((i+1))
         eval "DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q ${debug}"
         install_result="$?"
-        eval "tail -n 2 ${logfile} | grep 'Could not get lock'"
+        eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
         grep_result="$?"
     done
 


### PR DESCRIPTION
|Related issue|
|---|
|#1448|

## Description
- An error message could appear if another process is running when installing wazuh
- With -q in grep command it does not write anything to standard output.

![2022-04-21_13-08](https://user-images.githubusercontent.com/61159728/164448917-ebf448cf-600e-4cf2-9d9b-91e55ac5bb4a.png)

## Tests
After including -q
![2022-04-21_13-15](https://user-images.githubusercontent.com/61159728/164449011-4a2444d6-8a6f-4b87-87a0-a3b83c9995d9.png)

