### PR TITLE
Remove service disabling from packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Remove service disable from RPM and Debian packages [#1471](https://github.com/wazuh/wazuh-packages/pull/1480)
 - Disabled multitenancy by default in dashboard and changed the app default route [#1471](https://github.com/wazuh/wazuh-packages/pull/1471)
 - Set as warning the unhandled promises in wazuh dashboard [#1434](https://github.com/wazuh/wazuh-packages/pull/1434/)
 - Remove ip message from OVA [#1395](https://github.com/wazuh/wazuh-packages/pull/1395)

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
@@ -14,15 +14,6 @@ case "$1" in
             rm -rf ${WAZUH_TMP_DIR}
         fi
 
-        # Check for systemd
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-            systemctl disable wazuh-agent > /dev/null 2>&1
-            systemctl daemon-reload > /dev/null 2>&1
-        # Check for SysV
-        elif command -v service > /dev/null 2>&1; then
-            update-rc.d -f wazuh-agent remove > /dev/null 2>&1
-        fi
-
         # Back up the old configuration files as .save
         if [ ! -d ${DIR}/etc ]; then
             mkdir -p ${DIR}/etc

--- a/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-agent/debian/postrm
@@ -15,11 +15,11 @@ case "$1" in
         fi
 
         # Check for systemd
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             systemctl disable wazuh-agent > /dev/null 2>&1
             systemctl daemon-reload > /dev/null 2>&1
         # Check for SysV
-        elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+        elif command -v service > /dev/null 2>&1; then
             update-rc.d -f wazuh-agent remove > /dev/null 2>&1
         fi
 

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
@@ -12,15 +12,6 @@ case "$1" in
             rm -rf ${WAZUH_TMP_DIR}
         fi
 
-        # Check for systemd
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-            systemctl disable wazuh-manager > /dev/null 2>&1
-            systemctl daemon-reload > /dev/null 2>&1
-        # Check for SysV
-        elif command -v service > /dev/null 2>&1; then
-            update-rc.d -f wazuh-manager remove > /dev/null 2>&1
-        fi
-
         # Back up the old configuration files as .save
         if [ ! -d ${DIR}/etc/shared/default ]; then
             mkdir -p ${DIR}/etc/shared/default

--- a/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
+++ b/debs/SPECS/4.3.0/wazuh-manager/debian/postrm
@@ -13,11 +13,11 @@ case "$1" in
         fi
 
         # Check for systemd
-        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then
+        if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
             systemctl disable wazuh-manager > /dev/null 2>&1
             systemctl daemon-reload > /dev/null 2>&1
         # Check for SysV
-        elif command -v service > /dev/null 2>&1 && service wazuh-manager status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+        elif command -v service > /dev/null 2>&1; then
             update-rc.d -f wazuh-manager remove > /dev/null 2>&1
         fi
 

--- a/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-agent-4.3.0.spec
@@ -388,16 +388,6 @@ if [ $1 = 0 ]; then
   fi
   %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
 
-  # Check for systemd
-  if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    systemctl disable wazuh-agent > /dev/null 2>&1
-    systemctl daemon-reload > /dev/null 2>&1
-  # Check for SysV
-  elif command -v service > /dev/null 2>&1 && command -v chkconfig > /dev/null 2>&1; then
-    chkconfig wazuh-agent off > /dev/null 2>&1
-    chkconfig --del wazuh-agent > /dev/null 2>&1
-  fi
-
   # Remove the SELinux policy
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) != "Disabled" ]; then

--- a/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
+++ b/rpms/SPECS/4.3.0/wazuh-manager-4.3.0.spec
@@ -468,16 +468,6 @@ if [ $1 = 0 ]; then
   fi
   %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
 
-  # Check for systemd
-  if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
-    systemctl disable wazuh-manager > /dev/null 2>&1
-    systemctl daemon-reload > /dev/null 2>&1
-  # Check for SysV
-  elif command -v service > /dev/null 2>&1 && command -v chkconfig > /dev/null 2>&1; then
-    chkconfig wazuh-manager off > /dev/null 2>&1
-    chkconfig --del wazuh-manager > /dev/null 2>&1
-  fi
-
   # Remove the SELinux policy
   if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
     if [ $(getenforce) != "Disabled" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#1472|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
According to Fedora packaging guidelines, the packages should not enable services that do not meet the following criteria:
- Must not alter other services
- Must not require manual configuration to function
- Must not fail under normal operating conditions
- Must not listen for outside connections

For more information: https://docs.fedoraproject.org/en-US/packaging-guidelines/DefaultServices/#_enabling_services_by_default

Since 4.0.0 the packages do not enable the services, and it does not make sense for the package to disable it either.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - x ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
