### PR TITLE
Valid node name validation

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -82,6 +82,11 @@ function main() {
                 common_checkRoot
             fi
         fi
+        if [ "${args}" == "-wi" ] && [ "${args}" == "-wd" ] && [ "${args}" == "-ws" ] && [ "${args}" == "--wazuh-dashboard" ] && [ "${args}" == "--wazuh-indexer" ] && [ "${args}" == "--wazuh-server" ]; then
+            if [[ "${2}" == -* ]]; then
+                common_logger -e "Error on argument ${args}. Probably missing <node-name> after ${args} or ${2} Can't start with -"
+            fi
+        fi
     done
 
     while [ -n "${1}" ]

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -82,9 +82,11 @@ function main() {
                 common_checkRoot
             fi
         fi
-        if [ "${args}" == "-wi" ] && [ "${args}" == "-wd" ] && [ "${args}" == "-ws" ] && [ "${args}" == "--wazuh-dashboard" ] && [ "${args}" == "--wazuh-indexer" ] && [ "${args}" == "--wazuh-server" ]; then
+        if [ "${args}" == "-wi" ] || [ "${args}" == "-wd" ] || [ "${args}" == "-ws" ] || [ "${args}" == "--wazuh-dashboard" ] || [ "${args}" == "--wazuh-indexer" ] || [ "${args}" == "--wazuh-server" ]; then
             if [[ "${2}" == -* ]]; then
-                common_logger -e "Error on argument ${args}. Probably missing <node-name> after ${args} or ${2} Can't start with -"
+                common_logger -e "Error on argument ${args}. Check the given <node-name>, the parameter ${2} cannot start with \"-\" or is incorrect"
+                getHelp
+                exit 1
             fi
         fi
     done


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1481|

An additional validation is added to prevent the user from adding 2 arguments together and omitting the node name:

Example:
```
[root@centos7-1 ~]# ./wazuh-install.sh -wi -v
22/04/2022 15:15:16 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
22/04/2022 15:15:16 INFO: Verbose logging redirected to /var/log/wazuh-install.log
grep: invalid option -- '.'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
22/04/2022 15:15:17 ERROR: There is no certificate for the indexer node -v in /root/wazuh-install-files.tar.
```

After the Fix:
```
[root@centos7-1 unattended_installer]# ./wazuh-install.sh -wi -v
22/04/2022 18:42:05 ERROR: Error on argument -wi. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh -wd -v
22/04/2022 18:42:08 ERROR: Error on argument -wd. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh -ws -v
22/04/2022 18:42:10 ERROR: Error on argument -ws. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh --wazuh-indexer -v
22/04/2022 18:42:16 ERROR: Error on argument --wazuh-indexer. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh --wazuh-dashboard -v
22/04/2022 18:42:20 ERROR: Error on argument --wazuh-dashboard. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh --wazuh-server -v
22/04/2022 18:42:25 ERROR: Error on argument --wazuh-server. Check the given <node-name>, the parameter -v cannot start with "-" or is incorrect
[root@centos7-1 unattended_installer]# ./wazuh-install.sh --wazuh-server server -v
22/04/2022 18:42:53 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
22/04/2022 18:42:53 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/04/2022 18:42:58 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/pre-release/yum/
protect=1
```

Tests:

Centos: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/529/console
Ubuntu: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended/530/console
Distributed: https://devel.ci.wazuh.info/view/Tests/job/Test_unattended_distributed/446/console