### PR TITLE
Remove Wazuh dashboard password message

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -127,13 +127,11 @@ function dashboard_initialize() {
         else
             common_logger "--- Summary ---"
             common_logger "When Wazuh dashboard is able to connect to your Wazuh indexer cluster, you can access the web interface https://${nodes_dashboard_ip}.\n    User: admin\n    Password: ${u_pass}"
-            common_logger "The password can also be seen in the file ${logfile}"
         fi
     else
         common_logger "Wazuh dashboard web application initialized."
         common_logger "--- Summary ---"
         common_logger "You can access the web interface https://${nodes_dashboard_ip}.\n    User: admin\n    Password: ${u_pass}"
-        common_logger "The password can also be seen in the file ${logfile}"
     fi
 
 }
@@ -155,7 +153,6 @@ function dashboard_initializeAIO() {
     common_logger "Wazuh dashboard web application initialized."
     common_logger "--- Summary ---"
     common_logger "You can access the web interface https://<wazuh-dashboard-ip>.\n    User: admin\n    Password: ${u_pass}"
-    common_logger "The password can also be seen in the file ${logfile}"
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
In this PR we remove the message indicating that we can find the password to access Wazuh dashboard in the installation assistant log.

## Logs example

<!--
Paste here related logs
-->

```
[root@centos repo]# ./wazuh-install.sh -a -o
28/04/2022 08:27:53 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
28/04/2022 08:27:53 INFO: Verbose logging redirected to /var/log/wazuh-install.log
28/04/2022 08:27:54 INFO: --- Removing existing Wazuh installation ---
28/04/2022 08:27:54 INFO: Removing Wazuh manager.
28/04/2022 08:28:10 INFO: Wazuh manager removed.
28/04/2022 08:28:10 INFO: Removing Wazuh indexer.
28/04/2022 08:28:11 INFO: Wazuh indexer removed.
28/04/2022 08:28:11 INFO: Removing Filebeat.
28/04/2022 08:28:11 INFO: Filebeat removed.
28/04/2022 08:28:11 INFO: Removing Wazuh dashboard.
28/04/2022 08:28:15 INFO: Wazuh dashboard removed.
28/04/2022 08:28:15 INFO: Installation cleaned.
28/04/2022 08:28:18 INFO: Wazuh development repository added.
28/04/2022 08:28:18 INFO: --- Configuration files ---
28/04/2022 08:28:18 INFO: Generating configuration files.
28/04/2022 08:28:18 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
28/04/2022 08:28:18 INFO: --- Wazuh indexer ---
28/04/2022 08:28:18 INFO: Starting Wazuh indexer installation.
28/04/2022 08:29:01 INFO: Wazuh indexer installation finished.
28/04/2022 08:29:01 INFO: Wazuh indexer post-install configuration finished.
28/04/2022 08:29:01 INFO: Starting service wazuh-indexer.
28/04/2022 08:29:09 INFO: wazuh-indexer service started.
28/04/2022 08:29:09 INFO: Initializing Wazuh indexer cluster security settings.
28/04/2022 08:29:14 INFO: Wazuh indexer cluster initialized.
28/04/2022 08:29:14 INFO: --- Wazuh server ---
28/04/2022 08:29:14 INFO: Starting the Wazuh manager installation.
28/04/2022 08:29:49 INFO: Wazuh manager installation finished.
28/04/2022 08:29:49 INFO: Starting service wazuh-manager.
28/04/2022 08:29:58 INFO: wazuh-manager service started.
28/04/2022 08:29:58 INFO: Starting Filebeat installation.
28/04/2022 08:30:13 INFO: Filebeat installation finished.
28/04/2022 08:30:15 INFO: Filebeat post-install configuration finished.
28/04/2022 08:30:15 INFO: Starting service filebeat.
28/04/2022 08:30:15 INFO: filebeat service started.
28/04/2022 08:30:15 INFO: --- Wazuh dashboard ---
28/04/2022 08:30:15 INFO: Starting Wazuh dashboard installation.
28/04/2022 08:31:09 INFO: Wazuh dashboard installation finished.
28/04/2022 08:31:10 INFO: Wazuh dashboard post-install configuration finished.
28/04/2022 08:31:10 INFO: Starting service wazuh-dashboard.
28/04/2022 08:31:10 INFO: wazuh-dashboard service started.
28/04/2022 08:31:26 INFO: Initializing Wazuh dashboard web application.
28/04/2022 08:31:37 INFO: Wazuh dashboard web application initialized.
28/04/2022 08:31:37 INFO: --- Summary ---
28/04/2022 08:31:37 INFO: You can access the web interface https://<wazuh-dashboard-ip>.
    User: admin
    Password: cnG5J0f6GTZUBbXshKT4QZScAzbH4DkH
28/04/2022 08:31:37 INFO: Installation finished.

```
