### PR TITLE
Log's correction and cluster status check

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -354,7 +354,6 @@ function installCommon_restoreWazuhrepo() {
         eval "sed -i 's/-dev//g' ${file} ${debug}"
         eval "sed -i 's/pre-release/4.x/g' ${file} ${debug}"
         eval "sed -i 's/unstable/stable/g' ${file} ${debug}"
-        common_logger -d "The Wazuh repository set to production."
     fi
 
 }

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -105,7 +105,7 @@ function passwords_createBackUp() {
         common_logger -e "The backup could not be created"
         exit 1;
     fi
-    common_logger -d "Password backup created"
+    common_logger -d "Password backup created in /usr/share/wazuh-indexer/backup."
 
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1481|

## Description
Correct log's and check cluster status to be green.

---

### Test's:

#### Cluster status
```
[root@stack-centos7-2 vagrant]# curl -X GET -k -u admin:mTgsva4AXad7YYwcHlGMzPj9yh19X0Gm https://localhost:9200/_cluster/health?pretty
{
  "cluster_name" : "wazuh-cluster",
  "status" : "green",
  "timed_out" : false,
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "discovered_master" : true,
  "active_primary_shards" : 9,
  "active_shards" : 9,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 0,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0,
  "task_max_waiting_in_queue_millis" : 0,
  "active_shards_percent_as_number" : 100.0
}

```

---

**Unattended**
centos 7: https://devel.ci.wazuh.info/job/Test_unattended/539
ubuntu focal: https://devel.ci.wazuh.info/job/Test_unattended/540

**Unattended_distributed**
https://devel.ci.wazuh.info/job/Test_unattended_distributed/455