### PR TITLE
Improved APT locked message and retry time

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -87,7 +87,7 @@ function installCommon_aptInstall() {
     while [ "${grep_result}" -eq 0 ] && [ "${attempt}" -lt 10 ]; do
         attempt=$((attempt+1))
         common_logger "An external process is using APT. This process has to end to proceed with the Wazuh installation. Next retry in ${seconds} seconds (${attempt}/10)"
-        sleep 30
+        sleep "${seconds}"
         eval "${command}"
         install_result="$?"
         eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -86,35 +86,8 @@ function installCommon_aptInstall() {
     grep_result="$?"
     while [ "${grep_result}" -eq 0 ] && [ "${attempt}" -lt 10 ]; do
         attempt=$((attempt+1))
-        common_logger "An external process is using APT. This process has to end to proceed installation. Next retry in ${seconds} seconds (${attempt}/10)"
+        common_logger "An external process is using APT. This process has to end to proceed with the Wazuh installation. Next retry in ${seconds} seconds (${attempt}/10)"
         sleep 30
-        eval "${command}"
-        install_result="$?"
-        eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
-        grep_result="$?"
-    done
-
-}
-
-function installCommon_yumInstall() {
-
-    package="${1}"
-    version="${2}"
-    attempt=0
-    if [ -n "${version}" ]; then
-        installer=${package}${sep}${version}
-    else
-        installer=${package}
-    fi
-    command="yum install ${installer} -y -q ${debug}"
-    eval "${command}"
-    install_result="$?"
-    eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
-    grep_result="$?"
-    while [ "${grep_result}" -eq 0 ] && [ "${attempt}" -lt 10 ]; do
-        common_logger "Waiting for external locked YUM process to unlock (${attempt}/10)"
-        sleep 30
-        attempt=$((attempt+1))
         eval "${command}"
         install_result="$?"
         eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
@@ -265,8 +238,7 @@ function installCommon_installPrerequisites() {
             common_logger "--- Dependencies ---"
             for dep in "${not_installed[@]}"; do
                 common_logger "Installing $dep."
-                installCommon_yumInstall ${dep}
-                #eval "yum install ${dep} -y ${debug}"
+                eval "yum install ${dep} -y ${debug}"
                 if [  "$?" != 0  ]; then
                     common_logger -e "Cannot install dependency: ${dep}."
                     exit 1


### PR DESCRIPTION
|Related issue|
|---|
| #1493 |

Hello team,

We have added a better descriptive message among other code improvements, tested on Ubuntu 20
```
29/04/2022 12:16:44 INFO: --- Wazuh indexer ---
29/04/2022 12:16:44 INFO: Starting Wazuh indexer installation.
29/04/2022 12:16:44 INFO: An external process is using APT. This process has to end to proceed installation. Next retry in 30 seconds (1/10)
29/04/2022 12:17:14 INFO: An external process is using APT. This process has to end to proceed installation. Next retry in 30 seconds (2/10)
```