### PR TITLE
Fix error not showing verbose mode

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -113,7 +113,7 @@ function dashboard_initialize() {
 
         for i in "${!indexer_node_ips[@]}"; do
             curl=$(curl -XGET https://${indexer_node_ips[i]}:9200/ -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)
-            exit_code=$?
+            exit_code=${PIPESTATUS[0]}
             if [[ "${exit_code}" -eq "7" ]]; then
                 failed_connect=1
                 failed_nodes+=("${indexer_node_names[i]}")
@@ -160,10 +160,10 @@ function dashboard_install() {
     common_logger "Starting Wazuh dashboard installation."
     if [ "${sys_type}" == "zypper" ]; then
         eval "zypper -n install wazuh-dashboard=${wazuh_version}-${wazuh_revision} ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "yum" ]; then
         eval "yum install wazuh-dashboard${sep}${wazuh_version}-${wazuh_revision} -y ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "wazuh-dashboard" "${wazuh_version}-${wazuh_revision}"
     fi

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -79,15 +79,15 @@ function filebeat_install() {
     common_logger "Starting Filebeat installation."
     if [ "${sys_type}" == "zypper" ]; then
         eval "zypper -n install filebeat-${filebeat_version} ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "yum" ]; then
         eval "yum install filebeat${sep}${filebeat_version} -y -q  ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "filebeat" "${filebeat_version}"
     fi
 
-    install_result="$?"
+    install_result="${PIPESTATUS[0]}"
     common_checkInstalled
     if [  "$install_result" != 0  ] || [ -z "${filebeat_installed}" ]; then
         common_logger -e "Filebeat installation failed."

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -81,17 +81,17 @@ function installCommon_aptInstall() {
     command="DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q ${debug}"
     seconds=30
     eval "${command}"
-    install_result="$?"
+    install_result="${PIPESTATUS[0]}"
     eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
-    grep_result="$?"
+    grep_result="${PIPESTATUS[0]}"
     while [ "${grep_result}" -eq 0 ] && [ "${attempt}" -lt 10 ]; do
         attempt=$((attempt+1))
         common_logger "An external process is using APT. This process has to end to proceed with the Wazuh installation. Next retry in ${seconds} seconds (${attempt}/10)"
         sleep "${seconds}"
         eval "${command}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
         eval "tail -n 2 ${logfile} | grep -q 'Could not get lock'"
-        grep_result="$?"
+        grep_result="${PIPESTATUS[0]}"
     done
 
 }
@@ -239,7 +239,7 @@ function installCommon_installPrerequisites() {
             for dep in "${not_installed[@]}"; do
                 common_logger "Installing $dep."
                 eval "yum install ${dep} -y ${debug}"
-                if [  "$?" != 0  ]; then
+                if [  "${PIPESTATUS[0]}" != 0  ]; then
                     common_logger -e "Cannot install dependency: ${dep}."
                     exit 1
                 fi
@@ -486,7 +486,7 @@ function installCommon_startService() {
         eval "systemctl daemon-reload ${debug}"
         eval "systemctl enable ${1}.service ${debug}"
         eval "systemctl start ${1}.service ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
@@ -500,7 +500,7 @@ function installCommon_startService() {
         eval "chkconfig ${1} on ${debug}"
         eval "service ${1} start ${debug}"
         eval "/etc/init.d/${1} start ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
@@ -512,7 +512,7 @@ function installCommon_startService() {
         fi
     elif [ -x "/etc/rc.d/init.d/${1}" ] ; then
         eval "/etc/rc.d/init.d/${1} start ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -147,7 +147,7 @@ function main() {
                 ;;
             "-v"|"--verbose")
                 debugEnabled=1
-                debug="&>> ${logfile}"
+                debug="2>&1 | tee -a ${logfile}"
                 shift 1
                 ;;
             "-V"|"--version")

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -10,7 +10,7 @@ function getHelp() {
 
     echo -e ""
     echo -e "NAME"
-    echo -e "        $(basename "$0") - Install and configure Wazuh central components: Wazuh manager, Wazuh indexer, and Wazuh dashboard."
+    echo -e "        $(basename "$0") - Install and configure Wazuh central components: Wazuh server, Wazuh indexer, and Wazuh dashboard."
     echo -e ""
     echo -e "SYNOPSIS"
     echo -e "        $(basename "$0") [OPTIONS] -a | -c | -s | -wi <indexer-node-name> | -wd <dashboard-node-name> | -ws <server-node-name>"
@@ -23,7 +23,7 @@ function getHelp() {
     echo -e "                Path to the configuration file used to generate wazuh-install-files.tar file containing the files that will be needed for installation. By default, the Wazuh installation assistant will search for a file named config.yml in the same path as the script."
     echo -e ""
     echo -e "        -fd,  --force-install-dashboard"
-    echo -e "                Force Wazuh dashboard installation to continue even when it is not capable to connect to the Wazuh indexer."
+    echo -e "                Force Wazuh dashboard installation to continue even when it is not capable of connecting to the Wazuh indexer."
     echo -e ""
     echo -e "        -g,  --generate-config-files"
     echo -e "                Generate wazuh-install-files.tar file containing the files that will be needed for installation from config.yml. In distributed deployments you will need to copy this file to all hosts."
@@ -199,7 +199,7 @@ function main() {
                 getHelp
         esac
     done
-    
+
     cat /dev/null > "${logfile}"
 
     if [ -n "${showVersion}" ]; then

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -199,6 +199,8 @@ function main() {
                 getHelp
         esac
     done
+    
+    cat /dev/null > "${logfile}"
 
     if [ -n "${showVersion}" ]; then
         common_logger "Wazuh version: ${wazuh_version}"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -31,7 +31,6 @@ readonly indexer_cert_path="/etc/wazuh-indexer/certs"
 
 readonly logfile="/var/log/wazuh-install.log"
 debug=">> ${logfile} 2>&1"
-cat /dev/null > "${logfile}"
 
 ## Offline Installation vars
 readonly base_dest_folder="wazuh-offline"

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -46,10 +46,10 @@ function manager_install() {
     common_logger "Starting the Wazuh manager installation."
     if [ "${sys_type}" == "zypper" ]; then
         eval "${sys_type} -n install wazuh-manager=${wazuh_version}-${wazuh_revision} ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "yum" ]; then
         eval "${sys_type} install wazuh-manager${sep}${wazuh_version}-${wazuh_revision} -y ${debug}"
-        install_result="$?"
+        install_result="${PIPESTATUS[0]}"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "wazuh-manager" "${wazuh_version}-${wazuh_revision}"
     fi

--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -30,7 +30,7 @@ function offline_download() {
     eval "package_base_url=${package}_${package_type}_base_url"
 
     eval "curl -so ${dest_path}/${!package_name} ${!package_base_url}/${!package_name}"
-    if [  "$?" != 0  ]; then
+    if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "The ${package} package could not be downloaded. Exiting."
         exit 1
     else
@@ -60,7 +60,7 @@ function offline_download() {
   do
 
     eval "curl -sO ${file}"
-    if [  "$?" != 0  ]; then
+    if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "The resource ${file} could not be downloaded. Exiting."
         exit 1
     else

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -164,11 +164,11 @@ function passwords_generatePasswordFile() {
         "Admin user for the web user interface and Wazuh indexer. Use this user to log in to Wazuh dashboard"
         "Wazuh dashboard user for establishing the connection with Wazuh indexer"
         "Regular Dashboard user, only has read permissions to all indices and all permissions on the .kibana index"
-        "Filebeat user has CRUD and create index permissions on filebeat indices"
+        "Filebeat user for CRUD operations on Wazuh indices"
         "User with READ access to all indices"
         "User with permissions to perform snapshot and restore operations"
-        "Admin user used to comunicate with Wazuh API"
-        "Regular user able to query Wazuh API"
+        "Admin user used to communicate with Wazuh API"
+        "Regular user to query Wazuh API"
     )
     passwords_generatePassword
     for i in "${!users[@]}"; do

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -101,7 +101,7 @@ function passwords_createBackUp() {
     common_logger -d "Creating password backup."
     eval "mkdir /usr/share/wazuh-indexer/backup ${debug}"
     eval "JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -icl -p 9300 -backup /usr/share/wazuh-indexer/backup -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug}"
-    if [ "$?" != 0 ]; then
+    if [ "${PIPESTATUS[0]}" != 0 ]; then
         common_logger -e "The backup could not be created"
         exit 1;
     fi
@@ -116,7 +116,7 @@ function passwords_generateHash() {
         for i in "${!passwords[@]}"
         do
             nhash=$(bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/hash.sh -p "${passwords[i]}" | grep -v WARNING)
-            if [  "$?" != 0  ]; then
+            if [  "${PIPESTATUS[0]}" != 0  ]; then
                 common_logger -e "Hash generation failed."
                 exit 1;
             fi
@@ -126,7 +126,7 @@ function passwords_generateHash() {
     else
         common_logger "Generating password hash"
         hash=$(bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/hash.sh -p ${password} | grep -v WARNING)
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "Hash generation failed."
             exit 1;
         fi
@@ -140,7 +140,7 @@ function passwords_generatePassword() {
     if [ -n "${nuser}" ]; then
         common_logger -d "Generating random password."
         password=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c${1:-32};echo;)
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "The password could not been generated."
             exit 1;
         fi
@@ -149,7 +149,7 @@ function passwords_generatePassword() {
         for i in "${!users[@]}"; do
             PASS=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c${1:-32};echo;)
             passwords+=("${PASS}")
-            if [ "$?" != 0 ]; then
+            if [ "${PIPESTATUS[0]}" != 0 ]; then
                 common_logger -e "The password could not been generated."
                 exit 1;
             fi
@@ -298,7 +298,7 @@ function passwords_restartService() {
     if ps -e | grep -E -q "^\ *1\ .*systemd$"; then
         eval "systemctl daemon-reload ${debug}"
         eval "systemctl restart ${1}.service ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
@@ -312,7 +312,7 @@ function passwords_restartService() {
         fi
     elif ps -e | grep -E -q "^\ *1\ .*init$"; then
         eval "/etc/init.d/${1} restart ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
@@ -326,7 +326,7 @@ function passwords_restartService() {
         fi
     elif [ -x "/etc/rc.d/init.d/${1}" ] ; then
         eval "/etc/rc.d/init.d/${1} restart ${debug}"
-        if [  "$?" != 0  ]; then
+        if [  "${PIPESTATUS[0]}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
@@ -353,7 +353,7 @@ function passwords_runSecurityAdmin() {
     common_logger -d "Loading new passwords changes."
     eval "cp /usr/share/wazuh-indexer/backup/* /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ ${debug}"
     eval "OPENSEARCH_PATH_CONF=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9300 -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug}"
-    if [  "$?" != 0  ]; then
+    if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "Could not load the changes."
         exit 1;
     fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -361,11 +361,11 @@ function passwords_runSecurityAdmin() {
 
     if [[ -n "${nuser}" ]] && [[ -n ${autopass} ]]; then
         common_logger -nl $'\nThe password for user '${nuser}' is '${password}''
-        common_logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/opensearch_dashboards.yml if necessary and restart the services."
+        common_logger -w "Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services."
     fi
 
     if [[ -n "${nuser}" ]] && [[ -z ${autopass} ]]; then
-        common_logger -w "Password changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/opensearch_dashboards.yml if necessary and restart the services."
+        common_logger -w "Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services."
     fi
 
     if [ -n "${changeall}" ]; then
@@ -373,7 +373,7 @@ function passwords_runSecurityAdmin() {
             for i in "${!users[@]}"; do
                 common_logger -nl $'The password for user '${users[i]}' is '${passwords[i]}''
             done
-            common_logger -w "Passwords changed. Remember to update the password in /etc/filebeat/filebeat.yml and /etc/wazuh-dashboard/opensearch_dashboards.yml if necessary and restart the services."
+            common_logger -w "Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services."
         else
             common_logger -d "Passwords changed."
         fi


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error that caused the verbose log to not show when using -v option.

## Logs example
```
[root@centos repo]# ./wazuh-install.sh -a -o -v
...
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
03/05/2022 14:28:50 DEBUG: Passwords changed.
03/05/2022 14:28:50 INFO: Initializing Wazuh dashboard web application.
03/05/2022 14:29:01 INFO: Wazuh dashboard web application initialized.
03/05/2022 14:29:01 INFO: Installation finished.
[root@centos repo]# ./wazuh-install.sh -a -o -v
03/05/2022 15:37:59 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
03/05/2022 15:37:59 INFO: Verbose logging redirected to /var/log/wazuh-install.log
03/05/2022 15:38:00 INFO: --- Removing existing Wazuh installation ---
03/05/2022 15:38:00 INFO: Removing Wazuh manager.
Complementos cargados:fastestmirror
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-manager.x86_64 0:4.3.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión           Repositorio     Tamaño
================================================================================
Eliminando:
 wazuh-manager          x86_64          4.3.0-1           @wazuh          435 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 435 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Eliminando    : wazuh-manager-4.3.0-1.x86_64                              1/1 
advertencia:/var/ossec/etc/ossec.conf guardado como /var/ossec/etc/ossec.conf.rpmsave
  Comprobando   : wazuh-manager-4.3.0-1.x86_64                              1/1 

Eliminado(s):
  wazuh-manager.x86_64 0:4.3.0-1                                                

¡Listo!
03/05/2022 15:38:16 INFO: Wazuh manager removed.
03/05/2022 15:38:16 INFO: Removing Wazuh indexer.
Complementos cargados:fastestmirror
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-indexer.x86_64 0:4.3.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión           Repositorio     Tamaño
================================================================================
Eliminando:
 wazuh-indexer          x86_64          4.3.0-1           @wazuh          614 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 614 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Stopping wazuh-indexer service... OK
  Eliminando    : wazuh-indexer-4.3.0-1.x86_64                              1/1 
advertencia:/etc/wazuh-indexer/opensearch.yml guardado como /etc/wazuh-indexer/opensearch.yml.rpmsave
advertencia:/etc/wazuh-indexer/jvm.options guardado como /etc/wazuh-indexer/jvm.options.rpmsave
  Comprobando   : wazuh-indexer-4.3.0-1.x86_64                              1/1 

Eliminado(s):
  wazuh-indexer.x86_64 0:4.3.0-1                                                

¡Listo!
03/05/2022 15:38:17 INFO: Wazuh indexer removed.
03/05/2022 15:38:17 INFO: Removing Filebeat.
Complementos cargados:fastestmirror
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete filebeat.x86_64 0:7.10.2-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package            Arquitectura     Versión             Repositorio      Tamaño
================================================================================
Eliminando:
 filebeat           x86_64           7.10.2-1            @wazuh            70 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 70 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Eliminando    : filebeat-7.10.2-1.x86_64                                  1/1 
advertencia:/etc/filebeat/filebeat.yml guardado como /etc/filebeat/filebeat.yml.rpmsave
  Comprobando   : filebeat-7.10.2-1.x86_64                                  1/1 

Eliminado(s):
  filebeat.x86_64 0:7.10.2-1                                                    

¡Listo!
03/05/2022 15:38:18 INFO: Filebeat removed.
03/05/2022 15:38:18 INFO: Removing Wazuh dashboard.
Complementos cargados:fastestmirror
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-dashboard.x86_64 0:4.3.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                 Arquitectura   Versión            Repositorio    Tamaño
================================================================================
Eliminando:
 wazuh-dashboard         x86_64         4.3.0-1            @wazuh         768 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 768 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Stopping wazuh-dashboard service...  Eliminando    : wazuh-dashboard-4.3.0-1.x86_64                            1/1 
advertencia:/etc/wazuh-dashboard/opensearch_dashboards.yml guardado como /etc/wazuh-dashboard/opensearch_dashboards.yml.rpmsave
  Comprobando   : wazuh-dashboard-4.3.0-1.x86_64                            1/1 

Eliminado(s):
  wazuh-dashboard.x86_64 0:4.3.0-1                                              

¡Listo!
03/05/2022 15:38:22 INFO: Wazuh dashboard removed.
03/05/2022 15:38:22 INFO: Installation cleaned.
03/05/2022 15:38:23 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/pre-release/yum/
protect=1
03/05/2022 15:38:24 INFO: Wazuh development repository added.
03/05/2022 15:38:24 INFO: --- Configuration files ---
03/05/2022 15:38:24 INFO: Generating configuration files.
03/05/2022 15:38:24 DEBUG: Creating the root certificate.
Generating a 2048 bit RSA private key
............................................................................................................+++
..+++
writing new private key to '/tmp/wazuh-certificates/root-ca.key'
-----
Generating RSA private key, 2048 bit long modulus
..............................................+++
....+++
e is 65537 (0x10001)
Signature ok
subject=/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin
Getting CA Private Key
03/05/2022 15:38:24 DEBUG: Creating the Wazuh indexer certificates.
Generating a 2048 bit RSA private key
.............................+++
...............................................................+++
writing new private key to '/tmp/wazuh-certificates/indexer-key.pem'
-----
Signature ok
subject=/C=US/L=California/O=Wazuh/OU=Wazuh/CN=indexer
Getting CA Private Key
03/05/2022 15:38:24 DEBUG: Creating the Wazuh server certificates.
Generating a 2048 bit RSA private key
........................+++
.............................................................+++
writing new private key to '/tmp/wazuh-certificates/server-key.pem'
-----
Signature ok
subject=/C=US/L=California/O=Wazuh/OU=Wazuh/CN=server
Getting CA Private Key
03/05/2022 15:38:24 DEBUG: Creating the Wazuh dashboard certificates.
Generating a 2048 bit RSA private key
........................................+++
..................................+++
writing new private key to '/tmp/wazuh-certificates/dashboard-key.pem'
-----
Signature ok
subject=/C=US/L=California/O=Wazuh/OU=Wazuh/CN=dashboard
Getting CA Private Key
03/05/2022 15:38:24 DEBUG: Generating random passwords.
03/05/2022 15:38:25 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
03/05/2022 15:38:25 INFO: --- Wazuh indexer ---
03/05/2022 15:38:25 INFO: Starting Wazuh indexer installation.
Complementos cargados:fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.librelabucm.org
 * extras: mirror.librelabucm.org
 * updates: mirror.librelabucm.org
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-indexer.x86_64 0:4.3.0-1 debe ser instalado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión            Repositorio    Tamaño
================================================================================
Instalando:
 wazuh-indexer          x86_64          4.3.0-1            wazuh          361 M

Resumen de la transacción
================================================================================
Instalar  1 Paquete

Tamaño total de la descarga: 361 M
Tamaño instalado: 614 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Instalando    : wazuh-indexer-4.3.0-1.x86_64                              1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
  Comprobando   : wazuh-indexer-4.3.0-1.x86_64                              1/1 

Instalado:
  wazuh-indexer.x86_64 0:4.3.0-1                                                

¡Listo!
03/05/2022 15:39:38 INFO: Wazuh indexer installation finished.
03/05/2022 15:39:38 DEBUG: Configuring Wazuh indexer.
03/05/2022 15:39:38 INFO: Wazuh indexer post-install configuration finished.
03/05/2022 15:39:38 INFO: Starting service wazuh-indexer.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service to /usr/lib/systemd/system/wazuh-indexer.service.
03/05/2022 15:39:47 INFO: wazuh-indexer service started.
03/05/2022 15:39:47 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
03/05/2022 15:39:52 INFO: Wazuh indexer cluster initialized.
03/05/2022 15:39:52 INFO: --- Wazuh server ---
03/05/2022 15:39:52 INFO: Starting the Wazuh manager installation.
Complementos cargados:fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.librelabucm.org
 * extras: mirror.librelabucm.org
 * updates: mirror.librelabucm.org
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-manager.x86_64 0:4.3.0-1 debe ser instalado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión            Repositorio    Tamaño
================================================================================
Instalando:
 wazuh-manager          x86_64          4.3.0-1            wazuh          114 M

Resumen de la transacción
================================================================================
Instalar  1 Paquete

Tamaño total de la descarga: 114 M
Tamaño instalado: 435 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Instalando    : wazuh-manager-4.3.0-1.x86_64                              1/1 
  Comprobando   : wazuh-manager-4.3.0-1.x86_64                              1/1 

Instalado:
  wazuh-manager.x86_64 0:4.3.0-1                                                

¡Listo!
03/05/2022 15:40:36 INFO: Wazuh manager installation finished.
03/05/2022 15:40:36 INFO: Starting service wazuh-manager.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
03/05/2022 15:40:45 INFO: wazuh-manager service started.
03/05/2022 15:40:45 INFO: Starting Filebeat installation.
03/05/2022 15:40:52 INFO: Filebeat installation finished.
wazuh/
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
03/05/2022 15:40:54 INFO: Filebeat post-install configuration finished.
03/05/2022 15:40:54 INFO: Starting service filebeat.
Created symlink from /etc/systemd/system/multi-user.target.wants/filebeat.service to /usr/lib/systemd/system/filebeat.service.
03/05/2022 15:40:54 INFO: filebeat service started.
03/05/2022 15:40:54 INFO: --- Wazuh dashboard ---
03/05/2022 15:40:54 INFO: Starting Wazuh dashboard installation.
Complementos cargados:fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.librelabucm.org
 * extras: mirror.librelabucm.org
 * updates: mirror.librelabucm.org
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-dashboard.x86_64 0:4.3.0-1 debe ser instalado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                  Arquitectura    Versión          Repositorio    Tamaño
================================================================================
Instalando:
 wazuh-dashboard          x86_64          4.3.0-1          wazuh          187 M

Resumen de la transacción
================================================================================
Instalar  1 Paquete

Tamaño total de la descarga: 187 M
Tamaño instalado: 768 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Instalando    : wazuh-dashboard-4.3.0-1.x86_64                            1/1 
  Comprobando   : wazuh-dashboard-4.3.0-1.x86_64                            1/1 

Instalado:
  wazuh-dashboard.x86_64 0:4.3.0-1                                              

¡Listo!
03/05/2022 15:42:02 INFO: Wazuh dashboard installation finished.
03/05/2022 15:42:02 DEBUG: Wazuh dashboard certificate setup finished.
03/05/2022 15:42:02 INFO: Wazuh dashboard post-install configuration finished.
03/05/2022 15:42:02 INFO: Starting service wazuh-dashboard.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service to /etc/systemd/system/wazuh-dashboard.service.
03/05/2022 15:42:03 INFO: wazuh-dashboard service started.
03/05/2022 15:42:03 DEBUG: Setting Wazuh indexer cluster passwords.
03/05/2022 15:42:04 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '_doc/config' into /usr/share/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /usr/share/wazuh-indexer/backup/config.yml
Will retrieve '_doc/roles' into /usr/share/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /usr/share/wazuh-indexer/backup/roles.yml
Will retrieve '_doc/rolesmapping' into /usr/share/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /usr/share/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '_doc/internalusers' into /usr/share/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /usr/share/wazuh-indexer/backup/internal_users.yml
Will retrieve '_doc/actiongroups' into /usr/share/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /usr/share/wazuh-indexer/backup/action_groups.yml
Will retrieve '_doc/tenants' into /usr/share/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /usr/share/wazuh-indexer/backup/tenants.yml
Will retrieve '_doc/nodesdn' into /usr/share/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /usr/share/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '_doc/whitelist' into /usr/share/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /usr/share/wazuh-indexer/backup/whitelist.yml
Will retrieve '_doc/audit' into /usr/share/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /usr/share/wazuh-indexer/backup/audit.yml
03/05/2022 15:42:08 DEBUG: Password backup created in /usr/share/wazuh-indexer/backup.
03/05/2022 15:42:09 DEBUG: Generating password hashes.
03/05/2022 15:42:14 DEBUG: Password hashes generated.
Successfully updated the keystore
03/05/2022 15:42:14 DEBUG: filebeat started
03/05/2022 15:42:15 DEBUG: wazuh-dashboard started
03/05/2022 15:42:15 DEBUG: Loading new passwords changes.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
03/05/2022 15:42:18 DEBUG: Passwords changed.
03/05/2022 15:42:18 INFO: Initializing Wazuh dashboard web application.
03/05/2022 15:42:29 INFO: Wazuh dashboard web application initialized.
03/05/2022 15:42:29 INFO: --- Summary ---
03/05/2022 15:42:29 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: RHZXuTvY6CVbyChJkLPuZgs6kEHmNBUi
03/05/2022 15:42:29 INFO: Installation finished.
```
<!--
Paste here related logs
-->

## Tests

https://devel.ci.wazuh.info/job/Test_unattended_distributed/461/
https://ci.wazuh.info/job/Test_unattended/63/
https://ci.wazuh.info/job/Test_unattended/64/
https://ci.wazuh.info/job/Test_unattended/65/
https://ci.wazuh.info/job/Test_unattended/66/
