### PR TITLE
Update ova requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.3.0]
 
+- Update ova requirements [#1510](https://github.com/wazuh/wazuh-packages/pull/1510)
 - Hide passwords in log file [#1496] (https://github.com/wazuh/wazuh-packages/pull/1496)
 - Fix dashboard ip messages [#1500](https://github.com/wazuh/wazuh-packages/pull/1500)
 - Improved APT locked message and retry time [#1499](https://github.com/wazuh/wazuh-packages/pull/1499)

--- a/ova/Vagrantfile
+++ b/ova/Vagrantfile
@@ -4,10 +4,10 @@
 Vagrant.configure("2") do |config|
 
   config.vm.box = "centos/7"
-  config.vm.hostname = "wazuh-manager"
+  config.vm.hostname = "wazuh-server"
   config.vm.provider "virtualbox" do |vb|
     vb.name = "vm_wazuh"
-    vb.memory = "4096"
+    vb.memory = "8192"
     vb.cpus = "4"
   end
 

--- a/ova/assets/custom/automatic_set_ram.sh
+++ b/ova/assets/custom/automatic_set_ram.sh
@@ -7,5 +7,7 @@ ram="$(( ram_mb / 2 ))"
 if [ "${ram}" -eq "0" ]; then
     ram=1024;
 fi
-eval "sed -i "s/-Xms1g/-Xms${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
-eval "sed -i "s/-Xmx1g/-Xmx${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
+eval "sed -i "s/^-Xms.*$/-Xms${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
+eval "sed -i "s/^-Xmx.*$/-Xmx${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
+
+systemctl stop updateIndexerHeap.service

--- a/ova/assets/custom/automatic_set_ram.sh
+++ b/ova/assets/custom/automatic_set_ram.sh
@@ -7,7 +7,14 @@ ram="$(( ram_mb / 2 ))"
 if [ "${ram}" -eq "0" ]; then
     ram=1024;
 fi
-eval "sed -i "s/^-Xms.*$/-Xms${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
-eval "sed -i "s/^-Xmx.*$/-Xmx${ram}m/" /etc/wazuh-indexer/jvm.options ${debug}"
+
+regex="^\-Xmx\K[0-9]+"
+file="/etc/wazuh-indexer/jvm.options"
+value=$(grep -oP ${regex} ${file})
+
+if [[ ${value} != ${ram} ]]; then
+    eval "sed -i "s/^-Xms.*$/-Xms${ram}m/" ${file} ${debug}"
+    eval "sed -i "s/^-Xmx.*$/-Xmx${ram}m/" ${file} ${debug}"
+fi
 
 systemctl stop updateIndexerHeap.service

--- a/ova/assets/custom/automatic_set_ram.sh
+++ b/ova/assets/custom/automatic_set_ram.sh
@@ -12,7 +12,7 @@ regex="^\-Xmx\K[0-9]+"
 file="/etc/wazuh-indexer/jvm.options"
 value=$(grep -oP ${regex} ${file})
 
-if [[ ${value} != ${ram} ]]; then
+if [[ "${value}" != "${ram}" ]]; then
     eval "sed -i "s/^-Xms.*$/-Xms${ram}m/" ${file} ${debug}"
     eval "sed -i "s/^-Xmx.*$/-Xmx${ram}m/" ${file} ${debug}"
 fi

--- a/ova/assets/custom/updateIndexerHeap.service
+++ b/ova/assets/custom/updateIndexerHeap.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Update Wazuh Indexer jvm.option memory heap space
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/bin/bash /etc/automatic_set_ram.sh

--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -13,12 +13,12 @@ systemConfig() {
   mv ${CUSTOM_PATH}/grub/grub /etc/default/
   grub2-mkconfig -o /boot/grub2/grub.cfg > /dev/null 2>&1
 
-  # Set dinamic ram of vm
+  # Update Wazuh indexer jvm heap
   mv ${CUSTOM_PATH}/automatic_set_ram.sh /etc/
-  chmod +x "/etc/automatic_set_ram.sh"
-  echo "@reboot . /etc/automatic_set_ram.sh" >> cron
-  crontab cron
-  rm cron
+  chmod 755 /etc/automatic_set_ram.sh
+  mv ${CUSTOM_PATH}/updateIndexerHeap.service /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable updateIndexerHeap.service
 
   # Change root password (root:wazuh)
   sed -i "s/root:.*:/root:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41::0:99999:7:::/g" /etc/shadow


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-packages/issues/1507<br>Closes https://github.com/wazuh/wazuh-packages/issues/896|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR updates the ova  with the following changes

- Change of disk size (OVA aws from 40 to 50GB)
- Improved memory swapping of wazuh-indexer (from cron job to service)
- Change of hostname and minimum hardware revision


## Logs example

- https://github.com/wazuh/wazuh-packages/issues/1507#issuecomment-1116283299

<details><summary>Local ova</summary>

```
╰─➤  bash generate_ova.sh -r dev
Version to build: 4.3.0 with development repository
==> default: VM not created. Moving on...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'centos/7'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'centos/7' version '2004.01' is up to date...
==> default: Setting the name of the VM: vm_wazuh
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default: 
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Setting hostname...
==> default: Rsyncing folder: /home/xxx/Documents/Trabajo/WAZUH/Repos/wazuh-packages/1507-update_ova_requirements-4.3/ova/ => /tmp
==> default:   - Exclude: [".vagrant/", "output"]
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20220504-22453-m6x784.sh
    default: Using dev packages
    default: Upgrading the system. This may take a while ...
    default: Created symlink from /etc/systemd/system/multi-user.target.wants/updateIndexerHeap.service to /etc/systemd/system/updateIndexerHeap.service.
    default: Adding user wazuh-user to group wheel
    default: 04/05/2022 13:54:48 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.0
    default: 04/05/2022 13:54:48 INFO: Verbose logging redirected to /var/log/wazuh-install.log
    default: 04/05/2022 13:54:52 INFO: Wazuh development repository added.
    default: 04/05/2022 13:54:52 INFO: --- Configuration files ---
    default: 04/05/2022 13:54:52 INFO: Generating configuration files.
    default: 04/05/2022 13:54:53 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
    default: 04/05/2022 13:54:53 INFO: --- Wazuh indexer ---
    default: 04/05/2022 13:54:53 INFO: Starting Wazuh indexer installation.
    default: 04/05/2022 13:55:36 INFO: Wazuh indexer installation finished.
    default: 04/05/2022 13:55:36 INFO: Wazuh indexer post-install configuration finished.
    default: 04/05/2022 13:55:36 INFO: Starting service wazuh-indexer.
    default: 04/05/2022 13:55:45 INFO: wazuh-indexer service started.
    default: 04/05/2022 13:55:45 INFO: Initializing Wazuh indexer cluster security settings.
    default: 04/05/2022 13:55:50 INFO: Wazuh indexer cluster initialized.
    default: 04/05/2022 13:55:50 INFO: --- Wazuh server ---
    default: 04/05/2022 13:55:50 INFO: Starting the Wazuh manager installation.
    default: 04/05/2022 13:56:22 INFO: Wazuh manager installation finished.
    default: 04/05/2022 13:56:22 INFO: Starting service wazuh-manager.
    default: 04/05/2022 13:56:33 INFO: wazuh-manager service started.
    default: 04/05/2022 13:56:33 INFO: Starting Filebeat installation.
    default: 04/05/2022 13:56:40 INFO: Filebeat installation finished.
    default: 04/05/2022 13:56:42 INFO: Filebeat post-install configuration finished.
    default: 04/05/2022 13:56:42 INFO: Starting service filebeat.
    default: 04/05/2022 13:56:42 INFO: filebeat service started.
    default: 04/05/2022 13:56:42 INFO: --- Wazuh dashboard ---
    default: 04/05/2022 13:56:42 INFO: Starting Wazuh dashboard installation.
    default: 04/05/2022 13:57:41 INFO: Wazuh dashboard installation finished.
    default: 04/05/2022 13:57:41 INFO: Wazuh dashboard post-install configuration finished.
    default: 04/05/2022 13:57:41 INFO: Starting service wazuh-dashboard.
    default: 04/05/2022 13:57:41 INFO: wazuh-dashboard service started.
    default: 04/05/2022 13:57:54 INFO: Initializing Wazuh dashboard web application.
    default: 04/05/2022 13:58:05 INFO: Wazuh dashboard web application initialized.
    default: 04/05/2022 13:58:05 INFO: --- Summary ---
    default: 04/05/2022 13:58:05 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    default:     User: admin
    default:     Password: admin
    default: 04/05/2022 13:58:05 INFO: Installation finished.
    default: Loaded plugins: fastestmirror
    default: Cleaning repos: base extras updates wazuh
    default: Cleaning up list of fastest mirrors
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20220504-22453-hl4vlo.sh
    default: Created symlink from /etc/systemd/system/multi-user.target.wants/removeVagrant.service to /etc/systemd/system/removeVagrant.service.
==> default: Saving VM state and suspending execution...
Exporting ova
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Successfully exported 1 machine(s).
==> default: Discarding saved state of VM...
==> default: Destroying VM and associated drives...
wazuh-4.3.0.ovf
wazuh-4.3.0-disk001.vmdk
Setting up ova for VMware ESXi
Standarizing OVA
Setting OVA to default
wazuh-4.3.0.ovf
wazuh-4.3.0-disk001.vmdk
OVF extracted
mv: '/home/xxx/Documents/Trabajo/WAZUH/Repos/wazuh-packages/1507-update_ova_requirements-4.3/ova/new-ova/wazuh-4.3.0.ovf' and '/home/xx/Documents/Trabajo/WAZUH/Repos/wazuh-packages/1507-update_ova_requirements-4.3/ova/new-ova/wazuh-4.3.0.ovf' are the same file
mv: cannot stat '/home/xxx/Documents/Trabajo/WAZUH/Repos/wazuh-packages/1507-update_ova_requirements-4.3/ova/new-ova/*.mf': No such file or directory
Files renamed
OVF Version changed
OVF Size changed
Manifest changed
wazuh-4.3.0.ovf
wazuh-4.3.0-disk-1.vmdk
wazuh-4.3.0.mf
New OVA created
Cleaned temporary directory
Process finished
==> default: VM not created. Moving on...

```

</details>

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  