### PR TITLE
Add backup/db to specs4.4

### DIFF
--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -583,6 +583,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/api/scripts
 %attr(640, root, wazuh) %{_localstatedir}/api/scripts/wazuh-apid.py
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/db
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/agents
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup/shared
 %dir %attr(750, root, wazuh) %{_localstatedir}/bin


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds the backup/db directory to the manager RPM SPEC file.

## Logs example

<!--
Paste here related logs
-->

## Tests
https://ci.wazuh.info/job/Packages_builder/95718/
https://ci.wazuh.info/job/Test_install/89954/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary

