### PR TITLE
Fix sed error dashboard installation

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -92,18 +92,20 @@ function dashboard_initialize() {
         j=$((j+1))
     done
 
-    if [ "${#server_node_names[@]}" -eq 1 ]; then
-        wazuh_api_address=${server_node_ips[0]}
-    else
-        for i in "${!server_node_types[@]}"; do
-            if [[ "${server_node_types[i]}" == "master" ]]; then
-                wazuh_api_address=${server_node_ips[i]}
-            fi
-        done
-    fi
-    eval "sed -i 's,url: https://localhost,url: https://${wazuh_api_address},g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
-
-    if [ ${j} -eq 12 ]; then
+    if [ ${j} -lt 12 ]; then
+        if [ "${#server_node_names[@]}" -eq 1 ]; then
+            wazuh_api_address=${server_node_ips[0]}
+        else
+            for i in "${!server_node_types[@]}"; do
+                if [[ "${server_node_types[i]}" == "master" ]]; then
+                    wazuh_api_address=${server_node_ips[i]}
+                fi
+            done
+        fi
+        if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
+            eval "sed -i 's,url: https://localhost,url: https://${wazuh_api_address},g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+        fi
+    elif [ ${j} -eq 12 ]; then
         flag="-w"
         if [ -z "${force}" ]; then
             flag="-e"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -14,7 +14,7 @@ readonly wazuh_revision_rpm="1"
 readonly indexer_revision_deb="1"
 readonly indexer_revision_rpm="1"
 readonly dashboard_revision_deb="1"
-readonly dashboard_revision_rpm="2"
+readonly dashboard_revision_rpm="1"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 


### PR DESCRIPTION
|Related issue|
|---|
|#1545|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes an error that appeared in the installation log when the Wazuh dashboard failed to connect to Wazuh indexer.
## Logs example

<!--
Paste here related logs
-->
```
13/05/2022 15:50:43 INFO: Wazuh dashboard installation finished.
13/05/2022 15:50:43 INFO: Wazuh dashboard post-install configuration finished.
13/05/2022 15:50:45 INFO: Starting service wazuh-dashboard.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service to /etc/systemd/system/wazuh-dashboard.service.
13/05/2022 15:50:45 INFO: wazuh-dashboard service started.
13/05/2022 15:50:45 INFO: Initializing Wazuh dashboard web application.
13/05/2022 15:52:46 ERROR: Cannot connect to Wazuh dashboard.
13/05/2022 15:52:46 ERROR: Failed to connect with indexer. Connection refused.
13/05/2022 15:52:46 INFO: If you want to install Wazuh dashboard without waiting for the Wazuh indexer cluster, use the -fd option
13/05/2022 15:52:46 INFO: --- Removing existing Wazuh installation ---
13/05/2022 15:52:46 INFO: Removing Wazuh dashboard.
Complementos cargados:fastestmirror
Resolviendo dependencies

```
## Tests

