### PR TITLE
Fix SPECS to support GDB symbols autoloading

### DIFF
--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -508,8 +508,10 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
 %attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%attr(750, root, root) %{_localstatedir}/active-response/bin/.debug
 %dir %attr(750, root, root) %{_localstatedir}/bin
 %attr(750, root, root) %{_localstatedir}/bin/*
+%attr(750, root, root) %{_localstatedir}/bin/.debug
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
@@ -522,6 +524,7 @@ rm -fr %{buildroot}
 %attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/lib
 %attr(750, root, wazuh) %{_localstatedir}/lib/*
+%attr(750, root, root) %{_localstatedir}/lib/.debug
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
 %attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/active-responses.log
 %attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.log

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -590,6 +590,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
 %attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%attr(750, root, root) %{_localstatedir}/active-response/bin/.debug
 %dir %attr(750, root, wazuh) %{_localstatedir}/api
 %dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
@@ -630,6 +631,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
+%attr(750, root, root) %{_localstatedir}/bin/.debug
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
@@ -666,6 +668,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/integrations
 %attr(750, root, wazuh) %{_localstatedir}/integrations/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, root) %{_localstatedir}/lib/.debug
 %attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhext.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhshared.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#13446|

## Description

This PR aims to allow symlinks inside every binary folder that create symbol files(`bin`, `active-response/bin/`and `libs`) necessary to GDB symbols autoload mechanism. Those links will point, in case debuginfo package is installed, to `.symbols` folder


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] Build the package for armhf
  - [x] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
