### PR TITLE
Set `USER_DEBUG_SYMBOLS` option during packages generation

### DIFF
--- a/debs/SPECS/4.4.0/wazuh-agent/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-agent/debian/rules
@@ -59,6 +59,7 @@ override_dh_install:
 	USER_AGENT_SERVER_IP="MANAGER_IP" \
 	USER_CA_STORE="/path/to/my_cert.pem" \
 	USER_AUTO_START="n" \
+	USER_DEBUG_SYMBOLS="y" \
 	./install.sh
 
 	# Copying init.d script

--- a/debs/SPECS/4.4.0/wazuh-manager/debian/rules
+++ b/debs/SPECS/4.4.0/wazuh-manager/debian/rules
@@ -66,6 +66,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
+	USER_DEBUG_SYMBOLS="y" \
 	./install.sh
 
 	# Copying init.d script

--- a/macos/package_files/4.4.0/build.sh
+++ b/macos/package_files/4.4.0/build.sh
@@ -28,6 +28,7 @@ function configure() {
     echo USER_ENABLE_CISCAT="n" >> ${CONFIG}
     echo USER_ENABLE_ACTIVE_RESPONSE="y" >> ${CONFIG}
     echo USER_CA_STORE="n" >> ${CONFIG}
+    echo USER_DEBUG_SYMBOLS="y" >> ${CONFIG}
 }
 
 function build() {

--- a/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-agent-4.4.0.spec
@@ -81,6 +81,7 @@ echo 'USER_UPDATE="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_AGENT_SERVER_IP="MANAGER_IP"' >> ./etc/preloaded-vars.conf
 echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
+echo 'USER_DEBUG_SYMBOLS="y"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 %if 0%{?el} < 6 || 0%{?rhel} < 6

--- a/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
+++ b/rpms/SPECS/4.4.0/wazuh-manager-4.4.0.spec
@@ -75,6 +75,7 @@ echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
+echo 'USER_DEBUG_SYMBOLS="y"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#13532|

## Description

This PR aims to set `USER_DEBUG_SYMBOLS="y"` for GNU/Linux and macOS packages generation scripts. This will allow the creation of debuginfo packages/compressed zip files.

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [x] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
