### PR TITLE
Remove unnecessary plugins from default Wazuh dashboard to 4.4

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -113,7 +113,7 @@ brotli -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.j
 gzip -c ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js > ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js.gz
 brotli -c ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js > ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js.br
 
-#Remove plugins
+# Remove plugins
 /bin/bash ./bin/opensearch-dashboards-plugin remove queryWorkbenchDashboards --allow-root
 /bin/bash ./bin/opensearch-dashboards-plugin remove anomalyDetectionDashboards --allow-root
 /bin/bash ./bin/opensearch-dashboards-plugin remove observabilityDashboards --allow-root

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -113,6 +113,10 @@ brotli -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.j
 gzip -c ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js > ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js.gz
 brotli -c ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js > ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js.br
 
+#Remove plugins
+/bin/bash ./bin/opensearch-dashboards-plugin remove queryWorkbenchDashboards --allow-root
+/bin/bash ./bin/opensearch-dashboards-plugin remove anomalyDetectionDashboards --allow-root
+/bin/bash ./bin/opensearch-dashboards-plugin remove observabilityDashboards --allow-root
 
 find -type d -exec chmod 750 {} \;
 find -type f -perm 644 -exec chmod 640 {} \;

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -96,6 +96,10 @@ chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
 runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}.zip"
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;
+find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 644 -exec chmod 640 {} \;
+find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 755 -exec chmod 750 {} \;
+find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type d -exec chmod 750 {} \;
+
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1564|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The plugins mentioned in the issue are removed and various changes are applied to the dashboard checkfiles database

Before uninstall:
![Screenshot_20220523_151749](https://user-images.githubusercontent.com/64099752/170062693-79770c9d-1fc5-4a31-9c4f-5991e90b4964.png)

After uninstall:
![Screenshot_20220523_154439](https://user-images.githubusercontent.com/64099752/170062730-06453040-4ea7-4068-910a-f05a9d13a56f.png)


Builds:
RPM: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7603/console
DEB: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/7605/console

Tests install:

Centos 7: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/469/console

Ubuntu focal: https://devel.ci.wazuh.info/view/Tests/job/Test_install_stack/464/