### PR TITLE
Generate debug information packages

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/control
+++ b/debs/SPECS/wazuh-agent/debian/control
@@ -12,3 +12,12 @@ Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-agent-dbg
+Architecture: any
+Section: devel
+Conflicts: wazuh-agent (<< ${binary:Version}), wazuh-agent (>> ${binary:Version})
+Replaces: wazuh-agent-dbg
+Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
+ .
+ This package contains files necessary for debugging the wazuh-agent with gdb.

--- a/debs/SPECS/wazuh-agent/debian/rules
+++ b/debs/SPECS/wazuh-agent/debian/rules
@@ -59,6 +59,7 @@ override_dh_install:
 	USER_AGENT_SERVER_IP="MANAGER_IP" \
 	USER_CA_STORE="/path/to/my_cert.pem" \
 	USER_AUTO_START="n" \
+	USER_DEBUG_SYMBOLS="y" \
 	./install.sh
 
 	# Copying init.d script

--- a/debs/SPECS/wazuh-agent/debian/rules
+++ b/debs/SPECS/wazuh-agent/debian/rules
@@ -17,6 +17,7 @@ export DH_VERBOSE=1
 export DH_OPTIONS
 
 export TARGET_DIR=${CURDIR}/debian/wazuh-agent
+export TARGET_DIR_SYMS=${CURDIR}/debian/wazuh-agent-dbg
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
@@ -40,7 +41,7 @@ override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
 
 	# Build the binaries
-	make -C src deps TARGET=agent
+	make -j$(JOBS) -C src deps TARGET=agent
 	make -j$(JOBS) -C src/ TARGET=agent USE_SELINUX=yes DEBUG=$(DEBUG_ENABLED)
 
 	USER_LANGUAGE="en" \
@@ -143,11 +144,14 @@ override_dh_install:
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-agent.service
 	cp src/init/templates/wazuh-agent.service ${TARGET_DIR}/etc/systemd/system/
 
+	# Add debug symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}
+	mv ${TARGET_DIR}/${INSTALLATION_DIR}/.symbols ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+
 override_dh_auto_clean:
-	$(MAKE) -C src clean
+	$(MAKE) -j$(JOBS) -C src clean
 
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure

--- a/debs/SPECS/wazuh-manager/debian/control
+++ b/debs/SPECS/wazuh-manager/debian/control
@@ -13,3 +13,12 @@ Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-manager-dbg
+Architecture: any
+Section: devel
+Conflicts: wazuh-manager (<< ${binary:Version}), wazuh-manager (>> ${binary:Version})
+Replaces: wazuh-manager-dbg
+Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring.
+ .
+ This package contains files necessary for debugging the wazuh-manager with gdb.

--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -66,6 +66,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
+	USER_DEBUG_SYMBOLS="y" \
 	./install.sh
 
 	# Copying init.d script

--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -16,8 +16,10 @@ export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 export PKG_DIR=debian/wazuh-manager
+export DBG_DIR=debian/wazuh-manager-dbg
 
 export TARGET_DIR=${CURDIR}/${PKG_DIR}
+export TARGET_DIR_SYMS=${CURDIR}/${DBG_DIR}
 
 # Package build options
 export INSTALLATION_DIR="/var/ossec"
@@ -190,6 +192,10 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/18/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/18/04
 	cp etc/templates/config/ubuntu/20/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/20/04
 
+	# Add debug symbols
+	mkdir -p ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}
+	mv ${TARGET_DIR}/${INSTALLATION_DIR}/.symbols ${TARGET_DIR_SYMS}/${INSTALLATION_DIR}/.symbols
+
 override_dh_fixperms:
 	dh_fixperms
 	# Fix Python permissions
@@ -204,6 +210,5 @@ override_dh_auto_clean:
 	$(MAKE) -C src clean
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure override_dh_fixperms

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -94,10 +94,6 @@ if [ "${build_target}" == "api" ]; then
     fi
 fi
 
-if [[ "${debug}" == "yes" ]]; then
-    sed -i "s:dh_strip --no-automatic-dbgsym::g" ${sources_dir}/debian/rules
-fi
-
 # Installing build dependencies
 cd ${sources_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
@@ -113,10 +109,13 @@ else
 fi
 
 deb_file="wazuh-${build_target}_${wazuh_version}-${package_release}"
+dbg_file="wazuh-${build_target}-dbg_${wazuh_version}-${package_release}"
 if [[ "${architecture_target}" == "ppc64le" ]]; then
   deb_file="${deb_file}_ppc64el.deb"
+  dbg_file="${dbg_file}_ppc64el.deb"
 else
   deb_file="${deb_file}_${architecture_target}.deb"
+  dbg_file="${dbg_file}_${architecture_target}.deb"
 fi
 pkg_path="${build_dir}/${build_target}"
 
@@ -124,3 +123,5 @@ if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${deb_file} > /var/local/checksum/${deb_file}.sha512
 fi
 mv ${pkg_path}/${deb_file} /var/local/wazuh
+mv ${pkg_path}/${dbg_file} /var/local/wazuh
+

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -79,7 +79,7 @@ build_deb() {
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
         ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
-    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 2) added to ${OUTDIR}."
 
     return 0
 }
@@ -149,7 +149,7 @@ help() {
     echo "    -r, --revision <rev>       [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    -p, --path <path>          [Optional] Installation path for the package. By default: /var/ossec."
-    echo "    -d, --debug                [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -d, --debug                [Optional] Build the binaries without optimizations. By default: no."
     echo "    -c, --checksum <path>      [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>           [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."

--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -158,6 +158,7 @@ function build_package() {
             mkdir -p ${CHECKSUMDIR}
             cd ${DESTINATION} && shasum -a512 "${pkg_name}" > "${CHECKSUMDIR}/${pkg_name}.sha512"
         fi
+        tar -C ${WAZUH_PATH}/src/symbols -czf ${DESTINATION}wazuh-agent-macos-amd64-debug-info-${VERSION}-${REVISION}.tar.gz .
         clean_and_exit 0
     else
         echo "ERROR: something went wrong while building the package."

--- a/macos/package_files/build.sh
+++ b/macos/package_files/build.sh
@@ -28,6 +28,7 @@ function configure() {
     echo USER_ENABLE_CISCAT="n" >> ${CONFIG}
     echo USER_ENABLE_ACTIVE_RESPONSE="y" >> ${CONFIG}
     echo USER_CA_STORE="n" >> ${CONFIG}
+    echo USER_DEBUG_SYMBOLS="y" >> ${CONFIG}
 }
 
 function build() {

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -81,6 +81,7 @@ echo 'USER_UPDATE="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_AGENT_SERVER_IP="MANAGER_IP"' >> ./etc/preloaded-vars.conf
 echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
+echo 'USER_DEBUG_SYMBOLS="y"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 %if 0%{?el} < 6 || 0%{?rhel} < 6

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -29,6 +29,14 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+%package -n wazuh-agent-debuginfo
+Summary: Debug info for Wazuh
+Group: Development/Libraries
+Requires: wazuh-agent = %{version}-%{release}
+
+%description -n wazuh-agent-debuginfo
+This package contains files necessary for debugging the wazuh-agent with gdb.
+
 %prep
 %setup -q
 
@@ -40,14 +48,14 @@ pushd src
 make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
-    make deps TARGET=agent
+    make -j%{_threads} deps TARGET=agent
     make -j%{_threads} TARGET=agent USE_SELINUX=yes DEBUG=%{_debugenabled}
 %else
     %ifnarch x86_64
       MSGPACK="USE_MSGPACK_OPT=no"
     %endif
     deps_version=`cat Makefile | grep "DEPS_VERSION =" | cut -d " " -f 3`
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
+    make -j%{_threads} deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no DEBUG=%{_debugenabled} ${MSGPACK}
 
 %endif
@@ -168,9 +176,10 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 
-if [ %{_debugenabled} = "yes" ]; then
-  %{_rpmconfigdir}/find-debuginfo.sh
-fi
+# Add debug symbols
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+cp src/symbols/* ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+
 exit 0
 
 %pre
@@ -598,11 +607,9 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
-%if %{_debugenabled} == "yes"
-/usr/lib/debug/%{_localstatedir}/*
-/usr/src/debug/%{name}-%{version}/*
-%endif
-
+%files -n wazuh-agent-debuginfo
+%dir %attr(750, root, root) %{_localstatedir}/.symbols
+%attr(640, root, root) %{_localstatedir}/.symbols/*
 
 %changelog
 * Fri May 05 2023 support <info@wazuh.com> - 4.5.0

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -497,8 +497,10 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
 %attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%attr(750, root, root) %{_localstatedir}/active-response/bin/.debug
 %dir %attr(750, root, root) %{_localstatedir}/bin
 %attr(750, root, root) %{_localstatedir}/bin/*
+%attr(750, root, root) %{_localstatedir}/bin/.debug
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
@@ -511,6 +513,7 @@ rm -fr %{buildroot}
 %attr(660, root, wazuh) %config(missingok,noreplace) %{_localstatedir}/etc/shared/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/lib
 %attr(750, root, wazuh) %{_localstatedir}/lib/*
+%attr(750, root, root) %{_localstatedir}/lib/.debug
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
 %attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/active-responses.log
 %attr(660, root, wazuh) %ghost %{_localstatedir}/logs/ossec.log

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -584,6 +584,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response
 %dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
 %attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
+%attr(750, root, root) %{_localstatedir}/active-response/bin/.debug
 %dir %attr(750, root, wazuh) %{_localstatedir}/api
 %dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
@@ -624,6 +625,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
+%attr(750, root, root) %{_localstatedir}/bin/.debug
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
@@ -660,6 +662,7 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/integrations
 %attr(750, root, wazuh) %{_localstatedir}/integrations/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/lib
+%attr(750, root, root) %{_localstatedir}/lib/.debug
 %attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhext.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhshared.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -26,6 +26,14 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+%package -n wazuh-manager-debuginfo
+Summary: Debug info for Wazuh
+Group: Development/Libraries
+Requires: wazuh-manager = %{version}-%{release}
+
+%description -n wazuh-manager-debuginfo
+This package contains files necessary for debugging the wazuh-manager with gdb.
+
 %prep
 %setup -q
 
@@ -37,7 +45,7 @@ pushd src
 make clean
 
 # Build Wazuh sources
-make deps TARGET=server
+make -j%{_threads} deps TARGET=server
 make -j%{_threads} TARGET=server USE_SELINUX=yes DEBUG=%{_debugenabled}
 
 popd
@@ -163,9 +171,10 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 
-if [ %{_debugenabled} = "yes" ]; then
-  %{_rpmconfigdir}/find-debuginfo.sh
-fi
+# Add debug symbols
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+cp src/symbols/* ${RPM_BUILD_ROOT}%{_localstatedir}/.symbols
+
 exit 0
 
 %pre
@@ -814,10 +823,9 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
-%if %{_debugenabled} == "yes"
-/usr/lib/debug/%{_localstatedir}/*
-/usr/src/debug/%{name}-%{version}/*
-%endif
+%files -n wazuh-manager-debuginfo
+%dir %attr(750, root, root) %{_localstatedir}/.symbols
+%attr(640, root, root) %{_localstatedir}/.symbols/*
 
 
 %changelog

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -75,6 +75,7 @@ echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
+echo 'USER_DEBUG_SYMBOLS="y"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -53,6 +53,7 @@ fi
 build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+dbg_file="wazuh-${build_target}-debuginfo-${wazuh_version}-${package_release}"
 rpm_file="${file_name}.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
 pkg_path="${rpm_build_dir}/RPMS/${architecture_target}"
@@ -80,6 +81,7 @@ if [[ "${future}" == "yes" ]]; then
     MINOR=$(echo $base_version | cut -d. -f2)
     wazuh_version="${MAJOR}.30.0"
     file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+    dbg_file="wazuh-${build_target}-debuginfo-${wazuh_version}-${package_release}"
     old_name="wazuh-${build_target}-${base_version}-${package_release}"
     package_name=wazuh-${build_target}-${wazuh_version}
     old_package_name=wazuh-${build_target}-${base_version}
@@ -129,3 +131,4 @@ if [[ "${src}" == "yes" ]]; then
 fi
 
 find ${extract_path} -maxdepth 3 -type f -name "${file_name}*" -exec mv {} /var/local/wazuh \;
+find ${extract_path} -maxdepth 3 -type f -name "${dbg_file}*" -exec mv {} /var/local/wazuh \;

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -99,7 +99,7 @@ build_rpm() {
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
         ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
-    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 2) added to ${OUTDIR}."
 
     return 0
 }
@@ -178,7 +178,7 @@ help() {
     echo "    -s, --store <path>           [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    -j, --jobs <number>          [Optional] Number of parallel jobs when compiling."
     echo "    -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec."
-    echo "    -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
+    echo "    -d, --debug                  [Optional] Build the binaries without optimizations. By default: no."
     echo "    -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
     echo "    --dont-build-docker          [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -3,7 +3,19 @@ FROM ubuntu:20.04
 # Installing necessary packages
 RUN apt-get update && \
     apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
-    curl perl binutils zip libssl1.1 libssl-dev
+    curl perl binutils zip libssl1.1 libssl-dev lsb-release gnupg
+
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt -y install tzdata
+RUN dpkg --add-architecture i386
+RUN wget -qO - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+RUN echo "deb https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" >> /etc/apt/sources.list
+
+RUN apt update
+RUN apt install -y --install-recommends winehq-stable
+RUN apt install -y winbind
+
+ENV WINEPATH="/usr/i686-w64-mingw32/lib;/path/to/wazuh/src"
+ENV WINEARCH=win32
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && \

--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -15,15 +15,31 @@ wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip
 
 # Compile the wazuh agent for Windows
 FLAGS="-j ${JOBS} "
+VERSION=$(cat wazuh-*/src/VERSION | cut -dv -f2)
+ZIP_SYMBOLS_NAME="wazuh-agent-windows-x86_64-debug-info-${VERSION}-${REVISION}.zip"
 
 if [[ "${DEBUG}" = "yes" ]]; then
     FLAGS+="-d "
 fi
 
+rm /wazuh-*/src/symbols/.gitignore
+
 make -C /wazuh-*/src deps TARGET=winagent ${FLAGS}
-make -C /wazuh-*/src TARGET=winagent ${FLAGS}
+
+if [ ! -z "/tools" ]; then
+    make -C /wazuh-*/src TARGET=winagent ${FLAGS} WIN_STRIP_TOOL_PATH=/tools
+else
+    make -C /wazuh-*/src TARGET=winagent ${FLAGS}
+fi
+
+if [ "$(ls -A /wazuh-*/src/symbols)" ]; then
+    cd /wazuh-*/src/symbols && zip -r ${ZIP_SYMBOLS_NAME} .
+    cd /wazuh-*/src/symbols && mv ${ZIP_SYMBOLS_NAME} /shared
+    cd /
+fi
 
 rm -rf /wazuh-*/src/external
+rm -rf /wazuh-*/src/symbols
 
 # Zip the compiled agent and move it to the shared folder
 zip -r ${ZIP_NAME} wazuh-*

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -6,6 +6,7 @@ REVISION="1"
 DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
+CV2PDB_TOOLS_PATH=""
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -20,7 +21,11 @@ generate_compiled_win_agent() {
     fi
 
     docker build -t ${DOCKER_IMAGE_NAME} ./ || exit 1
-    docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
+    if [ ! -z "{CV2PDB_TOOLS_PATH}" ]; then
+        docker run --rm -v ${OUTDIR}:/shared -v ${CV2PDB_TOOLS_PATH}:/tools ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
+    else
+        docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
+    fi
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 }
 
@@ -34,6 +39,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -c, --cv2pdb-tool <path>  [Optional] Absolute path where cv2pdb tools to extract debug symbols are located."
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -56,6 +62,14 @@ main() {
             ;;
         "-h"|"--help")
             help 0
+            ;;
+        "-c"|"--cv2pdb-tool")
+            if [ -n "$2" ]; then
+                CV2PDB_TOOLS_PATH="$2"
+                shift 2
+            else
+                help 1
+            fi
             ;;
         "-j"|"--jobs")
             if [ -n "$2" ]; then

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -175,6 +175,9 @@ main() {
 
         # Compile agent
         make -C src -j ${JOBS} TARGET=${BUILD_TARGET} || exit 1
+        rm -rf ./src/symbols/.gitignore
+        tar -C src/symbols -czf ${OUTDIR}/wazuh-${BUILD_TARGET}-linux-x86_64-debug-info-${WAZUH_VERSION}-${REVISION}.tar.gz --owner=0 --group=0 .
+        echo "tar.gz symbols file created placed in ${OUTDIR} with name = wazuh-${BUILD_TARGET}-linux-x86_64-debug-info-${WAZUH_VERSION}-${REVISION}.tar.gz"
         # Clean unuseful files
         clean
         # Preload vars for installer
@@ -219,7 +222,7 @@ main() {
 clean() {
     rm -rf ./{api,framework}
     rm -rf doc wodles/oscap/content/* gen_ossec.sh add_localfiles.sh Jenkinsfile*
-    rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*}
+    rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*,symbols/*}
     rm -rf src/{headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd}
     rm -rf src/{os_dbdos_execd,os_integrator,os_maild,os_netos_regex,os_xml,os_zlib}
     rm -rf src/{remoted,reportd,shared,syscheckd,tests,update,wazuh_db}


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#9913|

## Description

This PR aims to add debug information packages

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
