### PR TITLE
Fix Suse init script installation in agent

### DIFF
--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -231,7 +231,9 @@ if [ $1 = 1 ]; then
   fi
 
   if [ ! -z "$sles" ]; then
-    install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
+    if [ -d /etc/init.d ]; then
+      install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
+    fi    
   fi
 
   touch %{_localstatedir}/logs/active-responses.log


### PR DESCRIPTION
|Related issue|
|---|
| #1607  |

## Description

Fixed the error by apply the same strategy as the manager

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64


Original trace
```
# zypper install wazuh-agent-4.3.3-1.x86_64.rpm 
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  wazuh-agent

1 new package to install.
Overall download size: 8.2 MiB. Already cached: 0 B. After the operation, additional 23.6 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package wazuh-agent-4.3.3-1.x86_64                                    (1/1),   8.2 MiB ( 23.6 MiB unpacked)
wazuh-agent-4.3.3-1.x86_64.rpm:
    Header V3 RSA/SHA256 Signature, key ID 96b3ee5f29111145: NOKEY
    V3 RSA/SHA256 Signature, key ID 96b3ee5f29111145: NOKEY

warning: /var/tmp/zypp.Ti3spw/zypper/_tmpRPMcache_/%CLI%/wazuh-agent-4.3.3-1.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 29111145: NOKEY
Looking for gpg key ID 29111145 in cache /var/cache/zypp/pubkeys.
Repository Plain RPM files cache does not define additional 'gpgkey=' URLs.
wazuh-agent-4.3.3-1.x86_64 (Plain RPM files cache): Signature verification failed [4-Signatures public key is not available]
Abort, retry, ignore? [a/r/i] (a): i   

Checking for file conflicts: ...................................................................................[done]
warning: /var/cache/zypper/RPMS/wazuh-agent-4.3.3-1.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 29111145: NOKEY
install: cannot create regular file '/etc/init.d/wazuh-agent': No such file or directory
(1/1) Installing: wazuh-agent-4.3.3-1.x86_64 ...................................................................[done]
Executing %posttrans scripts ...................................................................................[done]
```


Solved trace:
```
# zypper install wazuh-agent-4.3.3-0.test.suse.x86_64.rpm 
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  wazuh-agent

1 new package to install.
Overall download size: 8.2 MiB. Already cached: 0 B. After the operation, additional 23.6 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): 
Retrieving package wazuh-agent-4.3.3-0.test.suse.x86_64                          (1/1),   8.2 MiB ( 23.6 MiB unpacked)
wazuh-agent-4.3.3-0.test.suse.x86_64.rpm:
    Package header is not signed!

wazuh-agent-4.3.3-0.test.suse.x86_64 (Plain RPM files cache): Signature verification failed [6-File is unsigned]
Abort, retry, ignore? [a/r/i] (a): i       

Checking for file conflicts: ...................................................................................[done]
(1/1) Installing: wazuh-agent-4.3.3-0.test.suse.x86_64 .........................................................[done]
Executing %posttrans scripts ...................................................................................[done]
```

Remove trace:
```
# zypper remove wazuh-agent
Reading installed packages...
Resolving package dependencies...

The following package is going to be REMOVED:
  wazuh-agent

1 package to remove.
After the operation, 23.6 MiB will be freed.
Continue? [y/n/v/...? shows all options] (y): 
warning: /var/ossec/etc/ossec.conf saved as /var/ossec/etc/ossec.conf.rpmsave
warning: /var/ossec/etc/client.keys saved as /var/ossec/etc/client.keys.rpmsave
(1/1) Removing wazuh-agent-4.3.3-0.test.suse.x86_64 ............................................................[done]
```