### PR TITLE
Remove wazuh indexer required deps

### DIFF
--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -17,7 +17,7 @@ BuildRoot:   %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Vendor:      Wazuh, Inc <info@wazuh.com>
 Packager:    Wazuh, Inc <info@wazuh.com>
 AutoReqProv: no
-Requires: coreutils initscripts chkconfig
+Requires: coreutils
 ExclusiveOS: linux
 BuildRequires: tar shadow-utils
 


### PR DESCRIPTION
|Related issue|
|---|
|#1621|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR removes the dependencies from wazuh-indexer package.

## Logs example

<!--
Paste here related logs
-->
```
[root@rhel9 vagrant]# yum install ./wazuh-indexer-4.3.4-test.rhel9.x86_64.rpm 
Last metadata expiration check: 1:37:11 ago on Wed 08 Jun 2022 08:12:51 AM UTC.
Dependencies resolved.
============================================================================================================================================
 Package                           Architecture               Version                                Repository                        Size
============================================================================================================================================
Installing:
 wazuh-indexer                     x86_64                     4.3.4-test.rhel9                       @commandline                     361 M

Transaction Summary
============================================================================================================================================
Install  1 Package

Total size: 361 M
Installed size: 614 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                    1/1 
  Running scriptlet: wazuh-indexer-4.3.4-test.rhel9.x86_64                                                                              1/1 
  Installing       : wazuh-indexer-4.3.4-test.rhel9.x86_64                                                                              1/1 
  Running scriptlet: wazuh-indexer-4.3.4-test.rhel9.x86_64                                                                              1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore

Couldn't write '64' to 'kernel/random/read_wakeup_threshold', ignoring: No such file or directory

  Verifying        : wazuh-indexer-4.3.4-test.rhel9.x86_64                                                                              1/1 
Installed products updated.

Installed:
  wazuh-indexer-4.3.4-test.rhel9.x86_64      
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
