### PR TITLE
Fixing package building for Arch that was broken a few versions ago

### DIFF
--- a/arch/SPECS/wazuh-agent/arch/PKGBUILD
+++ b/arch/SPECS/wazuh-agent/arch/PKGBUILD
@@ -17,13 +17,13 @@ backup=('PARAM_INSTALLATION_BACKUP_DIR/etc/client.keys'
 install=wazuh.install
 
 build() {
-    mkdir -p ${srcdir}/wazuh
-    tar xzf ${srcdir}/"PARAM_SOURCE_FILE" -C ${srcdir}/wazuh
-    cd ${srcdir}/wazuh
-    make -C src deps
-    make -jPARAM_JOBS -C src TARGET=agent DEBUG=PARAM_DEBUG PREFIX="PARAM_INSTALLATION_DIR"
+	mkdir -p ${srcdir}/wazuh
+	tar xzf ${srcdir}/"PARAM_SOURCE_FILE" -C ${srcdir}/wazuh
+	cd ${srcdir}/wazuh
+	make -C src deps
+	make -jPARAM_JOBS -C src TARGET=agent DEBUG=PARAM_DEBUG PREFIX="PARAM_INSTALLATION_DIR"
 
-    rm -f /tmp/fake-install.saved
+	rm -f /tmp/fake-install.saved
 	USER_LANGUAGE="en" \
 	USER_NO_STOP="y" \
 	USER_INSTALL_TYPE="agent" \
@@ -41,19 +41,19 @@ build() {
 	USER_AUTO_START="n" \
 	fakeroot ./install.sh
 
-    echo "#!/bin/sh" > ${srcdir}/wazuh/fix_owner.sh
-    cat /tmp/fake-install.saved >> ${srcdir}/wazuh/fix_owner.sh
-    chmod +x ${srcdir}/wazuh/fix_owner.sh
+	echo "#!/bin/sh" > ${srcdir}/wazuh/fix_owner.sh
+	cat /tmp/fake-install.saved >> ${srcdir}/wazuh/fix_owner.sh
+	chmod +x ${srcdir}/wazuh/fix_owner.sh
 }
 
 package() {
-    install -Dm0644 ${srcdir}/wazuh.sysusers ${pkgdir}/usr/lib/sysusers.d/wazuh.conf
-    cd ${srcdir}/wazuh
+	install -Dm0644 ${srcdir}/wazuh.sysusers ${pkgdir}/usr/lib/sysusers.d/wazuh.conf
+	cd ${srcdir}/wazuh
 
 	# Copying systemd file
 	mkdir -p ${pkgdir}/usr/lib/systemd/system/
 	install -m 0644 src/init/templates/wazuh-agent.service ${pkgdir}/usr/lib/systemd/system/
-    sed -i 's:WAZUH_HOME_TMP:PARAM_INSTALLATION_DIR:g' ${pkgdir}/usr/lib/systemd/system/wazuh-agent.service
+	sed -i 's:WAZUH_HOME_TMP:PARAM_INSTALLATION_DIR:g' ${pkgdir}/usr/lib/systemd/system/wazuh-agent.service
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"
@@ -74,7 +74,7 @@ package() {
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/
 	cp -p gen_ossec.sh ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/
 	cp -p add_localfiles.sh ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/
-    cp -p fix_owner.sh ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"
+	cp -p fix_owner.sh ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"
 
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src
 
@@ -112,7 +112,7 @@ package() {
 	cp etc/templates/config/generic/sca.files ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/sca/generic
 
-    cp -r src/{REVISION,VERSION} ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src
+	cp -r src/{REVISION,VERSION} ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src
 
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src/init
 	cp -r src/init/*  ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src/init

--- a/arch/SPECS/wazuh-agent/arch/PKGBUILD
+++ b/arch/SPECS/wazuh-agent/arch/PKGBUILD
@@ -8,7 +8,7 @@ license=(GPL2)
 source=('PARAM_SOURCE_FILE'
         'wazuh.sysusers')
 sha512sums=('SKIP'
-            'adce723356b0b533854700d4c367cedf4caba13146e1b754d60e72939d301d248a48f7b61d82c9104616f1e7720e4712cca9f37d3d4de37f1d0b5581c159f3d6')
+            'f677eff94751d7ac485511cac8a19a2fb0294cce3434f77b38c3ad62d7a63c1ed76d2fa6f48a18fdbe3a11f498625b1ce3c8e73dc3db768572b257c0dbeb594a')
 depends=('python' 'brotli')
 noextract=('PARAM_SOURCE_FILE')
 backup=('PARAM_INSTALLATION_BACKUP_DIR/etc/client.keys'
@@ -53,6 +53,7 @@ package() {
 	# Copying systemd file
 	mkdir -p ${pkgdir}/usr/lib/systemd/system/
 	install -m 0644 src/init/templates/wazuh-agent.service ${pkgdir}/usr/lib/systemd/system/
+    sed -i 's:WAZUH_HOME_TMP:PARAM_INSTALLATION_DIR:g' ${pkgdir}/usr/lib/systemd/system/wazuh-agent.service
 
 	# Generating permission restoration file for postinstall
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"
@@ -110,6 +111,8 @@ package() {
 
 	cp etc/templates/config/generic/sca.files ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/sca/generic
 	cp etc/templates/config/generic/sca.manager.files ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/sca/generic
+
+    cp -r src/{REVISION,VERSION} ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src
 
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src/init
 	cp -r src/init/*  ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/src/init

--- a/arch/SPECS/wazuh-agent/arch/PKGBUILD
+++ b/arch/SPECS/wazuh-agent/arch/PKGBUILD
@@ -125,7 +125,4 @@ package() {
 
 	mkdir -p ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/etc/templates/config/ubuntu
 	cp -r etc/templates/config/ubuntu ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/etc/templates/config/
-
-	# Generate ossec-init.conf
-	./gen_ossec.sh conf agent $(lsb_release -si) $(lsb_release -sr) "PARAM_INSTALLATION_DIR" > ${pkgdir}/"PARAM_INSTALLATION_SCRIPTS_DIR"/ossec-init.conf
 }

--- a/arch/SPECS/wazuh-agent/arch/wazuh.install
+++ b/arch/SPECS/wazuh-agent/arch/wazuh.install
@@ -53,9 +53,11 @@ common() {
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :
 
-    # Fix /etc/ossec-init.conf
-    chmod 640 /etc/ossec-init.conf
-    chown root:${GROUP} /etc/ossec-init.conf
+    # Remove the deprecated /etc/ossec-init.conf file
+    if [ -f /etc/ossec-init.conf ] ; then
+        rm -f /etc/ossec-init.conf
+    fi
+
     ${SCRIPTS_DIR}/fix_owner.sh 2>/dev/null
 }
 

--- a/arch/SPECS/wazuh-agent/arch/wazuh.install
+++ b/arch/SPECS/wazuh-agent/arch/wazuh.install
@@ -1,5 +1,6 @@
 DIR="PARAM_INSTALLATION_DIR"
 SCRIPTS_DIR="PARAM_INSTALLATION_SCRIPTS_DIR"
+WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
 USER="wazuh"
 GROUP="wazuh"
@@ -81,4 +82,30 @@ post_install() {
     ${SCRIPTS_DIR}/add_localfiles.sh >> ${DIR}/etc/ossec.conf
 
     common
+}
+
+pre_remove() {
+    systemctl disable wazuh-agent.service 2>/dev/null || true
+    systemctl stop wazuh-agent.service 2>/dev/null || true
+}
+
+post_remove() {
+
+    if [ -d ${WAZUH_TMP_DIR} ]; then
+        rm -rf ${WAZUH_TMP_DIR}
+    fi
+
+    # If the directory is not empty, copy the files into ${DIR}/etc
+    if ls -A ${DIR}/tmp/conffiles > /dev/null 2>&1 ; then
+        if [ ! -d ${DIR}/etc ]; then
+            mkdir -p ${DIR}/etc
+        fi
+        mv ${DIR}/tmp/conffiles/* ${DIR}/etc
+    fi
+
+    rm -rf ${DIR}/tmp
+    rm -rf ${DIR}/ruleset
+    rm -rf ${DIR}/var
+    rm -rf ${DIR}/logs
+
 }

--- a/arch/SPECS/wazuh-agent/arch/wazuh.install
+++ b/arch/SPECS/wazuh-agent/arch/wazuh.install
@@ -1,8 +1,8 @@
 DIR="PARAM_INSTALLATION_DIR"
 SCRIPTS_DIR="PARAM_INSTALLATION_SCRIPTS_DIR"
 SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
-USER="ossec"
-GROUP="ossec"
+USER="wazuh"
+GROUP="wazuh"
 
 common() {
     # Install the SCA files
@@ -42,7 +42,7 @@ common() {
     fi
 
     touch ${DIR}/logs/active-responses.log
-    chown ossec:ossec ${DIR}/logs/active-responses.log
+    chown wazuh:wazuh ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
 
     # Register and configure agent if Wazuh environment variables are defined
@@ -55,7 +55,7 @@ common() {
 
     # Fix /etc/ossec-init.conf
     chmod 640 /etc/ossec-init.conf
-    chown root:ossec /etc/ossec-init.conf
+    chown root:wazuh /etc/ossec-init.conf
     ${SCRIPTS_DIR}/fix_owner.sh 2>/dev/null
 }
 
@@ -67,7 +67,7 @@ post_upgrade() {
 }
 
 post_install() {
-    if ! getent group | grep -q "^ossec" ; then
+    if ! getent group | grep -q "^wazuh" ; then
         systemd-sysusers
     fi
 

--- a/arch/SPECS/wazuh-agent/arch/wazuh.install
+++ b/arch/SPECS/wazuh-agent/arch/wazuh.install
@@ -42,7 +42,7 @@ common() {
     fi
 
     touch ${DIR}/logs/active-responses.log
-    chown wazuh:wazuh ${DIR}/logs/active-responses.log
+    chown ${USER}:${GROUP} ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
 
     # Register and configure agent if Wazuh environment variables are defined
@@ -55,7 +55,7 @@ common() {
 
     # Fix /etc/ossec-init.conf
     chmod 640 /etc/ossec-init.conf
-    chown root:wazuh /etc/ossec-init.conf
+    chown root:${GROUP} /etc/ossec-init.conf
     ${SCRIPTS_DIR}/fix_owner.sh 2>/dev/null
 }
 
@@ -67,7 +67,7 @@ post_upgrade() {
 }
 
 post_install() {
-    if ! getent group | grep -q "^wazuh" ; then
+    if ! getent group | grep -q "^${GROUP}" ; then
         systemd-sysusers
     fi
 

--- a/arch/SPECS/wazuh-agent/arch/wazuh.install
+++ b/arch/SPECS/wazuh-agent/arch/wazuh.install
@@ -48,7 +48,7 @@ common() {
 
     # Register and configure agent if Wazuh environment variables are defined
     if [ -z "$2" ] ; then
-        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh > /dev/null || :
+        ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
 
     # Restoring file permissions
@@ -62,11 +62,30 @@ common() {
     ${SCRIPTS_DIR}/fix_owner.sh 2>/dev/null
 }
 
+pre_upgrade() {
+    if [ ! -d ${WAZUH_TMP_DIR} ]; then
+        mkdir -p ${WAZUH_TMP_DIR}
+    fi
+    if systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
+        systemctl stop wazuh-agent.service > /dev/null 2>&1
+        touch ${WAZUH_TMP_DIR}/wazuh.restart
+    elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+        ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
+        touch ${WAZUH_TMP_DIR}/wazuh.restart
+    fi
+}
+
 post_upgrade() {
     ${SCRIPTS_DIR}/gen_ossec.sh conf agent Arch rolling > ${DIR}/etc/ossec.conf.new
     chmod 660 ${DIR}/etc/ossec.conf.new
 
     common
+
+    if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
+        rm -f ${WAZUH_TMP_DIR}/wazuh.restart
+        systemctl daemon-reload > /dev/null 2>&1
+        systemctl restart wazuh-agent.service > /dev/null 2>&1
+    fi
 }
 
 post_install() {
@@ -86,7 +105,11 @@ post_install() {
 
 pre_remove() {
     systemctl disable wazuh-agent.service 2>/dev/null || true
-    systemctl stop wazuh-agent.service 2>/dev/null || true
+    if systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
+        systemctl stop wazuh-agent.service > /dev/null 2>&1
+    elif ${DIR}/bin/wazuh-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+        ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
+    fi
 }
 
 post_remove() {

--- a/arch/build.sh
+++ b/arch/build.sh
@@ -28,17 +28,10 @@ if [ -z "${package_release}" ]; then
     package_release="1"
 fi
 
-if [ ${build_target} = "api" ]; then
-    if [ "${local_source_code}" = "no" ]; then
-        curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
-    fi
-    wazuh_version="$(grep version wazuh*/package.json | cut -d '"' -f 4)"
-else
-    if [ "${local_source_code}" = "no" ]; then
-        curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
-    fi
-    wazuh_version="$(cat wazuh*/src/VERSION | cut -d 'v' -f 2)"
+if [ "${local_source_code}" = "no" ]; then
+    curl -sL https://github.com/wazuh/wazuh/tarball/${wazuh_branch} | tar zx
 fi
+wazuh_version="$(cat wazuh*/src/VERSION | cut -d 'v' -f 2)"
 
 # Build directories
 build_dir=/build_wazuh

--- a/arch/build.sh
+++ b/arch/build.sh
@@ -41,11 +41,11 @@ pacman_dir="${build_dir}/${build_target}/build"
 
 tmp_dir=${build_dir}/tmp
 tmp_sources_dir=${tmp_dir}/source
-tmp_specs_path=${tmp_dir}/specs
 
 mkdir -p "${pacman_dir}"
 
 if [[ "${use_local_specs}" == "no" ]]; then
+    tmp_specs_path=${tmp_dir}/specs
     mkdir -p ${tmp_specs_path}
     cd ${tmp_specs_path}
     specs_path=${tmp_specs_path}
@@ -67,9 +67,7 @@ if [[ "${future}" == "yes" ]]; then
     # PREPARE FUTURE SPECS AND SOURCES
     mkdir -p ${tmp_dir}
     cp -r ${sources_dir} "${tmp_sources_dir}"
-    cp -r "${specs_path}" "${tmp_specs_path}"
     sources_dir="${tmp_sources_dir}"
-    specs_path="${tmp_specs_path}"
     find "${sources_dir}" "${specs_path}" \( -name "*VERSION*" -o -name "*changelog*" \) -exec sed -i "s/${base_version}/${wazuh_version}/g" {} \;
     sed -i "s/\$(VERSION)/${MAJOR}.${MINOR}/g" "${sources_dir}/src/Makefile"
 fi

--- a/arch/build.sh
+++ b/arch/build.sh
@@ -51,7 +51,7 @@ if [[ "${use_local_specs}" == "no" ]]; then
     specs_path=${tmp_specs_path}
     curl -sL https://github.com/wazuh/wazuh-packages/tarball/${wazuh_packages_branch} | tar zx
     specs_path=`pwd`/$(find . -type d -name "SPECS" -path "*arch*")
-    tmp_specs_path=${sepcs_path}
+    tmp_specs_path=${specs_path}
 else
     specs_path="/specs/SPECS"
 fi

--- a/arch/build.sh
+++ b/arch/build.sh
@@ -11,15 +11,15 @@
 set -ex
 
 # Script parameters to build the package
-build_target=$1
-wazuh_branch=$2
-architecture_target=$3
-package_release=$4
-jobs=$5
-dir_path=$6
-debug=$7
-checksum=$8
-wazuh_packages_branch=$9
+build_target=${1}
+wazuh_branch=${2}
+architecture_target=${3}
+package_release=${4}
+jobs=${5}
+dir_path=${6}
+debug=${7}
+checksum=${8}
+wazuh_packages_branch=${9}
 use_local_specs=${10}
 local_source_code=${11}
 future=${12}
@@ -52,23 +52,23 @@ tmp_specs_path=${tmp_dir}/specs
 
 mkdir -p "${pacman_dir}"
 
-if [ "${use_local_specs}" = "no" ]; then
+if [[ "${use_local_specs}" == "no" ]]; then
     mkdir -p ${tmp_specs_path}
     cd ${tmp_specs_path}
     specs_path=${tmp_specs_path}
     curl -sL https://github.com/wazuh/wazuh-packages/tarball/${wazuh_packages_branch} | tar zx
     specs_path=`pwd`/$(find . -type d -name "SPECS" -path "*arch*")
-    tmp_specs_path=$specs_path
+    tmp_specs_path=${sepcs_path}
 else
     specs_path="/specs/SPECS"
 fi
 
 if [[ "${future}" == "yes" ]]; then
     # MODIFY VARIABLES
-    base_version=$wazuh_version
-    MAJOR=$(echo $base_version | cut -dv -f2 | cut -d. -f1)
-    MINOR=$(echo $base_version | cut -d. -f2)
-    wazuh_version="${MAJOR}.30.0"
+    base_version=${wazuh_version}
+    MAJOR=$(echo ${base_version} | cut -dv -f2 | cut -d. -f1)
+    MINOR=$(echo ${base_version} | cut -d. -f2)
+    wazuh_version="99.99.0"
     package_full_name=wazuh-${build_target}-${wazuh_version}
 
     # PREPARE FUTURE SPECS AND SOURCES
@@ -116,25 +116,25 @@ cat >/usr/bin/install <<EOF
 
 for arg do
     shift
-    [ "\$last_arg" = "-o" ] && owner="\$arg"
-    [ "\$last_arg" = "-g" ] && group="\$arg"
-    last_arg="\$arg"
+    [[ "\${last_arg}" == "-o" ]] && owner="\${arg}"
+    [[ "\${last_arg}" == "-g" ]] && group="\${arg}"
+    last_arg="\${arg}"
 
-    [ "\$dual_arg" == "1" ] && dual_arg="0" continue
+    [[ "\${dual_arg}" == "1" ]] && dual_arg="0" continue
 
     # ignore the -o and -g flags
-    [ "\$arg" = "-o" ] && dual_arg="1" continue
-    [ "\$arg" = "-g" ] && dual_arg="1" continue
+    [[ "\${arg}" == "-o" ]] && dual_arg="1" continue
+    [[ "\${arg}" == "-g" ]] && dual_arg="1" continue
 
-    [[ ! "\$arg" =~ ^-.* ]] && dir="\$arg"
-    set -- "\$@" "\$arg"
+    [[ ! "\${arg}" =~ ^-.* ]] && dir="\${arg}"
+    set -- "\$@" "\${arg}"
 done
 
-if [ ! "\$owner" = "" ]; then
-    if [ ! "\$group" = "" ]; then
-        owner="\$owner:\$group"
+if [[ ! "\${owner}" == "" ]]; then
+    if [[ ! "\${group}" == "" ]]; then
+        owner="\${owner}:\${group}"
     fi
-    echo "chown -R \$owner \$dir" >> /tmp/fake-install.saved
+    echo "chown -R \${owner} \${dir}" >> /tmp/fake-install.saved
 fi
 
 exec real_install "\$@"
@@ -147,7 +147,7 @@ mv /usr/bin/{real_install,install}
 
 # copy the package out
 pkg_file="wazuh-${build_target}-${wazuh_version}-${package_release}-${architecture_target}.pkg.tar.zst"
-pkg_path="$pacman_dir"
+pkg_path="${pacman_dir}"
 
 if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${pkg_file} > /var/local/checksum/${pkg_file}.sha512

--- a/arch/generate_arch_package.sh
+++ b/arch/generate_arch_package.sh
@@ -83,7 +83,7 @@ build() {
         build_arch ${ARCH_BUILDER} ${ARCH_BUILDER_DOCKERFILE} || return 1
 
     else
-        echo "Invalid target. Choose: manager, agent or api."
+        echo "Invalid target. Only agent is supported."
         return 1
     fi
 
@@ -105,7 +105,7 @@ help() {
     echo "    --sources <path>              [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
     echo "    --packages-branch <branch>    [Required] Select Git branch or tag from wazuh-packages repository. e.g ${PACKAGES_BRANCH}"
     echo "    --dev                         [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub."
-    echo "    --future                      [Optional] Build test future package x.30.0 Used for development purposes."
+    echo "    --future                      [Optional] Build test future package 99.99.0 Used for development purposes."
     echo "    -h, --help                    Show this help."
     echo
     exit $1


### PR DESCRIPTION
Since a few versions ago, wazuh-packages is unable to create packages for Arch Linux. This commit fixes that.
(This is related to issue: #1649)