### PR TITLE
Fix error when checking if domain name was valid in wazuh certs tool

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -95,7 +95,7 @@ function cert_generateCertificateconfiguration() {
     echo "${conf}" > "/tmp/wazuh-certificates/${1}.conf"
 
     isIP=$(echo "${2}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
-    isDNS=$(echo "${2}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$" )
+    isDNS=$(echo "${2}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z-]{2,})+$" )
 
     if [[ -n "${isIP}" ]]; then
         conf="$(awk '{sub("IP.1 = cip", "IP.1 = '${2}'")}1' "/tmp/wazuh-certificates/${1}.conf")"


### PR DESCRIPTION
|Related issue|
|---|
|#1421|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error that caused the scripts to return the following error:
```
ERROR: The given information does not match with an IP address or a DNS
```

If the domain names specified in the config.yml file contained a `-` after the `. `. Here there is an example of a failing config.yml:
```
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: wazuh-elasticsearch-1-0
      ip: wazuh-elasticsearch-1-0.wazuh-elasticsearch
    - name: wazuh-elasticsearch-2-0
      ip: wazuh-elasticsearch-2-0.wazuh-elasticsearch
    - name: wazuh-elasticsearch-3-0
      ip: wazuh-elasticsearch-3-0.wazuh-elasticsearch

  # Wazuh server nodes
  # Use node_type only with more than one Wazuh manager
  server:
    - name: wazuh-manager-master-0
      ip: wazuh-manager-master-0.wazuh-clustera
      node_type: master
    - name: wazuh-manager-worker-1-0
      ip: wazuh-manager-worker-1-0.wazuh-cluster
      node_type: worker
    - name: wazuh-manager-worker-2-0
      ip: wazuh-manager-worker-2-0.wazuh-cluster
      node_type: worker

  # Wazuh dashboard nodes
  dashboard:
    - name: wazuh-kibana-0
      ip: wazuh-kibana-0.wazuh-kibana

```
