### PR TITLE
Fix log clean command in ova generation 4.4

### DIFF
--- a/ova/assets/postProvision.sh
+++ b/ova/assets/postProvision.sh
@@ -23,8 +23,8 @@ systemctl enable removeVagrant.service
 rm -rf ${CURRENT_PATH}/* ${CURRENT_PATH}/.gitignore
 
 # Remove logs
-find /var/log/ -type f -exec sh -c ': > "$1"' - {} \;
-find /var/ossec/logs/ -type f -exec sh -c ': > "$1"' - {} \;
+find /var/log/ -type f -exec bash -c 'cat /dev/null > {}' \;
+find /var/ossec/logs/ -type f -exec bash -c 'cat /dev/null > {}' \;
 
 rm /root/anaconda-ks.cfg
 rm /root/original-ks.cfg


### PR DESCRIPTION
|Related issue|
|---|
| Related https://github.com/wazuh/wazuh-packages/pull/1651 |


## Description

This PR fix the log clean up of /var/log and /var/ossec/logs files, to avoid inserting an empty line in each file.


## Logs example

<details><summary>End of local ova generation</summary>

```
    default: 14/06/2022 12:32:43 INFO: --- Summary ---
    default: 14/06/2022 12:32:43 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    default:     User: admin
    default:     Password: *KpLR7.jdO?pye272+3a+VlgUXV9lTQ*
    default: 14/06/2022 12:32:43 INFO: Installation finished.
    default: Loaded plugins: fastestmirror
    default: Cleaning repos: base extras updates wazuh
    default: Cleaning up list of fastest mirrors
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20220614-23697-1iugfck.sh
    default: Created symlink from /etc/systemd/system/multi-user.target.wants/removeVagrant.service to /etc/systemd/system/removeVagrant.service.
==> default: Saving VM state and suspending execution...
Exporting ova
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Successfully exported 1 machine(s).
==> default: Discarding saved state of VM...
==> default: Destroying VM and associated drives...
wazuh-4.3.4.ovf
wazuh-4.3.4-disk001.vmdk
Setting up ova for VMware ESXi
Standarizing OVA
Setting OVA to default
wazuh-4.3.4.ovf
wazuh-4.3.4-disk001.vmdk
OVF extracted
mv: '/ova/new-ova/wazuh-4.3.4.ovf' and '/ova/new-ova/wazuh-4.3.4.ovf' are the same file
mv: cannot stat '/ova/new-ova/*.mf': No such file or directory
Files renamed
OVF Version changed
OVF Size changed
Manifest changed
wazuh-4.3.4.ovf
wazuh-4.3.4-disk-1.vmdk
wazuh-4.3.4.mf
New OVA created
Cleaned temporary directory
Process finished

```

</details>

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux deb
  - [x] Build the package for x86_64