### PR TITLE
Add RBAC CLI to RPM SPEC files check

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -630,6 +630,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
+%attr(750, root, root) %{_localstatedir}/bin/rbac_control
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys


### PR DESCRIPTION
|Related issue|
|---|
|closes #1658 |

## Description

After adding a new CLI for the Wazuh API RBAC, we needed to update the RPM specs to include that file.

**IMPORTANT:** This PR cannot be merged until the branch [dev-13109-rbac-upgrade-migration](https://github.com/wazuh/wazuh/tree/dev-13109-rbac-upgrade-migration)
 is merged into `master` (`4.5`).
## Logs example

[Manager package build (CentOS)](https://devel.ci.wazuh.info/job/Packages_builder/7748)
[Agent package build (CentOS)](https://devel.ci.wazuh.info/job/Packages_builder/7749/)
[Test install](https://devel.ci.wazuh.info/job/Test_install/20664/)
[Test upgrade 4.3.4 -> 4.5.0 (CentOS)](https://devel.ci.wazuh.info/job/Test_upgrade/57136)

> The upgrade test fails because it seems that some of the scripts were renamed and the team did not update the `check_files_data.json` file. Either way, we should add to that file this CLI as well, but on a different issue.

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
