### PR TITLE
Fix RHEL9 init.d file installation

### DIFF
--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -228,12 +228,19 @@ if [ $1 = 1 ]; then
     elif `grep -q -i "\"opensuse" /etc/os-release` ; then
       sles="opensuse"
     fi
+    if `grep -q "Red Hat Enterprise Linux 9" /etc/os-release`; then
+      rhel="9"
+    fi
   fi
 
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
     fi    
+  fi
+
+  if [ -n "${rhel+x}" ]; then
+    rm -rf %{_initrddir}/wazuh-agent
   fi
 
   touch %{_localstatedir}/logs/active-responses.log
@@ -635,7 +642,7 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Sat Apr 24 2021 support <info@wazuh.com> - 3.13.3
 - More info: https://documentation.wazuh.com/current/release-notes/
-* Mon Apr 22 2021 support <info@wazuh.com> - 4.1.5
+* Thu Apr 22 2021 support <info@wazuh.com> - 4.1.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Mar 29 2021 support <info@wazuh.com> - 4.1.4
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -1,6 +1,6 @@
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-agent
-Version:     4.30.0
+Version:     4.3.5
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons
@@ -612,7 +612,7 @@ rm -fr %{buildroot}
 
 
 %changelog
-* Wed Jun 29 2022 support <info@wazuh.com> - 4.30.0
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -1,6 +1,6 @@
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-agent
-Version:     4.3.5
+Version:     4.30.0
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons
@@ -612,7 +612,7 @@ rm -fr %{buildroot}
 
 
 %changelog
-* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.30.0
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -228,19 +228,12 @@ if [ $1 = 1 ]; then
     elif `grep -q -i "\"opensuse" /etc/os-release` ; then
       sles="opensuse"
     fi
-    if `grep -q "Red Hat Enterprise Linux 9" /etc/os-release`; then
-      rhel="9"
-    fi
   fi
 
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
     fi    
-  fi
-
-  if [ -n "${rhel+x}" ]; then
-    rm -rf %{_initrddir}/wazuh-agent
   fi
 
   touch %{_localstatedir}/logs/active-responses.log
@@ -259,6 +252,13 @@ if [ $1 = 1 ]; then
 
   # Register and configure agent if Wazuh environment variables are defined
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
+fi
+
+if [ -f /etc/os-release ]; then
+  source /etc/os-release
+  if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
+    rm -f %{_initrddir}/wazuh-agent
+  fi
 fi
 
 # Delete the installation files used to configure the agent
@@ -488,7 +488,7 @@ rm -fr %{buildroot}
 
 %files
 %defattr(-,root,root)
-%{_initrddir}/wazuh-agent
+%config(missingok) %{_initrddir}/wazuh-agent
 %attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-agent.service
 %dir %attr(750, root, wazuh) %{_localstatedir}

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -298,19 +298,12 @@ if [ $1 = 1 ]; then
     elif `grep -q -i "\"opensuse" /etc/os-release` ; then
       sles="opensuse"
     fi
-    if `grep -q "Red Hat Enterprise Linux 9" /etc/os-release`; then
-      rhel="9"
-    fi
   fi
 
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
     fi
-  fi
-
-  if [ -n "${rhel+x}" ]; then
-    rm -rf %{_initrddir}/wazuh-agent
   fi
 
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh
@@ -327,6 +320,14 @@ if [ $1 = 1 ]; then
 
   # Add default local_files to ossec.conf
   %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
+fi
+
+if [ -f /etc/os-release ]; then
+  source /etc/os-release
+  if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
+    rm -f %{_initrddir}/wazuh-manager
+    echo "LOL2" >> /out.log
+  fi
 fi
 
 # Generation auto-signed certificate if not exists
@@ -572,7 +573,7 @@ rm -fr %{buildroot}
 
 %files
 %defattr(-,root,wazuh)
-%{_initrddir}/wazuh-manager
+%config(missingok) %{_initrddir}/wazuh-manager
 %attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-manager.service
 %dir %attr(750, root, wazuh) %{_localstatedir}

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -298,12 +298,19 @@ if [ $1 = 1 ]; then
     elif `grep -q -i "\"opensuse" /etc/os-release` ; then
       sles="opensuse"
     fi
+    if `grep -q "Red Hat Enterprise Linux 9" /etc/os-release`; then
+      rhel="9"
+    fi
   fi
 
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
     fi
+  fi
+
+  if [ -n "${rhel+x}" ]; then
+    rm -rf %{_initrddir}/wazuh-agent
   fi
 
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -857,7 +857,7 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Sat Apr 24 2021 support <info@wazuh.com> - 3.13.3
 - More info: https://documentation.wazuh.com/current/release-notes/
-* Mon Apr 22 2021 support <info@wazuh.com> - 4.1.5
+* Thu Apr 22 2021 support <info@wazuh.com> - 4.1.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Mon Mar 29 2021 support <info@wazuh.com> - 4.1.4
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -1,6 +1,6 @@
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-manager
-Version:     4.3.5
+Version:     4.30.0
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons
@@ -326,7 +326,6 @@ if [ -f /etc/os-release ]; then
   source /etc/os-release
   if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
     rm -f %{_initrddir}/wazuh-manager
-    echo "LOL2" >> /out.log
   fi
 fi
 
@@ -827,7 +826,7 @@ rm -fr %{buildroot}
 
 
 %changelog
-* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.30.0
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -1,6 +1,6 @@
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-manager
-Version:     4.30.0
+Version:     4.3.5
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons
@@ -826,7 +826,7 @@ rm -fr %{buildroot}
 
 
 %changelog
-* Wed Jun 29 2022 support <info@wazuh.com> - 4.30.0
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
 - More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION
|Related issue|
|---|
| Related #1626  |

## Description
Hello,

In this PR we propose a fix to the matter of enabling Wazuh service in RHEL 9 systems.


## Logs example
Error:
```
# systemctl enable wazuh-agent
Synchronizing state of wazuh-agent.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable wazuh-agent
Failed to execute /usr/lib/systemd/systemd-sysv-install: No such file or directory
```

Fixed:
```
# systemctl enable wazuh-agent
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-agent.service → /usr/lib/systemd/system/wazuh-agent.service.

```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64


## RHEL 9
- [x] Install
- [x] Upgrade 4.3.4 -> 4.3.5
- [x] Upgrade 4.3.5 -> 4.30.0
- [x] Remove
- [x] Systemctl enable
- [x] Systemctl disable
- [x] Systemctl start
- [x] Systemctl stop
- [x] Systemctl restart

## CentOS 6
- [x] Install
- [x] Upgrade 4.3.4 -> 4.3.5
- [x] Upgrade 4.3.5 -> 4.30.0
- [x] Remove
- [ ] ~Systemctl enable~
- [ ] ~Systemctl disable~
- [ ] ~Systemctl start~
- [ ] ~Systemctl stop~
- [ ] ~Systemctl restart~

## CentOS 7
- [x] Install
- [x] Upgrade 4.3.4 -> 4.3.5
- [x] Upgrade 4.3.5 -> 4.30.0
- [x] Remove
- [x] Systemctl enable
- [x] Systemctl disable
- [x] Systemctl start
- [x] Systemctl stop
- [x] Systemctl restart