### PR TITLE
Add custom path for indexer packages to 4.3

### DIFF
--- a/stack/indexer/base/generate_base.sh
+++ b/stack/indexer/base/generate_base.sh
@@ -67,6 +67,7 @@ help() {
     echo
     echo "Usage: $0 [OPTIONS]"
     echo
+    echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    --version <version>   [Optional] OpenSearch version, by default ${opensearch_version}"
     echo "    --reference <ref>     [Optional] wazuh-packages branch or tag"
     echo "    --future              [Optional] Build test future package 99.99.0 Used for development purposes."
@@ -84,6 +85,14 @@ main() {
         case "${1}" in
         "-h"|"--help")
             help 0
+            ;;
+        "-s"|"--store")
+            if [ -n "${2}" ]; then
+                outdir="${2}"
+                shift 2
+            else
+                help 1
+            fi
             ;;
         "--version")
             if [ -n "${2}" ]; then

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -17,6 +17,7 @@ deb_amd64_builder="deb_indexer_builder_amd64"
 deb_builder_dockerfile="${current_path}/docker"
 future="no"
 base="s3"
+base_path="${current_path}/../base/output"
 
 trap ctrl_c INT
 
@@ -54,7 +55,7 @@ build_deb() {
             ${future} ${base} ${reference} || return 1
     else
         if [ "${base}" = "local" ];then
-            volumes="${volumes} -v ${current_path}/../base/output:/root/output:Z"
+            volumes="${volumes} -v ${base_path}:/root/output:Z"
         fi
         docker run -t --rm ${volumes} \
             -v ${current_path}/../../..:/root:Z \
@@ -94,6 +95,7 @@ help() {
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
     echo "    --base <s3/local>          [Optional] Base file location, use local or s3, default: s3"
+    echo "    --base-path                [Optional] If base is local, you can indicate the full path where the base is located, default: stack/indexer/base/output"
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -142,6 +144,14 @@ main() {
         "--base")
             if [ -n "${2}" ]; then
                 base="${2}"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--base-path")
+            if [ -n "${2}" ]; then
+                base_path="${2}"
                 shift 2
             else
                 help 1

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -19,6 +19,7 @@ rpm_x86_builder="rpm_indexer_builder_x86"
 rpm_builder_dockerfile="${current_path}/docker"
 future="no"
 base="s3"
+base_path="${current_path}/../base/output"
 
 trap ctrl_c INT
 
@@ -55,7 +56,7 @@ build_rpm() {
             ${future} ${base} ${reference} || return 1
     else
         if [ "${base}" = "local" ];then
-            volumes="${volumes} -v ${current_path}/../base/output:/root/output:Z"
+            volumes="${volumes} -v ${base_path}:/root/output:Z"
         fi
         docker run -t --rm ${volumes} \
             -v ${current_path}/../../..:/root:Z \
@@ -95,6 +96,7 @@ help() {
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
     echo "    --base <s3/local>          [Optional] Base file location, use local or s3, default: s3"
+    echo "    --base-path                [Optional] If base is local, you can indicate the full path where the base is located, default: stack/indexer/base/output"
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -143,6 +145,14 @@ main() {
         "--base")
             if [ -n "$2" ]; then
                 base="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--base-path")
+            if [ -n "${2}" ]; then
+                base_path="${2}"
                 shift 2
             else
                 help 1


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

I add the configuration of the generate_base.sh and build_package.sh scripts of indexer so that it accepts the possibility of saving the built packages in a custom path, in the same way that it is done in the dashboard scripts:

```
ls -la /tmp | grep wazuh*
-rw-r--r--  1 root    root    356166794 jun 28 08:38 wazuh-indexer_4.3.5-1_amd64.deb
-rw-r--r--  1 root    root          162 jun 28 08:38 wazuh-indexer_4.3.5-1_amd64.deb.sha512
-rw-r--r--  1 root    root    378831260 jun 28 08:33 wazuh-indexer-4.3.5-1.x86_64.rpm
-rw-r--r--  1 root    root          163 jun 28 08:33 wazuh-indexer-4.3.5-1.x86_64.rpm.sha512
-rw-r--r--  1 root    root    357530656 jun 28 08:30 wazuh-indexer-base-4.3.5-1-linux-x64.tar.xz

```
