### PR TITLE
Remove performanceanalyzer directory on uninstall

### DIFF
--- a/stack/indexer/deb/debian/postrm
+++ b/stack/indexer/deb/debian/postrm
@@ -79,6 +79,13 @@ if [ "$REMOVE_DIRS" = "true" ]; then
     if [ -d "${LOG_DIR}" ]; then
         rmdir --ignore-fail-on-non-empty "${LOG_DIR}"
     fi
+
+    # Delete performanceanalyzer directory
+    if [ -d "/dev/shm/performanceanalyzer" ]; then
+        echo -n "Deleting performanceanalyzer directory..."
+        rm -rf "/dev/shm/performanceanalyzer" > /dev/null 2>&1
+        echo " OK"
+    fi
 fi
 
 

--- a/stack/indexer/deb/debian/postrm
+++ b/stack/indexer/deb/debian/postrm
@@ -82,9 +82,7 @@ if [ "$REMOVE_DIRS" = "true" ]; then
 
     # Delete performanceanalyzer directory
     if [ -d "/dev/shm/performanceanalyzer" ]; then
-        echo -n "Deleting performanceanalyzer directory..."
         rm -rf "/dev/shm/performanceanalyzer" > /dev/null 2>&1
-        echo " OK"
     fi
 fi
 

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -222,8 +222,8 @@ if [ $1 = 0 ];then
     fi
 
     # Remove lingering folders and files
-    if [ -d /dev/shm/perfomanceanalyzer ]; then
-        rm -rf /dev/shm/perfomanceanalyzer
+    if [ -d /dev/shm/performanceanalyzer ]; then
+        rm -rf /dev/shm/performanceanalyzer
     fi
     rm -rf %{INSTALL_DIR}
 fi

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -222,6 +222,9 @@ if [ $1 = 0 ];then
     fi
 
     # Remove lingering folders and files
+    if [ -d /dev/shm/perfomanceanalyzer ]; then
+        rm -rf /dev/shm/perfomanceanalyzer
+    fi
     rm -rf %{INSTALL_DIR}
 fi
 


### PR DESCRIPTION
|Related issue|
|---|
| #1693 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Uninstalling Wazuh indexer does not remove the /dev/shm/performanceanalyzer/ directory, it is expected to remove it with the uninstallation of the package.

## Logs example
Before:

<details><summary>RPM</summary>

```
[root@centos8stream shm]# ls -ld performanceanalyzer/
drwxr-xr-x. 2 wazuh-indexer wazuh-indexer 40 Jun 27 14:03 performanceanalyzer/
(bash wazuh-install.sh -u)
[root@centos8stream shm]# ls -ld performanceanalyzer/
drwxr-xr-x. 2 994 990 40 Jun 27 14:03 performanceanalyzer/
[root@centos8stream shm]# pwd
/dev/shm
[root@centos8stream shm]#
```

</details>

<details><summary>DEB</summary>

```
root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  3 root          root            60 Jun 28 13:33 .
drwxr-xr-x 18 root          root          3800 Jun 28 13:27 ..
drwxr-xr-x  2 wazuh-indexer wazuh-indexer  320 Jun 28 20:46 performanceanalyzer
root@stack-ubuntu1804:/home/vagrant# 

root@stack-ubuntu1804:/home/vagrant# apt purge wazuh-indexer
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 137 not upgraded.
After this operation, 639 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 119772 files and directories currently installed.)
Removing wazuh-indexer (4.3.5-1) ...
Stopping wazuh-indexer service... OK
(Reading database ... 118840 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.3.5-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
Processing triggers for systemd (237-3ubuntu10.52) ...
Processing triggers for ureadahead (0.100.0-21) ...
root@stack-ubuntu1804:/home/vagrant#

root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  3 root root   60 Jun 28 13:33 .
drwxr-xr-x 18 root root 3800 Jun 28 13:27 ..
drwxr-xr-x  2  112  116  420 Jun 28 20:47 performanceanalyzer
root@stack-ubuntu1804:/home/vagrant# 
```

</details>

## Tests
After changes:

<details><summary>RPM</summary>

```
[root@centos8 vagrant]# yum install wazuh-indexer-4.3.5-1.x86_64.rpm
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:48:43 ago on Tue Jun 28 19:52:19 2022.
Dependencies resolved.
================================================================================================================================================================================
 Package                                      Architecture                          Version                                   Repository                                   Size
================================================================================================================================================================================
Installing:
 wazuh-indexer                                x86_64                                4.3.5-1                                   @commandline                                361 M

Transaction Summary
================================================================================================================================================================================
Install  1 Package

Total size: 361 M
Installed size: 614 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                        1/1 
  Running scriptlet: wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
  Installing       : wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
  Running scriptlet: wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
  Verifying        : wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 

Installed:
  wazuh-indexer-4.3.5-1.x86_64                                                                                                                                                  

Complete!

[root@centos8 vagrant]# ls -la /dev/shm/
total 0
drwxrwxrwt.  3 root root   60 Jun 28 19:45 .
drwxr-xr-x. 19 root root 2940 Jun 28 19:34 ..
drwxr-xr-x.  2  993  990   40 Jun 28 19:43 performanceanalyzer

[root@centos8 vagrant]# yum remove wazuh-indexer
Failed to set locale, defaulting to C.UTF-8
Dependencies resolved.
================================================================================================================================================================================
 Package                                      Architecture                          Version                                  Repository                                    Size
================================================================================================================================================================================
Removing:
 wazuh-indexer                                x86_64                                4.3.5-1                                  @@commandline                                614 M

Transaction Summary
================================================================================================================================================================================
Remove  1 Package

Freed space: 614 M
Is this ok [y/N]: y
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                        1/1 
  Running scriptlet: wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
Stopping wazuh-indexer service... OK

  Erasing          : wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
  Running scriptlet: wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 
  Verifying        : wazuh-indexer-4.3.5-1.x86_64                                                                                                                           1/1 

Removed:
  wazuh-indexer-4.3.5-1.x86_64                                                                                                                                                  

Complete!

[root@centos8 vagrant]# ls -la /dev/shm/
total 0
drwxrwxrwt.  2 root root   40 Jun 28 20:42 .
drwxr-xr-x. 19 root root 2940 Jun 28 19:34 ..
[root@centos8 vagrant]# 
```

</details>

<details><summary>DEB</summary>


```
root@stack-ubuntu1804:/home/vagrant# apt install /home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of '/home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb'
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 137 not upgraded.
Need to get 0 B/362 MB of archives.
After this operation, 639 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb wazuh-indexer amd64 4.3.5-1 [362 MB]
Selecting previously unselected package wazuh-indexer.
(Reading database ... 118828 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.3.5-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.3.5-1) ...
Setting up wazuh-indexer (4.3.5-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for systemd (237-3ubuntu10.52) ...
Processing triggers for ureadahead (0.100.0-21) ...
Processing triggers for libc-bin (2.27-3ubuntu1.4) ...

root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  3 root          root            60 Jun 28 13:33 .
drwxr-xr-x 18 root          root          3800 Jun 28 13:27 ..
drwxr-xr-x  2 wazuh-indexer wazuh-indexer  420 Jun 28 20:47 performanceanalyzer
root@stack-ubuntu1804:/home/vagrant# 

root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  3 root          root            60 Jun 28 13:33 .
drwxr-xr-x 18 root          root          3800 Jun 28 13:27 ..
drwxr-xr-x  2 wazuh-indexer wazuh-indexer  420 Jun 28 20:47 performanceanalyzer
root@stack-ubuntu1804:/home/vagrant# 
root@stack-ubuntu1804:/home/vagrant# 
root@stack-ubuntu1804:/home/vagrant# apt remove wazuh-indexer
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  wazuh-indexer
0 upgraded, 0 newly installed, 1 to remove and 137 not upgraded.
After this operation, 639 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 119772 files and directories currently installed.)
Removing wazuh-indexer (4.3.5-1) ...
Stopping wazuh-indexer service... OK
Deleting performanceanalyzer directory... OK
root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  2 root root   40 Jun 28 21:21 .
drwxr-xr-x 18 root root 3800 Jun 28 13:27 ..
root@stack-ubuntu1804:/home/vagrant# 

root@stack-ubuntu1804:/home/vagrant# apt install /home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of '/home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb'
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 137 not upgraded.
Need to get 0 B/362 MB of archives.
After this operation, 639 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-indexer_4.3.5-1_amd64.deb wazuh-indexer amd64 4.3.5-1 [362 MB]
Selecting previously unselected package wazuh-indexer.
(Reading database ... 118828 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.3.5-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.3.5-1) ...
Setting up wazuh-indexer (4.3.5-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for systemd (237-3ubuntu10.52) ...
Processing triggers for ureadahead (0.100.0-21) ...
Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
root@stack-ubuntu1804:/home/vagrant# 

root@stack-ubuntu1804:/home/vagrant# curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0   8885      0  0:00:01  0:00:01 --:--:--  8893

root@stack-ubuntu1804:/home/vagrant# tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
root@stack-ubuntu1804:/home/vagrant# mkdir -p /etc/wazuh-indexer/certs/
root@stack-ubuntu1804:/home/vagrant# mv ./certs/demo-indexer-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
root@stack-ubuntu1804:/home/vagrant# mv ./certs/demo-indexer.pem /etc/wazuh-indexer/certs/indexer.pem
root@stack-ubuntu1804:/home/vagrant# mv ./certs/admin-key.pem /etc/wazuh-indexer/certs/admin-key.pem
root@stack-ubuntu1804:/home/vagrant# mv ./certs/admin.pem /etc/wazuh-indexer/certs/admin.pem
root@stack-ubuntu1804:/home/vagrant# mv ./certs/root-ca.pem /etc/wazuh-indexer/certs/root-ca.pem
root@stack-ubuntu1804:/home/vagrant# rm -rf ./certs/
root@stack-ubuntu1804:/home/vagrant# systemctl daemon-reload
root@stack-ubuntu1804:/home/vagrant# systemctl enable wazuh-indexer
Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /usr/lib/systemd/system/wazuh-indexer.service.

root@stack-ubuntu1804:/home/vagrant# systemctl start wazuh-indexer

root@stack-ubuntu1804:/home/vagrant# /usr/share/wazuh-indexer/bin/indexer-security-init.sh
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
root@stack-ubuntu1804:/home/vagrant# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
   Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2022-06-28 21:29:51 UTC; 15s ago
     Docs: https://documentation.wazuh.com
 Main PID: 14617 (java)
    Tasks: 74 (limit: 4655)
   CGroup: /system.slice/wazuh-indexer.service
           └─14617 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreT

Jun 28 21:29:40 stack-ubuntu1804 systemd[1]: Starting Wazuh-indexer...
Jun 28 21:29:49 stack-ubuntu1804 systemd-entrypoint[14617]: WARNING: An illegal reflective access operation has occurred
Jun 28 21:29:49 stack-ubuntu1804 systemd-entrypoint[14617]: WARNING: Illegal reflective access by io.protostuff.runtime.PolymorphicThrowableSchema (file:/usr/share/wazuh-indexe
Jun 28 21:29:49 stack-ubuntu1804 systemd-entrypoint[14617]: WARNING: Please consider reporting this to the maintainers of io.protostuff.runtime.PolymorphicThrowableSchema
Jun 28 21:29:49 stack-ubuntu1804 systemd-entrypoint[14617]: WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
Jun 28 21:29:49 stack-ubuntu1804 systemd-entrypoint[14617]: WARNING: All illegal access operations will be denied in a future release
Jun 28 21:29:51 stack-ubuntu1804 systemd[1]: Started Wazuh-indexer.

root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  3 root          root            60 Jun 28 21:29 .
drwxr-xr-x 18 root          root          3800 Jun 28 13:27 ..
drwxr-xr-x  2 wazuh-indexer wazuh-indexer  200 Jun 28 21:30 performanceanalyzer

root@stack-ubuntu1804:/home/vagrant# apt purge wazuh-indexer
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 137 not upgraded.
After this operation, 639 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 119772 files and directories currently installed.)
Removing wazuh-indexer (4.3.5-1) ...
Stopping wazuh-indexer service... OK
Deleting performanceanalyzer directory... OK
(Reading database ... 118840 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.3.5-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
Processing triggers for systemd (237-3ubuntu10.52) ...
Processing triggers for ureadahead (0.100.0-21) ...

root@stack-ubuntu1804:/home/vagrant# ls -la /dev/shm/
total 0
drwxrwxrwt  2 root root   40 Jun 28 21:31 .
drwxr-xr-x 18 root root 3800 Jun 28 13:27 ..
root@stack-ubuntu1804:/home/vagrant#


```

</details>

