### PR TITLE
The app path is changed for future packages to master

### DIFF
--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -91,7 +91,6 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-
 	if [ "$(BASE_VERSION)" = "99.99.0" ]; then \
 		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip" ;\
 	else \

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -91,7 +91,12 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-	runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-${BASE_REVISION}.zip"
+
+	if [ "$(BASE_VERSION)" = "99.99.0" ]; then \
+		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip" ;\
+	else \
+		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-${BASE_REVISION}.zip" ;\
+	fi
 
 	find $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/wazuh/ -exec chown $(USER):$(GROUP) {} \;
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -93,7 +93,11 @@ find %{buildroot}%{CONFIG_DIR} -exec chown %{USER}:%{GROUP} {} \;
 chown %{USER}:%{GROUP} %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
-runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
+if [ "%{version}" = "99.99.0" ];then
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip"
+else
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
+fi
 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -type f -perm 644 -exec chmod 640 {} \;


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1644|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

A validation is added in the specs so that in the case of building the package in the future, the zip of the app is downloaded from a specific path

### RPM
```
+ '[' 99.99.0 = 99.99.0 ']'
+ runuser wazuh-dashboard --shell=/bin/bash '--command=/build/rpmbuild/BUILDROOT/wazuh-dashboard-99.99.0-1.x86_64/usr/share/wazuh-dashboard/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip'
Attempting to transfer from https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip
Transferring 30605690 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete

```
### DEB
```
if [ "99.99.0" = "99.99.0" ]; then \
        runuser wazuh-dashboard --shell="/bin/bash" --command="/build/wazuh-dashboard/wazuh-dashboard-99.99.0/debian/wazuh-dashboard/usr/share/wazuh-dashboard/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip" ;\
else \
        runuser wazuh-dashboard --shell="/bin/bash" --command="/build/wazuh-dashboard/wazuh-dashboard-99.99.0/debian/wazuh-dashboard/usr/share/wazuh-dashboard/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-99.99.0-1.zip" ;\
fi
Attempting to transfer from https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip
Transferring 30605690 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete

```

![Screenshot_20220629_165103](https://user-images.githubusercontent.com/64099752/176533564-142746db-f087-4ee5-8f81-dd7ad9b215b6.png)

