### PR TITLE
Fix installation assistant API error in single Wazuh manager nodes

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -223,9 +223,8 @@ function installCommon_changePasswords() {
     if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
         passwords_runSecurityAdmin
     fi
-
     if [ -n "${wazuh}" ] || [ -n "${dashboard}" ] || [ -n "${AIO}" ]; then
-        if [ "${server_node_types[pos]}" == "master" ] || [ "${#server_node_names[@]}" -eq 0 ] || [ -n "${dashboard_installed}" ]; then
+        if [ "${server_node_types[pos]}" == "master" ] || [ "${#server_node_names[@]}" -eq 1 ] || [ -n "${dashboard_installed}" ]; then
             installCommon_changePasswordApi
         fi
     fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -109,7 +109,9 @@ function passwords_changeDashboardApiPassword() {
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
             eval 'sed -i "s|password: .*|password: ${1}|g" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml'
-            common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
+            if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
+                common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
+            fi
             file_exists=1
         fi
         sleep 5


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error where API passwords were not changed in Wazuh manager single-node installation-

## Logs example

<!--
Paste here related logs
-->

```
root@ubuntu:/home/vagrant/repo# ./wazuh-install.sh -ws wazuh-server
04/07/2022 07:37:19 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
04/07/2022 07:37:19 INFO: Verbose logging redirected to /var/log/wazuh-install.log
04/07/2022 07:37:26 INFO: --- Dependencies ----
04/07/2022 07:37:26 INFO: Installing apt-transport-https.
04/07/2022 07:37:30 INFO: Wazuh repository added.
04/07/2022 07:37:30 INFO: --- Wazuh server ---
04/07/2022 07:37:30 INFO: Starting the Wazuh manager installation.
04/07/2022 07:38:03 INFO: Wazuh manager installation finished.
04/07/2022 07:38:03 INFO: Starting service wazuh-manager.
04/07/2022 07:38:19 INFO: wazuh-manager service started.
04/07/2022 07:38:19 INFO: Starting Filebeat installation.
04/07/2022 07:38:24 INFO: Filebeat installation finished.
04/07/2022 07:38:25 INFO: Filebeat post-install configuration finished.
04/07/2022 07:38:27 INFO: Starting service filebeat.
04/07/2022 07:38:29 INFO: filebeat service started.
04/07/2022 07:38:29 INFO: Installation finished.
root@ubuntu:/home/vagrant/repo# curl -u "wazuh-wui":"SLg9btH0NXX?t63RAf3iRLV8jnewGInT" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
{"title": "Unauthorized", "detail": "Invalid credentials"}
root@ubuntu:/home/vagrant/repo# curl -u "wazuh-wui":"wazuh-wui" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjU2OTIxMDEwLCJleHAiOjE2NTY5MjE5MTAsInN1YiI6IndhenVoLXd1aSIsInJ1bl9hcyI6ZmFsc2UsInJiYWNfcm9sZXMiOlsxXSwicmJhY19tb2RlIjoid2hpdGUifQ.AYQHDjg_mDAXotarr1zNii6RUjquBwBvdF7YKAIC6oNlWN6GWKYiIx4ynCZpr5zn6NGKQTqDJUBatIcjI6CHEZcOAArKcnalj8bWXjvFvxpj8fEz9uaFzfrvPVAc_-Ezg-84QhVBpp0OgKjqxdU5niKdTWQx_rQX5lwYtUfWbqasoPPd
```

## Tests

```
root@ubuntu:/home/vagrant/repo# rm wazuh-install.sh 
root@ubuntu:/home/vagrant/repo# ./builder.sh -i
root@ubuntu:/home/vagrant/repo# ./wazuh-install.sh -ws wazuh-server -o
04/07/2022 07:56:36 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
04/07/2022 07:56:36 INFO: Verbose logging redirected to /var/log/wazuh-install.log
04/07/2022 07:56:37 INFO: --- Removing existing Wazuh installation ---
04/07/2022 07:56:37 INFO: Removing Wazuh manager.
04/07/2022 07:56:43 INFO: Wazuh manager removed.
04/07/2022 07:56:43 INFO: Removing Filebeat.
04/07/2022 07:56:44 INFO: Filebeat removed.
04/07/2022 07:56:44 INFO: Installation cleaned.
04/07/2022 07:56:49 INFO: Wazuh repository added.
04/07/2022 07:56:49 INFO: --- Wazuh server ---
04/07/2022 07:56:49 INFO: Starting the Wazuh manager installation.
04/07/2022 07:57:19 INFO: Wazuh manager installation finished.
04/07/2022 07:57:19 INFO: Starting service wazuh-manager.
04/07/2022 07:57:35 INFO: wazuh-manager service started.
04/07/2022 07:57:35 INFO: Starting Filebeat installation.
04/07/2022 07:57:39 INFO: Filebeat installation finished.
04/07/2022 07:57:39 INFO: Filebeat post-install configuration finished.
04/07/2022 07:57:43 INFO: Starting service filebeat.
04/07/2022 07:57:45 INFO: filebeat service started.
04/07/2022 07:57:45 INFO: Installation finished.
root@ubuntu:/home/vagrant/repo# curl -u "wazuh-wui":"wazuh-wui" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
{"title": "Unauthorized", "detail": "Invalid credentials"}
root@ubuntu:/home/vagrant/repo# curl -u "wazuh-wui":"SLg9btH0NXX?t63RAf3iRLV8jnewGInT" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjU2OTIxNDk3LCJleHAiOjE2NTY5MjIzOTcsInN1YiI6IndhenVoLXd1aSIsInJ1bl9hcyI6ZmFsc2UsInJiYWNfcm9sZXMiOlsxXSwicmJhY19tb2RlIjoid2hpdGUifQ.AU0enPQ1zk2GFHA5kRLvH8r5NfVJeO3mBgpOPxhGbH9KGpUmr3zzmXrOinal9SzyEBQUVNNF-AJlEntNB_rEvFUQAY1_RlJXQV0VMiR6_G9-Cm-31yyc5eHIwmm_Lnyxd1PuN6pKidozJdsFJ_wxAfigizwRw6t9bhap_cG1BBAuM2Keroot@ubuntu:/home/vagrant/repo# 
```
