### PR TITLE
Remove package libssl1.1 from Windows build image

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Installing necessary packages
 RUN apt-get update && \
     apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
-    curl perl binutils zip libssl1.1 libssl-dev
+    curl perl binutils zip libssl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && \


### PR DESCRIPTION
|Related issue|
|---|
|Fixes #1077|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR removes package `libssl1.1` from the Windows package builder image setup.

On Ubuntu 22.04, `libssl-dev` is enough as it depends on `libssl3`.

## Logs example

Here is the result of building branch `11025-win-dw2-dll` (related to https://github.com/wazuh/wazuh/pull/11354):

```
./generate_compiled_windows_agent.sh -b 11025-win-dw2-dll
```

[result.log](https://github.com/wazuh/wazuh-packages/files/9054604/result.log)

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
