### PR TITLE
Fixed IP error in distributed configuration when installing every component in the same host

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -26,7 +26,11 @@ function dashboard_configure() {
             ip=${dashboard_node_ips[pos]}
         fi
 
-        echo 'server.host: "'${ip}'"' >> /etc/wazuh-dashboard/opensearch_dashboards.yml
+        if [[ "${ip}" != "127.0.0.1" ]]; then
+            echo 'server.host: "'${ip}'"' >> /etc/wazuh-dashboard/opensearch_dashboards.yml
+        else
+            echo 'server.host: '0.0.0.0'' >> /etc/wazuh-dashboard/opensearch_dashboards.yml
+        fi
 
         if [ "${#indexer_node_names[@]}" -eq 1 ]; then
             echo "opensearch.hosts: https://"${indexer_node_ips[0]}":9200" >> /etc/wazuh-dashboard/opensearch_dashboards.yml

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -8,7 +8,7 @@
 
 ## Package vars
 readonly wazuh_major="4.3"
-readonly wazuh_version="4.3.6"
+readonly wazuh_version="4.3.5"
 readonly wazuh_revision_deb="1"
 readonly wazuh_revision_rpm="1"
 readonly indexer_revision_deb="1"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -8,7 +8,7 @@
 
 ## Package vars
 readonly wazuh_major="4.3"
-readonly wazuh_version="4.3.5"
+readonly wazuh_version="4.3.6"
 readonly wazuh_revision_deb="1"
 readonly wazuh_revision_rpm="1"
 readonly indexer_revision_deb="1"


### PR DESCRIPTION
|Related issue|
|---|
|#1529|

## Description

As mentioned in the issue, the installation fails if the distributed installation is carried out in the same host and ``wazuh-config.yml`` has the value ``127.0.0.1``. The variable ``server.host`` in ``/etc/wazuh-dashboard/opensearch_dashboards.yml`` takes the value ``127.0.0.1`` when it should be ``0.0.0.0``.

I have just added a simple check that changes the IP to ``0.0.0.0`` if the value is ``127.0.0.1``

## Logs example

<details><summary> Distributed installation all in the same host</summary>

````
[root@ip-172-31-31-229 ec2-user]# bash wazuh-install.sh -wi wazuh-indexer
07/07/2022 09:24:33 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:24:33 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:24:38 INFO: Wazuh repository added.
07/07/2022 09:24:38 INFO: --- Wazuh indexer ---
07/07/2022 09:24:38 INFO: Starting Wazuh indexer installation.
07/07/2022 09:25:28 INFO: Wazuh indexer installation finished.
07/07/2022 09:25:28 INFO: Wazuh indexer post-install configuration finished.
07/07/2022 09:25:28 INFO: Starting service wazuh-indexer.
07/07/2022 09:25:43 INFO: wazuh-indexer service started.
07/07/2022 09:25:43 INFO: Initializing Wazuh indexer cluster security settings.
07/07/2022 09:25:45 INFO: Wazuh indexer cluster initialized.
07/07/2022 09:25:45 INFO: Installation finished.
[root@ip-172-31-31-229 ec2-user]# bash wazuh-install.sh -s
07/07/2022 09:26:37 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:26:37 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:26:46 INFO: Wazuh indexer cluster security configuration initialized.
07/07/2022 09:27:06 INFO: Wazuh indexer cluster started.
[root@ip-172-31-31-229 ec2-user]# bash wazuh-install.sh -ws wazuh-server
07/07/2022 09:28:54 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:28:54 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:28:59 INFO: Wazuh repository added.
07/07/2022 09:28:59 INFO: --- Wazuh server ---
07/07/2022 09:28:59 INFO: Starting the Wazuh manager installation.
07/07/2022 09:29:18 INFO: Wazuh manager installation finished.
07/07/2022 09:29:18 INFO: Starting service wazuh-manager.
07/07/2022 09:29:34 INFO: wazuh-manager service started.
07/07/2022 09:29:34 INFO: Starting Filebeat installation.
07/07/2022 09:29:45 INFO: Filebeat installation finished.
07/07/2022 09:29:46 INFO: Filebeat post-install configuration finished.
07/07/2022 09:29:55 INFO: Starting service filebeat.
07/07/2022 09:29:56 INFO: filebeat service started.
07/07/2022 09:29:56 INFO: Installation finished.
[root@ip-172-31-31-229 ec2-user]# bash wazuh-install.sh -wd wazuh-dashboard
07/07/2022 09:30:06 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:30:06 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:30:12 INFO: Wazuh repository added.
07/07/2022 09:30:12 INFO: --- Wazuh dashboard ----
07/07/2022 09:30:12 INFO: Starting Wazuh dashboard installation.
07/07/2022 09:31:12 INFO: Wazuh dashboard installation finished.
07/07/2022 09:31:12 INFO: Wazuh dashboard post-install configuration finished.
07/07/2022 09:31:12 INFO: Starting service wazuh-dashboard.
07/07/2022 09:31:13 INFO: wazuh-dashboard service started.
07/07/2022 09:31:34 INFO: Initializing Wazuh dashboard web application.
07/07/2022 09:31:34 INFO: Wazuh dashboard web application initialized.
07/07/2022 09:31:34 INFO: --- Summary ---
07/07/2022 09:31:34 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: gsTDouk6gLj*DtHK40DJ*7MW+TKLsIuV
````
````
[root@ip-172-31-31-229 ec2-user]# cat /etc/wazuh-dashboard/opensearch_dashboards.yml
server.port: 443
opensearch.ssl.verificationMode: certificate
# opensearch.username: kibanaserver
# opensearch.password: kibanaserver
opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
opensearch_security.multitenancy.enabled: false
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
server.ssl.enabled: true
server.ssl.key: "/etc/wazuh-dashboard/certs/wazuh-dashboard-key.pem"
server.ssl.certificate: "/etc/wazuh-dashboard/certs/wazuh-dashboard.pem"
opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
uiSettings.overrides.defaultRoute: /app/wazuh
server.host: 0.0.0.0
opensearch.hosts: https://127.0.0.1:9200
````
 </details>

<details><summary> AIO </summary>

````
[root@ip-172-31-31-229 ec2-user]# bash wazuh-install.sh -a
07/07/2022 09:50:50 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:50:50 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:50:55 INFO: Wazuh repository added.
07/07/2022 09:50:55 INFO: --- Configuration files ---
07/07/2022 09:50:55 INFO: Generating configuration files.
07/07/2022 09:50:56 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
07/07/2022 09:50:56 INFO: --- Wazuh indexer ---
07/07/2022 09:50:56 INFO: Starting Wazuh indexer installation.
07/07/2022 09:51:50 INFO: Wazuh indexer installation finished.
07/07/2022 09:51:50 INFO: Wazuh indexer post-install configuration finished.
07/07/2022 09:51:50 INFO: Starting service wazuh-indexer.
07/07/2022 09:52:04 INFO: wazuh-indexer service started.
07/07/2022 09:52:04 INFO: Initializing Wazuh indexer cluster security settings.
07/07/2022 09:52:11 INFO: Wazuh indexer cluster initialized.
07/07/2022 09:52:11 INFO: --- Wazuh server ---
07/07/2022 09:52:11 INFO: Starting the Wazuh manager installation.
07/07/2022 09:52:30 INFO: Wazuh manager installation finished.
07/07/2022 09:52:30 INFO: Starting service wazuh-manager.
07/07/2022 09:52:45 INFO: wazuh-manager service started.
07/07/2022 09:52:45 INFO: Starting Filebeat installation.
07/07/2022 09:53:00 INFO: Filebeat installation finished.
07/07/2022 09:53:00 INFO: Filebeat post-install configuration finished.
07/07/2022 09:53:00 INFO: Starting service filebeat.
07/07/2022 09:53:01 INFO: filebeat service started.
07/07/2022 09:53:01 INFO: --- Wazuh dashboard ---
07/07/2022 09:53:01 INFO: Starting Wazuh dashboard installation.
07/07/2022 09:53:53 INFO: Wazuh dashboard installation finished.
07/07/2022 09:53:53 INFO: Wazuh dashboard post-install configuration finished.
07/07/2022 09:53:53 INFO: Starting service wazuh-dashboard.
07/07/2022 09:53:54 INFO: wazuh-dashboard service started.
07/07/2022 09:54:30 INFO: Initializing Wazuh dashboard web application.
07/07/2022 09:54:30 INFO: Wazuh dashboard web application initialized.
07/07/2022 09:54:30 INFO: --- Summary ---
07/07/2022 09:54:30 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: 0EkoxFZrKw5PtB*V*X2uhj5JXyKcfbon
07/07/2022 09:54:30 INFO: Installation finished.
````
````
[root@ip-172-31-31-229 ec2-user]# cat /etc/wazuh-dashboard/opensearch_dashboards.yml
server.host: 0.0.0.0
opensearch.hosts: https://127.0.0.1:9200
server.port: 443
opensearch.ssl.verificationMode: certificate
# opensearch.username: kibanaserver
# opensearch.password: kibanaserver
opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
opensearch_security.multitenancy.enabled: false
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
server.ssl.enabled: true
server.ssl.key: "/etc/wazuh-dashboard/certs/wazuh-dashboard-key.pem"
server.ssl.certificate: "/etc/wazuh-dashboard/certs/wazuh-dashboard.pem"
opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
uiSettings.overrides.defaultRoute: /app/wazuh
````
 </details>

<details><summary> Distributed </summary>

````
[root@ip-172-31-8-198 ec2-user]# bash wazuh-install.sh -wi wazuh-indexer
07/07/2022 09:34:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:34:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:34:39 INFO: Wazuh repository added.
07/07/2022 09:34:39 INFO: --- Wazuh indexer ---
07/07/2022 09:34:39 INFO: Starting Wazuh indexer installation.
07/07/2022 09:35:32 INFO: Wazuh indexer installation finished.
07/07/2022 09:35:32 INFO: Wazuh indexer post-install configuration finished.
07/07/2022 09:35:32 INFO: Starting service wazuh-indexer.
07/07/2022 09:35:48 INFO: wazuh-indexer service started.
07/07/2022 09:35:48 INFO: Initializing Wazuh indexer cluster security settings.
07/07/2022 09:35:51 INFO: Wazuh indexer cluster initialized.
07/07/2022 09:35:51 INFO: Installation finished.
[root@ip-172-31-8-198 ec2-user]# bash wazuh-install.sh -s
07/07/2022 09:37:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:37:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:38:09 INFO: Wazuh indexer cluster security configuration initialized.
07/07/2022 09:38:30 INFO: Wazuh indexer cluster started.
````
````
[root@ip-172-31-11-12 ec2-user]# bash wazuh-install.sh -ws wazuh-server
07/07/2022 09:38:36 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:38:36 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:38:42 INFO: Wazuh repository added.
07/07/2022 09:38:42 INFO: --- Wazuh server ---
07/07/2022 09:38:42 INFO: Starting the Wazuh manager installation.
07/07/2022 09:39:02 INFO: Wazuh manager installation finished.
07/07/2022 09:39:02 INFO: Starting service wazuh-manager.
07/07/2022 09:39:18 INFO: wazuh-manager service started.
07/07/2022 09:39:18 INFO: Starting Filebeat installation.
07/07/2022 09:39:29 INFO: Filebeat installation finished.
07/07/2022 09:39:30 INFO: Filebeat post-install configuration finished.
07/07/2022 09:39:39 INFO: Starting service filebeat.
07/07/2022 09:39:39 INFO: filebeat service started.
07/07/2022 09:39:39 INFO: Installation finished.
````
````
[root@ip-172-31-4-239 ec2-user]# bash wazuh-install.sh -wd wazuh-dashboard
07/07/2022 09:39:49 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.5
07/07/2022 09:39:49 INFO: Verbose logging redirected to /var/log/wazuh-install.log
07/07/2022 09:39:55 INFO: Wazuh repository added.
07/07/2022 09:39:55 INFO: --- Wazuh dashboard ----
07/07/2022 09:39:55 INFO: Starting Wazuh dashboard installation.
07/07/2022 09:40:45 INFO: Wazuh dashboard installation finished.
07/07/2022 09:40:45 INFO: Wazuh dashboard post-install configuration finished.
07/07/2022 09:40:45 INFO: Starting service wazuh-dashboard.
07/07/2022 09:40:45 INFO: wazuh-dashboard service started.
07/07/2022 09:41:10 INFO: Initializing Wazuh dashboard web application.
07/07/2022 09:41:10 INFO: Wazuh dashboard web application initialized.
07/07/2022 09:41:10 INFO: --- Summary ---
07/07/2022 09:41:10 INFO: You can access the web interface https://172.31.4.239
    User: admin
    Password: *2ueyg*0WbTs+Dxzqvsh?xh9+M.+7+xn
07/07/2022 09:41:10 INFO: Installation finished.
````
````
[root@ip-172-31-4-239 ec2-user]# cat /etc/wazuh-dashboard/opensearch_dashboards.yml
server.port: 443
opensearch.ssl.verificationMode: certificate
# opensearch.username: kibanaserver
# opensearch.password: kibanaserver
opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
opensearch_security.multitenancy.enabled: false
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
server.ssl.enabled: true
server.ssl.key: "/etc/wazuh-dashboard/certs/wazuh-dashboard-key.pem"
server.ssl.certificate: "/etc/wazuh-dashboard/certs/wazuh-dashboard.pem"
opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
uiSettings.overrides.defaultRoute: /app/wazuh
server.host: "172.31.4.239"
opensearch.hosts: https://172.31.8.198:9200
````
 </details>

- All three installations can access the web interface correctly.
