### PR TITLE
wazuh-install.sh skip check OS when downloading

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -201,8 +201,11 @@ function main() {
     common_logger "Verbose logging redirected to ${logfile}"
 
 # -------------- Uninstall case  ------------------------------------
+    
+    if [ -z "${download}" ]; then
+        check_dist
+    fi
 
-    check_dist
     common_checkSystem
     common_checkInstalled
     checks_arguments


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1633|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The script ```wazuh-install.sh``` checks the OS always, this is not very useful when just downloading the files for offline installation. I  added a simple if condition to skip the check when performing the download. 

## Logs example

````
[root@localhost vagrant]# cat /etc/os-release 
NAME=Fedora
VERSION="32 (Cloud Edition)"
ID=fedora
VERSION_ID=32
VERSION_CODENAME=""
PLATFORM_ID="platform:f32"
PRETTY_NAME="Fedora 32 (Cloud Edition)"
ANSI_COLOR="0;34"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:32"
HOME_URL="https://fedoraproject.org/"
````
- Before the change:
````
[root@localhost vagrant]# ./wazuh-install.sh -dw rpm
21/07/2022 13:42:42 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
21/07/2022 13:42:42 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/07/2022 13:42:42 ERROR: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check.
[root@localhost vagrant]# ./wazuh-install.sh -dw rpm -i
21/07/2022 13:44:06 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
...
````
- After the change:
````
[root@localhost vagrant]# ./wazuh-install.sh -dw rpm
21/07/2022 13:46:19 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
21/07/2022 13:46:19 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/07/2022 13:46:20 INFO: --- Download Packages ---
21/07/2022 13:46:20 INFO: Starting Wazuh packages download.
21/07/2022 13:46:20 INFO: Downloading Wazuh rpm packages for x86_64.
21/07/2022 13:46:35 INFO: The manager package was downloaded.
21/07/2022 13:46:36 INFO: The filebeat package was downloaded.
21/07/2022 13:46:49 INFO: The indexer package was downloaded.
21/07/2022 13:46:55 INFO: The dashboard package was downloaded.
21/07/2022 13:46:55 INFO: The packages are in wazuh-offline/wazuh-packages
21/07/2022 13:46:55 INFO: Downloading configuration files and assets.
21/07/2022 13:46:55 INFO: The resource https://packages.wazuh.com/key/GPG-KEY-WAZUH was downloaded.
21/07/2022 13:46:55 INFO: The resource https://packages.wazuh.com/4.3/tpl/wazuh/filebeat/filebeat.yml was downloaded.
21/07/2022 13:46:56 INFO: The resource https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json was downloaded.
21/07/2022 13:46:56 INFO: The resource https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz was downloaded.
21/07/2022 13:46:56 INFO: The configuration files and assets are in wazuh-offline/wazuh-files
21/07/2022 13:47:11 INFO: You can follow the installation guide here https://documentation.wazuh.com/current/installation-guide/more-installation-alternatives/offline-installation.html
````

````
[root@localhost vagrant]# ./wazuh-install.sh -a
21/07/2022 13:57:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
21/07/2022 13:57:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/07/2022 13:57:34 ERROR: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check.
````

- Supported OS
````
[root@localhost vagrant]# cat /etc/os-release 
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

[root@localhost vagrant]# ./wazuh-install.sh -dw rpm
21/07/2022 14:16:39 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
21/07/2022 14:16:39 INFO: Verbose logging redirected to /var/log/wazuh-install.log
21/07/2022 14:16:40 INFO: --- Download Packages ---
21/07/2022 14:16:40 INFO: Starting Wazuh packages download.
21/07/2022 14:16:40 INFO: Downloading Wazuh rpm packages for x86_64.
21/07/2022 14:17:02 INFO: The manager package was downloaded.
21/07/2022 14:17:05 INFO: The filebeat package was downloaded.
21/07/2022 14:17:24 INFO: The indexer package was downloaded.
21/07/2022 14:17:31 INFO: The dashboard package was downloaded.
21/07/2022 14:17:31 INFO: The packages are in wazuh-offline/wazuh-packages
21/07/2022 14:17:31 INFO: Downloading configuration files and assets.
21/07/2022 14:17:31 INFO: The resource https://packages.wazuh.com/key/GPG-KEY-WAZUH was downloaded.
21/07/2022 14:17:31 INFO: The resource https://packages.wazuh.com/4.3/tpl/wazuh/filebeat/filebeat.yml was downloaded.
21/07/2022 14:17:31 INFO: The resource https://raw.githubusercontent.com/wazuh/wazuh/4.3/extensions/elasticsearch/7.x/wazuh-template.json was downloaded.
21/07/2022 14:17:32 INFO: The resource https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz was downloaded.
21/07/2022 14:17:32 INFO: The configuration files and assets are in wazuh-offline/wazuh-files
21/07/2022 14:17:47 INFO: You can follow the installation guide here https://documentation.wazuh.com/current/installation-guide/more-installation-alternatives/offline-installation.html
````

