### PR TITLE
Wazuh install assistant with error handler

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -99,6 +99,12 @@ function buildInstaller() {
     ## JAVA_HOME
     echo "export JAVA_HOME=\"/usr/share/wazuh-indexer/jdk/\"" >> "${output_script_path}"
 
+    echo "set -o pipefail" >> "${output_script_path}"
+    echo "shopt -s expand_aliases" >> "${output_script_path}"
+
+    echo "alias try=\"(set -e;\"" >> "${output_script_path}"
+    echo "alias catch=\" ); Error \\\$? || \"" >> "${output_script_path}"
+
     ## Functions for all install function modules
     install_modules=($(find "${resources_installer}" -type f))
     install_modules_names=($(eval "echo \"${install_modules[*]}\" | sed 's,${resources_installer}/,,g'"))

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -68,9 +68,9 @@ function common_checkInstalled() {
     dashboard_installed=""
 
     if [ "${sys_type}" == "yum" ]; then
-        wazuh_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
+        wazuh_installed=$(yum list installed 2>/dev/null | grep wazuh-manager || true)
     elif [ "${sys_type}" == "apt-get" ]; then
-        wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
+        wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager || true)
     fi
 
     if [ -d "/var/ossec" ]; then
@@ -78,9 +78,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
+        indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer || true)
     elif [ "${sys_type}" == "apt-get" ]; then
-        indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
+        indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer || true)
     fi
 
     if [ -d "/var/lib/wazuh-indexer/" ] || [ -d "/usr/share/wazuh-indexer" ] || [ -d "/etc/wazuh-indexer" ] || [ -f "${base_path}/search-guard-tlstool*" ]; then
@@ -88,9 +88,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
+        filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat || true)
     elif [ "${sys_type}" == "apt-get" ]; then
-        filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
+        filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat || true)
     fi
 
     if [ -d "/var/lib/filebeat/" ] || [ -d "/usr/share/filebeat" ] || [ -d "/etc/filebeat" ]; then
@@ -98,9 +98,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
+        dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard || true)
     elif [ "${sys_type}" == "apt-get" ]; then
-        dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
+        dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard || true)
     fi
 
     if [ -d "/var/lib/wazuh-dashboard/" ] || [ -d "/usr/share/wazuh-dashboard" ] || [ -d "/etc/wazuh-dashboard" ] || [ -d "/run/wazuh-dashboard/" ]; then

--- a/unattended_installer/install_functions/error.sh
+++ b/unattended_installer/install_functions/error.sh
@@ -1,0 +1,15 @@
+# Wazuh installer - dashboard.sh functions.
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+function Error() {
+    local retVal=$1
+    if [[ $retVal -gt 0 ]]
+    then
+        return 1
+    fi
+}

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -291,10 +291,14 @@ function main() {
             manager_startCluster
         fi
         installCommon_startService "wazuh-manager"
-        filebeat_install
-        filebeat_configure
-        installCommon_changePasswords
-        installCommon_startService "filebeat"
+        try {
+            filebeat_install
+            filebeat_configure
+            installCommon_changePasswords
+            installCommon_startService "filebeat"
+        } catch {
+            installCommon_rollBack
+        }
     fi
 
 # -------------- AIO case  ------------------------------------------

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -254,11 +254,17 @@ function main() {
 # -------------- Wazuh indexer case -------------------------------
 
     if [ -n "${indexer}" ]; then
-        common_logger "--- Wazuh indexer ---"
-        indexer_install
-        indexer_configure
-        installCommon_startService "wazuh-indexer"
-        indexer_initialize
+        try {
+            common_logger "--- Wazuh indexer ---"
+            indexer_install
+            indexer_configure
+            installCommon_startService "wazuh-indexer"
+            indexer_initialize
+        } catch {
+            common_logger "Wazuh-indexer installation failed"
+            indexer_installed="true"
+            installCommon_rollBack
+        }
     fi
 
 # -------------- Start Wazuh indexer cluster case  ------------------
@@ -273,11 +279,17 @@ function main() {
     if [ -n "${dashboard}" ]; then
         common_logger "--- Wazuh dashboard ----"
 
-        dashboard_install
-        dashboard_configure
-        installCommon_startService "wazuh-dashboard"
-        installCommon_changePasswords
-        dashboard_initialize
+        try {
+            dashboard_install
+            dashboard_configure
+            installCommon_startService "wazuh-dashboard"
+            installCommon_changePasswords
+            dashboard_initialize
+        } catch {
+            common_logger "Wazuh-dashboard installation failed"
+            dashboard_installed="true"
+            installCommon_rollBack
+        }
 
     fi
 
@@ -285,18 +297,26 @@ function main() {
 
     if [ -n "${wazuh}" ]; then
         common_logger "--- Wazuh server ---"
+        try {
+            manager_install
+            if [ -n "${server_node_types[*]}" ]; then
+                manager_startCluster
+            fi
+            installCommon_startService "wazuh-manager"
+        } catch {
+            common_logger "Wazuh-manager installation failed"
+            wazuh_installed="true"
+            installCommon_rollBack
+        }
 
-        manager_install
-        if [ -n "${server_node_types[*]}" ]; then
-            manager_startCluster
-        fi
-        installCommon_startService "wazuh-manager"
         try {
             filebeat_install
             filebeat_configure
             installCommon_changePasswords
             installCommon_startService "filebeat"
         } catch {
+            common_logger "Filebeat installation failed"
+            filebeat_installed="true"
             installCommon_rollBack
         }
     fi
@@ -305,23 +325,28 @@ function main() {
 
     if [ -n "${AIO}" ]; then
 
-        common_logger "--- Wazuh indexer ---"
-        indexer_install
-        indexer_configure
-        installCommon_startService "wazuh-indexer"
-        indexer_initialize
-        common_logger "--- Wazuh server ---"
-        manager_install
-        installCommon_startService "wazuh-manager"
-        filebeat_install
-        filebeat_configure
-        installCommon_startService "filebeat"
-        common_logger "--- Wazuh dashboard ---"
-        dashboard_install
-        dashboard_configure
-        installCommon_startService "wazuh-dashboard"
-        installCommon_changePasswords
-        dashboard_initializeAIO
+        try {
+            common_logger "--- Wazuh indexer ---"
+            indexer_install
+            indexer_configure
+            installCommon_startService "wazuh-indexer"
+            indexer_initialize
+            common_logger "--- Wazuh server ---"
+            manager_install
+            installCommon_startService "wazuh-manager"
+            filebeat_install
+            filebeat_configure
+            installCommon_startService "filebeat"
+            common_logger "--- Wazuh dashboard ---"
+            dashboard_install
+            dashboard_configure
+            installCommon_startService "wazuh-dashboard"
+            installCommon_changePasswords
+            dashboard_initializeAIO
+        } catch {
+            common_logger "AIO installation failed"
+            installCommon_rollBack
+        }
         
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|closes #1736|

## Description

<!--
Add a clear description of how the problem has been solved.
-->
SE adds new functionality to generate try-catch blocks to handle unexpected errors.
With this PR it is tried that the installation script executes the rollback in case of unexpected failures, such as those reported in the related issue.

## Logs example

<!--
Paste here related logs
-->

```
07/07/2022 10:29:53 INFO: Starting Filebeat installation.
07/07/2022 10:30:07 INFO: Filebeat installation finished.
chmod: cannot access '/etc/filebeat/wazuh-template.json': No such file or directory

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
07/07/2022 10:30:07 INFO: Filebeat post-install configuration finished.
07/07/2022 10:30:07 INFO: Starting service filebeat.
07/07/2022 10:30:07 INFO: filebeat service started.
```

## Tests

Test forcing error without verbose:

```
[root@manager-wpk vagrant]# bash ./wazuh-install-with-try-2.sh -ws wazuh-1 
22/07/2022 11:23:06 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
22/07/2022 11:23:06 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/07/2022 11:23:13 INFO: Wazuh repository added.
22/07/2022 11:23:13 INFO: --- Wazuh server ---
22/07/2022 11:23:13 INFO: Starting the Wazuh manager installation.
22/07/2022 11:23:55 INFO: Wazuh manager installation finished.
22/07/2022 11:23:55 INFO: Starting service wazuh-manager.
22/07/2022 11:24:10 INFO: wazuh-manager service started.
22/07/2022 11:24:10 INFO: Starting Filebeat installation.
22/07/2022 11:24:17 INFO: Filebeat installation finished.
22/07/2022 11:24:17 INFO: Filebeat installation failed
22/07/2022 11:24:17 INFO: --- Removing existing Wazuh installation ---
22/07/2022 11:24:17 INFO: Removing Filebeat.
22/07/2022 11:24:18 INFO: Filebeat removed.
22/07/2022 11:24:18 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
22/07/2022 11:24:18 INFO: Installation finished.
[root@manager-wpk vagrant]# sh ./wazuh-install-with-try-2.sh -u
22/07/2022 11:25:28 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
22/07/2022 11:25:28 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/07/2022 11:25:31 INFO: Filebeat not found in the system so it was not uninstalled.
22/07/2022 11:25:31 INFO: Wazuh indexer not found in the system so it was not uninstalled.
22/07/2022 11:25:31 INFO: Wazuh dashboard not found in the system so it was not uninstalled.
22/07/2022 11:25:31 INFO: Removing Wazuh manager.
22/07/2022 11:25:49 INFO: Wazuh manager removed.
[root@manager-wpk vagrant]# 
```

Test forcing error with verbose:

```
[root@manager-wpk vagrant]# 
[root@manager-wpk vagrant]# bash ./wazuh-install-with-try-2.sh -ws wazuh-1 -v 
22/07/2022 11:25:59 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
22/07/2022 11:25:59 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/07/2022 11:26:05 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages.wazuh.com/4.x/yum/
protect=1
22/07/2022 11:26:06 INFO: Wazuh repository added.
22/07/2022 11:26:06 INFO: --- Wazuh server ---
22/07/2022 11:26:06 INFO: Starting the Wazuh manager installation.
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: centos.zero.com.ar
 * extras: mirrors.eze.sysarmy.com
 * updates: mirrors.eze.sysarmy.com
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.3.6-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch            Version            Repository      Size
================================================================================
Installing:
 wazuh-manager          x86_64          4.3.6-1            wazuh          114 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 114 M
Installed size: 437 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.3.6-1.x86_64                                 1/1 
  Verifying  : wazuh-manager-4.3.6-1.x86_64                                 1/1 

Installed:
  wazuh-manager.x86_64 0:4.3.6-1                                                

Complete!
22/07/2022 11:26:45 INFO: Wazuh manager installation finished.
22/07/2022 11:26:45 INFO: Starting service wazuh-manager.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
22/07/2022 11:27:00 INFO: wazuh-manager service started.
22/07/2022 11:27:00 INFO: Starting Filebeat installation.
Failed to set locale, defaulting to C
22/07/2022 11:27:05 INFO: Filebeat installation finished.
chmod: cannot access '/etc/filebeat/wazuh-template.json': No such file or directory
22/07/2022 11:27:05 INFO: Filebeat installation failed
22/07/2022 11:27:05 INFO: --- Removing existing Wazuh installation ---
22/07/2022 11:27:05 INFO: Removing Filebeat.
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Resolving Dependencies
--> Running transaction check
---> Package filebeat.x86_64 0:7.10.2-1 will be erased
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package            Arch             Version             Repository        Size
================================================================================
Removing:
 filebeat           x86_64           7.10.2-1            @wazuh            70 M

Transaction Summary
================================================================================
Remove  1 Package

Installed size: 70 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Erasing    : filebeat-7.10.2-1.x86_64                                     1/1 
  Verifying  : filebeat-7.10.2-1.x86_64                                     1/1 

Removed:
  filebeat.x86_64 0:7.10.2-1                                                    

Complete!
22/07/2022 11:27:06 INFO: Filebeat removed.
22/07/2022 11:27:06 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
22/07/2022 11:27:06 INFO: Installation finished.
[root@manager-wpk vagrant]# bash ./wazuh-install-with-try-2.sh -u            
22/07/2022 11:42:27 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
22/07/2022 11:42:27 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/07/2022 11:42:29 INFO: Filebeat not found in the system so it was not uninstalled.
22/07/2022 11:42:29 INFO: Wazuh indexer not found in the system so it was not uninstalled.
22/07/2022 11:42:29 INFO: Wazuh dashboard not found in the system so it was not uninstalled.
22/07/2022 11:42:29 INFO: Removing Wazuh manager.
22/07/2022 11:42:45 INFO: Wazuh manager removed.
[root@manager-wpk vagrant]# 
```

Test  finish ok:

```
[root@manager-wpk vagrant]# vi wazuh-install-with-try-2.sh 
[root@manager-wpk vagrant]# bash ./wazuh-install-with-try-2.sh -ws wazuh-1 -v
22/07/2022 11:44:29 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
22/07/2022 11:44:29 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/07/2022 11:44:35 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages.wazuh.com/4.x/yum/
protect=1
22/07/2022 11:44:35 INFO: Wazuh repository added.
22/07/2022 11:44:35 INFO: --- Wazuh server ---
22/07/2022 11:44:35 INFO: Starting the Wazuh manager installation.
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: centos.zero.com.ar
 * extras: mirrors.eze.sysarmy.com
 * updates: mirrors.eze.sysarmy.com
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.3.6-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch            Version            Repository      Size
================================================================================
Installing:
 wazuh-manager          x86_64          4.3.6-1            wazuh          114 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 114 M
Installed size: 437 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.3.6-1.x86_64                                 1/1 
  Verifying  : wazuh-manager-4.3.6-1.x86_64                                 1/1 

Installed:
  wazuh-manager.x86_64 0:4.3.6-1                                                

Complete!
22/07/2022 11:45:12 INFO: Wazuh manager installation finished.
22/07/2022 11:45:12 INFO: Starting service wazuh-manager.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
22/07/2022 11:45:27 INFO: wazuh-manager service started.
22/07/2022 11:45:27 INFO: Starting Filebeat installation.
Failed to set locale, defaulting to C
22/07/2022 11:45:32 INFO: Filebeat installation finished.
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
22/07/2022 11:45:33 INFO: Filebeat post-install configuration finished.
22/07/2022 11:45:33 DEBUG: Setting Wazuh indexer cluster passwords.
Successfully updated the keystore
22/07/2022 11:45:37 DEBUG: filebeat started
22/07/2022 11:45:39 INFO: Starting service filebeat.
Created symlink from /etc/systemd/system/multi-user.target.wants/filebeat.service to /usr/lib/systemd/system/filebeat.service.
22/07/2022 11:45:39 INFO: filebeat service started.
22/07/2022 11:45:39 INFO: Installation finished.
[root@manager-wpk vagrant]# 

```