### PR TITLE
Remove GPG key when uninstalling with wazuh assistant

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -137,7 +137,7 @@ function common_remove_gpg_key() {
     elif [ "${sys_type}" == "apt-get" ]; then
         if { apt-key list | grep "Wazuh"; } >/dev/null 2>&1; then
             key=$(apt-key list  2>/dev/null | grep -B 1 "Wazuh" | head -1)
-            apt-key del "${key}" 2>/dev/null
+            apt-key del "${key}" >/dev/null 2>&1
         else
             common_logger "Wazuh GPG key not found in the system"
             return 1

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -123,3 +123,25 @@ function common_checkSystem() {
     fi
 
 }
+
+function common_remove_gpg_key() {
+    
+    if [ "${sys_type}" == "yum" ]; then
+        if { rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh"; } >/dev/null ; then
+            key=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh Signing Key" | awk '{print $1}' )
+            rpm -e "${key}"
+        else
+            common_logger "Wazuh GPG key not found in the system"
+            return 1
+        fi
+    elif [ "${sys_type}" == "apt-get" ]; then
+        if { apt-key list | grep "Wazuh"; } >/dev/null 2>&1; then
+            key=$(apt-key list  2>/dev/null | grep -B 1 "Wazuh" | head -1)
+            apt-key del "${key}" 2>/dev/null
+        else
+            common_logger "Wazuh GPG key not found in the system"
+            return 1
+        fi
+    fi
+
+}

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -535,6 +535,8 @@ function installCommon_rollBack() {
 
     eval "rm -rf ${elements_to_remove[*]}"
 
+    common_remove_gpg_key
+
     if [ -z "${uninstall}" ]; then
         if [ -n "${rollback_conf}" ] || [ -n "${overwrite}" ]; then
             common_logger "Installation cleaned."

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -211,6 +211,7 @@ function main() {
     checks_arguments
     if [ -n "${uninstall}" ]; then
         installCommon_rollBack
+        common_remove_gpg_key
         exit 0
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -211,7 +211,6 @@ function main() {
     checks_arguments
     if [ -n "${uninstall}" ]; then
         installCommon_rollBack
-        common_remove_gpg_key
         exit 0
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/1682|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Wazuh GPG key is not removed when uninstalling all wazuh components with the installation assistant. This needs to be changed, the key has to be removed with all the others components.


## Logs example

- CentOS7

````
[root@localhost vagrant]# rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh"
gpg-pubkey-29111145-591cd381	gpg(Wazuh.com (Wazuh Signing Key) <support@wazuh.com>)
[root@localhost vagrant]# ./wazuh-install.sh -u
26/07/2022 10:34:35 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
26/07/2022 10:34:35 INFO: Verbose logging redirected to /var/log/wazuh-install.log
26/07/2022 10:34:38 INFO: Removing Wazuh manager.
26/07/2022 10:34:56 INFO: Wazuh manager removed.
26/07/2022 10:34:56 INFO: Removing Wazuh indexer.
26/07/2022 10:35:01 INFO: Wazuh indexer removed.
26/07/2022 10:35:01 INFO: Removing Filebeat.
26/07/2022 10:35:04 INFO: Filebeat removed.
26/07/2022 10:35:04 INFO: Removing Wazuh dashboard.
26/07/2022 10:35:11 INFO: Wazuh dashboard removed.
[root@localhost vagrant]# rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep "Wazuh"
[root@localhost vagrant]# ./wazuh-install.sh -u
26/07/2022 10:41:16 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
26/07/2022 10:41:16 INFO: Verbose logging redirected to /var/log/wazuh-install.log
26/07/2022 10:41:17 INFO: Wazuh manager not found in the system so it was not uninstalled.
26/07/2022 10:41:17 INFO: Filebeat not found in the system so it was not uninstalled.
26/07/2022 10:41:17 INFO: Wazuh indexer not found in the system so it was not uninstalled.
26/07/2022 10:41:17 INFO: Wazuh dashboard not found in the system so it was not uninstalled.
26/07/2022 10:41:17 INFO: Wazuh GPG key not found in the system

````

- Ubuntu20

````
root@ubuntu:/home/vagrant# apt-key list | grep "Wazuh"
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
uid           [ unknown] Wazuh.com (Wazuh Signing Key) <support@wazuh.com>
root@ubuntu:/home/vagrant# ./wazuh-install.sh -u 
26/07/2022 11:00:00 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
26/07/2022 11:00:00 INFO: Verbose logging redirected to /var/log/wazuh-install.log
26/07/2022 11:00:01 INFO: Removing Wazuh manager.
26/07/2022 11:00:07 INFO: Wazuh manager removed.
26/07/2022 11:00:07 INFO: Removing Wazuh indexer.
26/07/2022 11:00:08 INFO: Wazuh indexer removed.
26/07/2022 11:00:08 INFO: Removing Filebeat.
26/07/2022 11:00:09 INFO: Filebeat removed.
26/07/2022 11:00:09 INFO: Removing Wazuh dashboard.
26/07/2022 11:00:11 INFO: Wazuh dashboard removed.
root@ubuntu2010:/home/vagrant# apt-key list | grep "Wazuh"
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
root@ubuntu:/home/vagrant# ./wazuh-install.sh -u 
26/07/2022 11:01:00 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.6
26/07/2022 11:01:00 INFO: Verbose logging redirected to /var/log/wazuh-install.log
26/07/2022 11:01:01 INFO: Wazuh manager not found in the system so it was not uninstalled.
26/07/2022 11:01:01 INFO: Filebeat not found in the system so it was not uninstalled.
26/07/2022 11:01:01 INFO: Wazuh indexer not found in the system so it was not uninstalled.
26/07/2022 11:01:01 INFO: Wazuh dashboard not found in the system so it was not uninstalled.
26/07/2022 11:01:01 INFO: Wazuh GPG key not found in the system
````


