### PR TITLE
Added service removal to common rollback

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -470,7 +470,6 @@ function installCommon_rollBack() {
 
     if [[ -n "${wazuh_installed}" ]]; then
         installCommon_removeService 'wazuh-manager'
-        common_logger "Wazuh manager service removed."
     fi
 
     if [[ ( -n "${wazuh_remaining_files}"  || -n "${wazuh_installed}" ) && ( -n "${wazuh}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
@@ -495,7 +494,6 @@ function installCommon_rollBack() {
 
     if [[ -n "${indexer_installed}" ]]; then
         installCommon_removeService 'wazuh-indexer'
-        common_logger "Wazuh indexer service removed."
     fi
 
     if [[ -n "${filebeat_installed}" && ( -n "${wazuh}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
@@ -516,7 +514,6 @@ function installCommon_rollBack() {
 
     if [[ -n "${filebeat_installed}" ]]; then
         installCommon_removeService 'filebeat'
-        common_logger "Filebeat service removed."
     fi
 
     if [[ -n "${dashboard_installed}" && ( -n "${dashboard}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
@@ -538,7 +535,6 @@ function installCommon_rollBack() {
 
     if [[ -n "${dashboard_installed}" ]]; then
         installCommon_removeService 'wazuh-dashboard'
-        common_logger "Wazuh dashboard service removed."
     fi
 
     elements_to_remove=(    "/var/log/wazuh-indexer/"
@@ -638,7 +634,6 @@ function installCommon_removeService() {
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
             fi
-            installCommon_rollBack
             exit 1
         else
             common_logger "${1} service stopped and removed."
@@ -649,11 +644,10 @@ function installCommon_removeService() {
         eval "/etc/init.d/${1} stop ${debug}"
         eval "update-rc.d -f ${1} remove"
         if [  "${PIPESTATUS[0]}" != 0  ]; then
-            common_logger -e "${1} could not be stopped and/or removed."
+            common_logger -e "${1} could not be stopped and/or removed. Consider stopping and removing it manually."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
             fi
-            installCommon_rollBack
             exit 1
         else
             common_logger "${1} service stopped and removed."
@@ -662,17 +656,16 @@ function installCommon_removeService() {
         eval "/etc/rc.d/init.d/${1} stop ${debug}"
         eval "update-rc.d -f ${1} remove"
         if [  "${PIPESTATUS[0]}" != 0  ]; then
-            common_logger -e "${1} could not be stopped and/or removed."
+            common_logger -e "${1} could not be stopped and/or removed. Consider stopping and removing it manually."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"
             fi
-            installCommon_rollBack
             exit 1
         else
             common_logger "${1} service stopped and removed."
         fi
     else
-        common_logger -e "${1} could not be removed. No service manager found on the system."
+        common_logger -e "${1} could not be removed. No service manager found on the system. Consider stopping and removing it manually."
         exit 1
     fi
 }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/1773 |

## Description

The method `installCommon_rollBack` is used extensively to rollback the Wazuh installation in case of a failure. However, it does not remove service installations.

This PR makes two additions to the installation process:

1. Adds a method called `installCommon_removeService` to remove installed services.
2. Added checks for each service in `installCommon_rollBack` method that calls `installCommon_removeService` method.


## Logs example

<!--
Paste here related logs
-->
N/A
## Tests

Tests are not applicable for the PR.

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
