### PR TITLE
Add firewall rules during installation

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -273,6 +273,7 @@ function main() {
     if [ -n "${indexer}" ]; then
         common_logger "--- Wazuh indexer ---"
         indexer_install
+        installCommon_setupFirewall "wazuh-indexer"
         indexer_configure
         installCommon_startService "wazuh-indexer"
         indexer_initialize
@@ -290,6 +291,7 @@ function main() {
     if [ -n "${dashboard}" ]; then
         common_logger "--- Wazuh dashboard ----"
         dashboard_install
+        installCommon_setupFirewall "wazuh-dashboard"
         dashboard_configure
         installCommon_startService "wazuh-dashboard"
         installCommon_changePasswords
@@ -302,6 +304,7 @@ function main() {
     if [ -n "${wazuh}" ]; then
         common_logger "--- Wazuh server ---"
         manager_install
+        installCommon_setupFirewall "wazuh-manager"
         if [ -n "${server_node_types[*]}" ]; then
             manager_startCluster
         fi
@@ -318,17 +321,20 @@ function main() {
 
         common_logger "--- Wazuh indexer ---"
         indexer_install
+        installCommon_setupFirewall "wazuh-indexer"
         indexer_configure
         installCommon_startService "wazuh-indexer"
         indexer_initialize
         common_logger "--- Wazuh server ---"
         manager_install
+        installCommon_setupFirewall "wazuh-manager"
         installCommon_startService "wazuh-manager"
         filebeat_install
         filebeat_configure
         installCommon_startService "filebeat"
         common_logger "--- Wazuh dashboard ---"
         dashboard_install
+        installCommon_setupFirewall "wazuh-dashboard"
         dashboard_configure
         installCommon_startService "wazuh-dashboard"
         installCommon_changePasswords


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/1217 |

## Description

Wazuh installation documents make an implicit assumption that the user configured the host firewall previously. Therefore, [the installation guide](https://documentation.wazuh.com/current/installation-guide/index.html) does include the hardware and OS requirements but excludes firewall configuration. Basically, it requires firewall to be planned and configured ahead with no mention in the installation steps.

However, it can be an issue for the new users. It might create problems during installation, especially during cluster discovery phase, causing new users waste time during troubleshooting.

This PR adds a firewall setup step to the installation script that checks for existence of `firewalld` and `iptables`, adds rules for default mandatory ports and save/reload settings. It reminds the user to check and verify the firewall configuration in a verbose way.


## Logs example

N/A

## Tests

N/A

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
