### PR TITLE
Fix build.sh for future deb packages

### DIFF
--- a/debs/build.sh
+++ b/debs/build.sh
@@ -67,6 +67,7 @@ if [[ "${future}" == "yes" ]]; then
     old_name="wazuh-${build_target}-${base_version}-${package_release}"
     package_full_name=wazuh-${build_target}-${wazuh_version}
     old_package_name=wazuh-${build_target}-${base_version}
+    mv "${build_dir}/${build_target}/${old_package_name}" "${build_dir}/${build_target}/${package_full_name}"
     sources_dir="${build_dir}/${build_target}/${package_full_name}"
 
     # PREPARE FUTURE SPECS AND SOURCES


### PR DESCRIPTION
|Related issue|
|---|
|related https://github.com/wazuh/wazuh-jenkins/issues/3289|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
An error was detected while trying to generate future images:
```
12:30:44  {"name":"Build Linux amd64 manager deb package(future)","head_sha":"f1a77b6d5c43a8ae8a99e97b1878746a3dd0a8ac","status":"completed","conclusion":"failure","completed_at":"2022-08-10T15:30:30Z","started_at":"2022-08-10T15:28:05Z","details_url":"https://devel.ci.wazuh.info/job/Packages_builder/8156/","output":{"summary":"Below you have the stage output","title":"Packages_builder_debian","text":"```\n+ build_target=manager\n+ wazuh_branch=f1a77b6d5c43a8ae8a99e97b1878746a3dd0a8ac\n+ architecture_target=amd64\n+ package_release=0.40500.20220810\n+ jobs=4\n+ dir_path=/var/ossec\n+ debug=no\n+ checksum=no\n+ wazuh_packages_branch=master\n+ use_local_specs=no\n+ local_source_code=no\n+ future=yes\n+ '[' -z 0.40500.20220810 ']'\n+ '[' manager = api ']'\n+ '[' no = no ']'\n+ curl -sL [https://github.com/wazuh/wazuh/tarball/f1a77b6d5c43a8ae8a99e97b1878746a3dd0a8ac\n+](https://github.com/wazuh/wazuh/tarball/f1a77b6d5c43a8ae8a99e97b1878746a3dd0a8ac/n+) tar zx\n++ cut -d v -f 2\n++ cat wazuh-wazuh-f1a77b6/src/VERSION\n+ wazuh_version=4.5.0\n+ build_dir=/build_wazuh\n+ package_full_name=wazuh-manager-4.5.0\n+ sources_dir=/build_wazuh/manager/wazuh-manager-4.5.0\n+ mkdir -p /build_wazuh/manager\n+ cp -R wazuh-wazuh-f1a77b6 /build_wazuh/manager/wazuh-manager-4.5.0\n+ '[' no = no ']'\n+ curl -sL [https://github.com/wazuh/wazuh-packages/tarball/master\n+](https://github.com/wazuh/wazuh-packages/tarball/master/n+) tar zx\n+ package_files='wazuh*/debs'\n++ find wazuh-wazuh-packages-99bfbe9/debs -type d -name SPECS -path '*debs*'\n+ specs_path=wazuh-wazuh-packages-99bfbe9/debs/SPECS\n+ [[ yes == \\y\\e\\s ]]\n+ base_version=4.5.0\n++ echo 4.5.0\n++ cut -dv -f2\n++ cut -d. -f1\n+ MAJOR=4\n++ cut -d. -f2\n++ echo 4.5.0\n+ MINOR=5\n+ wazuh_version=4.30.0\n+ file_name=wazuh-manager-4.30.0-0.40500.20220810\n+ old_name=wazuh-manager-4.5.0-0.40500.20220810\n+ package_full_name=wazuh-manager-4.30.0\n+ old_package_name=wazuh-manager-4.5.0\n+ sources_dir=/build_wazuh/manager/wazuh-manager-4.30.0\n+ find /build_wazuh/ wazuh-wazuh-packages-99bfbe9/debs/SPECS '(' -name '*VERSION*' -o -name '*changelog*' ')' -exec sed -i s/4.5.0/4.30.0/g '{}' ';'\n+ sed -i 's/$(VERSION)/4.5/g' /build_wazuh/manager/wazuh-manager-4.30.0/src/Makefile\nsed: can't read /build_wazuh/manager/wazuh-manager-4.30.0/src/Makefile: No such file or directory\n\n```"}}
```

## Logs example

<!--
Paste here related logs
-->

## Tests
https://devel.ci.wazuh.info/job/Packages_builder/8392/
https://devel.ci.wazuh.info/job/Packages_builder/8393/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
