### PR TITLE
Fix build.sh for future deb packages to 4.4

### DIFF
--- a/debs/build.sh
+++ b/debs/build.sh
@@ -67,6 +67,7 @@ if [[ "${future}" == "yes" ]]; then
     old_name="wazuh-${build_target}-${base_version}-${package_release}"
     package_full_name=wazuh-${build_target}-${wazuh_version}
     old_package_name=wazuh-${build_target}-${base_version}
+    mv "${build_dir}/${build_target}/${old_package_name}" "${build_dir}/${build_target}/${package_full_name}"
     sources_dir="${build_dir}/${build_target}/${package_full_name}"
 
     # PREPARE FUTURE SPECS AND SOURCES


### PR DESCRIPTION
|Related issue|
|---|
|related https://github.com/wazuh/wazuh-jenkins/issues/3289|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
An error was detected while trying to generate future images:
```
 sed -i 's/$(VERSION)/4.5/g' /build_wazuh/manager/wazuh-manager-4.30.0/src/Makefile\nsed: can't read /build_wazuh/manager/wazuh-manager-4.30.0/src/Makefile: No such file or directory\n\n```"}}
```

## Logs example

<!--
Paste here related logs
-->

## Tests
https://devel.ci.wazuh.info/job/Packages_builder/8392/
https://devel.ci.wazuh.info/job/Packages_builder/8393/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
