### PR TITLE
Fix cert-tool errors

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -122,6 +122,8 @@ function cert_generateIndexercertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_names[i]}-key.pem -out ${cert_tmp_path}/${indexer_node_names[i]}.csr -config ${cert_tmp_path}/${indexer_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${indexer_node_names[i]}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${indexer_node_names[i]}.pem -extfile ${cert_tmp_path}/${indexer_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
+    else
+        return 1
     fi
 
 }
@@ -136,6 +138,8 @@ function cert_generateFilebeatcertificates() {
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_node_names[i]}-key.pem -out ${cert_tmp_path}/${server_node_names[i]}.csr -config ${cert_tmp_path}/${server_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${server_node_names[i]}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${server_node_names[i]}.pem -extfile ${cert_tmp_path}/${server_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
         done
+    else
+        return 1
     fi
 
 }
@@ -149,8 +153,9 @@ function cert_generateDashboardcertificates() {
             cert_generateCertificateconfiguration "${dashboard_node_names[i]}" "${dashboard_node_ips[i]}"
             eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_names[i]}-key.pem -out ${cert_tmp_path}/${dashboard_node_names[i]}.csr -config ${cert_tmp_path}/${dashboard_node_names[i]}.conf -days 3650 ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${dashboard_node_names[i]}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${dashboard_node_names[i]}.pem -extfile ${cert_tmp_path}/${dashboard_node_names[i]}.conf -extensions v3_req -days 3650 ${debug}"
-
         done
+    else
+        return 1
     fi
 
 }
@@ -206,37 +211,37 @@ function cert_readConfig() {
 
         eval "server_node_types=( $(cert_parseYaml "${config_file}" | grep nodes_server__node_type | sed 's/nodes_server__node_type=//' | sed -r 's/\s+//g') )"
 
-        mapfile -t unique_names < <(printf "%s\n" "${indexer_node_names[@]}" | sort -u)
+        unique_names=($(echo "${indexer_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_names[@]}" -ne "${#indexer_node_names[@]}" ]; then 
             common_logger -e "Duplicated indexer node names."
             exit 1
         fi
 
-        mapfile -t unique_ips < <(printf "%s\n" "${indexer_node_ips[@]}" | sort -u)
+        unique_ips=($(echo "${indexer_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_ips[@]}" -ne "${#indexer_node_ips[@]}" ]; then 
             common_logger -e "Duplicated indexer node ips."
             exit 1
         fi
 
-        mapfile -t unique_names < <(printf "%s\n" "${server_node_names[@]}" | sort -u)
+        unique_names=($(echo "${server_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_names[@]}" -ne "${#server_node_names[@]}" ]; then 
             common_logger -e "Duplicated Wazuh server node names."
             exit 1
         fi
 
-        mapfile -t unique_ips < <(printf "%s\n" "${server_node_ips[@]}" | sort -u)
+        unique_ips=($(echo "${server_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_ips[@]}" -ne "${#server_node_ips[@]}" ]; then 
             common_logger -e "Duplicated Wazuh server node ips."
             exit 1
         fi
 
-        mapfile -t unique_names < <(printf "%s\n" "${dashboard_node_names[@]}" | sort -u)
+        unique_names=($(echo "${dashboard_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_names[@]}" -ne "${#dashboard_node_names[@]}" ]; then
             common_logger -e "Duplicated dashboard node names."
             exit 1
         fi
 
-        mapfile -t unique_ips < <(printf "%s\n" "${dashboard_node_ips[@]}" | sort -u)
+        unique_ips=($(echo "${dashboard_node_ips[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
         if [ "${#unique_ips[@]}" -ne "${#dashboard_node_ips[@]}" ]; then
             common_logger -e "Duplicated dashboard node ips."
             exit 1

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -189,12 +189,15 @@ function main() {
             cert_checkRootCA
             cert_generateAdmincertificate
             common_logger "Admin certificates created."
-            cert_generateIndexercertificates
-            common_logger "Wazuh indexer certificates created."
-            cert_generateFilebeatcertificates
-            common_logger "Wazuh server certificates created."
-            cert_generateDashboardcertificates
-            common_logger "Wazuh dashboard certificates created."
+            if cert_generateIndexercertificates; then
+                common_logger "Wazuh indexer certificates created."
+            fi
+            if cert_generateFilebeatcertificates; then
+                common_logger "Wazuh server certificates created."
+            fi
+            if cert_generateDashboardcertificates; then
+                common_logger "Wazuh dashboard certificates created."
+            fi
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -43,7 +43,7 @@ function common_logger() {
 
     if [ -z "${debugLogger}" ] || { [ -n "${debugLogger}" ] && [ -n "${debugEnabled}" ]; }; then
         if [ "$EUID" -eq 0 ] && [ -z "${nolog}" ]; then
-            printf "%s\n" "${now} ${mtype} ${message}" | tee -a "${logfile}"
+            printf "%s\n" "${now} ${mtype} ${message}" | tee -a ${logfile}
         else
             printf "%b\n" "${now} ${mtype} ${message}"
         fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1797|

## Description

The wazuh-certs-tool.sh has some errors that need to be fixed.


## Logs example

- Creating all certificates with -A
````
[root@centos7 vagrant]# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: node-1
      ip: 127.0.0.1
  server:
    - name: server
      ip: 127.0.0.1
  dashboard:
    - name: dashboard
      ip: 127.0.0.1
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 07:57:27 INFO: Admin certificates created.
25/08/2022 07:57:27 INFO: Wazuh indexer certificates created.
25/08/2022 07:57:27 INFO: Wazuh server certificates created.
25/08/2022 07:57:28 INFO: Wazuh dashboard certificates created.
````

````
[root@centos7 vagrant]# cat config.yml 
nodes:
  # Wazuh indexer nodes
  server:
    - name: server
      ip: 127.0.0.1
  dashboard:
    - name: dashboard
      ip: 127.0.0.1
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 07:59:18 INFO: Admin certificates created.
25/08/2022 07:59:18 INFO: Wazuh server certificates created.
25/08/2022 07:59:18 INFO: Wazuh dashboard certificates created.
````
````
[root@centos7 vagrant]# cat config.yml 
nodes:
  dashboard:
    - name: dashboard
      ip: 127.0.0.1
    - name: dashboard2
      ip: 127.0.0.2

[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:11:22 INFO: Admin certificates created.
25/08/2022 08:11:22 INFO: Wazuh dashboard certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
admin-key.pem  dashboard2-key.pem  dashboard-key.pem  root-ca.key
admin.pem      dashboard2.pem      dashboard.pem      root-ca.pem
````
- Creating certificates separately
````
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -ca
25/08/2022 08:14:21 INFO: Authority certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
root-ca.key  root-ca.pem
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -a wazuh-certificates-2/root-ca.pem wazuh-certificates-2/root-ca.key 
25/08/2022 08:17:45 INFO: Admin certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
admin-key.pem  admin.pem  root-ca.key  root-ca.pem
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -wi wazuh-certificates-2/root-ca.pem wazuh-certificates-2/root-ca.key 
25/08/2022 07:57:43 INFO: Wazuh indexer certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
node-1-key.pem  node-1.pem  root-ca.key  root-ca.pem
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -ws wazuh-certificates-2/root-ca.pem wazuh-certificates-2/root-ca.key 
25/08/2022 07:57:55 INFO: Wazuh server certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
root-ca.key  root-ca.pem  server-key.pem  server.pem
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -wd wazuh-certificates-2/root-ca.pem wazuh-certificates-2/root-ca.key 
25/08/2022 07:58:04 INFO: Wazuh dashboard certificates created.
[root@centos7 vagrant]# ls wazuh-certificates
dashboard-key.pem  dashboard.pem  root-ca.key  root-ca.pem
````

- Expected failures
````
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:01:42 ERROR: Duplicated indexer node ips.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:01:56 ERROR: Duplicated indexer node names.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:02:06 ERROR: Duplicated indexer node ips.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:02:35 ERROR: Duplicated Wazuh server node names.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:02:46 ERROR: Duplicated Wazuh server node ips.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:02:53 ERROR: The tag node_type needs to be specified for all Wazuh server nodes.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:03:10 ERROR: Wazuh cluster needs a single master node.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:03:34 ERROR: Duplicated dashboard node names.
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# bash wazuh-certs-tool.sh -A 
25/08/2022 08:03:42 ERROR: Duplicated dashboard node ips.
````

