### PR TITLE
Fix wazuh-dashboard API error and typo

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -333,8 +333,8 @@ For Wazuh API users, the file must have this format:
         exit 1
     fi
 
-    sfileusers=$(grep username: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")
-    sfilepasswords=$(grep password: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")
+    sfileusers=$(grep indexer_username: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")
+    sfilepasswords=$(grep indexer_password: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")
 
     sfileapiusers=$(grep api_username: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")
     sfileapipasswords=$(grep api_password: "${p_file}" | awk '{ print substr( $2, 1, length($2) ) }' | sed -e "s/[\'\"]//g")

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -108,7 +108,7 @@ function passwords_changeDashboardApiPassword() {
     j=0
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
-            eval "sed -i 's|password: .*|password: "'"'"${1}"'"'"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml"
+            eval "sed -i 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml"
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
                 common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
             fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -108,8 +108,7 @@ function passwords_changeDashboardApiPassword() {
     j=0
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
-            eval 'sed -i "s|password: .*|password: ${1}|g" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml'
-            eval "sed -i 's|${1}|"'"'"${1}"'"'"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml"
+            eval "sed -i 's|password: .*|password: "'"'"${1}"'"'"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml"
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
                 common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
             fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -109,6 +109,7 @@ function passwords_changeDashboardApiPassword() {
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
             eval 'sed -i "s|password: .*|password: ${1}|g" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml'
+            eval "sed -i 's|${1}|"'"'"${1}"'"'"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml"
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
                 common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
             fi
@@ -515,7 +516,7 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started"
+            common_logger -d "${1} started."
         fi
     elif ps -e | grep -E -q "^\ *1\ .*init$"; then
         eval "/etc/init.d/${1} restart ${debug}"
@@ -529,7 +530,7 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started"
+            common_logger -d "${1} started."
         fi
     elif [ -x "/etc/rc.d/init.d/${1}" ] ; then
         eval "/etc/rc.d/init.d/${1} restart ${debug}"
@@ -543,7 +544,7 @@ function passwords_restartService() {
             fi
             exit 1;
         else
-            common_logger -d "${1} started"
+            common_logger -d "${1} started."
         fi
     else
         if [[ $(type -t installCommon_rollBack) == "function" ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1804|
|https://github.com/wazuh/wazuh-packages/issues/1805|

## Description

Fix for those two issues, also I have seen a new error and fixed it.
The first issue is fixed by adding double quotes to the password. If the password started with * without the double quotes yaml treat it as an alias and produce the error. For the second issue, I have just added a single dot where it was missing. 
The third error that I found was this:

````
26/08/2022 11:35:13 DEBUG: The given user wazuh does not exist
26/08/2022 11:35:13 DEBUG: The given user wazuh-wui does not exist
````

## Logs example

````
[root@ip-172-31-8-198 ec2-user]# tail /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml

hosts:
  - default:
      url: https://localhost
      port: 55000
      username: wazuh-wui
      password: "bVM8YNHM.lqjmgnnOpuUm3QX1xutQZUm"
      run_as: false
````
Installing again with -o

````
[root@ip-172-31-11-12 ec2-user]# bash wazuh-install.sh -wd dashboard -o
26/08/2022 12:47:15 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.7
26/08/2022 12:47:15 INFO: Verbose logging redirected to /var/log/wazuh-install.log
26/08/2022 12:47:17 INFO: --- Removing existing Wazuh installation ---
26/08/2022 12:47:17 INFO: Removing Wazuh dashboard.
26/08/2022 12:47:28 INFO: Wazuh dashboard removed.
26/08/2022 12:47:28 INFO: Installation cleaned.
26/08/2022 12:47:37 INFO: Wazuh repository added.
dashboard
26/08/2022 12:47:37 INFO: --- Wazuh dashboard ----
26/08/2022 12:47:37 INFO: Starting Wazuh dashboard installation.
26/08/2022 12:48:30 INFO: Wazuh dashboard installation finished.
26/08/2022 12:48:30 INFO: Wazuh dashboard post-install configuration finished.
26/08/2022 12:48:30 INFO: Starting service wazuh-dashboard.
26/08/2022 12:48:30 INFO: wazuh-dashboard service started.
26/08/2022 12:48:55 INFO: Initializing Wazuh dashboard web application.
26/08/2022 12:48:55 INFO: Wazuh dashboard web application initialized.
26/08/2022 12:48:55 INFO: --- Summary ---
26/08/2022 12:48:55 INFO: You can access the web interface https://172.31.11.12
    User: admin
    Password: ZjMhnUXIMkGIW9*4t1A.TETTYw3qjqfO
26/08/2022 12:48:55 INFO: Installation finished.
[root@ip-172-31-11-12 ec2-user]# tail /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml
#       password: "kCTB449e*hyixgRepuCv9Nj?3vPE?baj"
#       run_as: true

hosts:
  - default:
      url: https://172.31.8.198
      port: 55000
      username: wazuh-wui
      password: "kCTB449e*hyixgRepuCv9Nj?3vPE?baj"
      run_as: false

````
![image](https://user-images.githubusercontent.com/61159728/186907580-0636a144-563d-4d9a-a352-2a4cb16c19c6.png)

