### PR TITLE
Adapt the manager package to use wazuh-authd

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -329,8 +329,8 @@ if [ -f /etc/os-release ]; then
 fi
 
 # Generation auto-signed certificate if not exists
-if type openssl >/dev/null 2>&1 && [ ! -f "%{_localstatedir}/etc/sslmanager.key" ] && [ ! -f "%{_localstatedir}/etc/sslmanager.cert" ]; then
-  openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=California/CN=Wazuh/" -keyout %{_localstatedir}/etc/sslmanager.key -out %{_localstatedir}/etc/sslmanager.cert 2>/dev/null
+if [ ! -f "%{_localstatedir}/etc/sslmanager.key" ] && [ ! -f "%{_localstatedir}/etc/sslmanager.cert" ]; then
+  %{_localstatedir}/bin/wazuh-authd -C 365 -B 2048 -S "/C=US/ST=California/CN=Wazuh/" -K %{_localstatedir}/etc/sslmanager.key -X %{_localstatedir}/etc/sslmanager.cert 2>/dev/null
   chmod 640 %{_localstatedir}/etc/sslmanager.key
   chmod 640 %{_localstatedir}/etc/sslmanager.cert
 fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1676|

## Description

Core is developing a new option for ```wazuh-authd``` to avoid having OpenSSL as a dependency. We need to adapt the packages to this new changes.


## Logs example

````

[root@ip-172-31-28-40 ec2-user]# openssl version -a
bash: openssl: command not found
````
````
[root@ip-172-31-28-40 ec2-user]# yum install -y wazuh-manager-4.5.0-1.x86_64.rpm 
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Examining wazuh-manager-4.5.0-1.x86_64.rpm: wazuh-manager-4.5.0-1.x86_64
Marking wazuh-manager-4.5.0-1.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.5.0-1 will be installed
--> Finished Dependency Resolution
amzn2-core/2/x86_64                                                                                        | 3.7 kB  00:00:00     

Dependencies Resolved

==================================================================================================================================
 Package                       Arch                   Version                 Repository                                     Size
==================================================================================================================================
Installing:
 wazuh-manager                 x86_64                 4.5.0-1                 /wazuh-manager-4.5.0-1.x86_64                 440 M

Transaction Summary
==================================================================================================================================
Install  1 Package

Total size: 440 M
Installed size: 440 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.5.0-1.x86_64                                                                                   1/1 
  Verifying  : wazuh-manager-4.5.0-1.x86_64                                                                                   1/1 

Installed:
  wazuh-manager.x86_64 0:4.5.0-1                                                                                                  

Complete!
````
````
[root@ip-172-31-28-40 ec2-user]# systemctl daemon-reload 
[root@ip-172-31-28-40 ec2-user]# systemctl enable wazuh-manager
[root@ip-172-31-28-40 ec2-user]# systemctl start  wazuh-manager
````
````
[root@ip-172-31-28-40 ec2-user]# systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
   Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: disabled)
   Active: active (running) since mar 2022-08-30 09:11:53 UTC; 3s ago
  Process: 9898 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/wazuh-manager.service
           ├─ 9957 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─ 9999 /var/ossec/bin/wazuh-authd
           ├─10016 /var/ossec/bin/wazuh-db
           ├─10029 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─10032 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─10047 /var/ossec/bin/wazuh-execd
           ├─10062 /var/ossec/bin/wazuh-analysisd
           ├─10106 /var/ossec/bin/wazuh-syscheckd
           ├─10122 /var/ossec/bin/wazuh-remoted
           ├─10154 /var/ossec/bin/wazuh-logcollector
           ├─10177 /var/ossec/bin/wazuh-monitord
           ├─10201 /var/ossec/bin/wazuh-modulesd
           └─10697 rpm -q firewalld

ago 30 09:11:45 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-execd...
ago 30 09:11:46 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-analysisd...
ago 30 09:11:47 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-syscheckd...
ago 30 09:11:48 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-remoted...
ago 30 09:11:49 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-logcollector...
ago 30 09:11:50 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-monitord...
ago 30 09:11:50 ip-172-31-28-40.us-east-2.compute.internal crontab[10291]: (root) LIST (root)
ago 30 09:11:51 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Started wazuh-modulesd...
ago 30 09:11:53 ip-172-31-28-40.us-east-2.compute.internal env[9898]: Completed.
ago 30 09:11:53 ip-172-31-28-40.us-east-2.compute.internal systemd[1]: Started Wazuh manager.
````
