### PR TITLE
Allow DNS names in indexer-security-init.sh 

### DIFF
--- a/stack/indexer/indexer-security-init.sh
+++ b/stack/indexer/indexer-security-init.sh
@@ -64,15 +64,22 @@ getNetworkHost() {
     HOST="${HOST//$NH}"
     HOST=$(echo "${HOST}" | tr -d "[\"\']")
 
+    isIP=$(echo "${HOST}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
+    isDNS=$(echo "${HOST}" | grep -P "^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$")
+
     # Allow to find ip with an interface
-    PATTERN="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"
-    if [[ ! "${HOST}" =~ ${PATTERN} ]]; then
+    if [ -z "${isIP}" ] && [ -z "${isDNS}" ]; then
         interface="${HOST//_}"
-        HOST=$(ip -o -4 addr list "${interface}" | awk '{print $4}' | cut -d/ -f1)
+        HOST=$(ip -o -4 addr list "${interface}" 2>/dev/null | awk '{print $4}' | cut -d/ -f1) 
     fi
 
     if [ "${HOST}" = "0.0.0.0" ]; then
         HOST="127.0.0.1"
+    fi
+
+    if [ -z "${HOST}" ]; then
+        echo "ERROR: network host not valid, check ${CONFIG_FILE}"
+        exit 1
     fi
 
 }

--- a/stack/indexer/indexer-security-init.sh
+++ b/stack/indexer/indexer-security-init.sh
@@ -70,7 +70,7 @@ getNetworkHost() {
     # Allow to find ip with an interface
     if [ -z "${isIP}" ] && [ -z "${isDNS}" ]; then
         interface="${HOST//_}"
-        HOST=$(ip -o -4 addr list "${interface}" 2>/dev/null | awk '{print $4}' | cut -d/ -f1) 
+        HOST=$(ip -o -4 addr list "${interface}" | awk '{print $4}' | cut -d/ -f1) 
     fi
 
     if [ "${HOST}" = "0.0.0.0" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1789|


## Description

The ```indexer-security-init.sh``` script did not allow DNS names in ```network.host``` variable causing an error. This could be fixed by executing the script with the parameter -ho but this behavior is not right. Now there is no need to use the -ho parameter the script will use the DNS name just like it uses an IP.


## Logs example

https://github.com/wazuh/wazuh-packages/issues/1789#issuecomment-1234259270

