### PR TITLE
Fix wazuh-certs-tool.sh certs generation when it differs from the config.yml

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -16,6 +16,11 @@ function cert_cleanFiles() {
 
 }
 
+function cert_cleanRootCA(){
+    eval "rm -f ${cert_tmp_path}/root-ca.pem ${debug}"
+    eval "rm -f ${cert_tmp_path}/root-ca.key ${debug}"
+}
+
 function cert_checkOpenSSL() {
 
     if [ -z "$(command -v openssl)" ]; then

--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -16,11 +16,6 @@ function cert_cleanFiles() {
 
 }
 
-function cert_cleanRootCA(){
-    eval "rm -f ${cert_tmp_path}/root-ca.pem ${debug}"
-    eval "rm -f ${cert_tmp_path}/root-ca.key ${debug}"
-}
-
 function cert_checkOpenSSL() {
 
     if [ -z "$(command -v openssl)" ]; then

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -178,13 +178,8 @@ function main() {
 
         if [[ -n "${cadmin}" ]]; then
             cert_checkRootCA
-            if cert_generateAdmincertificate; then
-                cert_cleanRootCA
-                common_logger "Admin certificates created."
-            else
-                common_logger -e "Error creating admin certificates."
-                exit 1
-            fi
+            cert_generateAdmincertificate
+            common_logger "Admin certificates created."
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
@@ -216,45 +211,45 @@ function main() {
         fi
 
         if [[ -n "${cindexer}" ]]; then
-            cert_checkRootCA
-            if cert_generateIndexercertificates; then
-                cert_cleanRootCA
+            if [ ${#indexer_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateIndexercertificates
                 common_logger "Wazuh indexer certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
             else
-                common_logger -e "Error creating Wazuh indexer certificates."
+                common_logger -e "Indexer node not present in config.yml."
                 exit 1
             fi
-            cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
         if [[ -n "${cserver}" ]]; then
-            cert_checkRootCA
-            if cert_generateFilebeatcertificates; then
-                cert_cleanRootCA
+            if [ ${#server_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateFilebeatcertificates
                 common_logger "Wazuh server certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
             else
-                common_logger -e "Error creating Wazuh server certificates."
+                common_logger -e "Server node not present in config.yml."
                 exit 1
             fi
-            cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
         if [[ -n "${cdashboard}" ]]; then
-            cert_checkRootCA
-            if cert_generateDashboardcertificates; then
-                cert_cleanRootCA
+            if [ ${#dashboard_node_names[@]} -gt 0 ]; then
+                cert_checkRootCA
+                cert_generateDashboardcertificates
                 common_logger "Wazuh dashboard certificates created."
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
             else
-                common_logger -e "Error creating Wazuh dashboard certificates."
+                common_logger -e "Dashboard node not present in config.yml."
                 exit 1
             fi
-            cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
     else

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -178,8 +178,13 @@ function main() {
 
         if [[ -n "${cadmin}" ]]; then
             cert_checkRootCA
-            cert_generateAdmincertificate
-            common_logger "Admin certificates created."
+            if cert_generateAdmincertificate; then
+                cert_cleanRootCA
+                common_logger "Admin certificates created."
+            else
+                common_logger -e "Error creating admin certificates."
+                exit 1
+            fi
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
@@ -212,8 +217,13 @@ function main() {
 
         if [[ -n "${cindexer}" ]]; then
             cert_checkRootCA
-            cert_generateIndexercertificates
-            common_logger "Wazuh indexer certificates created."
+            if cert_generateIndexercertificates; then
+                cert_cleanRootCA
+                common_logger "Wazuh indexer certificates created."
+            else
+                common_logger -e "Error creating Wazuh indexer certificates."
+                exit 1
+            fi
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
@@ -221,8 +231,13 @@ function main() {
 
         if [[ -n "${cserver}" ]]; then
             cert_checkRootCA
-            cert_generateFilebeatcertificates
-            common_logger "Wazuh server certificates created."
+            if cert_generateFilebeatcertificates; then
+                cert_cleanRootCA
+                common_logger "Wazuh server certificates created."
+            else
+                common_logger -e "Error creating Wazuh server certificates."
+                exit 1
+            fi
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
@@ -230,8 +245,13 @@ function main() {
 
         if [[ -n "${cdashboard}" ]]; then
             cert_checkRootCA
-            cert_generateDashboardcertificates
-            common_logger "Wazuh dashboard certificates created."
+            if cert_generateDashboardcertificates; then
+                cert_cleanRootCA
+                common_logger "Wazuh dashboard certificates created."
+            else
+                common_logger -e "Error creating Wazuh dashboard certificates."
+                exit 1
+            fi
             cert_cleanFiles
             cert_setpermisions
             eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1802|

## Description

A function to remove rootCA certs has been added. This function removes rootCA certs when creating certs for a single component: indexer, server, dashboard, and admin certs. Also, it will raise an error if we try to use a component that is not in the config file.

## Logs example

https://github.com/wazuh/wazuh-packages/issues/1802#issuecomment-1235185230