### PR TITLE
wazuh-certs-tool.sh add check for every node when executing with --all

### DIFF
--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -186,21 +186,26 @@ function main() {
         fi
 
         if [[ -n "${all}" ]]; then
-            cert_checkRootCA
-            cert_generateAdmincertificate
-            common_logger "Admin certificates created."
-            if cert_generateIndexercertificates; then
-                common_logger "Wazuh indexer certificates created."
+            if [[ ${#indexer_node_names[@]} -gt 0 ]] && [[ ${#server_node_names[@]} -gt 0 ]] && [[ ${#dashboard_node_names[@]} -gt 0 ]]; then
+                cert_checkRootCA
+                cert_generateAdmincertificate
+                common_logger "Admin certificates created."
+                if cert_generateIndexercertificates; then
+                    common_logger "Wazuh indexer certificates created."
+                fi
+                if cert_generateFilebeatcertificates; then
+                    common_logger "Wazuh server certificates created."
+                fi
+                if cert_generateDashboardcertificates; then
+                    common_logger "Wazuh dashboard certificates created."
+                fi
+                cert_cleanFiles
+                cert_setpermisions
+                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            else
+                common_logger -e "You must specify at least one indexer, one server and one dashboard node."
+                exit 1
             fi
-            if cert_generateFilebeatcertificates; then
-                common_logger "Wazuh server certificates created."
-            fi
-            if cert_generateDashboardcertificates; then
-                common_logger "Wazuh dashboard certificates created."
-            fi
-            cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
         if [[ -n "${ca}" ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1803|


## Description

The --all parameter did not check if at least existed one node for indexer, manager, and dashboard. Now, if any of these nodes do not exist in the config.yml file the script will exit and display an error.


## Logs example

https://github.com/wazuh/wazuh-packages/issues/1803#issuecomment-1235371937

