### PR TITLE
The creation of the base is integrated within the script build_packages.sh

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -8,13 +8,13 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 
 # Script parameters to build the package
-opensearch_version="${1}"
-future="${2}"
-revision="${3}"
-reference="${4}"
+future="${1}"
+revision="${2}"
+reference="${3}"
+opensearch_version="2.1.0"
 base_dir=/tmp/output/wazuh-dashboard-base
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/base/generate_base.sh
+++ b/stack/dashboard/base/generate_base.sh
@@ -15,7 +15,6 @@ reference=""
 current_path="$( cd $(dirname $0) ; pwd -P )"
 dockerfile_path="${current_path}/docker"
 container_name="dashboard_base_builder"
-opensearch_version="2.1.0"
 outdir="${current_path}/output"
 revision="1"
 future="no"
@@ -49,11 +48,11 @@ build() {
 
     if [ "${reference}" ];then
         docker run -t --rm -v ${outdir}/:/tmp/output:Z \
-            ${container_name} ${opensearch_version} ${future} ${revision} ${reference}  || return 1
+            ${container_name} ${future} ${revision} ${reference}  || return 1
     else
         docker run -t --rm -v ${outdir}/:/tmp/output:Z \
             -v ${current_path}/../../..:/root:Z \
-            ${container_name} ${opensearch_version} ${future} ${revision} || return 1
+            ${container_name} ${future} ${revision} || return 1
     fi
 
     echo "Base file $(ls -Art ${outdir} | tail -n 1) added to ${outdir}."
@@ -68,7 +67,6 @@ help() {
     echo "Usage: $0 [OPTIONS]"
     echo
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
-    echo "    -v, --version <path>       [Optional] The OpenSearch-dashboards Version. By default, ${opensearch_version}"
     echo "    --reference <ref>          [Optional] wazuh-packages branch or tag"
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
     echo "    -r, --revision <rev>       [Optional] Package revision. By default ${revision}"
@@ -89,14 +87,6 @@ main() {
         "-s"|"--store")
             if [ -n "${2}" ]; then
                 outdir="${2}"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "-v"|"--version")
-            if [ -n "${2}" ]; then
-                opensearch_version="${2}"
                 shift 2
             else
                 help 1

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -16,7 +16,6 @@ build_docker="yes"
 deb_amd64_builder="deb_dashboard_builder_amd64"
 deb_builder_dockerfile="${current_path}/docker"
 future="no"
-base_path="/tmp"
 base_cmd=""
 
 trap ctrl_c INT
@@ -48,7 +47,7 @@ build_deb() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -60,12 +59,10 @@ build_deb() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
             ${future} ${reference} || return 1
     else
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} ${revision} \
             ${future} || return 1

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -16,8 +16,8 @@ build_docker="yes"
 deb_amd64_builder="deb_dashboard_builder_amd64"
 deb_builder_dockerfile="${current_path}/docker"
 future="no"
-base="s3"
-base_path="${current_path}/../base/output"
+base_path="/tmp"
+base_cmd=""
 
 trap ctrl_c INT
 
@@ -41,6 +41,15 @@ build_deb() {
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
+    # Base generation
+    if [ "${future}" == "yes" ];then
+        base_cmd+="--future "
+    fi
+    if [ "${reference}" ];then
+        base_cmd+="--reference ${reference}"
+    fi
+    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
         docker build -t ${container_name} ${dockerfile_path} || return 1
@@ -51,16 +60,15 @@ build_deb() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
-            ${future} ${base} ${reference} || return 1
+            ${future} ${reference} || return 1
     else
-        if [ "${base}" = "local" ];then
-            volumes="${volumes} -v ${base_path}:/root/output:Z"
-        fi
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} ${revision} \
-            ${future} ${base} || return 1
+            ${future} || return 1
     fi
 
     echo "Package $(ls -Art ${outdir} | tail -n 1) added to ${outdir}."
@@ -94,8 +102,6 @@ help() {
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
-    echo "    --base <s3/local>          [Optional] Base file location, use local or s3, default: s3"
-    echo "    --base-path                [Optional] If base is local, you can indicate the full path where the base is located, default: stack/dashboard/base/output"
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -140,22 +146,6 @@ main() {
         "--future")
             future="yes"
             shift 1
-            ;;
-        "--base")
-            if [ -n "${2}" ]; then
-                base="${2}"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "--base-path")
-            if [ -n "${2}" ]; then
-                base_path="${2}"
-                shift 2
-            else
-                help 1
-            fi
             ;;
         "-s"|"--store")
             if [ -n "${2}" ]; then

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -48,7 +48,7 @@ build_deb() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then

--- a/stack/dashboard/deb/builder.sh
+++ b/stack/dashboard/deb/builder.sh
@@ -62,7 +62,7 @@ cd ${source_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
 
 # Build package
-debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
+debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eVERSION="${version}" -eREVISION="${revision}" -b -uc -us
 
 deb_file="${target}_${version}-${revision}_${architecture}.deb"
 

--- a/stack/dashboard/deb/builder.sh
+++ b/stack/dashboard/deb/builder.sh
@@ -8,14 +8,13 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 # Script parameters to build the package
 target="wazuh-dashboard"
 architecture=$1
 revision=$2
 future=$3
-base_location=$4
-reference=$5
+reference=$4
 directory_base="/usr/share/wazuh-dashboard"
 
 if [ -z "${revision}" ]; then
@@ -63,7 +62,7 @@ cd ${source_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
 
 # Build package
-debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE="${base_location}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
+debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
 
 deb_file="${target}_${version}-${revision}_${architecture}.deb"
 

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -52,12 +52,7 @@ override_dh_auto_install:
 # -----------------------------------------------------------------------------
 
 override_dh_install:
-	if [ "$(BASE)" = "s3" ]; then \
-		curl -kOL https://packages-dev.wazuh.com/stack/dashboard/base/$(DASHBOARD_FILE) ;\
-	else \
-		cp /root/output/$(DASHBOARD_FILE) ./ ;\
-	fi
-
+	cp /root/output/$(DASHBOARD_FILE) ./ ;\
 
 	groupadd $(GROUP)
 	useradd -g $(GROUP) $(USER)
@@ -92,7 +87,7 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
 	if [ "$(BASE_VERSION)" = "99.99.0" ]; then \
-		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip" ;\
+		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-$(BASE_REVISION).zip" ;\
 	else \
 		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-${BASE_REVISION}.zip" ;\
 	fi

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -52,7 +52,7 @@ override_dh_auto_install:
 # -----------------------------------------------------------------------------
 
 override_dh_install:
-	cp /root/output/$(DASHBOARD_FILE) ./ ;\
+	cp /root/output/$(DASHBOARD_FILE) ./
 
 	groupadd $(GROUP)
 	useradd -g $(GROUP) $(USER)

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -30,7 +30,7 @@ export CONFIG_DIR=/etc/${NAME}
 export INSTALLATION_DIR=$(INSTALLATION_DIR)
 export USER=${NAME}
 export GROUP=${NAME}
-export DASHBOARD_FILE=wazuh-dashboard-base-$(BASE_VERSION)-$(BASE_REVISION)-linux-x64.tar.xz
+export DASHBOARD_FILE=wazuh-dashboard-base-$(VERSION)-$(REVISION)-linux-x64.tar.xz
 
 # -----------------------------------------------------------------------------
 
@@ -86,10 +86,10 @@ override_dh_install:
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/systemd/system/$(NAME)
 	chown $(USER):$(GROUP) $(TARGET_DIR)/etc/default/$(NAME)
 
-	if [ "$(BASE_VERSION)" = "99.99.0" ]; then \
-		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-$(BASE_REVISION).zip" ;\
+	if [ "$(VERSION)" = "99.99.0" ]; then \
+		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-$(REVISION).zip" ;\
 	else \
-		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(BASE_VERSION)-${BASE_REVISION}.zip" ;\
+		runuser $(USER) --shell="/bin/bash" --command="$(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-$(VERSION)-${REVISION}.zip" ;\
 	fi
 
 	find $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/wazuh/ -exec chown $(USER):$(GROUP) {} \;

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -52,7 +52,7 @@ override_dh_auto_install:
 # -----------------------------------------------------------------------------
 
 override_dh_install:
-	cp /root/output/$(DASHBOARD_FILE) ./
+	cp /tmp/$(DASHBOARD_FILE) ./
 
 	groupadd $(GROUP)
 	useradd -g $(GROUP) $(USER)

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -16,7 +16,6 @@ build_docker="yes"
 rpm_x86_builder="rpm_dashboard_builder_x86"
 rpm_builder_dockerfile="${current_path}/docker"
 future="no"
-base_path="/tmp"
 base_cmd=""
 
 trap ctrl_c INT
@@ -48,7 +47,7 @@ build_rpm() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -59,12 +58,10 @@ build_rpm() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
             ${future} ${reference} || return 1
     else
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} \
             ${revision} ${future} || return 1

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -16,8 +16,8 @@ build_docker="yes"
 rpm_x86_builder="rpm_dashboard_builder_x86"
 rpm_builder_dockerfile="${current_path}/docker"
 future="no"
-base="s3"
-base_path="${current_path}/../base/output"
+base_path="/tmp"
+base_cmd=""
 
 trap ctrl_c INT
 
@@ -41,6 +41,15 @@ build_rpm() {
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
+    # Base generation
+    if [ "${future}" == "yes" ];then
+        base_cmd+="--future "
+    fi
+    if [ "${reference}" ];then
+        base_cmd+="--reference ${reference}"
+    fi
+    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
         docker build -t ${container_name} ${dockerfile_path} || return 1
@@ -50,16 +59,15 @@ build_rpm() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
-            ${future} ${base} ${reference} || return 1
+            ${future} ${reference} || return 1
     else
-        if [ "${base}" = "local" ];then
-            volumes="${volumes} -v ${base_path}:/root/output:Z"
-        fi
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} \
-            ${revision} ${future} ${base} || return 1
+            ${revision} ${future} || return 1
     fi
 
     echo "Package $(ls -Art ${outdir} | tail -n 1) added to ${outdir}."
@@ -93,8 +101,6 @@ help() {
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
-    echo "    --base <s3/local>          [Optional] Base file location, use local or s3, default: s3"
-    echo "    --base-path                [Optional] If base is local, you can indicate the full path where the base is located, default: stack/dashboard/base/output"
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -139,22 +145,6 @@ main() {
         "--future")
             future="yes"
             shift 1
-            ;;
-        "--base")
-            if [ -n "$2" ]; then
-                base="$2"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "--base-path")
-            if [ -n "$2" ]; then
-                base_path="$2"
-                shift 2
-            else
-                help 1
-            fi
             ;;
         "-s"|"--store")
             if [ -n "$2" ]; then

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -48,7 +48,7 @@ build_rpm() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then

--- a/stack/dashboard/rpm/builder.sh
+++ b/stack/dashboard/rpm/builder.sh
@@ -14,8 +14,7 @@ target="wazuh-dashboard"
 architecture=$1
 revision=$2
 future=$3
-base_location=$4
-reference=$5
+reference=$4
 directory_base="/usr/share/wazuh-dashboard"
 
 if [ -z "${revision}" ]; then
@@ -61,7 +60,6 @@ cd ${build_dir} && tar czf "${rpm_build_dir}/SOURCES/${pkg_name}.tar.gz" "${pkg_
 # Building RPM
 /usr/bin/rpmbuild --define "_topdir ${rpm_build_dir}" --define "_version ${version}" \
     --define "_release ${revision}" --define "_localstatedir ${directory_base}" \
-    --define "_base ${base_location}" \
     --target ${architecture} -ba ${rpm_build_dir}/SPECS/${pkg_name}.spec
 
 cd ${pkg_path} && sha512sum ${rpm_file} > /tmp/${rpm_file}.sha512

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -42,12 +42,8 @@ Wazuh dashboard is a user interface and visualization tool for security-related 
 
 %prep
 
-# Set up required files
-if [ "%{_base}" = "s3" ];then
-    curl -kOL https://packages-dev.wazuh.com/stack/dashboard/base/%{DASHBOARD_FILE}
-else
-    cp /root/output/%{DASHBOARD_FILE} ./
-fi
+cp /root/output/%{DASHBOARD_FILE} ./
+
 groupadd %{GROUP}
 useradd -g %{GROUP} %{USER}
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -42,7 +42,7 @@ Wazuh dashboard is a user interface and visualization tool for security-related 
 
 %prep
 
-cp /root/output/%{DASHBOARD_FILE} ./
+cp /tmp/%{DASHBOARD_FILE} ./
 
 groupadd %{GROUP}
 useradd -g %{GROUP} %{USER}

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -90,7 +90,7 @@ chown %{USER}:%{GROUP} %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 chown %{USER}:%{GROUP} %{buildroot}/etc/init.d/wazuh-dashboard
 
 if [ "%{version}" = "99.99.0" ];then
-    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-1.zip"
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
 else
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
 fi

--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -10,10 +10,10 @@
 
 set -e
 
-opensearch_version="${1}"
-future="${2}"
-revision="${3}"
-reference="${4}"
+future="${1}"
+revision="${2}"
+reference="${3}"
+opensearch_version="2.1.0"
 base_dir=/tmp/output/wazuh-indexer-base
 
 # -----------------------------------------------------------------------------

--- a/stack/indexer/base/generate_base.sh
+++ b/stack/indexer/base/generate_base.sh
@@ -11,8 +11,6 @@
 set -e
 
 reference=""
-opensearch_version="2.1.0"
-
 current_path="$( cd $(dirname $0) ; pwd -P )"
 outdir="${current_path}/output"
 dockerfile_path="${current_path}/docker"
@@ -49,11 +47,11 @@ build_base() {
     # Build the RPM package with a Docker container
     if [ "${reference}" ];then
         docker run -t --rm -v ${outdir}/:/tmp/output:Z \
-            ${container_name} ${opensearch_version} ${future} ${revision} ${reference} || return 1
+            ${container_name} ${future} ${revision} ${reference} || return 1
     else
         docker run -t --rm -v ${outdir}/:/tmp/output:Z \
             -v ${current_path}/../../..:/root:Z \
-            ${container_name} ${opensearch_version} ${future} ${revision} || return 1
+            ${container_name} ${future} ${revision} || return 1
     fi
 
     echo "Base file $(ls -Art ${outdir} | tail -n 1) added to ${outdir}."
@@ -68,7 +66,6 @@ help() {
     echo "Usage: $0 [OPTIONS]"
     echo
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
-    echo "    -v, --version <version>   [Optional] OpenSearch version, by default ${opensearch_version}"
     echo "    --reference <ref>     [Optional] wazuh-packages branch or tag"
     echo "    --future              [Optional] Build test future package 99.99.0 Used for development purposes."
     echo "    -r, --revision <rev>  [Optional] Package revision. By default ${revision}"
@@ -89,14 +86,6 @@ main() {
         "-s"|"--store")
             if [ -n "${2}" ]; then
                 outdir="${2}"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "-v"|"--version")
-            if [ -n "${2}" ]; then
-                opensearch_version="${2}"
                 shift 2
             else
                 help 1

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -16,7 +16,6 @@ build_docker="yes"
 deb_amd64_builder="deb_indexer_builder_amd64"
 deb_builder_dockerfile="${current_path}/docker"
 future="no"
-base_path="/tmp"
 base_cmd=""
 
 trap ctrl_c INT
@@ -48,7 +47,7 @@ build_deb() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -60,12 +59,10 @@ build_deb() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
             ${future} ${reference} || return 1
     else
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} \
             ${revision} ${future} || return 1

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -48,7 +48,7 @@ build_deb() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then

--- a/stack/indexer/deb/builder.sh
+++ b/stack/indexer/deb/builder.sh
@@ -61,7 +61,7 @@ cd ${source_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
 
 # Build package
-debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
+debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eVERSION="${version}" -eREVISION="${revision}" -b -uc -us
 
 deb_file="${target}_${version}-${revision}_${architecture}.deb"
 

--- a/stack/indexer/deb/builder.sh
+++ b/stack/indexer/deb/builder.sh
@@ -8,15 +8,14 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 
 # Script parameters to build the package
 target="wazuh-indexer"
 architecture=$1
 revision=$2
 future=$3
-base_location=$4
-reference=$5
+reference=$4
 directory_base="/usr/share/wazuh-indexer"
 
 if [ -z "${revision}" ]; then
@@ -62,7 +61,7 @@ cd ${source_dir}
 mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
 
 # Build package
-debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE="${base_location}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
+debuild --no-lintian -eINSTALLATION_DIR="${directory_base}" -eBASE_VERSION="${version}" -eBASE_REVISION="${revision}" -b -uc -us
 
 deb_file="${target}_${version}-${revision}_${architecture}.deb"
 

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -36,7 +36,7 @@ export LIB_DIR=/var/lib/${NAME}
 export PID_DIR=/run/${NAME}
 export SYS_DIR=/usr/lib
 export BASE_DIR=${NAME}-*
-export INDEXER_FILE=wazuh-indexer-base-$(BASE_VERSION)-$(BASE_REVISION)-linux-x64.tar.xz
+export INDEXER_FILE=wazuh-indexer-base-$(VERSION)-$(REVISION)-linux-x64.tar.xz
 export REPO_DIR=/root/unattended_installer
 
 # -----------------------------------------------------------------------------

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -60,12 +60,8 @@ override_dh_auto_install:
 
 override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
+	cp /root/output/$(INDEXER_FILE) ./ ;\
 
-	if [ "$(BASE)" = "s3" ]; then \
-		curl -kOL https://packages-dev.wazuh.com/stack/indexer/base/$(INDEXER_FILE) ;\
-	else \
-		cp /root/output/$(INDEXER_FILE) ./ ;\
-	fi
 	tar -xf $(INDEXER_FILE)
 
 	# Copy to the target

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -60,7 +60,7 @@ override_dh_auto_install:
 
 override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
-	cp /root/output/$(INDEXER_FILE) ./
+	cp /tmp/$(INDEXER_FILE) ./
 
 	tar -xf $(INDEXER_FILE)
 

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -60,7 +60,7 @@ override_dh_auto_install:
 
 override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
-	cp /root/output/$(INDEXER_FILE) ./ ;\
+	cp /root/output/$(INDEXER_FILE) ./
 
 	tar -xf $(INDEXER_FILE)
 

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -18,7 +18,6 @@ build_docker="yes"
 rpm_x86_builder="rpm_indexer_builder_x86"
 rpm_builder_dockerfile="${current_path}/docker"
 future="no"
-base_path="/tmp"
 base_cmd=""
 
 trap ctrl_c INT
@@ -50,7 +49,7 @@ build_rpm() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -61,12 +60,10 @@ build_rpm() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
             ${future} ${reference} || return 1
     else
         docker run -t --rm ${volumes} \
-            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} \
             ${revision} ${future} || return 1

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -50,7 +50,7 @@ build_rpm() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+    ../base/generate_base.sh -s ${base_path} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -18,8 +18,8 @@ build_docker="yes"
 rpm_x86_builder="rpm_indexer_builder_x86"
 rpm_builder_dockerfile="${current_path}/docker"
 future="no"
-base="s3"
-base_path="${current_path}/../base/output"
+base_path="/tmp"
+base_cmd=""
 
 trap ctrl_c INT
 
@@ -43,6 +43,15 @@ build_rpm() {
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
+    # Base generation
+    if [ "${future}" == "yes" ];then
+        base_cmd+="--future "
+    fi
+    if [ "${reference}" ];then
+        base_cmd+="--reference ${reference}"
+    fi
+    ../base/generate_base.sh -s /tmp -r ${revision} ${base_cmd}
+
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
         docker build -t ${container_name} ${dockerfile_path} || return 1
@@ -52,16 +61,15 @@ build_rpm() {
     volumes="-v ${outdir}/:/tmp:Z"
     if [ "${reference}" ];then
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             ${container_name} ${architecture} ${revision} \
-            ${future} ${base} ${reference} || return 1
+            ${future} ${reference} || return 1
     else
-        if [ "${base}" = "local" ];then
-            volumes="${volumes} -v ${base_path}:/root/output:Z"
-        fi
         docker run -t --rm ${volumes} \
+            -v ${base_path}:/root/output:Z \
             -v ${current_path}/../../..:/root:Z \
             ${container_name} ${architecture} \
-            ${revision} ${future} ${base} || return 1
+            ${revision} ${future} || return 1
     fi
 
     echo "Package $(ls -Art ${outdir} | tail -n 1) added to ${outdir}."
@@ -95,8 +103,6 @@ help() {
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --future                   [Optional] Build test future package 99.99.0 Used for development purposes."
-    echo "    --base <s3/local>          [Optional] Base file location, use local or s3, default: s3"
-    echo "    --base-path                [Optional] If base is local, you can indicate the full path where the base is located, default: stack/indexer/base/output"
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -141,22 +147,6 @@ main() {
         "--future")
             future="yes"
             shift 1
-            ;;
-        "--base")
-            if [ -n "$2" ]; then
-                base="$2"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "--base-path")
-            if [ -n "${2}" ]; then
-                base_path="${2}"
-                shift 2
-            else
-                help 1
-            fi
             ;;
         "-s"|"--store")
             if [ -n "$2" ]; then

--- a/stack/indexer/rpm/builder.sh
+++ b/stack/indexer/rpm/builder.sh
@@ -15,8 +15,7 @@ target="wazuh-indexer"
 architecture=$1
 revision=$2
 future=$3
-base_location=$4
-reference=$5
+reference=$4
 directory_base="/usr/share/wazuh-indexer"
 
 if [ -z "${revision}" ]; then
@@ -60,7 +59,6 @@ cd ${build_dir} && tar czf "${rpm_build_dir}/SOURCES/${pkg_name}.tar.gz" "${pkg_
 # Building RPM
 /usr/bin/rpmbuild --define "_topdir ${rpm_build_dir}" --define "_version ${version}" \
     --define "_release ${revision}" --define "_localstatedir ${directory_base}" \
-    --define "_base ${base_location}" \
     --target ${architecture} -ba ${rpm_build_dir}/SPECS/${pkg_name}.spec
 
 cd ${pkg_path} && sha512sum ${rpm_file} > /tmp/${rpm_file}.sha512

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -69,7 +69,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{LIB_DIR}
 mkdir -p ${RPM_BUILD_ROOT}%{SYS_DIR}
 
 # Set up required files
-cp /root/output/%{INDEXER_FILE} ./
+cp /tmp/%{INDEXER_FILE} ./
 
 tar -xf %{INDEXER_FILE} && rm -f %{INDEXER_FILE}
 chown -R %{USER}:%{GROUP} wazuh-indexer-*/*

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -69,11 +69,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{LIB_DIR}
 mkdir -p ${RPM_BUILD_ROOT}%{SYS_DIR}
 
 # Set up required files
-if [ "%{_base}" = "s3" ];then
-    curl -kOL https://packages-dev.wazuh.com/stack/indexer/base/%{INDEXER_FILE}
-else
-    cp /root/output/%{INDEXER_FILE} ./
-fi
+cp /root/output/%{INDEXER_FILE} ./
+
 tar -xf %{INDEXER_FILE} && rm -f %{INDEXER_FILE}
 chown -R %{USER}:%{GROUP} wazuh-indexer-*/*
 


### PR DESCRIPTION
|Related issue|
|---|
| Related https://github.com/wazuh/wazuh-jenkins/issues/3898 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Changes are made in the build_packages.sh, a call is integrated so that the base is generated locally and both the base and the package are built in the same execution

## Logs example

<!--
Paste here related logs
-->
```
-rw-r--r--  1 root    root    141650768 sep  2 16:29 wazuh-dashboard_4.4.0-1_amd64.deb
-rw-r--r--  1 root    root          164 sep  2 16:29 wazuh-dashboard_4.4.0-1_amd64.deb.sha512
-rw-r--r--  1 root    root    172479728 sep  2 16:20 wazuh-dashboard-4.4.0-1.x86_64.rpm
-rw-r--r--  1 root    root          165 sep  2 16:20 wazuh-dashboard-4.4.0-1.x86_64.rpm.sha512
-rw-r--r--  1 root    root    126598524 sep  2 16:27 wazuh-dashboard-base-4.4.0-1-linux-x64.tar.xz
-rw-r--r--  1 root    root    126602520 sep  2 12:52 wazuh-dashboard-base-99.99.0-1-linux-x64.tar.xz
-rw-r--r--  1 root    root    126591984 sep  2 13:15 wazuh-dashboard-base-99.99.0-2-linux-x64.tar.xz
-rw-r--r--  1 root    root    392200282 sep  2 16:44 wazuh-indexer_4.4.0-1_amd64.deb
-rw-r--r--  1 root    root          162 sep  2 16:44 wazuh-indexer_4.4.0-1_amd64.deb.sha512
-rw-r--r--  1 root    root    414535196 sep  2 16:53 wazuh-indexer-4.4.0-1.x86_64.rpm
-rw-r--r--  1 root    root          163 sep  2 16:53 wazuh-indexer-4.4.0-1.x86_64.rpm.sha512
-rw-r--r--  1 root    root    393219320 sep  2 16:07 wazuh-indexer-base-4.3.8-1-linux-x64.tar.xz
-rw-r--r--  1 root    root    393199248 sep  2 16:50 wazuh-indexer-base-4.4.0-1-linux-x64.tar.xz

```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
