### PR TITLE
Reload services on rollback

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -541,6 +541,8 @@ function installCommon_rollBack() {
 
     common_remove_gpg_key
 
+    eval "systemctl daemon-reload ${debug}"
+
     if [ -z "${uninstall}" ]; then
         if [ -n "${rollback_conf}" ] || [ -n "${overwrite}" ]; then
             common_logger "Installation cleaned."


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/1773,  https://github.com/wazuh/wazuh-packages/issues/1822 |

## Description

> NB! This is an exact copy of the PR https://github.com/wazuh/wazuh-packages/pull/1824. It is merged to master whil this one targets 4.4.


During uninstallation, uninstalled services still kept running in-memory (https://github.com/wazuh/wazuh-packages/issues/1773). In order to remove them, first, I added a service removal method (https://github.com/wazuh/wazuh-packages/issues/1774). However, there was a better and simpler method to solve the issue as @DFolchA discovered (https://github.com/wazuh/wazuh-packages/issues/1822), adding a `systemctl daemon-reload` into the common rollback method. This PR does one thing, adds the said command and solves this issue.


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
