### PR TITLE
Fix wazuh offline installation messages

### DIFF
--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -158,11 +158,11 @@ function offline_download() {
 
   eval "chmod 500 ${base_dest_folder}"
 
-  common_logger "The configuration files and assets are in ${dest_path}"
+  common_logger "The configuration files and assets are in wazuh-offline.tar.gz"
 
   eval "tar -czf ${base_dest_folder}.tar.gz ${base_dest_folder}"
   eval "chmod -R 700 ${base_dest_folder} && rm -rf ${base_dest_folder}"
 
-  common_logger "You can follow the installation guide here https://documentation.wazuh.com/current/installation-guide/more-installation-alternatives/offline-installation.html"
+  common_logger "You can follow the installation guide here https://documentation.wazuh.com/current/deployment-options/offline-installation.html"
 
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1799|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Two messages that appear when downloading the files for offline installation needed to be updated.
- The URL was outdated, now it has a new one.
- The message about where the configuration files and assets are stored was not accurate.

## Logs example

````
root@ubuntu2004:/home/vagrant# bash wazuh-install.sh -dw rpm
06/09/2022 14:02:52 INFO: Starting Wazuh installation assistant. Wazuh version: 4.4.0
06/09/2022 14:02:52 INFO: Verbose logging redirected to /var/log/wazuh-install.log
06/09/2022 14:02:53 INFO: --- Download Packages ---
06/09/2022 14:02:53 INFO: Starting Wazuh packages download.
06/09/2022 14:02:53 INFO: Downloading Wazuh rpm packages for x86_64.
06/09/2022 14:02:56 INFO: The manager package was downloaded.
06/09/2022 14:03:00 INFO: The filebeat package was downloaded.
06/09/2022 14:03:01 INFO: The indexer package was downloaded.
06/09/2022 14:03:01 INFO: The dashboard package was downloaded.
06/09/2022 14:03:01 INFO: The packages are in wazuh-offline/wazuh-packages
06/09/2022 14:03:01 INFO: Downloading configuration files and assets.
06/09/2022 14:03:01 INFO: The resource https://packages.wazuh.com/key/GPG-KEY-WAZUH was downloaded.
06/09/2022 14:03:02 INFO: The resource https://packages.wazuh.com/4.4/tpl/wazuh/filebeat/filebeat.yml was downloaded.
06/09/2022 14:03:02 INFO: The resource https://raw.githubusercontent.com/wazuh/wazuh/4.4/extensions/elasticsearch/7.x/wazuh-template.json was downloaded.
06/09/2022 14:03:02 INFO: The resource https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz was downloaded.
06/09/2022 14:03:02 INFO: The configuration files and assets are in wazuh-offline.tar.gz
06/09/2022 14:03:03 INFO: You can follow the installation guide here https://documentation.wazuh.com/current/deployment-options/offline-installation.html
````

````
root@ubuntu2004:/home/vagrant# bash wazuh-install.sh -dw deb
06/09/2022 13:56:23 INFO: Starting Wazuh installation assistant. Wazuh version: 4.4.0
06/09/2022 13:56:23 INFO: Verbose logging redirected to /var/log/wazuh-install.log
06/09/2022 13:56:24 INFO: --- Download Packages ---
06/09/2022 13:56:24 INFO: Starting Wazuh packages download.
06/09/2022 13:56:24 INFO: Downloading Wazuh deb packages for x86_64.
06/09/2022 13:56:27 INFO: The manager package was downloaded.
06/09/2022 13:56:31 INFO: The filebeat package was downloaded.
06/09/2022 13:56:31 INFO: The indexer package was downloaded.
06/09/2022 13:56:31 INFO: The dashboard package was downloaded.
06/09/2022 13:56:31 INFO: The packages are in wazuh-offline/wazuh-packages
06/09/2022 13:56:31 INFO: Downloading configuration files and assets.
06/09/2022 13:56:31 INFO: The resource https://packages.wazuh.com/key/GPG-KEY-WAZUH was downloaded.
06/09/2022 13:56:32 INFO: The resource https://packages.wazuh.com/4.4/tpl/wazuh/filebeat/filebeat.yml was downloaded.
06/09/2022 13:56:32 INFO: The resource https://raw.githubusercontent.com/wazuh/wazuh/4.4/extensions/elasticsearch/7.x/wazuh-template.json was downloaded.
06/09/2022 13:56:33 INFO: The resource https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz was downloaded.
06/09/2022 13:56:33 INFO: The configuration files and assets are in wazuh-offline.tar.gz
06/09/2022 13:56:33 INFO: You can follow the installation guide here https://documentation.wazuh.com/current/deployment-options/offline-installation.html
root@ubuntu2004:/home/vagrant# ls
wazuh-install.sh  wazuh-offline.tar.gz
````

