### PR TITLE
Changed the internal directory in the base container

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -15,7 +15,7 @@ future="${1}"
 revision="${2}"
 reference="${3}"
 opensearch_version="2.1.0"
-base_dir=/tmp/output/wazuh-dashboard-base
+base_dir=/opt/wazuh-dashboard-base
 
 # -----------------------------------------------------------------------------
 
@@ -39,7 +39,7 @@ wazuh_minor=$(echo ${version} | cut -c1-3)
 # -----------------------------------------------------------------------------
 
 mkdir -p /tmp/output
-cd /tmp/output
+cd /opt
 
 curl -sL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/"${opensearch_version}"/opensearch-dashboards-"${opensearch_version}"-linux-x64.tar.gz | tar xz
 
@@ -136,6 +136,7 @@ find -type f -perm 755 -exec chmod 750 {} \;
 # -----------------------------------------------------------------------------
 
 # Base output
-cd /tmp/output
+cd /opt
 tar -cJf wazuh-dashboard-base-"${version}"-"${revision}"-linux-x64.tar.xz wazuh-dashboard-base
 rm -rf "${base_dir}"
+cp wazuh-dashboard-base-"${version}"-"${revision}"-linux-x64.tar.xz /tmp/output/

--- a/stack/dashboard/rpm/builder.sh
+++ b/stack/dashboard/rpm/builder.sh
@@ -8,7 +8,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 # Script parameters to build the package
 target="wazuh-dashboard"
 architecture=$1

--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -14,7 +14,7 @@ future="${1}"
 revision="${2}"
 reference="${3}"
 opensearch_version="2.1.0"
-base_dir=/tmp/output/wazuh-indexer-base
+base_dir=/opt/wazuh-indexer-base
 
 # -----------------------------------------------------------------------------
 
@@ -40,7 +40,7 @@ fi
 # -----------------------------------------------------------------------------
 
 mkdir -p /tmp/output
-cd /tmp/output
+cd /opt
 
 curl -sL https://artifacts.opensearch.org/releases/bundle/opensearch/"${opensearch_version}"/opensearch-"${opensearch_version}"-linux-x64.tar.gz | tar xz
 
@@ -80,6 +80,7 @@ rm -rf OpenSearch
 # -----------------------------------------------------------------------------
 
 # Base output
-cd /tmp/output
+cd /opt
 tar -Jcvf wazuh-indexer-base-"${version}"-"${revision}"-linux-x64.tar.xz wazuh-indexer-base
 rm -rf "${base_dir}"
+cp wazuh-indexer-base-"${version}"-"${revision}"-linux-x64.tar.xz /tmp/output

--- a/stack/indexer/rpm/builder.sh
+++ b/stack/indexer/rpm/builder.sh
@@ -8,7 +8,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 
 # Script parameters to build the package
 target="wazuh-indexer"


### PR DESCRIPTION
|Related issue|
|---|
|related https://github.com/wazuh/wazuh-jenkins/issues/3898|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
A change is made to the base builders so that the base creation process is done inside an internal directory of the container, and then only the .tar is copied to the mounted directory

This change is motivated by performance problems with the EFS when creating the bases in AWS.

With this the performance improves substantially.
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests
#### Before fix
```
2022-09-07T07:17:44.723-03:00 | + curl -sL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.1.0/opensearch-dashboards-2.1.0-linux-x64.tar.gz
2022-09-07T07:17:44.723-03:00 | + tar xz
2022-09-07T07:46:08.426-03:00 | + mv opensearch-dashboards-2.1.0 /tmp/output/wazuh-dashboard-base
```
#### After fix
```
2022-09-07T11:38:29.537-03:00 | + curl -sL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.1.0/opensearch-dashboards-2.1.0-linux-x64.tar.gz
2022-09-07T11:38:29.537-03:00 | + tar xz
2022-09-07T11:38:37.550-03:00 | + mv opensearch-dashboards-2.1.0 /opt/wazuh-dashboard-base
```


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
