### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -288,7 +288,7 @@ function installCommon_installPrerequisites() {
         fi
 
     elif [ "${sys_type}" == "apt-get" ]; then
-        eval "apt update -q ${debug}"
+        eval "apt-get update -q ${debug}"
         dependencies=( apt-transport-https curl libcap2-bin tar software-properties-common gnupg openssl )
         not_installed=()
 
@@ -467,7 +467,7 @@ function installCommon_rollBack() {
         if [ "${sys_type}" == "yum" ]; then
             eval "yum remove wazuh-manager -y ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt remove --purge wazuh-manager -y ${debug}"
+            eval "apt-get remove --purge wazuh-manager -y ${debug}"
         fi
         common_logger "Wazuh manager removed."
     fi
@@ -481,7 +481,7 @@ function installCommon_rollBack() {
         if [ "${sys_type}" == "yum" ]; then
             eval "yum remove wazuh-indexer -y ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt remove --purge wazuh-indexer -y ${debug}"
+            eval "apt-get remove --purge wazuh-indexer -y ${debug}"
         fi
         common_logger "Wazuh indexer removed."
     fi
@@ -497,7 +497,7 @@ function installCommon_rollBack() {
         if [ "${sys_type}" == "yum" ]; then
             eval "yum remove filebeat -y ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt remove --purge filebeat -y ${debug}"
+            eval "apt-get remove --purge filebeat -y ${debug}"
         fi
         common_logger "Filebeat removed."
     fi
@@ -513,7 +513,7 @@ function installCommon_rollBack() {
         if [ "${sys_type}" == "yum" ]; then
             eval "yum remove wazuh-dashboard -y ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt remove --purge wazuh-dashboard -y ${debug}"
+            eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
         fi
         common_logger "Wazuh dashboard removed."
     fi


### PR DESCRIPTION
|Related issue|
|---|
|#1756|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR changes the use of apt with apt-get to avoid warning messages.
```
WARNING : apt does not have a stable CLI interface. Use with caution in scripts.

 ```

## Tests

<details><summary>Test logs</summary>

```
root@ubuntu:/home/vagrant/repo# ./wazuh-install.sh -a -v
05/09/2022 15:08:56 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.7
05/09/2022 15:08:56 INFO: Verbose logging redirected to /var/log/wazuh-install.log
Hit:1 http://in.archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://in.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:3 http://in.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:4 http://in.archive.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:5 http://in.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2075 kB]
Get:6 http://in.archive.ubuntu.com/ubuntu focal-updates/main Translation-en [369 kB]
Get:7 http://in.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1252 kB]
Get:8 http://in.archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [178 kB]
Get:9 http://in.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [949 kB]
Get:10 http://in.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [216 kB]
Get:11 http://in.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [24.4 kB]
Get:12 http://in.archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.6 kB]
Get:13 http://in.archive.ubuntu.com/ubuntu focal-backports/main Translation-en [16.3 kB]
Get:14 http://in.archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [23.9 kB]
Get:15 http://in.archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [16.0 kB]
Get:16 http://in.archive.ubuntu.com/ubuntu focal-security/main amd64 Packages [1705 kB]
Get:17 http://in.archive.ubuntu.com/ubuntu focal-security/main Translation-en [286 kB]
Get:18 http://in.archive.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1165 kB]
Get:19 http://in.archive.ubuntu.com/ubuntu focal-security/restricted Translation-en [165 kB]
Get:20 http://in.archive.ubuntu.com/ubuntu focal-security/universe amd64 Packages [717 kB]
Get:21 http://in.archive.ubuntu.com/ubuntu focal-security/universe Translation-en [131 kB]
Get:22 http://in.archive.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [22.2 kB]
Fetched 9694 kB in 2s (4770 kB/s)
Reading package lists...
05/09/2022 15:09:02 INFO: --- Dependencies ----
05/09/2022 15:09:02 INFO: Installing apt-transport-https.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  apt-transport-https
0 upgraded, 1 newly installed, 0 to remove and 69 not upgraded.
Need to get 1704 B of archives.
After this operation, 162 kB of additional disk space will be used.
Get:1 http://in.archive.ubuntu.com/ubuntu focal-updates/universe amd64 apt-transport-https all 2.0.9 [1704 B]
Fetched 1704 B in 0s (15.7 kB/s)
                                Selecting previously unselected package apt-transport-https.
(Reading database ... 41035 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_2.0.9_all.deb ...
Unpacking apt-transport-https (2.0.9) ...
Setting up apt-transport-https (2.0.9) ...
05/09/2022 15:09:03 DEBUG: Adding the Wazuh repository.
Warning: apt-key output should not be parsed (stdout is not a terminal)
OK
deb https://packages.wazuh.com/4.x/apt/ stable main
Hit:1 http://in.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://in.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://in.archive.ubuntu.com/ubuntu focal-backports InRelease
Get:4 https://packages.wazuh.com/4.x/apt stable InRelease [17.3 kB]
Hit:5 http://in.archive.ubuntu.com/ubuntu focal-security InRelease
Get:6 https://packages.wazuh.com/4.x/apt stable/main amd64 Packages [24.0 kB]
Fetched 41.3 kB in 0s (95.1 kB/s)
Reading package lists...
05/09/2022 15:09:06 INFO: Wazuh repository added.
05/09/2022 15:09:06 INFO: --- Configuration files ---
05/09/2022 15:09:06 INFO: Generating configuration files.
05/09/2022 15:09:06 DEBUG: Creating the root certificate.
Generating a RSA private key
.......................................+++++
..................................................................+++++
writing new private key to '/tmp/wazuh-certificates//root-ca.key'
-----
Generating RSA private key, 2048 bit long modulus (2 primes)
.+++++
.....................................................................+++++
e is 65537 (0x010001)
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
Getting CA Private Key
05/09/2022 15:09:06 DEBUG: Creating the Wazuh indexer certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
.......................+++++
....................................+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-indexer-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-indexer
Getting CA Private Key
05/09/2022 15:09:06 DEBUG: Creating the Wazuh server certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
.......................+++++
.....................................+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-server-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-server
Getting CA Private Key
05/09/2022 15:09:06 DEBUG: Creating the Wazuh dashboard certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
..........+++++
............+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-dashboard-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-dashboard
Getting CA Private Key
05/09/2022 15:09:06 DEBUG: Generating random passwords.
05/09/2022 15:09:06 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
05/09/2022 15:09:07 INFO: --- Wazuh indexer ---
05/09/2022 15:09:07 INFO: Starting Wazuh indexer installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 69 not upgraded.
Need to get 363 MB of archives.
After this operation, 639 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-indexer amd64 4.3.7-1 [363 MB]
Fetched 363 MB in 14s (25.1 MB/s)
                                 Selecting previously unselected package wazuh-indexer.
(Reading database ... 41039 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.3.7-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.3.7-1) ...
Setting up wazuh-indexer (4.3.7-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for systemd (245.4-4ubuntu3.17) ...
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
05/09/2022 15:09:46 INFO: Wazuh indexer installation finished.
05/09/2022 15:09:46 DEBUG: Configuring Wazuh indexer.
05/09/2022 15:09:46 INFO: Wazuh indexer post-install configuration finished.
05/09/2022 15:09:46 INFO: Starting service wazuh-indexer.
Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
05/09/2022 15:09:56 INFO: wazuh-indexer service started.
05/09/2022 15:09:56 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
WARNING: Seems you want connect to the OpenSearch HTTP port.
         securityadmin connects on the transport port which is normally 9300.
Will connect to 127.0.0.1:9200 ... done
ERR: Cannot connect to OpenSearch. Please refer to opensearch logfile for more information
Trace:
NoNodeAvailableException[None of the configured nodes are available: [{#transport#-1}{YO0Dp3znTD-6lpIV6EZAuA}{127.0.0.1}{127.0.0.1:9200}]]
	at org.opensearch.client.transport.TransportClientNodesService.ensureNodesAreAvailable(TransportClientNodesService.java:381)
	at org.opensearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:272)
	at org.opensearch.client.transport.TransportProxyClient.execute(TransportProxyClient.java:79)
	at org.opensearch.client.transport.TransportClient.doExecute(TransportClient.java:484)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:433)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:419)
	at org.opensearch.security.tools.SecurityAdmin.execute(SecurityAdmin.java:524)
	at org.opensearch.security.tools.SecurityAdmin.main(SecurityAdmin.java:157)


05/09/2022 15:10:59 INFO: Wazuh indexer cluster initialized.
05/09/2022 15:10:59 INFO: --- Wazuh server ---
05/09/2022 15:10:59 INFO: Starting the Wazuh manager installation.
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 69 not upgraded.
Need to get 120 MB of archives.
After this operation, 461 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-manager amd64 4.3.7-1 [120 MB]
Fetched 120 MB in 6s (20.8 MB/s)
                                Selecting previously unselected package wazuh-manager.
(Reading database ... 41984 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.3.7-1_amd64.deb ...
Unpacking wazuh-manager (4.3.7-1) ...
Setting up wazuh-manager (4.3.7-1) ...
Processing triggers for systemd (245.4-4ubuntu3.17) ...
05/09/2022 15:11:40 INFO: Wazuh manager installation finished.
05/09/2022 15:11:40 INFO: Starting service wazuh-manager.
Synchronizing state of wazuh-manager.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-manager
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
05/09/2022 15:11:57 INFO: wazuh-manager service started.
05/09/2022 15:11:57 INFO: Starting Filebeat installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  filebeat
0 upgraded, 1 newly installed, 0 to remove and 69 not upgraded.
Need to get 22.1 MB of archives.
After this operation, 73.6 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 filebeat amd64 7.10.2 [22.1 MB]
Fetched 22.1 MB in 1s (18.4 MB/s)
                                 Selecting previously unselected package filebeat.
(Reading database ... 60676 files and directories currently installed.)
Preparing to unpack .../filebeat_7.10.2_amd64.deb ...
Unpacking filebeat (7.10.2) ...
Setting up filebeat (7.10.2) ...
Processing triggers for systemd (245.4-4ubuntu3.17) ...
05/09/2022 15:12:01 INFO: Filebeat installation finished.
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
05/09/2022 15:12:01 INFO: Filebeat post-install configuration finished.
05/09/2022 15:12:01 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
05/09/2022 15:12:03 INFO: filebeat service started.
05/09/2022 15:12:03 INFO: --- Wazuh dashboard ---
05/09/2022 15:12:03 INFO: Starting Wazuh dashboard installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-dashboard
0 upgraded, 1 newly installed, 0 to remove and 69 not upgraded.
Need to get 131 MB of archives.
After this operation, 638 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-dashboard amd64 4.3.7-1 [131 MB]
Fetched 131 MB in 5s (26.4 MB/s)
                                Selecting previously unselected package wazuh-dashboard.
(Reading database ... 60995 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.3.7-1_amd64.deb ...
Creating wazuh-dashboard group... OK
Creating wazuh-dashboard user... OK
Unpacking wazuh-dashboard (4.3.7-1) ...
Setting up wazuh-dashboard (4.3.7-1) ...
05/09/2022 15:12:35 INFO: Wazuh dashboard installation finished.
05/09/2022 15:12:35 DEBUG: Wazuh dashboard certificate setup finished.
05/09/2022 15:12:35 INFO: Wazuh dashboard post-install configuration finished.
05/09/2022 15:12:35 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
05/09/2022 15:12:36 INFO: wazuh-dashboard service started.
05/09/2022 15:12:36 DEBUG: Setting Wazuh indexer cluster passwords.
grep: /etc/wazuh-indexer/opensearch-security/internal_users.yml: No such file or directory
05/09/2022 15:12:37 DEBUG: The given user admin does not exist
05/09/2022 15:12:37 DEBUG: The given user kibanaserver does not exist
05/09/2022 15:12:37 DEBUG: The given user kibanaro does not exist
05/09/2022 15:12:37 DEBUG: The given user logstash does not exist
05/09/2022 15:12:37 DEBUG: The given user readall does not exist
05/09/2022 15:12:37 DEBUG: The given user snapshotrestore does not exist
05/09/2022 15:12:37 DEBUG: Generating password hashes.
05/09/2022 15:12:41 DEBUG: Password hashes generated.
Successfully updated the keystore
05/09/2022 15:12:41 DEBUG: filebeat started.
05/09/2022 15:12:41 DEBUG: Loading new passwords changes.
Security Admin v7
WARNING: Seems you want connect to the OpenSearch HTTP port.
         securityadmin connects on the transport port which is normally 9300.
Will connect to 127.0.0.1:9200 ... done
ERR: Cannot connect to OpenSearch. Please refer to opensearch logfile for more information
Trace:
NoNodeAvailableException[None of the configured nodes are available: [{#transport#-1}{MNJDsoSOSymoxkJ-bgMO6A}{127.0.0.1}{127.0.0.1:9200}]]
	at org.opensearch.client.transport.TransportClientNodesService.ensureNodesAreAvailable(TransportClientNodesService.java:381)
	at org.opensearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:272)
	at org.opensearch.client.transport.TransportProxyClient.execute(TransportProxyClient.java:79)
	at org.opensearch.client.transport.TransportClient.doExecute(TransportClient.java:484)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:433)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:419)
	at org.opensearch.security.tools.SecurityAdmin.execute(SecurityAdmin.java:524)
	at org.opensearch.security.tools.SecurityAdmin.main(SecurityAdmin.java:157)


05/09/2022 15:13:43 DEBUG: Passwords changed.
05/09/2022 15:14:46 INFO: Initializing Wazuh dashboard web application.
05/09/2022 15:16:46 ERROR: Cannot connect to Wazuh dashboard.
05/09/2022 15:16:46 INFO: --- Removing existing Wazuh installation ---
05/09/2022 15:16:46 INFO: Removing Wazuh manager.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-manager*
0 upgraded, 0 newly installed, 1 to remove and 69 not upgraded.
After this operation, 461 MB disk space will be freed.
(Reading database ... 121084 files and directories currently installed.)... 
Removing wazuh-manager (4.3.7-1) ...
(Reading database ... 102410 files and directories currently installed.)
Purging configuration files for wazuh-manager (4.3.7-1) ...
Processing triggers for systemd (245.4-4ubuntu3.17) ...
05/09/2022 15:16:53 INFO: Wazuh manager removed.
05/09/2022 15:16:53 INFO: Removing Wazuh indexer.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 69 not upgraded.
After this operation, 639 MB disk space will be freed.
(Reading database ... 102392 files and directories currently installed.)... 
Removing wazuh-indexer (4.3.7-1) ...
Stopping wazuh-indexer service... OK
(Reading database ... 101460 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.3.7-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/usr/lib/systemd/system' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
Processing triggers for systemd (245.4-4ubuntu3.17) ...
05/09/2022 15:16:56 INFO: Wazuh indexer removed.
05/09/2022 15:16:56 INFO: Removing Filebeat.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  filebeat*
0 upgraded, 0 newly installed, 1 to remove and 69 not upgraded.
After this operation, 73.6 MB disk space will be freed.
(Reading database ... 101447 files and directories currently installed.) ... 
Removing filebeat (7.10.2) ...
(Reading database ... 101155 files and directories currently installed.)
Purging configuration files for filebeat (7.10.2) ...
dpkg: warning: while removing filebeat, directory '/etc/filebeat' not empty so not removed
dpkg: warning: while removing filebeat, directory '/usr/share/filebeat/module' not empty so not removed
Processing triggers for systemd (245.4-4ubuntu3.17) ...
05/09/2022 15:16:59 INFO: Filebeat removed.
05/09/2022 15:16:59 INFO: Removing Wazuh dashboard.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-dashboard*
0 upgraded, 0 newly installed, 1 to remove and 69 not upgraded.
After this operation, 638 MB disk space will be freed.
(Reading database ... 101128 files and directories currently installed.)... 
Removing wazuh-dashboard (4.3.7-1) ...
Stopping wazuh-dashboard service... OK
Deleting PID directory... OK
Deleting installation directory... OK
(Reading database ... 41048 files and directories currently installed.)
Purging configuration files for wazuh-dashboard (4.3.7-1) ...
 OK
05/09/2022 15:17:03 INFO: Wazuh dashboard removed.
05/09/2022 15:17:04 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.

```
</details>