### PR TITLE
Change legacy OVA pre-release repository

### DIFF
--- a/ova/Libraries/elastic_functions.sh
+++ b/ova/Libraries/elastic_functions.sh
@@ -97,7 +97,7 @@ install_kibana_app(){
 
     if [ "${STATUS_PACKAGES}" = "unstable" ]; then
         # Wazuh-app pre-release repository
-        sudo -u kibana ${usr_kibana}/bin/kibana-plugin install https://packages-dev.wazuh.com/pre-release-3.x/wazuhapp-${WAZUH_VERSION}_${ELK_VERSION}.zip
+        sudo -u kibana ${usr_kibana}/bin/kibana-plugin install https://packages-dev.wazuh.com/pre-release-3.x/wazuhapp/wazuhapp-${WAZUH_VERSION}_${ELK_VERSION}.zip
     fi
 
     setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node

--- a/ova/generate_ova.sh
+++ b/ova/generate_ova.sh
@@ -106,7 +106,7 @@ check_version() {
     if [ "${STATUS_PACKAGES}" = "stable" ]; then
         curl -Isf https://raw.githubusercontent.com/wazuh/wazuh-kibana-app/v${WAZUH_VERSION}-${ELK_VERSION}/README.md > /dev/null || ( echo "Error version ${WAZUH_VERSION}-${ELK_VERSION} not supported." && exit 1 )
     elif [ "${STATUS_PACKAGES}" = "unstable" ]; then
-        curl -Isf https://packages-dev.wazuh.com/pre-release/app/kibana/wazuhapp-${WAZUH_VERSION}_${ELK_VERSION}.zip > /dev/null || ( echo "Error version ${WAZUH_VERSION}-${ELK_VERSION} not supported." && exit 1 )
+        curl -Isf https://packages-dev.wazuh.com/pre-release-3.x/wazuhapp/wazuhapp-${WAZUH_VERSION}_${ELK_VERSION}.zip > /dev/null || ( echo "Error version ${WAZUH_VERSION}-${ELK_VERSION} not supported." && exit 1 )
     else
         echo "Error, repository value must take 'stable' or 'unstable' value."
         exit


### PR DESCRIPTION
|Related issue|
|---|
| Closes #1849 |

## Description

This PR change the pre-release repository used to build the legacy OVA.


## Logs example

Output log: [ova_log.txt](https://github.com/wazuh/wazuh-packages/files/9598946/ova_log.txt)


## Tests

- Build the package in any supported platform
  - [x] Linux

