### PR TITLE
Fix ambiguous indentation of server's node_type

### DIFF
--- a/documentation-templates/wazuh/config.yml
+++ b/documentation-templates/wazuh/config.yml
@@ -13,10 +13,10 @@ nodes:
   server:
     - name: wazuh-1
       ip: <wazuh-manager-ip>
-    # node_type: master
-    # - name: wazuh-2
-    #   ip: <wazuh-manager-ip>
-    # node_type: worker
+  #   node_type: master
+  # - name: wazuh-2
+  #   ip: <wazuh-manager-ip>
+  #   node_type: worker
 
   # Wazuh dashboard nodes
   dashboard:


### PR DESCRIPTION
Make the `node_type` field indentation unambiguous.

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
The indenation of comments made the `node_type: worker` indentation ambiguous (should it be indented the same as `ip` or 2 spaces "earlier")?

## Logs example
N/A

## Tests

Change in comments - not applicable

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
