### PR TITLE
Improve command to change user and group from version 4.2.x to 4.x.x

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -240,17 +240,17 @@ case "$1" in
     # Remove old ossec user and group if exists and change ownwership of files
 
     if getent group ossec > /dev/null 2>&1; then
-        find ${DIR}/ -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+        find ${DIR}/ -group ossec -user root -print0 | xargs -0 chown root:wazuh > /dev/null 2>&1 || true
         if getent passwd ossec > /dev/null 2>&1; then
-            find ${DIR}/ -group ossec -user ossec -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            find ${DIR}/ -group ossec -user ossec -print0 | xargs -0 chown ${USER}:${GROUP} > /dev/null 2>&1 || true
             deluser ossec > /dev/null 2>&1
         fi
         if getent passwd ossecm > /dev/null 2>&1; then
-            find ${DIR}/ -group ossec -user ossecm -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            find ${DIR}/ -group ossec -user ossecm -print0 | xargs -0 chown ${USER}:${GROUP} > /dev/null 2>&1 || true
             deluser ossecm > /dev/null 2>&1
         fi
         if getent passwd ossecr > /dev/null 2>&1; then
-            find ${DIR}/ -group ossec -user ossecr -exec chown ${USER}:${GROUP} {} \; > /dev/null 2>&1 || true
+            find ${DIR}/ -group ossec -user ossecr -print0 | xargs -0 chown ${USER}:${GROUP} > /dev/null 2>&1 || true
             deluser ossecr > /dev/null 2>&1
         fi
         if getent group ossec > /dev/null 2>&1; then 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -451,17 +451,17 @@ rm -f %{_localstatedir}/etc/shared/default/*.rpmnew
 # Remove old ossec user and group if exists and change ownwership of files
 
 if getent group ossec > /dev/null 2>&1; then
-  find %{_localstatedir}/ -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
+  find %{_localstatedir}/ -group ossec -user root -print0 | xargs -0 chown root:wazuh > /dev/null 2>&1 || true
   if getent passwd ossec > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossec -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
     userdel ossec > /dev/null 2>&1
   fi
   if getent passwd ossecm > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossecm -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
     userdel ossecm > /dev/null 2>&1
   fi
   if getent passwd ossecr > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossecr -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
     userdel ossecr > /dev/null 2>&1
   fi
   if getent group ossec > /dev/null 2>&1; then


### PR DESCRIPTION
|Related issue|
|---|
|Closes [#14175 Session timeout during YUM upgrade](https://github.com/wazuh/wazuh/issues/14175)|

This PR attempts to provide a solution to timeout that is generated when an update is made due to user and group change in the manager by improving the find command with xargs.

### Previous behavior

Previously, when the manager has many files with different user and group that `wazuh:wazuh`,  it took a long time for the find command to apply the change.

### Proposed behavior

## Tests description
To solve this problem, two VMs with 2 cores and 1Gb of RAM, both from CentOS, were used, one locally and one being an AWS instance. First installed a manager version 4.2.7 in both VMs and take the time neccesary to update using the old version of installer, i.e that one with the command `find ./folder -user u -group g -exec chown nu:ng {} \;` and using the new version, i.e, with the command `find ./folder -user u -group g -print0 | xargs -0 chown nu:ng`.

In both VMs a half million of files was created on the folder `/var/ossec/quque/rids`

## Results
For the local VM, the following results were got:

| update w/ | time[s]   |
|--------------|---------|
| old version | 566.92 |
| new version | 38.87 |
_(Table 1: Local VM with 2 core and 1Gb of memory. Update from 4.2.7 to 4.x.x)_

Also, we can see the following proof that te command take almost the 90% of the update process.

| update w/ | time[s]   |
|--------------|---------|
| old version | 965.01 |
| new version | 14.57 |
_(Table 2: AWS VM with 2 core and 1Gb of memory. Update from 4.2.7 to 4.x.x)_

![long_command_proof](https://user-images.githubusercontent.com/27935340/192624132-5c7f21a4-dbb2-41b6-8549-f5c049bbedf8.png)
_(Figure 1: Proof command long execution time on local VM)_

![command_aws](https://user-images.githubusercontent.com/27935340/192624338-574d0d69-ce54-4cb8-b3b3-df405c046941.png)
_(Figure 2: Proof command long execution time on AWS VM)_

![split_command_chown](https://user-images.githubusercontent.com/27935340/192624705-d52bfd5b-dd7c-4838-adea-e6f613498af0.png)
_(Figure 3: Proof aplit the new chown command in `find` and `xargs`)_

## Conclutions
The improvement show an increment of speed of 4000% in average, proving that the use of `xargs` it's the best option to solve the issue.


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
