### PR TITLE
 Remove deprecated apt-key from the installation assistant

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -34,8 +34,8 @@ function getHelp() {
     echo -e "        -c,  --cert-tool"
     echo -e "                Builds the certificate creation tool cert-tool.sh"
     echo -e ""
-    echo -e "        -d,  --development"
-    echo -e "                Use development repos"
+    echo -e "        -d [staging],  --development"
+    echo -e "                Use development repos. By default it uses pre-release. If staging is specified, it will be used"
     echo -e ""
     echo -e "        -p,  --password-tool"
     echo -e "                Builds the password creation and modification tool password-tool.sh"
@@ -68,11 +68,11 @@ function buildInstaller() {
     if [ -n "${development}" ]; then
         echo 'readonly development=1' >> "${output_script_path}"
         echo 'readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
-        echo 'readonly repobaseurl="https://packages-dev.wazuh.com/pre-release"' >> "${output_script_path}"
+        echo 'readonly repobaseurl="https://packages-dev.wazuh.com/'${devrepo}'"' >> "${output_script_path}"
         echo 'readonly reporelease="unstable"' >> "${output_script_path}"
         echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
-        echo 'readonly repository="pre-release"' >> "${output_script_path}"
+        echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -228,7 +228,13 @@ function builder_main() {
                 ;;
             "-d"|"--development")
                 development=1
-                shift 1
+                if [ -n "${2}" ] && [ "${2}" = "staging" ]; then
+                    devrepo="staging"
+                    shift 2
+                else
+                    devrepo="pre-release"
+                    shift 1
+                fi
                 ;;
             "-p"|"--password-tool")
                 passwordsTool=1

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -145,9 +145,8 @@ function common_remove_gpg_key() {
             return 1
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
-        if { apt-key list | grep "Wazuh"; } >/dev/null 2>&1; then
-            key=$(apt-key list  2>/dev/null | grep -B 1 "Wazuh" | head -1)
-            apt-key del "${key}" >/dev/null 2>&1
+        if [ -f "/usr/share/keyrings/wazuh.gpg" ]; then
+            rm -rf "/usr/share/keyrings/wazuh.gpg"
         else
             common_logger "Wazuh GPG key not found in the system"
             return 1

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -45,7 +45,8 @@ function installCommon_addWazuhRepo() {
             eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo ${debug}"
             eval "chmod 644 /etc/yum.repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "curl -s ${repogpg} --max-time 300 | apt-key add - ${debug}"
+            eval "curl -s ${repogpg} --max-time 300 | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ${debug}"
+            eval "chmod 644 /usr/share/keyrings/wazuh.gpg ${debug}"
             eval "echo \"deb ${repobaseurl}/apt/ ${reporelease} main\" | tee /etc/apt/sources.list.d/wazuh.list ${debug}"
             eval "apt-get update -q ${debug}"
             eval "chmod 644 /etc/apt/sources.list.d/wazuh.list ${debug}"

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -60,10 +60,6 @@ function installCommon_addWazuhRepo() {
     else
         common_logger "Wazuh repository added."
     fi
-
-    echo "Stop"
-    read var1
-
 }
 
 function installCommon_aptInstall() {

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -47,7 +47,7 @@ function installCommon_addWazuhRepo() {
         elif [ "${sys_type}" == "apt-get" ]; then
             eval "curl -s ${repogpg} --max-time 300 | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
             eval "chmod 644 /usr/share/keyrings/wazuh.gpg ${debug}"
-            eval "echo \"deb ${repobaseurl}/apt/ ${reporelease} main\" | tee /etc/apt/sources.list.d/wazuh.list ${debug}"
+            eval "echo \"deb [signed-by=/usr/share/keyrings/wazuh.gpg] ${repobaseurl}/apt/ ${reporelease} main\" | tee /etc/apt/sources.list.d/wazuh.list ${debug}"
             eval "apt-get update -q ${debug}"
             eval "chmod 644 /etc/apt/sources.list.d/wazuh.list ${debug}"
         fi
@@ -60,6 +60,9 @@ function installCommon_addWazuhRepo() {
     else
         common_logger "Wazuh repository added."
     fi
+
+    echo "Stop"
+    read var1
 
 }
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -45,7 +45,7 @@ function installCommon_addWazuhRepo() {
             eval "echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo ${debug}"
             eval "chmod 644 /etc/yum.repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "curl -s ${repogpg} --max-time 300 | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ${debug}"
+            eval "curl -s ${repogpg} --max-time 300 | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
             eval "chmod 644 /usr/share/keyrings/wazuh.gpg ${debug}"
             eval "echo \"deb ${repobaseurl}/apt/ ${reporelease} main\" | tee /etc/apt/sources.list.d/wazuh.list ${debug}"
             eval "apt-get update -q ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|#1846|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
All usages of apt-key have been removed. Instead, the script creates a file with the key as `/usr/share/keyrings/wazuh.gpg` and adds the path to it to the repository description in `sources.list.d`

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests
- [x] AIO for DEB system
- [x] AIO for RPM system
- [x] Distributed installation

