### PR TITLE
Fix package conflicts between `wazuh-manager` and `azure-cli` on CentOS 8

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -26,6 +26,8 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+# Don't generate build_id links to prevent conflicts with other
+# packages, as azure-cli
 %global _build_id_links none
 
 %prep

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -26,6 +26,8 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
+%global _build_id_links none
+
 %prep
 %setup -q
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -27,7 +27,7 @@ hosts at an operating system and application level. It provides the following ca
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
 # Don't generate build_id links to prevent conflicts with other
-# packages, as azure-cli
+# packages.
 %global _build_id_links none
 
 %prep


### PR DESCRIPTION
|Related issue|
|---|
|#1796|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
We add a macro to the SPECS for the RPM generation for the `wazuh-manager` package. It prevents the installation of the package to create build ids, debugging links that may conflict with the installation of other packages, as `azure-cli`

## Logs example

<!--
Paste here related logs
-->

```
[vagrant@centos-8 output]$ sudo dnf install wazuh-manager-4.4.0-1.x86_64.rpm 
Last metadata expiration check: 4:25:43 ago on Fri 07 Oct 2022 10:12:00 AM UTC.
Dependencies resolved.
=========================================================================
 Package             Architecture Version       Repository          Size
=========================================================================
Installing:
 wazuh-manager       x86_64       4.4.0-1       @commandline       116 M

Transaction Summary
=========================================================================
Install  1 Package

Total size: 116 M
Installed size: 443 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                 1/1 
  Running scriptlet: wazuh-manager-4.4.0-1.x86_64                    1/1 
  Installing       : wazuh-manager-4.4.0-1.x86_64                    1/1 
  Running scriptlet: wazuh-manager-4.4.0-1.x86_64                    1/1 
  Verifying        : wazuh-manager-4.4.0-1.x86_64                    1/1 

Installed:
  wazuh-manager-4.4.0-1.x86_64                                           

Complete!
[vagrant@centos-8 output]$ ls -la /usr/lib/.build-id/96/
total 16
drwxr-xr-x.   2 root root 4096 Oct  7 14:37 .
drwxr-xr-x. 258 root root 8192 Oct  7 14:13 ..
lrwxrwxrwx.   1 root root   51 Aug 26  2021 166261150d54429d14a1b7b37166efdd6c5551 -> ../../../../usr/lib64/krb5/plugins/preauth/spake.so
lrwxrwxrwx.   1 root root   38 Aug 24  2021 39b522bbd05ddc4cf0bbfa264b35c77fbf330f -> ../../../../usr/lib64/gconv/IBM4909.so
lrwxrwxrwx.   1 root root   56 May 17  2021 42a0bc86b4c461f4295fd9caebee7f841c7cd3 -> ../../../../usr/lib64/libibverbs/libhfi1verbs-rdmav34.so
lrwxrwxrwx.   1 root root   46 Aug 24  2021 42a5943ea793571c20fc9c71aca50ce62d002c -> ../../../../usr/lib64/gconv/ISO-2022-CN-EXT.so
lrwxrwxrwx.   1 root root   47 May  7  2021 5cc78c67a33b4259f8a006f3209961222f33d9 -> ../../../../usr/lib64/security/pam_mkhomedir.so
lrwxrwxrwx.   1 root root   47 Aug 24  2021 5eb97a522e7ad64be16cabf416013e93d9b868 -> ../../../../usr/lib64/xtables/libebt_pkttype.so
lrwxrwxrwx.   1 root root   34 Apr  7  2020 6112df0d37fc1834e754c1a88f6b22fc0a1c29 -> ../../../../usr/bin/nl-list-caches
lrwxrwxrwx.   1 root root   27 Jul 21  2021 77dfd644b2023412d28bdef14b96d199484b9a -> ../../../../usr/bin/setpriv
lrwxrwxrwx.   1 root root   44 Aug 24  2021 792ab584d9fef4c782a96dfdec9456df63ce6f -> ../../../../usr/lib64/xtables/libebt_mark.so
lrwxrwxrwx.   1 root root   37 Aug 24  2021 a8ae65e78b35617a91bed41c4ee1719ca7e7b0 -> ../../../../usr/lib64/gconv/IBM037.so
lrwxrwxrwx.   1 root root   33 Dec 21  2021 a9e1b12e84161a39bbaf8e63d1188b43222b77 -> ../../../../usr/sbin/makedumpfile
lrwxrwxrwx.   1 root root   42 May 11  2019 cfd0064dbefb3f0929870654f57df04daa6d51 -> ../../../../usr/lib64/libjansson.so.4.11.0
lrwxrwxrwx.   1 root root   40 Aug 10  2021 e62b057c3aca089dd38d92c522b71314c58d68 -> ../../../../usr/lib64/rsyslog/mmcount.so
[vagrant@centos-8 output]$ ls
wazuh-manager-4.4.0-1.x86_64.rpm
[vagrant@centos-8 output]$ sudo dnf install azure-cli
Last metadata expiration check: 4:27:30 ago on Fri 07 Oct 2022 10:12:00 AM UTC.
Dependencies resolved.
=========================================================================
 Package    Arch   Version                              Repository  Size
=========================================================================
Installing:
 azure-cli  x86_64 2.40.0-1.el8                         packages-microsoft-com-prod
                                                                    52 M
Installing dependencies:
 python39   x86_64 3.9.6-2.module_el8.5.0+897+68c4c210  appstream   33 k
 python39-libs
            x86_64 3.9.6-2.module_el8.5.0+897+68c4c210  appstream  8.2 M
 python39-pip-wheel
            noarch 20.2.4-6.module_el8.5.0+897+68c4c210 appstream  1.3 M
 python39-setuptools-wheel
            noarch 50.3.2-4.module_el8.5.0+897+68c4c210 appstream  497 k
Installing weak dependencies:
 python39-pip
            noarch 20.2.4-6.module_el8.5.0+897+68c4c210 appstream  2.0 M
 python39-setuptools
            noarch 50.3.2-4.module_el8.5.0+897+68c4c210 appstream  871 k

Transaction Summary
=========================================================================
Install  7 Packages

Total size: 65 M
Installed size: 785 M
Is this ok [y/N]: y
Downloading Packages:
[SKIPPED] python39-3.9.6-2.module_el8.5.0+897+68c4c210.x86_64.rpm: Already downloaded
[SKIPPED] python39-libs-3.9.6-2.module_el8.5.0+897+68c4c210.x86_64.rpm: Already downloaded
[SKIPPED] python39-pip-20.2.4-6.module_el8.5.0+897+68c4c210.noarch.rpm: Already downloaded
[SKIPPED] python39-pip-wheel-20.2.4-6.module_el8.5.0+897+68c4c210.noarch.rpm: Already downloaded
[SKIPPED] python39-setuptools-50.3.2-4.module_el8.5.0+897+68c4c210.noarch.rpm: Already downloaded
[SKIPPED] python39-setuptools-wheel-50.3.2-4.module_el8.5.0+897+68c4c210.noarch.rpm: Already downloaded
[SKIPPED] azure-cli-2.40.0-1.el8.x86_64.rpm: Already downloaded         
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                 1/1 
  Installing       : python39-setuptools-wheel-50.3.2-4.module_el8   1/7 
  Installing       : python39-pip-wheel-20.2.4-6.module_el8.5.0+89   2/7 
  Installing       : python39-libs-3.9.6-2.module_el8.5.0+897+68c4   3/7 
  Installing       : python39-3.9.6-2.module_el8.5.0+897+68c4c210.   4/7 
  Running scriptlet: python39-3.9.6-2.module_el8.5.0+897+68c4c210.   4/7 
  Installing       : python39-setuptools-50.3.2-4.module_el8.5.0+8   5/7 
  Running scriptlet: python39-setuptools-50.3.2-4.module_el8.5.0+8   5/7 
  Installing       : python39-pip-20.2.4-6.module_el8.5.0+897+68c4   6/7 
  Running scriptlet: python39-pip-20.2.4-6.module_el8.5.0+897+68c4   6/7 
  Installing       : azure-cli-2.40.0-1.el8.x86_64                   7/7 
  Running scriptlet: azure-cli-2.40.0-1.el8.x86_64                   7/7 
  Verifying        : python39-3.9.6-2.module_el8.5.0+897+68c4c210.   1/7 
  Verifying        : python39-libs-3.9.6-2.module_el8.5.0+897+68c4   2/7 
  Verifying        : python39-pip-20.2.4-6.module_el8.5.0+897+68c4   3/7 
  Verifying        : python39-pip-wheel-20.2.4-6.module_el8.5.0+89   4/7 
  Verifying        : python39-setuptools-50.3.2-4.module_el8.5.0+8   5/7 
  Verifying        : python39-setuptools-wheel-50.3.2-4.module_el8   6/7 
  Verifying        : azure-cli-2.40.0-1.el8.x86_64                   7/7 

Installed:
  azure-cli-2.40.0-1.el8.x86_64                                          
  python39-3.9.6-2.module_el8.5.0+897+68c4c210.x86_64                    
  python39-libs-3.9.6-2.module_el8.5.0+897+68c4c210.x86_64               
  python39-pip-20.2.4-6.module_el8.5.0+897+68c4c210.noarch               
  python39-pip-wheel-20.2.4-6.module_el8.5.0+897+68c4c210.noarch         
  python39-setuptools-50.3.2-4.module_el8.5.0+897+68c4c210.noarch        
  python39-setuptools-wheel-50.3.2-4.module_el8.5.0+897+68c4c210.noarch  

Complete!
[vagrant@centos-8 output]$ 
```

## Tests


<!-- Minimum checks required -->
I have created the package locally and installed it on a CentOS machine. I have seen none of the build ids `wazuh-manager` creates were created with this package and I have installed Azure CLI without problem, as seen in the logs.