### PR TITLE
Remove Ignoring days warning

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -125,7 +125,7 @@ function cert_generateIndexercertificates() {
         for i in "${!indexer_node_names[@]}"; do
             indexer_node_name=${indexer_node_names[$i]}
             cert_generateCertificateconfiguration "${indexer_node_name}" "${indexer_node_ips[i]}"
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_name}-key.pem -out ${cert_tmp_path}/${indexer_node_name}.csr -config ${cert_tmp_path}/${indexer_node_name}.conf -days 3650 ${debug}"
+            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_name}-key.pem -out ${cert_tmp_path}/${indexer_node_name}.csr -config ${cert_tmp_path}/${indexer_node_name}.conf ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${indexer_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${indexer_node_name}.pem -extfile ${cert_tmp_path}/${indexer_node_name}.conf -extensions v3_req -days 3650 ${debug}"
         done
     else
@@ -144,7 +144,7 @@ function cert_generateFilebeatcertificates() {
             j=$((i+1))
             declare -a server_ips=(server_node_ip_"$j"[@])
             cert_generateCertificateconfiguration "${server_name}" "${!server_ips}"
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_name}-key.pem -out ${cert_tmp_path}/${server_name}.csr  -config ${cert_tmp_path}/${server_name}.conf -days 3650 ${debug}"
+            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_name}-key.pem -out ${cert_tmp_path}/${server_name}.csr  -config ${cert_tmp_path}/${server_name}.conf ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${server_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${server_name}.pem -extfile ${cert_tmp_path}/${server_name}.conf -extensions v3_req -days 3650 ${debug}"
         done
     else
@@ -161,7 +161,7 @@ function cert_generateDashboardcertificates() {
         for i in "${!dashboard_node_names[@]}"; do
             dashboard_node_name="${dashboard_node_names[i]}"
             cert_generateCertificateconfiguration "${dashboard_node_name}" "${dashboard_node_ips[i]}"
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_name}-key.pem -out ${cert_tmp_path}/${dashboard_node_name}.csr -config ${cert_tmp_path}/${dashboard_node_name}.conf -days 3650 ${debug}"
+            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_name}-key.pem -out ${cert_tmp_path}/${dashboard_node_name}.csr -config ${cert_tmp_path}/${dashboard_node_name}.conf ${debug}"
             eval "openssl x509 -req -in ${cert_tmp_path}/${dashboard_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${dashboard_node_name}.pem -extfile ${cert_tmp_path}/${dashboard_node_name}.conf -extensions v3_req -days 3650 ${debug}"
         done
     else


### PR DESCRIPTION
## Description

When using wazuh-certs-tool.sh warnings are given about the "-days" option. With this code change the warnings are gone.


## Logs example

```
bash wazuh-certs-tool.sh -A -v
15/10/2022 15:51:57 DEBUG: Creating the root certificate.
Generating a RSA private key
...........................................................+++++
...........................................................................................+++++
writing new private key to '/tmp/wazuh-certificates/root-ca.key'
-----
Generating RSA private key, 2048 bit long modulus (2 primes)
...............+++++
.............................+++++
e is 65537 (0x010001)
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
Getting CA Private Key
15/10/2022 15:51:57 INFO: Admin certificates created.
15/10/2022 15:51:57 DEBUG: Creating the Wazuh indexer certificates.
Ignoring -days; not generating a certificate
```

## Tests

When using the new code, the warnings are gone.

```
bash wazuh-certs-tool.sh -A -v
15/10/2022 15:51:57 DEBUG: Creating the root certificate.
Generating a RSA private key
...........................................................+++++
...........................................................................................+++++
writing new private key to '/tmp/wazuh-certificates/root-ca.key'
-----
Generating RSA private key, 2048 bit long modulus (2 primes)
...............+++++
.............................+++++
e is 65537 (0x010001)
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
Getting CA Private Key
15/10/2022 15:51:57 INFO: Admin certificates created.
15/10/2022 15:51:57 DEBUG: Creating the Wazuh indexer certificates.
```