### PR TITLE
Remove `Wazuh dashboard` and `Wazuh indexer` `init.d` service for `Red Hat 9` 4.4

### DIFF
--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -68,16 +68,13 @@ cp wazuh-dashboard-base/VERSION %{buildroot}%{INSTALL_DIR}
 
 mv wazuh-dashboard-base/* %{buildroot}%{INSTALL_DIR}
 
-
 # Set custom welcome styles
 
 mkdir -p %{buildroot}%{INSTALL_DIR}/config
 
 cp %{buildroot}%{INSTALL_DIR}/etc/services/wazuh-dashboard.service %{buildroot}/etc/systemd/system/wazuh-dashboard.service
-cp %{buildroot}%{INSTALL_DIR}/etc/services/wazuh-dashboard %{buildroot}/etc/init.d/wazuh-dashboard
 cp %{buildroot}%{INSTALL_DIR}/etc/services/default %{buildroot}/etc/default/wazuh-dashboard
 
-chmod 750 %{buildroot}/etc/init.d/wazuh-dashboard
 chmod 640 %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 chmod 640 %{buildroot}/etc/default/wazuh-dashboard
 
@@ -87,7 +84,6 @@ find %{buildroot}%{INSTALL_DIR} -exec chown %{USER}:%{GROUP} {} \;
 find %{buildroot}%{CONFIG_DIR} -exec chown %{USER}:%{GROUP} {} \;
 
 chown root:root %{buildroot}/etc/systemd/system/wazuh-dashboard.service
-chown root:root %{buildroot}/etc/init.d/wazuh-dashboard
 
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
@@ -212,7 +208,6 @@ rm -fr %{buildroot}
 %defattr(-,%{USER},%{GROUP})
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}
 
-%attr(0750, root, root) "/etc/init.d/wazuh-dashboard"
 %attr(0750, %{USER}, %{GROUP}) "/etc/default/wazuh-dashboard"
 %config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch_dashboards.yml"
 %attr(440, %{USER}, %{GROUP}) %{INSTALL_DIR}/VERSION

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -92,7 +92,7 @@ chown root:root %{buildroot}/etc/init.d/wazuh-dashboard
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
 else
-    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/warehouse/test/4.4/ui/dashboard/wazuh-4.4.0-1.zip"
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
 fi
 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -60,7 +60,7 @@ tar -xf %{DASHBOARD_FILE}
 mkdir -p %{buildroot}%{CONFIG_DIR}
 mkdir -p %{buildroot}%{INSTALL_DIR}
 mkdir -p %{buildroot}/etc/systemd/system
-mkdir -p %{buildroot}/etc/init.d
+mkdir -p %{buildroot}%{_initrddir}
 mkdir -p %{buildroot}/etc/default
 
 cp wazuh-dashboard-base/etc/node.options %{buildroot}%{CONFIG_DIR}
@@ -75,9 +75,9 @@ mkdir -p %{buildroot}%{INSTALL_DIR}/config
 
 cp %{buildroot}%{INSTALL_DIR}/etc/services/wazuh-dashboard.service %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 cp %{buildroot}%{INSTALL_DIR}/etc/services/default %{buildroot}/etc/default/wazuh-dashboard
-cp %{buildroot}%{INSTALL_DIR}/etc/services/wazuh-dashboard %{buildroot}/etc/init.d/wazuh-dashboard
+cp %{buildroot}%{INSTALL_DIR}/etc/services/wazuh-dashboard %{buildroot}%{_initrddir}/wazuh-dashboard
 
-chmod 750 %{buildroot}/etc/init.d/wazuh-dashboard
+chmod 750 %{buildroot}%{_initrddir}/wazuh-dashboard
 chmod 640 %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 chmod 640 %{buildroot}/etc/default/wazuh-dashboard
 
@@ -87,7 +87,7 @@ find %{buildroot}%{INSTALL_DIR} -exec chown %{USER}:%{GROUP} {} \;
 find %{buildroot}%{CONFIG_DIR} -exec chown %{USER}:%{GROUP} {} \;
 
 chown root:root %{buildroot}/etc/systemd/system/wazuh-dashboard.service
-chown root:root %{buildroot}/etc/init.d/wazuh-dashboard
+chown root:root %{buildroot}%{_initrddir}/wazuh-dashboard
 
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
@@ -142,7 +142,7 @@ fi
 if [ -f /etc/os-release ]; then
   source /etc/os-release
   if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
-    rm -f /etc/init.d/wazuh-dashboard
+    rm -f %{_initrddir}/wazuh-dashboard
   fi
 fi
 
@@ -220,7 +220,7 @@ rm -fr %{buildroot}
 %defattr(-,%{USER},%{GROUP})
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}
 
-%config(missingok) "/etc/init.d/wazuh-dashboard"
+%config(missingok) "%{_initrddir}/wazuh-dashboard"
 %attr(0750, %{USER}, %{GROUP}) "/etc/default/wazuh-dashboard"
 %config(noreplace) %attr(0640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch_dashboards.yml"
 %attr(440, %{USER}, %{GROUP}) %{INSTALL_DIR}/VERSION

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -87,7 +87,7 @@ chown root:root %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
 else
-    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/warehouse/test/4.4/ui/dashboard/wazuh-4.4.0-1.zip"
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
 fi
 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -59,7 +59,6 @@ tar -xf %{DASHBOARD_FILE}
 mkdir -p %{buildroot}%{CONFIG_DIR}
 mkdir -p %{buildroot}%{INSTALL_DIR}
 mkdir -p %{buildroot}/etc/systemd/system
-mkdir -p %{buildroot}/etc/init.d
 mkdir -p %{buildroot}/etc/default
 
 cp wazuh-dashboard-base/etc/node.options %{buildroot}%{CONFIG_DIR}

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -92,7 +92,7 @@ chown root:root %{buildroot}/etc/init.d/wazuh-dashboard
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
 else
-    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/warehouse/test/4.4/ui/dashboard/wazuh-4.4.0-1.zip"
 fi
 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -88,7 +88,7 @@ chown root:root %{buildroot}/etc/systemd/system/wazuh-dashboard.service
 if [ "%{version}" = "99.99.0" ];then
     runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/futures/ui/dashboard/wazuh-99.99.0-%{release}.zip"
 else
-    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-%{version}-%{release}.zip"
+    runuser %{USER} --shell="/bin/bash" --command="%{buildroot}%{INSTALL_DIR}/bin/opensearch-dashboards-plugin install https://packages-dev.wazuh.com/warehouse/test/4.4/ui/dashboard/wazuh-4.4.0-1.zip"
 fi
 
 find %{buildroot}%{INSTALL_DIR}/plugins/wazuh/ -exec chown %{USER}:%{GROUP} {} \;

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -158,6 +158,13 @@ if [ $1 = 1 ];then # Install
     if command -v systemctl > /dev/null 2>&1; then
         systemctl restart systemd-sysctl > /dev/null 2>&1 || true
     fi
+
+    if [ -f /etc/os-release ]; then
+      source /etc/os-release
+      if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
+        rm -f /etc/init.d/wazuh-indexer
+      fi
+    fi
 fi
 
 # -----------------------------------------------------------------------------
@@ -293,7 +300,8 @@ rm -fr %{buildroot}
 %dir %attr(750, %{USER}, %{GROUP}) %{LOG_DIR}
 
 %config(noreplace) %attr(0660, root, %{GROUP}) "/etc/sysconfig/%{name}"
-%attr(0750, root, root) /etc/init.d/%{name}
+
+%config(missingok) /etc/init.d/%{name}
 %attr(0640, root, root) %{SYS_DIR}/sysctl.d/%{name}.conf
 %attr(0640, root, root) %{SYS_DIR}/systemd/system/%{name}.service
 %attr(0640, root, root) %{SYS_DIR}/systemd/system/%{name}-performance-analyzer.service

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -99,6 +99,8 @@ cp %{REPO_DIR}/config/indexer/roles/roles_mapping.yml ${RPM_BUILD_ROOT}%{CONFIG_
 
 cp /root/stack/indexer/indexer-security-init.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/bin/
 
+chmod 750 ${RPM_BUILD_ROOT}/etc/init.d/wazuh-indexer
+
 # -----------------------------------------------------------------------------
 
 %pre

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -159,12 +159,13 @@ if [ $1 = 1 ];then # Install
         systemctl restart systemd-sysctl > /dev/null 2>&1 || true
     fi
 
-    if [ -f /etc/os-release ]; then
-      source /etc/os-release
-      if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
-        rm -f /etc/init.d/wazuh-indexer
-      fi
-    fi
+fi
+
+if [ -f /etc/os-release ]; then
+  source /etc/os-release
+  if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
+    rm -f /etc/init.d/%{name}
+  fi
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION


## Description

This pull request removes the `init.d` service from the Wazuh indexer and Wazuh dashboard on the Red Hat 9 system since the Red Hat 9 system has withdrawn support for `init.d`.

Now, when using the `service` command, it is redirected to `systemctl`, also fixing the problem of showing the log by the terminal when using the `service` command.

## Logs example

See https://github.com/wazuh/wazuh-packages/issues/1880 comments. It can be seen in the comments of the issue the tests carried out with Vagrant, links to Jenkins with the package generation and tests carried out on different systems using the `Test_install_stack` pipeline

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] `%files` section is correctly updated if necessary