### PR TITLE
Fixing service enablement in SUSE packages

### DIFF
--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -257,6 +257,22 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
+if [ -f /etc/SuSE-release ]; then
+  sles="suse"
+elif [ -f /etc/os-release ]; then
+  if grep -q "\"sles" /etc/os-release ; then
+    sles="suse"
+  elif grep -q -i "\"opensuse" /etc/os-release ; then
+    sles="opensuse"
+  fi
+fi
+
+if [ -n "$sles" ]; then
+  if [ ! -f /etc/init.d/wazuh-agent ]; then
+    ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
+  fi
+fi
+
 if [ -f /etc/os-release ]; then
   source /etc/os-release
   if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
@@ -456,24 +472,6 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
-
-sles=""
-if [ -f /etc/SuSE-release ]; then
-  sles="suse"
-elif [ -f /etc/os-release ]; then
-  if `grep -q "\"sles" /etc/os-release` ; then
-    sles="suse"
-  elif `grep -q -i "\"opensuse" /etc/os-release` ; then
-    sles="opensuse"
-  fi
-fi
-
-if [ ! -z "$sles" ]; then
-  if [ ! -d /etc/init.d/wazuh-agent ]; then
-    ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
-  fi
-fi
-
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -236,7 +236,6 @@ if [ $1 = 1 ]; then
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
-      ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
     fi
   fi
 
@@ -459,21 +458,21 @@ fi
 %posttrans
 
 sles=""
-  if [ -f /etc/SuSE-release ]; then
+if [ -f /etc/SuSE-release ]; then
+  sles="suse"
+elif [ -f /etc/os-release ]; then
+  if `grep -q "\"sles" /etc/os-release` ; then
     sles="suse"
-  elif [ -f /etc/os-release ]; then
-    if `grep -q "\"sles" /etc/os-release` ; then
-      sles="suse"
-    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
-      sles="opensuse"
-    fi
+  elif `grep -q -i "\"opensuse" /etc/os-release` ; then
+    sles="opensuse"
   fi
+fi
 
-  if [ ! -z "$sles" ]; then
-    if [ ! -d /etc/init.d/wazuh-agent ]; then
-      ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
-    fi
+if [ ! -z "$sles" ]; then
+  if [ ! -d /etc/init.d/wazuh-agent ]; then
+    ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
   fi
+fi
 
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -257,6 +257,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
+#Enable service in openSUSE environment
 if [ -f /etc/SuSE-release ]; then
   sles="suse"
 elif [ -f /etc/os-release ]; then
@@ -268,9 +269,7 @@ elif [ -f /etc/os-release ]; then
 fi
 
 if [ -n "$sles" ]; then
-  if [ ! -f /etc/init.d/wazuh-agent ]; then
-    ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
-  fi
+  ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
 fi
 
 if [ -f /etc/os-release ]; then

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -247,8 +247,8 @@ if [ -f /etc/os-release ]; then
   fi
 fi
 
-# We create this fix for the operating system that deprecated the SySV. For now, this fix is for suse/openSUSE
-sles=""
+  # We create this fix for the operating system that deprecated the SySV. For now, this fix is for suse/openSUSE
+  sles=""
   if [ -f /etc/SuSE-release ]; then
     sles="suse"
   elif [ -f /etc/os-release ]; then

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -262,7 +262,7 @@ sles=""
   if [ ! -z "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
     #If it's an upgrade and there is a service file in /etc/init.d/ we deleted.
     if [ -f /etc/init.d/wazuh-agent ]; then
-      rm /etc/init.d/wazuh-agent
+      rm -f /etc/init.d/wazuh-agent
     fi
   fi
 

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -457,6 +457,25 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
+
+sles=""
+  if [ -f /etc/SuSE-release ]; then
+    sles="suse"
+  elif [ -f /etc/os-release ]; then
+    if `grep -q "\"sles" /etc/os-release` ; then
+      sles="suse"
+    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
+      sles="opensuse"
+    fi
+  fi
+
+  if [ ! -z "$sles" ]; then
+    if [ ! -d /etc/init.d/wazuh-agent ]; then
+      install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
+      ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
+    fi
+  fi
+
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -236,6 +236,7 @@ if [ $1 = 1 ]; then
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
+      ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
     fi
   fi
 

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -259,8 +259,7 @@ sles=""
     fi
   fi
 
-  if [ ! -z "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
-    #If it's an upgrade and there is a service file in /etc/init.d/ we deleted.
+  if [ -n "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
     if [ -f /etc/init.d/wazuh-agent ]; then
       rm -f /etc/init.d/wazuh-agent
     fi

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -222,23 +222,6 @@ fi
 # If the package is being installed
 if [ $1 = 1 ]; then
 
-  sles=""
-  if [ -f /etc/SuSE-release ]; then
-    sles="suse"
-  elif [ -f /etc/os-release ]; then
-    if `grep -q "\"sles" /etc/os-release` ; then
-      sles="suse"
-    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
-      sles="opensuse"
-    fi
-  fi
-
-  if [ ! -z "$sles" ]; then
-    if [ -d /etc/init.d ]; then
-      install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
-    fi
-  fi
-
   touch %{_localstatedir}/logs/active-responses.log
   chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
@@ -257,27 +240,31 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
-#Enable service in openSUSE environment
-if [ -f /etc/SuSE-release ]; then
-  sles="suse"
-elif [ -f /etc/os-release ]; then
-  if grep -q "\"sles" /etc/os-release ; then
-    sles="suse"
-  elif grep -q -i "\"opensuse" /etc/os-release ; then
-    sles="opensuse"
-  fi
-fi
-
-if [ -n "$sles" ]; then
-  ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
-fi
-
 if [ -f /etc/os-release ]; then
   source /etc/os-release
   if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
     rm -f %{_initrddir}/wazuh-agent
   fi
 fi
+
+# We create this fix for the operating system that deprecated the SySV. For now, this fix is for suse/openSUSE
+sles=""
+  if [ -f /etc/SuSE-release ]; then
+    sles="suse"
+  elif [ -f /etc/os-release ]; then
+    if `grep -q "\"sles" /etc/os-release` ; then
+      sles="suse"
+    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
+      sles="opensuse"
+    fi
+  fi
+
+  if [ ! -z "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
+    #If it's an upgrade and there is a service file in /etc/init.d/ we deleted.
+    if [ -f /etc/init.d/wazuh-agent ]; then
+      rm /etc/init.d/wazuh-agent
+    fi
+  fi
 
 # Delete the installation files used to configure the agent
 rm -rf %{_localstatedir}/packages_files

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -471,7 +471,6 @@ sles=""
 
   if [ ! -z "$sles" ]; then
     if [ ! -d /etc/init.d/wazuh-agent ]; then
-      install -m 755 %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
       ln -sf ../wazuh-agent /etc/init.d/wazuh-agent
     fi
   fi

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -312,8 +312,8 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 fi
 
-# We create this fix for the operating system that decraped the SySV. For now, this fix is for suse/openSUSE
-sles=""
+  # We create this fix for the operating system that decraped the SySV. For now, this fix is for suse/openSUSE
+  sles=""
   if [ -f /etc/SuSE-release ]; then
     sles="suse"
   elif [ -f /etc/os-release ]; then

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -328,6 +328,7 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 fi
 
+#Enable service in openSUSE environment
 if [ -f /etc/SuSE-release ]; then
   sles="suse"
 elif [ -f /etc/os-release ]; then
@@ -339,9 +340,7 @@ elif [ -f /etc/os-release ]; then
 fi
 
 if [ -n "$sles" ]; then
-  if [ ! -f /etc/init.d/wazuh-manager ]; then
-    ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
-  fi
+  ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
 fi
 
 if [ -f /etc/os-release ]; then

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -324,8 +324,7 @@ sles=""
     fi
   fi
 
-  if [ ! -z "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
-    #If it's an upgrade and there is a service file in /etc/init.d/ we deleted.
+  if [ -n "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
     if [ -f /etc/init.d/wazuh-manager ]; then
       rm -f /etc/init.d/wazuh-manager
     fi

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -552,7 +552,6 @@ sles=""
 
   if [ ! -z "$sles" ]; then
     if [ ! -d /etc/init.d/wazuh-manager ]; then
-      install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
       ln -sf ../wazuh-agent /etc/init.d/wazuh-manager
     fi
   fi

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -539,6 +539,24 @@ fi
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
 
+sles=""
+  if [ -f /etc/SuSE-release ]; then
+    sles="suse"
+  elif [ -f /etc/os-release ]; then
+    if `grep -q "\"sles" /etc/os-release` ; then
+      sles="suse"
+    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
+      sles="opensuse"
+    fi
+  fi
+
+  if [ ! -z "$sles" ]; then
+    if [ ! -d /etc/init.d/wazuh-manager ]; then
+      install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
+      ln -sf ../wazuh-agent /etc/init.d/wazuh-manager
+    fi
+  fi
+
 if [ -f %{_sysconfdir}/systemd/system/wazuh-manager.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-manager.service
   systemctl daemon-reload > /dev/null 2>&1

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -309,6 +309,7 @@ if [ $1 = 1 ]; then
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
+      ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
     fi
   fi
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -309,7 +309,6 @@ if [ $1 = 1 ]; then
   if [ ! -z "$sles" ]; then
     if [ -d /etc/init.d ]; then
       install -m 755 %{_localstatedir}/packages_files/manager_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-manager
-      ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
     fi
   fi
 
@@ -540,21 +539,21 @@ fi
 %posttrans
 
 sles=""
-  if [ -f /etc/SuSE-release ]; then
+if [ -f /etc/SuSE-release ]; then
+  sles="suse"
+elif [ -f /etc/os-release ]; then
+  if `grep -q "\"sles" /etc/os-release` ; then
     sles="suse"
-  elif [ -f /etc/os-release ]; then
-    if `grep -q "\"sles" /etc/os-release` ; then
-      sles="suse"
-    elif `grep -q -i "\"opensuse" /etc/os-release` ; then
-      sles="opensuse"
-    fi
+  elif `grep -q -i "\"opensuse" /etc/os-release` ; then
+    sles="opensuse"
   fi
+fi
 
-  if [ ! -z "$sles" ]; then
-    if [ ! -d /etc/init.d/wazuh-manager ]; then
-      ln -sf ../wazuh-agent /etc/init.d/wazuh-manager
-    fi
+if [ ! -z "$sles" ]; then
+  if [ ! -d /etc/init.d/wazuh-manager ]; then
+    ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
   fi
+fi
 
 if [ -f %{_sysconfdir}/systemd/system/wazuh-manager.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-manager.service

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -328,6 +328,22 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh %{_localstatedir} >> %{_localstatedir}/etc/ossec.conf
 fi
 
+if [ -f /etc/SuSE-release ]; then
+  sles="suse"
+elif [ -f /etc/os-release ]; then
+  if grep -q "\"sles" /etc/os-release ; then
+    sles="suse"
+  elif grep -q -i "\"opensuse" /etc/os-release ; then
+    sles="opensuse"
+  fi
+fi
+
+if [ -n "$sles" ]; then
+  if [ ! -f /etc/init.d/wazuh-manager ]; then
+    ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
+  fi
+fi
+
 if [ -f /etc/os-release ]; then
   source /etc/os-release
   if [ "${NAME}" = "Red Hat Enterprise Linux" ] && [ "$((${VERSION_ID:0:1}))" -ge 9 ]; then
@@ -537,24 +553,6 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
-
-sles=""
-if [ -f /etc/SuSE-release ]; then
-  sles="suse"
-elif [ -f /etc/os-release ]; then
-  if `grep -q "\"sles" /etc/os-release` ; then
-    sles="suse"
-  elif `grep -q -i "\"opensuse" /etc/os-release` ; then
-    sles="opensuse"
-  fi
-fi
-
-if [ ! -z "$sles" ]; then
-  if [ ! -d /etc/init.d/wazuh-manager ]; then
-    ln -sf ../wazuh-manager /etc/init.d/wazuh-manager
-  fi
-fi
-
 if [ -f %{_sysconfdir}/systemd/system/wazuh-manager.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-manager.service
   systemctl daemon-reload > /dev/null 2>&1

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -327,7 +327,7 @@ sles=""
   if [ ! -z "$sles" ] && [ $(ps --no-headers -o comm 1) == "systemd" ]; then
     #If it's an upgrade and there is a service file in /etc/init.d/ we deleted.
     if [ -f /etc/init.d/wazuh-manager ]; then
-      rm /etc/init.d/wazuh-manager
+      rm -f /etc/init.d/wazuh-manager
     fi
   fi
 


### PR DESCRIPTION
|Related issue|
|---|
| [#14924](https://github.com/wazuh/wazuh/issues/14924)  |

# Solution report

## Goal
This report has for goal to make a summary of the implemented solution.

## Issue research
This issue is produced by a wrong symbolink in the openSUSE Leap 15.4 distribution in the RPM packages.

When post-installation, it try to enable the service (agent or manager). It raised an error because openSUSE try to create a symbolic link to `/etc/init.d/rc2.d` it doesn't exist. This problem has been found in this [forum thread](https://forums.opensuse.org/showthread.php/569830-Can-systemctl-start-elasticsearch-but-not-systemctl-enable-it), where the explain of the reason it's because the package it's an original openSUSE package so it tries to use `/etc/init.d/rc2.d` which directory belongs to the old SystemV ways of doing but in openSUSE that directory is no longer in use and most probably not available anymore.


## Test description & results
To solve this problem we create a symbolic link to the correct path and then enable the service. 

We attach the ouput of this fix, with a new installation and upgrade from 4.3 to 4.4

OS: **openSUSE 15.3**
<details> <summary>Install and enable wazuh from packages :green_circle: </summary>

```bash
rpm -i wazuh-agent-4.3.9-rev.fix.x86_64.rpm
```

```bash
systemctl is-enabled wazuh-agent.service 
enabled
```
```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.3.9"
WAZUH_REVISION="40322"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Update and enable wazuh from packages, v4.3 to v4.4 :green_circle: </summary>

```bash
rpm -U wazuh-agent-4.4.0-rev.fix.x86_64.rpm 
```

```bash
systemctl is-enabled wazuh-agent.service 
enabled
```
```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.4.0"
WAZUH_REVISION="40400"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Install and enable wazuh from source code:green_circle: </summary>

```bash
bash install.sh
```

```bash
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...

Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-agent.service → /etc/systemd/system/wazuh-agent.service.
```
```bash
systemctl is-enabled wazuh-agent.service 
enabled
```

```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.3.9"
WAZUH_REVISION="40322"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Update and enable wazuh from source code, v4.3 to v4.4:green_circle: </summary>

```bash
bash install.sh
```

```bash
Stopping Wazuh...
agent
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Wait for success...
success
Starting Wazuh...
Update completed.
```
```bash
systemctl is-enabled wazuh-agent.service 
enabled
```

```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.4.0"
WAZUH_REVISION="40400"
WAZUH_TYPE="agent"
```
</details>

OS: **openSUSE 15.4**
<details> <summary>Install and enable wazuh from packages :green_circle: </summary>

```bash
rpm -i wazuh-agent-4.3.9-rev.fix.x86_64.rpm
```

```bash
systemctl is-enabled wazuh-agent.service 
enabled
```
```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.3.9"
WAZUH_REVISION="40322"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Update and enable wazuh from packages, v4.3 to v4.4 :green_circle: </summary>

```bash
rpm -U wazuh-agent-4.4.0-rev.fix.x86_64.rpm 
```

```bash
systemctl is-enabled wazuh-agent.service 
enabled
```
```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.4.0"
WAZUH_REVISION="40400"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Install and enable wazuh from source code:green_circle: </summary>

```bash
bash install.sh
```

```bash
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...

Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-agent.service → /etc/systemd/system/wazuh-agent.service.
```
```bash
systemctl is-enabled wazuh-agent.service 
enabled
```

```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.3.9"
WAZUH_REVISION="40322"
WAZUH_TYPE="agent"
```
</details>

<details> <summary>Update and enable wazuh from source code, v4.3 to v4.4:green_circle: </summary>

```bash
bash install.sh
```

```bash
Stopping Wazuh...
agent
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Wait for success...
success
Starting Wazuh...
Update completed.
```
```bash
systemctl is-enabled wazuh-agent.service 
enabled
```

```bash
/var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.4.0"
WAZUH_REVISION="40400"
WAZUH_TYPE="agent"
```
</details>

We tested in the version 15.3 too, because this version uses the old version of `init.d` since openSUSE 15.4 the support for System V init.d scripts is deprecated [cite](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP4/index.html#jsc-SLE-7690)

In both cases, the packages were built locally, with this command:

```bash
./generate_rpm_package.sh -b 4.x --packages-branch 4.x -s /tmp -t type -a x86_64 -r rev.fix --dev
```

## Conclutions
The proposed solution is similar to other symbolic links used in other operating systems. Also, it is important to remember that, the `ln` command does not care if the source file exists, so if there is an error in the path, it will not complain and it is relative to the parent directory of the symbolic link and not where `ln` is executed.


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [X] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
