### PR TITLE
Fixed `shasum` command in the `AIX` package generation 4.4

### DIFF
--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -62,7 +62,7 @@ build_perl() {
 
 build_cmake() {
   socket_lib=$(find /opt/freeware/lib/gcc/*/6.3.0/include-fixed/sys/ -name socket.h)
-  mv ${socket_lib} ${socket_lib}.bkp 
+  mv ${socket_lib} ${socket_lib}.bkp
   curl -LO http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz -k -s
   ln -s /usr/bin/make /usr/bin/gmake
   gunzip cmake-3.12.4.tar.gz && tar -xf cmake-3.12.4.tar && cd cmake-3.12.4
@@ -170,7 +170,7 @@ build_environment() {
     $rpm http://packages-dev.wazuh.com/deps/aix/libstdc%2B%2B-devel-6.3.0-1.aix7.2.ppc.rpm || true
     $rpm http://packages-dev.wazuh.com/deps/aix/gcc-c%2B%2B-6.3.0-1.aix7.2.ppc.rpm || true
   fi
-  
+
   build_perl
 
   if [[ "${aix_major}" = "6" ]] || [[ "${aix_major}" = "7" ]]; then
@@ -234,7 +234,7 @@ build_package() {
   if [ -f ${target_dir}/${rpm_file} ]; then
     echo "Your package ${rpm_file} is stored in ${target_dir}"
     if [[ "${compute_checksums}" = "yes" ]]; then
-      cd ${target_dir} && /usr/local/bin/shasum -a 512 ${rpm_file} > "${checksum_dir}/${rpm_file}.sha512"
+      cd ${target_dir} && echo "$(openssl dgst -sha512 ${rpm_file} | cut -d' ' -f2) ${rpm_file}" > "${checksum_dir}/${rpm_file}.sha512"
     fi
   else
     echo "Error: RPM package could not be created"

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -245,7 +245,7 @@ build_package() {
     if [[ "${compute_checksums}" = "yes" ]]; then
       cd ${target_dir}
       pkg_checksum="$(openssl dgst -sha512 ${rpm_file} | cut -d' ' -f "2")"
-      echo "${pkg_checksum} ${rpm_file}" > "${checksum_dir}/${rpm_file}.sha512"
+      echo "${pkg_checksum}  ${rpm_file}" > "${checksum_dir}/${rpm_file}.sha512"
     fi
   else
     echo "Error: RPM package could not be created"

--- a/aix/generate_wazuh_packages.sh
+++ b/aix/generate_wazuh_packages.sh
@@ -47,7 +47,7 @@ show_help() {
 }
 
 check_openssl() {
-  if [[ -z "$(command -v openssl)" && "${compute_checksums}" == "yes" ]]; then
+  if [[ -z "$(command -v openssl)" ]] && [[ "${compute_checksums}" = "yes" ]]; then
     echo "OpenSSL is not installed. OpenSSL is required to get the package checksum."
     return 1
   else


### PR DESCRIPTION

Related https://github.com/wazuh/wazuh-jenkins/pull/4251

## Description

This pull request fixes the binary used to obtain the `sha512` from the Wazuh `AIX` agent, since the `shasum` binary is not available on machines leased from `Site OX`, instead the `openssl` command (used internally by `shasum`) is used as well as it is done in the generation of the `HPUX` package

## Logs example

See: https://devel.ci.wazuh.info/view/Packages/job/Packages_builder_special/119/

## Tests

- Build the package in any supported platform
  - [x] AIX

