### PR TITLE
Fixing different typos in WPK generation

### DIFF
--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -218,18 +218,17 @@ main() {
 
 clean() {
     rm -rf ./{api,framework}
-    rm -rf doc wodles/oscap/content/* gen_ossec.sh add_localfiles.sh Jenkinsfile*
+    rm -rf doc gen_ossec.sh add_localfiles.sh Jenkinsfile*
     rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*}
     rm -rf src/{headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd}
-    rm -rf src/{os_dbdos_execd,os_integrator,os_maild,os_netos_regex,os_xml,os_zlib}
-    rm -rf src/{remoted,reportd,shared,syscheckd,tests,update,wazuh_db}
+    rm -rf src/{os_dbd,os_execd,os_integrator,os_maild,os_net,os_regex,os_xml,os_zlib}
+    rm -rf src/{remoted,reportd,shared,syscheckd,unit_tests,wazuh_db}
 
     if [[ "${BUILD_TARGET}" != "winagent" ]]; then
         rm -rf src/win32
     fi
 
     rm -rf src/*.a
-    rm -rf etc/{decoders,lists,rules}
 
     find etc/templates/config -not -name "sca.files" -delete 2>/dev/null
     find etc/templates/* -maxdepth 0 -not -name "en" -not -name "config" | xargs rm -rf


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-documentation/issues/5681|

## Description

The changes in this PR are aimed at fixing different typos in folders found when deleting unnecessary files, as well as removing several removals that are no longer needed.

These fixes have been found in the following PR to the documentation: https://github.com/wazuh/wazuh-documentation/pull/5701

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] WPK
- [x] Package installation
- [x] Package upgrade
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
