### PR TITLE
Added Wazuh dashboard light loading screen logo in dark mode 4.4

### DIFF
--- a/stack/dashboard/base/files/etc/styles.js
+++ b/stack/dashboard/base/files/etc/styles.js
@@ -129,8 +129,8 @@ const Styles = ({
           }
 
           .osdLoaderWrap svg {
-            width: 512px;
-            height: 150px;
+            width: 384px;
+            height: 112px;
             margin: auto;
             line-height: 1;
           }
@@ -166,7 +166,7 @@ const Styles = ({
             height: 150px;
             padding: 10px 10px 10px 10px;
           }
-          
+
           .loadingLogo {
             height: 100%;
             max-width: 100%;

--- a/stack/dashboard/base/files/etc/template.js
+++ b/stack/dashboard/base/files/etc/template.js
@@ -86,6 +86,18 @@ const Template = ({
   _react.default.createElement("path",{d:"M883.3,93.62A85.09,85.09,0,0,0,878.86,76a56.88,56.88,0,0,0-9.46-16.64A45.46,45.46,0,0,0,853.3,47q-9.93-4.71-24.54-4.7-19.05,0-32.48,8.22A53,53,0,0,0,782.19,63V8.35h-24.4V187h27.66V113.71q0-12.52,2.8-21.27A37.82,37.82,0,0,1,796,78.35a28.86,28.86,0,0,1,11.42-7.76,39.44,39.44,0,0,1,13.83-2.42c7.47,0,13.55,1.53,18.2,4.57a31.27,31.27,0,0,1,10.82,12,52.22,52.22,0,0,1,5.22,16.12,107.39,107.39,0,0,1,1.38,16.89V187h27.66V108.75A114.2,114.2,0,0,0,883.3,93.62Z", fill:"black"}),
 	_react.default.createElement("circle",{fill:"#3585F9",cx:"937.12",cy:"167.6",r:"22.24"}));
 
+  const openSearchLogoSpinnerDark = _react.default.createElement("svg", {
+    viewBox:"0 0 1024 200",
+    fill: "none",
+    xmlns: "http://www.w3.org/2000/svg"
+  },
+  _react.default.createElement("polygon",{points:"204.11 142.81 174.37 46.12 150.88 46.12 121.13 142.81 91.65 46.06 64.64 46.06 107.69 187.04 129.61 187.04 162.63 85 195.5 187.04 217.42 187.04 260.48 46.12 233.6 46.12 204.11 142.81", fill:"white"}),
+  _react.default.createElement("polygon",{points:"451.67 70.52 524.33 70.52 444.36 182.73 444.36 187.04 563.74 187.04 563.74 162.64 487.81 162.64 567.65 50.56 567.65 46.12 451.67 46.12 451.67 70.52", fill:"white"}),
+  _react.default.createElement("path",{d:"M390,61c-12.09-12.61-28.57-19.24-48-19.24-41,0-72,32.22-72,75s30.95,75,72,75c19.35,0,35.84-6.6,48-19.12v16.16h27.58V44.7H390Zm-45.15,104.7c-27.1,0-46.77-20.6-46.77-49s19.67-48.84,46.77-48.84S391.5,88.4,391.5,116.7,371.89,165.68,344.88,165.68Z", fill:"white"}),
+  _react.default.createElement("path",{d:"M696.14,125.88c0,25.29-13.92,39.8-38.18,39.8s-38.32-14.51-38.32-39.8V44.7H592v83.39c0,46.91,35.51,63.56,65.92,63.56s65.77-16.65,65.77-63.56V44.7H696.14Z", fill:"white"}),
+  _react.default.createElement("path",{d:"M883.3,93.62A85.09,85.09,0,0,0,878.86,76a56.88,56.88,0,0,0-9.46-16.64A45.46,45.46,0,0,0,853.3,47q-9.93-4.71-24.54-4.7-19.05,0-32.48,8.22A53,53,0,0,0,782.19,63V8.35h-24.4V187h27.66V113.71q0-12.52,2.8-21.27A37.82,37.82,0,0,1,796,78.35a28.86,28.86,0,0,1,11.42-7.76,39.44,39.44,0,0,1,13.83-2.42c7.47,0,13.55,1.53,18.2,4.57a31.27,31.27,0,0,1,10.82,12,52.22,52.22,0,0,1,5.22,16.12,107.39,107.39,0,0,1,1.38,16.89V187h27.66V108.75A114.2,114.2,0,0,0,883.3,93.62Z", fill:"white"}),
+  _react.default.createElement("circle",{fill:"#3585F9",cx:"937.12",cy:"167.6",r:"22.24"}));
+
 
   const loadingLogoDefault = (_injectedMetadata$bra = injectedMetadata.branding.loadingLogo) === null || _injectedMetadata$bra === void 0 ? void 0 : _injectedMetadata$bra.defaultUrl;
   const loadingLogoDarkMode = (_injectedMetadata$bra2 = injectedMetadata.branding.loadingLogo) === null || _injectedMetadata$bra2 === void 0 ? void 0 : _injectedMetadata$bra2.darkModeUrl;
@@ -170,7 +182,7 @@ const Template = ({
       }));
     }
 
-    return openSearchLogoSpinner;
+    return darkMode ? openSearchLogoSpinnerDark : openSearchLogoSpinner;
   };
 
   return /*#__PURE__*/_react.default.createElement("html", {

--- a/stack/dashboard/deb/debian/changelog
+++ b/stack/dashboard/deb/debian/changelog
@@ -1,11 +1,65 @@
-wazuh-dashboard (VERSION-RELEASE) unstable; urgency=low
+wazuh-dashboard (4.4.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Sat, 04 Dec 2021 14:04:26 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 03 Nov 2022 12:31:50 +0000
 
- wazuh-dashboard (4.2.5-1) UNRELEASED; urgency=low
+wazuh-dashboard (4.3.9-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Mon, 15 Nov 2021 16:47:07 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 03 Oct 2022 15:00:00 +0000
+
+wazuh-dashboard (4.3.8-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 19 Sep 2022 15:00:00 +0000
+
+wazuh-dashboard (4.3.7-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 08 Aug 2022 15:00:00 +0000
+
+wazuh-dashboard (4.3.6-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 07 Jul 2022 15:00:00 +0000
+
+wazuh-dashboard (4.3.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 29 Jun 2022 15:00:00 +0000
+
+wazuh-dashboard (4.3.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 07 Jun 2022 15:41:39 +0000
+
+wazuh-dashboard (4.3.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 31 May 2022 15:41:39 +0000
+
+wazuh-dashboard (4.3.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 30 May 2022 15:41:39 +0000
+
+wazuh-dashboard (4.3.1-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 18 May 2022 12:14:41 +0000
+
+wazuh-dashboard (4.3.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 05 May 2022 12:15:57 +0000

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -435,3 +435,4 @@ rm -fr %{buildroot}
 * Wed May 18 2022 support <info@wazuh.com> - 4.3.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu May 05 2022 support <info@wazuh.com> - 4.3.0
+- See https://documentation.wazuh.com/current/release-notes/

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -210,12 +210,6 @@ rm -fr %{buildroot}
 
 # -----------------------------------------------------------------------------
 
-%changelog
-* Mon Jan 10 2022 support <info@wazuh.com> - %{version}
-- More info: https://documentation.wazuh.com/current/release-notes/
-
-# -----------------------------------------------------------------------------
-
 %files
 %defattr(-,%{USER},%{GROUP})
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}
@@ -435,4 +429,4 @@ rm -fr %{buildroot}
 * Wed May 18 2022 support <info@wazuh.com> - 4.3.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu May 05 2022 support <info@wazuh.com> - 4.3.0
-- See https://documentation.wazuh.com/current/release-notes/
+- More info: https://documentation.wazuh.com/current/release-notes/

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -412,3 +412,26 @@ rm -fr %{buildroot}
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/config"
 %attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/node.options"
 %attr(640, root, root) "/etc/systemd/system/wazuh-dashboard.service"
+
+%changelog
+* Thu Nov 03 2022 support <info@wazuh.com> - 4.4.0
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Oct 03 2022 support <info@wazuh.com> - 4.3.9
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Sep 19 2022 support <info@wazuh.com> - 4.3.8
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Aug 08 2022 support <info@wazuh.com> - 4.3.7
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Thu Jul 07 2022 support <info@wazuh.com> - 4.3.6
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Tue May 31 2022 support <info@wazuh.com> - 4.3.3
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon May 30 2022 support <info@wazuh.com> - 4.3.2
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Wed May 18 2022 support <info@wazuh.com> - 4.3.1
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Thu May 05 2022 support <info@wazuh.com> - 4.3.0

--- a/stack/indexer/deb/debian/changelog
+++ b/stack/indexer/deb/debian/changelog
@@ -1,11 +1,65 @@
-wazuh-indexer (VERSION-RELEASE) unstable; urgency=low
+wazuh-indexer (4.4.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Tue, 01 Feb 2022 10:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 03 Nov 2022 12:31:50 +0000
 
-wazuh-indexer (4.2.5-1) UNRELEASED; urgency=low
+wazuh-indexer (4.3.9-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Mon, 15 Nov 2021 16:47:07 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 03 Oct 2022 15:00:00 +0000
+
+wazuh-indexer (4.3.8-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 19 Sep 2022 15:00:00 +0000
+
+wazuh-indexer (4.3.7-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 08 Aug 2022 15:00:00 +0000
+
+wazuh-indexer (4.3.6-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 07 Jul 2022 15:00:00 +0000
+
+wazuh-indexer (4.3.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 29 Jun 2022 15:00:00 +0000
+
+wazuh-indexer (4.3.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 07 Jun 2022 15:41:39 +0000
+
+wazuh-indexer (4.3.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 31 May 2022 15:41:39 +0000
+
+wazuh-indexer (4.3.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 30 May 2022 15:41:39 +0000
+
+wazuh-indexer (4.3.1-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 18 May 2022 12:14:41 +0000
+
+wazuh-indexer (4.3.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 05 May 2022 12:15:57 +0000

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -1339,3 +1339,4 @@ rm -fr %{buildroot}
 * Wed May 18 2022 support <info@wazuh.com> - 4.3.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu May 05 2022 support <info@wazuh.com> - 4.3.0
+- See https://documentation.wazuh.com/current/release-notes/

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -1316,3 +1316,26 @@ rm -fr %{buildroot}
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/jdk/lib/libjsvml.so
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/jdk/lib/libsyslookup.so
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/jdk/lib/security/blocked.certs
+
+%changelog
+* Thu Nov 03 2022 support <info@wazuh.com> - 4.4.0
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Oct 03 2022 support <info@wazuh.com> - 4.3.9
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Sep 19 2022 support <info@wazuh.com> - 4.3.8
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon Aug 08 2022 support <info@wazuh.com> - 4.3.7
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Thu Jul 07 2022 support <info@wazuh.com> - 4.3.6
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Wed Jun 29 2022 support <info@wazuh.com> - 4.3.5
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Tue Jun 07 2022 support <info@wazuh.com> - 4.3.4
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Tue May 31 2022 support <info@wazuh.com> - 4.3.3
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Mon May 30 2022 support <info@wazuh.com> - 4.3.2
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Wed May 18 2022 support <info@wazuh.com> - 4.3.1
+- More info: https://documentation.wazuh.com/current/release-notes/
+* Thu May 05 2022 support <info@wazuh.com> - 4.3.0

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -290,12 +290,6 @@ rm -fr %{buildroot}
 
 # -----------------------------------------------------------------------------
 
-%changelog
-* Tue Feb 01 2022 support <info@wazuh.com> - %{version}
-- More info: https://documentation.wazuh.com/current/release-notes/
-
-# -----------------------------------------------------------------------------
-
 %files
 %defattr(-, %{USER}, %{GROUP})
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}
@@ -1339,4 +1333,4 @@ rm -fr %{buildroot}
 * Wed May 18 2022 support <info@wazuh.com> - 4.3.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu May 05 2022 support <info@wazuh.com> - 4.3.0
-- See https://documentation.wazuh.com/current/release-notes/
+- More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION


## Description

This pull request modifies the `template.js` and `style.js` files of the Wazuh dashboard package to add a new light logo on the loading screen when the dark mode is activated, in addition, it reduces the size of the logo (both in light and dark mode) a 25%.

Additionally, the changelog of the Wazuh indexer and Wazuh dashboard is fixed to reflect the versions that have been released so far and avoid messages during the package generation like:

```
14:33:50  mk-build-deps: warning:     debian/changelog(l7): unrecognized line
14:33:50  LINE:  wazuh-dashboard (4.2.5-1) UN1D; urgency=low
```

## Logs example


- Wazuh dashboard
  - DEB
    - https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/8959/ 
    - https://packages-dev.wazuh.com/warehouse/test/4.4/deb/wazuh-dashboard_4.4.0-wp.1924_amd64.deb
  - RPM
    - https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/8964/ 
    - https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/wazuh-dashboard-4.4.0-wp.1924.x86_64.rpm
- Wazuh indexer
  - DEB
    - https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/8961/ 
    - https://packages-dev.wazuh.com/warehouse/test/4.4/deb/wazuh-indexer_4.4.0-wp.1924_amd64.deb
  - RPM
    - https://devel.ci.wazuh.info/view/Packages/job/Packages_builder/8967/ 
    - https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/wazuh-indexer-4.4.0-wp.1924.x86_64.rpm


<details><summary>All in One installation - 4.4.0</summary>

```
root@ubuntu20:/home/vagrant/packages# bash wazuh-install.sh -a -i
11/11/2022 19:27:42 INFO: Starting Wazuh installation assistant. Wazuh version: 4.4.0
11/11/2022 19:27:42 INFO: Verbose logging redirected to /var/log/wazuh-install.log
11/11/2022 19:27:43 WARNING: Hardware and system checks ignored.
11/11/2022 19:27:50 INFO: Wazuh development repository added.
11/11/2022 19:27:50 INFO: --- Configuration files ---
11/11/2022 19:27:50 INFO: Generating configuration files.
11/11/2022 19:27:51 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
11/11/2022 19:27:51 INFO: --- Wazuh indexer ---
11/11/2022 19:27:51 INFO: Starting Wazuh indexer installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/391 MB of archives.
After this operation, 670 MB of additional disk space will be used.
Get:1 /home/vagrant/packages/wazuh-indexer_4.4.0-wp.1924_amd64.deb wazuh-indexer amd64 4.4.0-wp.1924 [391 MB]
Selecting previously unselected package wazuh-indexer.
(Reading database ... 111722 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.4.0-wp.1924_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.4.0-wp.1924) ...
Setting up wazuh-indexer (4.4.0-wp.1924) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for systemd (245.4-4ubuntu3.18) ...
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
11/11/2022 19:28:20 INFO: Wazuh indexer installation finished.
11/11/2022 19:28:20 INFO: Wazuh indexer post-install configuration finished.
11/11/2022 19:28:20 INFO: Starting service wazuh-indexer.
11/11/2022 19:28:31 INFO: wazuh-indexer service started.
11/11/2022 19:28:31 INFO: Initializing Wazuh indexer cluster security settings.
11/11/2022 19:28:41 INFO: Wazuh indexer cluster initialized.
11/11/2022 19:28:41 INFO: --- Wazuh server ---
11/11/2022 19:28:41 INFO: Starting the Wazuh manager installation.
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/122 MB of archives.
After this operation, 466 MB of additional disk space will be used.
Get:1 /home/vagrant/packages/wazuh-manager_4.4.0-wp.1924_amd64.deb wazuh-manager amd64 4.4.0-0.0 [122 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 112785 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.4.0-wp.1924_amd64.deb ...
Unpacking wazuh-manager (4.4.0-0.0) ...
Setting up wazuh-manager (4.4.0-0.0) ...
Processing triggers for systemd (245.4-4ubuntu3.18) ...
11/11/2022 19:29:10 INFO: Wazuh manager installation finished.
11/11/2022 19:29:10 INFO: Starting service wazuh-manager.
11/11/2022 19:29:22 INFO: wazuh-manager service started.
11/11/2022 19:29:22 INFO: Starting Filebeat installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  filebeat
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 22.1 MB of archives.
After this operation, 73.6 MB of additional disk space will be used.
Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 filebeat amd64 7.10.2 [22.1 MB]
Fetched 22.1 MB in 3s (7,857 kB/s)
Selecting previously unselected package filebeat.
(Reading database ... 131512 files and directories currently installed.)
Preparing to unpack .../filebeat_7.10.2_amd64.deb ...
Unpacking filebeat (7.10.2) ...
Setting up filebeat (7.10.2) ...
Processing triggers for systemd (245.4-4ubuntu3.18) ...
11/11/2022 19:29:29 INFO: Filebeat installation finished.
11/11/2022 19:29:31 INFO: Filebeat post-install configuration finished.
11/11/2022 19:29:31 INFO: Starting service filebeat.
11/11/2022 19:29:32 INFO: filebeat service started.
11/11/2022 19:29:32 INFO: --- Wazuh dashboard ---
11/11/2022 19:29:32 INFO: Starting Wazuh dashboard installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-dashboard
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/156 MB of archives.
After this operation, 848 MB of additional disk space will be used.
Get:1 /home/vagrant/packages/wazuh-dashboard_4.4.0-wp.1924_amd64.deb wazuh-dashboard amd64 4.4.0-wp.1924 [156 MB]
Selecting previously unselected package wazuh-dashboard.
(Reading database ... 131831 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.4.0-wp.1924_amd64.deb ...
Creating wazuh-dashboard group... OK
Creating wazuh-dashboard user... OK
Unpacking wazuh-dashboard (4.4.0-wp.1924) ...
Setting up wazuh-dashboard (4.4.0-wp.1924) ...
11/11/2022 19:30:05 INFO: Wazuh dashboard installation finished.
11/11/2022 19:30:05 INFO: Wazuh dashboard post-install configuration finished.
11/11/2022 19:30:05 INFO: Starting service wazuh-dashboard.
11/11/2022 19:30:06 INFO: wazuh-dashboard service started.
11/11/2022 19:30:25 INFO: Initializing Wazuh dashboard web application.
11/11/2022 19:30:26 INFO: Wazuh dashboard web application initialized.
11/11/2022 19:30:26 INFO: --- Summary ---
11/11/2022 19:30:26 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: h.V6RP*j8sGkCi2Bde8znNvGguOyNzc*
11/11/2022 19:30:26 INFO: Installation finished.
```
</details>

<details><summary>New logo screenshots</summary>

- Dark mode loading screen

![image](https://user-images.githubusercontent.com/14913942/201417637-ab791496-139b-4e29-99dc-b7e570d3d53e.png)

- Light mode loading screen

![image](https://user-images.githubusercontent.com/14913942/201418556-f1e78710-d02b-43dd-8385-dcbe609131a0.png)


</details>

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
- Tests for Linux deb
  - [x] Build the package for x86_64
