### PR TITLE
Add flag mechanism to configure the protection for untrusted libraries verification

### DIFF
--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -7,6 +7,7 @@ JOBS=$2
 DEBUG=$3
 REVISION=$4
 TRUST_VERIFICATION=$5
+CA_NAME=$6
 ZIP_NAME="windows_agent_${REVISION}.zip"
 
 URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
@@ -15,14 +16,14 @@ URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
 wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip
 
 # Compile the wazuh agent for Windows
-FLAGS="-j ${JOBS} IMAGE_TRUST_CHECKS=${TRUST_VERIFICATION}"
+FLAGS="-j ${JOBS} IMAGE_TRUST_CHECKS=${TRUST_VERIFICATION} CA_NAME=\"${CA_NAME}\" "
 
 if [[ "${DEBUG}" = "yes" ]]; then
     FLAGS+="-d "
 fi
 
-make -C /wazuh-*/src deps TARGET=winagent ${FLAGS}
-make -C /wazuh-*/src TARGET=winagent ${FLAGS}
+bash -c "make -C /wazuh-*/src deps TARGET=winagent ${FLAGS}"
+bash -c "make -C /wazuh-*/src TARGET=winagent ${FLAGS}"
 
 rm -rf /wazuh-*/src/external
 

--- a/windows/entrypoint.sh
+++ b/windows/entrypoint.sh
@@ -6,6 +6,7 @@ BRANCH=$1
 JOBS=$2
 DEBUG=$3
 REVISION=$4
+TRUST_VERIFICATION=$5
 ZIP_NAME="windows_agent_${REVISION}.zip"
 
 URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
@@ -14,7 +15,7 @@ URL_REPO=https://github.com/wazuh/wazuh/archive/${BRANCH}.zip
 wget -O wazuh.zip ${URL_REPO} && unzip wazuh.zip
 
 # Compile the wazuh agent for Windows
-FLAGS="-j ${JOBS} "
+FLAGS="-j ${JOBS} IMAGE_TRUST_CHECKS=${TRUST_VERIFICATION}"
 
 if [[ "${DEBUG}" = "yes" ]]; then
     FLAGS+="-d "

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -7,6 +7,7 @@ DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
 TRUST_VERIFICATION="1"
+CA_NAME="DigiCert High Assurance EV Root CA"
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -21,7 +22,7 @@ generate_compiled_win_agent() {
     fi
 
     docker build -t ${DOCKER_IMAGE_NAME} ./ || exit 1
-    docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} ${TRUST_VERIFICATION} || exit 1
+    docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} ${TRUST_VERIFICATION} "${CA_NAME}" || exit 1
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 }
 
@@ -36,6 +37,7 @@ help() {
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: 1 (only warnings)."
+    echo "    -c, --ca_name <CA name>   [Optional] CA name to be used to verify the trust of the agent. By default: DigiCert High Assurance EV Root CA."
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -90,6 +92,14 @@ main() {
         "-t"|"--trust_verification")
             if [ -n "$2" ]; then
                 TRUST_VERIFICATION="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "-c"|"--ca_name")
+            if [ -n "$2" ]; then
+                CA_NAME="$2"
                 shift 2
             else
                 help 1

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -6,6 +6,7 @@ REVISION="1"
 DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
+TRUST_VERIFICATION="no"
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -20,7 +21,7 @@ generate_compiled_win_agent() {
     fi
 
     docker build -t ${DOCKER_IMAGE_NAME} ./ || exit 1
-    docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} || exit 1
+    docker run --rm -v ${OUTDIR}:/shared ${DOCKER_IMAGE_NAME} ${BRANCH} ${JOBS} ${DEBUG} ${REVISION} ${TRUST_VERIFICATION} || exit 1
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 }
 
@@ -34,6 +35,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
+    echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: no."
     echo "    -h, --help                Show this help."
     echo
     exit $1
@@ -80,6 +82,14 @@ main() {
         "-s"|"--store")
             if [ -n "$2" ]; then
                 OUTDIR="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "-t"|"--trust_verification")
+            if [ -n "$2" ]; then
+                TRUST_VERIFICATION="$2"
                 shift 2
             else
                 help 1

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -6,7 +6,7 @@ REVISION="1"
 DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
-TRUST_VERIFICATION="no"
+TRUST_VERIFICATION="1"
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -35,7 +35,7 @@ help() {
     echo "    -r, --revision <rev>      [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-    echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: no."
+    echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: 1 (only warnings)."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -78,6 +78,7 @@ function BuildWazuhMsi(){
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\InstallerScripts.vbs"
         Write-Host "Signing .dll files..."
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\*.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\*.dll"
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\data_provider\build\bin\sysinfo.dll"
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"


### PR DESCRIPTION
|Related issue|
|---|
|Closes wazuh/wazuh#15327|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This pull request aims to add a new flag at compile time, to identify when the signature is done and when not in windows, so that based on this the trusted dll verification is activated or not.


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
