### PR TITLE
Add libffi-dev to WPK package common builder

### DIFF
--- a/wpk/common/Dockerfile
+++ b/wpk/common/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:9
 
 RUN apt-get update && \
-    apt-get -y install python git curl jq python3 python3-pip && \
+    apt-get -y install python git curl jq python3 python3-pip libffi-dev && \
     pip3 install --upgrade cryptography==2.9.2 awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack


### PR DESCRIPTION
|Related issue|
|---|
| closes #1050 |

## Description
Hello!

We have included the fix to the Dockerfile.

## Tests
```
./generate_wpk_package.sh -t windows -b v4.3.10 -pn /.../wazuh-packages-tmp/wpk/wazuh-agent-4.3.10-1.msi -o wazuh-agent.wpk -d /.../wazuh-packages-tmp/wpk/output -k /.../wazuh-packages-tmp/wpk/keys
.
.
.
+++ PRETTY_NAME='Debian GNU/Linux 9 (stretch)'
+++ NAME='Debian GNU/Linux'
+++ VERSION_ID=9
+++ VERSION='9 (stretch)'
+++ VERSION_CODENAME=stretch
+++ ID=debian
+++ HOME_URL=https://www.debian.org/
+++ SUPPORT_URL=https://www.debian.org/support
+++ BUG_REPORT_URL=https://bugs.debian.org/
++ DIST_NAME=debian
+++ echo 9
+++ sed -rn 's/[^0-9]*([0-9]+).*/\1/p'
++ DIST_VER=9
++ '[' X9 = X ']'
++ '[' debian = amzn ']'
+++ echo 9
+++ sed -rn 's/[^0-9]*[0-9]+\.([0-9]+).*/\1/p'
++ DIST_SUBVER=
++ '[' X = X ']'
++ DIST_SUBVER=0
++ '[' '!' -r /etc/os-release ']'
++ '[' debian = centos ']'
++ cat src/VERSION
+ VERSION=v4.3.10
++ cat src/VERSION
++ cut -dv -f2
+ SHORT_VERSION=4.3.10
++ uname -m
+ ARCH=x86_64
+ '[' -z '' ']'
+ '[' debian = centos ']'
+ BUILD_TARGET=winagent
+ NO_COMPILE=true
+ OUTPUT=/var/local/wazuh/wazuh-agent.wpk
+ mkdir -p /var/local/wazuh
++ cat src/VERSION
+ WAZUH_VERSION=v4.3.10
++ echo v4.3.10
++ cut -dv -f2
++ cut -d. -f1
+ MAJOR=4
++ echo v4.3.10
++ cut -d. -f2
+ MINOR=3
+ '[' true == false ']'
+ '[' debian = centos ']'
+ '[' true == true ']'
++ pwd
+ CURRENT_DIR=/wazuh-wazuh-89530f1
+ echo 'wpkpack /var/local/wazuh/wazuh-agent.wpk /etc/wazuh/wpkcert.pem /etc/wazuh/wpkcert.key wazuh-agent-4.3.10-1.msi upgrade.bat do_upgrade.ps1'
wpkpack /var/local/wazuh/wazuh-agent.wpk /etc/wazuh/wpkcert.pem /etc/wazuh/wpkcert.key wazuh-agent-4.3.10-1.msi upgrade.bat do_upgrade.ps1
+ cd /var/local/wazuh
+ cp /wazuh-wazuh-89530f1/src/win32/upgrade.bat /wazuh-wazuh-89530f1/src/win32/do_upgrade.ps1 .
+ cp /var/pkg/wazuh-agent-4.3.10-1.msi /var/local/wazuh
+ wpkpack /var/local/wazuh/wazuh-agent.wpk /etc/wazuh/wpkcert.pem /etc/wazuh/wpkcert.key wazuh-agent-4.3.10-1.msi upgrade.bat do_upgrade.ps1
+ rm -f upgrade.bat do_upgrade.ps1 wazuh-agent-4.3.10-1.msi
+ echo 'PACKED FILE -> /var/local/wazuh/wazuh-agent.wpk'
PACKED FILE -> /var/local/wazuh/wazuh-agent.wpk
+ cd /var/local/wazuh
+ [[ yes == \y\e\s ]]
+ mkdir -p /var/local/checksum
+ sha512sum wazuh-agent.wpk
```

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
