### PR TITLE
Remove grep from getent command

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/postrm
+++ b/debs/SPECS/wazuh-agent/debian/postrm
@@ -40,10 +40,10 @@ case "$1" in
 
         purge)
 
-        if getent passwd | grep -q "^wazuh" ; then
+        if getent passwd wazuh ; then
             deluser wazuh > /dev/null 2>&1
         fi
-        if getent group | grep -q "^wazuh" ; then
+        if getent group wazuh ; then
             delgroup wazuh > /dev/null 2>&1
         fi
         rm -rf ${DIR}/*

--- a/solaris/solaris10/postremove.sh
+++ b/solaris/solaris10/postremove.sh
@@ -2,10 +2,10 @@
 # postremove script for wazuh-agent
 # Wazuh, Inc 2015
 
-if getent passwd | grep "^wazuh"; then
+if getent passwd wazuh; then
   userdel wazuh
 fi
 
-if getent group | grep "^wazuh"; then
+if getent group wazuh; then
   groupdel wazuh
 fi

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -39,7 +39,7 @@ if [ "$?" -eq 1 ]; then
     groupadd ${GROUP}
 fi
 
-getent passwd | grep "^wazuh"
+getent passwd wazuh
 if [ "$?" -eq 1 ]; then
     useradd -d ${DIR} -s ${OSMYSHELL} -g ${GROUP} ${USER} > /dev/null 2>&1
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#1931|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes an error that appeared when uninstalling the wazuh-agent if wazuh-dashboard or wazuh-indexer was installed.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
