### PR TITLE
Added lsof as a dependency of the unattended installer

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -211,12 +211,9 @@ def test_check_log_errors():
     with open('/var/ossec/logs/ossec.log', 'r') as f:
         for line in f.readlines():
             if 'ERROR' in line:
-                found_error = True
-                if get_wazuh_version() == 'v4.5.0':
-                    if 'ERROR: Cluster error detected' in line or 'agent-upgrade: ERROR: (8123): There has been an error executing the request in the tasks manager.' in line:
-                        found_error = False
-                    else:
-                      break
+                if 'ERROR: Cluster error detected' not in line and 'agent-upgrade: ERROR: (8123): There has been an error executing the request in the tasks manager.' not in line:
+                    found_error = True
+                    break
     assert found_error == False, line
 
 @pytest.mark.wazuh_cluster
@@ -235,12 +232,9 @@ def test_check_cluster_log_errors():
     with open('/var/ossec/logs/cluster.log', 'r') as f:
         for line in f.readlines():
             if 'ERROR' in line:
-                found_error = True
-                if get_wazuh_version() == 'v4.5.0':
-                    if 'Could not connect to master' in line or 'Worker node is not connected to master' in line or 'Connection reset by peer' in line:
-                        found_error = False
-                    else:
-                      break
+                if 'Could not connect to master' not in line and 'Worker node is not connected to master' not in line and 'Connection reset by peer' not in line and "Error sending sendsync response to local client: Error 3020 - Timeout sending" not in line:
+                    found_error = True
+                    break
     assert found_error == False, line
 
 @pytest.mark.wazuh_cluster

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -311,7 +311,7 @@ function checks_ports() {
     ports=("$@")
 
     if command -v lsof > /dev/null; then
-        port_command="lsof -i:"
+        port_command="lsof -sTCP:LISTEN  -i:"
     else
         common_logger -w "Cannot find lsof. Port checking will be skipped."
         return 1

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -310,15 +310,11 @@ function checks_ports() {
     used_port=0
     ports=("$@")
 
-    if command -v ss > /dev/null; then
-        port_command="ss -lntup | grep -q "
+    if command -v lsof > /dev/null; then
+        port_command="lsof -i:"
     else
-        if command -v lsof > /dev/null; then
-            port_command="lsof -i:"
-        else
-            common_logger -w "Cannot find ss or lsof. Port checking will be skipped."
-            return 1
-        fi
+        common_logger -w "Cannot find lsof. Port checking will be skipped."
+        return 1
     fi
 
     for i in "${!ports[@]}"; do

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -119,7 +119,7 @@ function installCommon_changePasswordApi() {
                 passwords_changeDashboardApiPassword "${password}"
         fi
     fi
-    
+
 }
 
 function installCommon_createCertificates() {
@@ -211,7 +211,7 @@ function installCommon_changePasswords() {
         passwords_getNetworkHost
         passwords_generateHash
     fi
-    
+
     passwords_changePassword
 
     if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
@@ -263,7 +263,7 @@ function installCommon_getPass() {
 function installCommon_installPrerequisites() {
 
     if [ "${sys_type}" == "yum" ]; then
-        dependencies=( curl libcap tar gnupg openssl )
+        dependencies=( curl libcap tar gnupg openssl lsof )
         not_installed=()
         for dep in "${dependencies[@]}"; do
             if [ "${dep}" == "openssl" ]; then
@@ -289,7 +289,7 @@ function installCommon_installPrerequisites() {
 
     elif [ "${sys_type}" == "apt-get" ]; then
         eval "apt-get update -q ${debug}"
-        dependencies=( apt-transport-https curl libcap2-bin tar software-properties-common gnupg openssl )
+        dependencies=( apt-transport-https curl libcap2-bin tar software-properties-common gnupg openssl lsof )
         not_installed=()
 
         for dep in "${dependencies[@]}"; do


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1857|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill in the table above. Feel free to extend it at your convenience.
-->

## Description

This pull request modifies how the unattended installer checks the used ports before installing.
It is a copy of PR: https://github.com/wazuh/wazuh-packages/pull/1942 because of renaming the branch to `1857-check-ports-change-grep-master`.

This modification consists of removing the `grep` command as an alternative to the `checks_ports()` function and keeping the `lsof` command as the only port command checker.

With this change, it is compulsory to make the `lsof` package a dependency of the unattended installer.

## Tests
The tests are defined in the related issue, specifically in https://github.com/wazuh/wazuh-packages/issues/1857#issuecomment-1324943850
