### PR TITLE
Fix error when creating user in Solaris 10

### DIFF
--- a/solaris/solaris10/postremove.sh
+++ b/solaris/solaris10/postremove.sh
@@ -2,10 +2,10 @@
 # postremove script for wazuh-agent
 # Wazuh, Inc 2015
 
-if getent passwd wazuh; then
+if getent passwd wazuh > /dev/null 2>&1; then
   userdel wazuh
 fi
 
-if getent group wazuh; then
+if getent group wazuh > /dev/null 2>&1; then
   groupdel wazuh
 fi

--- a/solaris/solaris10/preinstall.sh
+++ b/solaris/solaris10/preinstall.sh
@@ -34,13 +34,13 @@ if [ ! -f ${OSMYSHELL} ]; then
     fi
 fi
 
-getent group | grep "^wazuh"
-if [ "$?" -eq 1 ]; then
+getent group wazuh > /dev/null 2>&1
+if [ "$?" -ne 0 ]; then
     groupadd ${GROUP}
 fi
 
-getent passwd wazuh
-if [ "$?" -eq 1 ]; then
+getent passwd wazuh > /dev/null 2>&1
+if [ "$?" -ne 0 ]; then
     useradd -d ${DIR} -s ${OSMYSHELL} -g ${GROUP} ${USER} > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error with the creation of the users in Solaris 10 agents.

## Logs example

<!--
Paste here related logs
-->
```
# pkgadd -i -d wazuh-agent_v4.4.0-test.user-sol10-i386.pkg 

The following packages are available:
  1  wazuh-agent     Wazuh - Improved OSSEC agent for Intrusion Detection, File Integrity Monitoring, Policy Monitoring and Rootkits Detection.
                     (i386) 4.4.0

Select package(s) you wish to process (or 'all' to process
all packages). (default: all) [?,??,q]: 

Processing package instance <wazuh-agent> from </export/home/vagrant/wazuh-agent_v4.4.0-test.user-sol10-i386.pkg>

Wazuh - Improved OSSEC agent for Intrusion Detection, File Integrity Monitoring, Policy Monitoring and Rootkits Detection.(i386) 4.4.0

This appears to be an attempt to install the same architecture and
version of a package which is already installed.  This installation
will attempt to overwrite this package.


The installation of this package was previously terminated and
installation was never successfully completed.

Do you want to continue with the installation of <wazuh-agent> [y,n,?] y
Wazuh, Inc <info@wazuh.com>
## Executing checkinstall script.
Using </> as the package base directory.
## Processing package information.
## Processing system information.
   3 package pathnames are already properly installed.
## Verifying disk space requirements.
## Checking for conflicts with packages already installed.
## Checking for setuid/setgid programs.

This package contains scripts which will be executed with super-user
permission during the process of installing this package.

Do you want to continue with the installation of <wazuh-agent> [y,n,?] y

Installing Wazuh - Improved OSSEC agent for Intrusion Detection, File Integrity Monitoring, Policy Monitoring and Rootkits Detection. as <wazuh-agent>

## Executing preinstall script.
=====================================================================================
= Backup from your ossec.conf has been created at /var/ossec/etc/ossec.conf.deborig =
= Please verify your ossec.conf configuration at /var/ossec/etc/ossec.conf          =
=====================================================================================
## Installing part 1 of 1.
/etc/init.d/wazuh-agent
/var/ossec/active-response/bin/default-firewall-drop
/var/ossec/active-response/bin/disable-account
/var/ossec/active-response/bin/firewall-drop
/var/ossec/active-response/bin/firewalld-drop
/var/ossec/active-response/bin/host-deny
/var/ossec/active-response/bin/ip-customblock
/var/ossec/active-response/bin/ipfw
/var/ossec/active-response/bin/kaspersky
/var/ossec/active-response/bin/kaspersky.py
/var/ossec/active-response/bin/npf
/var/ossec/active-response/bin/pf
/var/ossec/active-response/bin/restart-wazuh
/var/ossec/active-response/bin/restart.sh
/var/ossec/active-response/bin/route-null
/var/ossec/active-response/bin/wazuh-slack
/var/ossec/agentless/main.exp
/var/ossec/agentless/register_host.sh
/var/ossec/agentless/ssh.exp
/var/ossec/agentless/ssh_asa-fwsmconfig_diff
/var/ossec/agentless/ssh_foundry_diff
/var/ossec/agentless/ssh_generic_diff
/var/ossec/agentless/ssh_integrity_check_bsd
/var/ossec/agentless/ssh_integrity_check_linux
/var/ossec/agentless/ssh_nopass.exp
/var/ossec/agentless/ssh_pixconfig_diff
/var/ossec/agentless/sshlogin.exp
/var/ossec/agentless/su.exp
/var/ossec/bin/agent-auth
/var/ossec/bin/manage_agents
/var/ossec/bin/wazuh-agentd
/var/ossec/bin/wazuh-control
/var/ossec/bin/wazuh-execd
/var/ossec/bin/wazuh-logcollector
/var/ossec/bin/wazuh-modulesd
/var/ossec/bin/wazuh-syscheckd
/var/ossec/etc/TIMEZONE
/var/ossec/etc/client.keys
/var/ossec/etc/internal_options.conf
/var/ossec/etc/local_internal_options.conf
/var/ossec/etc/ossec.conf
/var/ossec/etc/shared/cis_apache2224_rcl.txt
/var/ossec/etc/shared/cis_debian_linux_rcl.txt
/var/ossec/etc/shared/cis_mysql5-6_community_rcl.txt
/var/ossec/etc/shared/cis_mysql5-6_enterprise_rcl.txt
/var/ossec/etc/shared/cis_rhel5_linux_rcl.txt
/var/ossec/etc/shared/cis_rhel6_linux_rcl.txt
/var/ossec/etc/shared/cis_rhel7_linux_rcl.txt
/var/ossec/etc/shared/cis_rhel_linux_rcl.txt
/var/ossec/etc/shared/cis_sles11_linux_rcl.txt
/var/ossec/etc/shared/cis_sles12_linux_rcl.txt
/var/ossec/etc/shared/cis_win2012r2_domainL1_rcl.txt
/var/ossec/etc/shared/cis_win2012r2_domainL2_rcl.txt
/var/ossec/etc/shared/cis_win2012r2_memberL1_rcl.txt
/var/ossec/etc/shared/cis_win2012r2_memberL2_rcl.txt
/var/ossec/etc/shared/rootkit_files.txt
/var/ossec/etc/shared/rootkit_trojans.txt
/var/ossec/etc/shared/system_audit_rcl.txt
/var/ossec/etc/shared/system_audit_ssh.txt
/var/ossec/etc/shared/win_applications_rcl.txt
/var/ossec/etc/shared/win_audit_rcl.txt
/var/ossec/etc/shared/win_malware_rcl.txt
/var/ossec/etc/wpk_root.pem
/var/ossec/lib/libdbsync.so
/var/ossec/lib/libgcc_s.so.1
/var/ossec/lib/librsync.so
/var/ossec/lib/libstdc++.so.6
/var/ossec/lib/libsyscollector.so
/var/ossec/lib/libsysinfo.so
/var/ossec/lib/libwazuhext.so
/var/ossec/lib/libwazuhshared.so
/var/ossec/logs/active-responses.log
/var/ossec/logs/ossec.json
/var/ossec/logs/ossec.log
/var/ossec/queue/syscollector/norm_config.json
/var/ossec/ruleset/sca/sca_unix_audit.yml
/var/ossec/wodles/__init__.py
/var/ossec/wodles/aws/aws-s3
/var/ossec/wodles/azure/azure-logs
/var/ossec/wodles/azure/orm.py
/var/ossec/wodles/docker/DockerListener
/var/ossec/wodles/gcloud/buckets/access_logs.py
/var/ossec/wodles/gcloud/buckets/bucket.py
/var/ossec/wodles/gcloud/exceptions.py
/var/ossec/wodles/gcloud/gcloud
/var/ossec/wodles/gcloud/integration.py
/var/ossec/wodles/gcloud/pubsub/subscriber.py
/var/ossec/wodles/gcloud/tools.py
/var/ossec/wodles/utils.py
[ verifying class <none> ]
## Executing postinstall script.

Installation of <wazuh-agent> was successful.
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [ ] Change added to CHANGELOG.md

- Tests for Solaris
  - [x] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template

