### PR TITLE
Added ossec.conf file generation and improved SPECs

### DIFF
--- a/alpine/SPECS/wazuh-agent/APKBUILD
+++ b/alpine/SPECS/wazuh-agent/APKBUILD
@@ -7,13 +7,14 @@ pkgdesc="Wazuh helps you to gain security visibility into your infrastructure."
 url="https://www.wazuh.com/"
 arch="${architecture}"
 license="GPL"
-depends="busybox procps"
+depends="bash busybox procps"
 makedepends="make cmake git openssl-dev libgcc gcc automake autoconf libtool"
 checkdepends=""
 install="${pkgname}.pre-install ${pkgname}.post-install ${pkgname}.pre-upgrade ${pkgname}.post-upgrade ${pkgname}.pre-deinstall ${pkgname}.post-deinstall"
 subpackages=""
 source=""
-builddir="${srcdir}/"
+builddir="${srcdir}"
+options="!check"
 
 build() {
   set -x
@@ -42,8 +43,6 @@ build() {
   ./install.sh
 }
 
-check(){ :; }
-
 package() {
   set -x
   rootdir="${builddir}/.."
@@ -56,5 +55,18 @@ package() {
   sed -i "s|DIRECTORY_BASE|${directory_base}|g" "${rootdir}/${pkgname}.pre-deinstall"
   sed -i "s|DIRECTORY_BASE|${directory_base}|g" "${rootdir}/${pkgname}.post-deinstall"
   cp -a "${directory_base}"/* "${pkgdir}${directory_base}"
+
+  package_files_dir="${pkgdir}${directory_base}/packages_files"
+  mkdir -p "${pkgdir}${directory_base}/packages_files/src/init"
+  mkdir -p "${pkgdir}${directory_base}/packages_files/etc/templates/config/generic/localfile-logs"
+  cp -a /wazuh-wazuh*/gen_ossec.sh "${package_files_dir}"
+  cp -a /wazuh-wazuh*/add_localfiles.sh "${package_files_dir}"
+  cp -a /wazuh-wazuh*/src/init/dist-detect.sh "${package_files_dir}/src/init"
+  cp -a /wazuh-wazuh*/src/init/shared.sh "${package_files_dir}/src/init"
+  cp -a /wazuh-wazuh*/src/init/inst-functions.sh "${package_files_dir}/src/init"
+  cp -a /wazuh-wazuh*/src/init/template-select.sh "${package_files_dir}/src/init"
+  cp -a /wazuh-wazuh*/src/VERSION "${package_files_dir}/src"
+  cp -a /wazuh-wazuh*/src/REVISION "${package_files_dir}/src"
+  cp -a /wazuh-wazuh*/etc/templates/config/generic/* "${package_files_dir}/etc/templates/config/generic"
 }
 

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-deinstall
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-deinstall
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -ex
-
 # add something which happens after deinstall
 
 directory_base="DIRECTORY_BASE"

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
@@ -2,4 +2,16 @@
 
 # add something which happens after install
 
+directory_base="DIRECTORY_BASE"
+
+touch ${directory_base}/logs/active-responses.log
+
+. ${directory_base}/packages_files/src/init/dist-detect.sh
+
+# Generating ossec.conf file
+${directory_base}/packages_files/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} ${directory_base} > ${directory_base}/etc/ossec.conf
+
+# Add default local_files to ossec.conf
+${directory_base}/packages_files/add_localfiles.sh ${directory_base} >> ${directory_base}/etc/ossec.conf
+
 exit 0

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-upgrade
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-upgrade
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -ex
-
 # add something which happens after upgrade
 
 directory_base="DIRECTORY_BASE"

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.pre-deinstall
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.pre-deinstall
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -ex
-
 # add something which happens before deinstall
 
 directory_base="DIRECTORY_BASE"

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.pre-install
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.pre-install
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -ex
-
 # add something which happens before install
 
 directory_base="DIRECTORY_BASE"

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.pre-upgrade
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.pre-upgrade
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -ex
-
 # add something which happens before upgrade
 
 directory_base="DIRECTORY_BASE"


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-documentation/issues/5775 |

## Description

Hello! We have improved the Alpine packages.

## Tests

Install
```
# apk add wazuh-agent-4.4.0-r1.apk --allow-untrusted
(1/10) Installing ncurses-terminfo-base (6.3_p20221119-r0)
(2/10) Installing ncurses-libs (6.3_p20221119-r0)
(3/10) Installing readline (8.2.0-r0)
(4/10) Installing bash (5.2.12-r0)
Executing bash-5.2.12-r0.post-install
(5/10) Installing libintl (0.21.1-r1)
(6/10) Installing libproc (3.3.17-r2)
(7/10) Installing procps (3.3.17-r2)
(8/10) Installing libgcc (12.2.1_git20220924-r4)
(9/10) Installing libstdc++ (12.2.1_git20220924-r4)
(10/10) Installing wazuh-agent (4.4.0-r1)
Executing wazuh-agent-4.4.0-r1.pre-install
Executing wazuh-agent-4.4.0-r1.post-install
Executing busybox-1.35.0-r29.trigger
OK: 29 MiB in 25 packages
```

Remove
```
# apk del wazuh-agent
(1/10) Purging wazuh-agent (4.4.0-r1)
Executing wazuh-agent-4.4.0-r1.pre-deinstall
Executing wazuh-agent-4.4.0-r1.post-deinstall
(2/10) Purging bash (5.2.12-r0)
Executing bash-5.2.12-r0.pre-deinstall
(3/10) Purging procps (3.3.17-r2)
(4/10) Purging readline (8.2.0-r0)
(5/10) Purging ncurses-libs (6.3_p20221119-r0)
(6/10) Purging ncurses-terminfo-base (6.3_p20221119-r0)
(7/10) Purging libintl (0.21.1-r1)
(8/10) Purging libproc (3.3.17-r2)
(9/10) Purging libstdc++ (12.2.1_git20220924-r4)
(10/10) Purging libgcc (12.2.1_git20220924-r4)
Executing busybox-1.35.0-r29.trigger
OK: 7 MiB in 15 packages

```