### PR TITLE
Fix wrongful removing of files by function clean_and_exit

### DIFF
--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -37,8 +37,8 @@ trap ctrl_c INT
 
 function clean_and_exit() {
     exit_code=$1
-    rm -f ${AGENT_PKG_FILE} ${CURRENT_PATH}/package_files/*.sh
     rm -rf "${SOURCES_DIRECTORY}"
+    rm "${CURRENT_PATH}"/specs/wazuh-agent.pkgproj-e
     ${CURRENT_PATH}/uninstall.sh
     exit ${exit_code}
 }

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -1,11 +1,11 @@
-#/bin/sh
+#!/bin/sh
 
 ## Stop and remove application
 sudo /Library/Ossec/bin/ossec-control stop
 sudo /bin/rm -r /Library/Ossec*
 
 ## stop and unload dispatcher
-#sudo /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+/bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 # remove launchdaemons
 sudo /bin/rm -f /Library/LaunchDaemons/com.wazuh.agent.plist


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1965|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The function `clean_and_exit` in script `generate_wazuh_packages.sh` of macOS removed wrongfully the necessary scripts for the installation when an installation finished with an error. When trying to run the installation again it gave an error, as explained in the issue

## Logs example

<!--
Paste here related logs
-->

## Tests
Tested for macOS package creation with and without errors, and it gives no problem.
