### PR TITLE
Remove check for node types in `-A` option of `wazuh-certs-tool.s`

### DIFF
--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -20,7 +20,7 @@ function getHelp() {
     echo -e "                Creates the admin certificates, add root-ca.pem and root-ca.key."
     echo -e ""
     echo -e "        -A, --all </path/to/root-ca.pem> </path/to/root-ca.key>"
-    echo -e "                Creates Wazuh server, Wazuh indexer, Wazuh dashboard, and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created."
+    echo -e "                Creates certificates specified in config.yml and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created."
     echo -e ""
     echo -e "        -ca, --root-ca-certificates"
     echo -e "                Creates the root-ca certificates."
@@ -186,26 +186,21 @@ function main() {
         fi
 
         if [[ -n "${all}" ]]; then
-            if [[ ${#indexer_node_names[@]} -gt 0 ]] && [[ ${#server_node_names[@]} -gt 0 ]] && [[ ${#dashboard_node_names[@]} -gt 0 ]]; then
-                cert_checkRootCA
-                cert_generateAdmincertificate
-                common_logger "Admin certificates created."
-                if cert_generateIndexercertificates; then
-                    common_logger "Wazuh indexer certificates created."
-                fi
-                if cert_generateFilebeatcertificates; then
-                    common_logger "Wazuh server certificates created."
-                fi
-                if cert_generateDashboardcertificates; then
-                    common_logger "Wazuh dashboard certificates created."
-                fi
-                cert_cleanFiles
-                cert_setpermisions
-                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
-            else
-                common_logger -e "You must specify at least one indexer, one server and one dashboard node."
-                exit 1
+            cert_checkRootCA
+            cert_generateAdmincertificate
+            common_logger "Admin certificates created."
+            if cert_generateIndexercertificates; then
+                common_logger "Wazuh indexer certificates created."
             fi
+            if cert_generateFilebeatcertificates; then
+                common_logger "Wazuh server certificates created."
+            fi
+            if cert_generateDashboardcertificates; then
+                common_logger "Wazuh dashboard certificates created."
+            fi
+            cert_cleanFiles
+            cert_setpermisions
+            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
         if [[ -n "${ca}" ]]; then


### PR DESCRIPTION

|Related issue|
|---|
|#1988|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR removes the check for all types of nodes in the -A option of wazuh-certs-tool.sh.
## Logs example

<!--
Paste here related logs
-->
<details><summary>config.yml</summary>

```
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: indexer-1
      ip: 1.1.1.1
    - name: indexer-2
      ip: 1.1.1.2
    - name: indexer-3
      ip: 1.1.1.3

```
</details>

```
dfolcha@pop-os:~/wazuh-packages/unattended_installer$ bash wazuh-certs-tool.sh -A
15/12/2022 13:19:12 INFO: Admin certificates created.
15/12/2022 13:19:13 INFO: Wazuh indexer certificates created.
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
