### PR TITLE
Replace deprecated `requestHeadersWhitelist` for `requestHeadersAllowlist`

### DIFF
--- a/stack/dashboard/base/files/etc/opensearch_dashboards.yml
+++ b/stack/dashboard/base/files/etc/opensearch_dashboards.yml
@@ -4,7 +4,7 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 #opensearch.username:
 #opensearch.password:
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard.yml
+++ b/unattended_installer/config/dashboard/dashboard.yml
@@ -4,7 +4,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -4,7 +4,7 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -4,7 +4,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
@@ -2,7 +2,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true


### PR DESCRIPTION
|Related issue|
|---|
| #1969 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR replaces setting `requestHeadersWhitelist` for `requestHeadersAllowlist` as per the deprecation seen in warning
```
Dec 07 14:45:54 ip-172-31-92-159 opensearch-dashboards[41195]: {"type":"log","@timestamp":"2022-12-07T14:45:54Z","tags":["warning","config","deprecation"],"pid":41195,"message":"\"opensearch.requestHeadersWhitelist\" is deprecated and has been replaced by \"opensearch.requestHeadersAllowlist\""}
```

Justification and testing in the Issue.