### PR TITLE
Fixes in `clean_and_exit` function and `uninstall.sh` file for macOS package generation

### DIFF
--- a/macos/generate_wazuh_packages.sh
+++ b/macos/generate_wazuh_packages.sh
@@ -37,8 +37,8 @@ trap ctrl_c INT
 
 function clean_and_exit() {
     exit_code=$1
-    rm -f ${AGENT_PKG_FILE} ${CURRENT_PATH}/package_files/*.sh
     rm -rf "${SOURCES_DIRECTORY}"
+    rm "${CURRENT_PATH}"/specs/wazuh-agent.pkgproj-e
     ${CURRENT_PATH}/uninstall.sh
     exit ${exit_code}
 }

--- a/macos/uninstall.sh
+++ b/macos/uninstall.sh
@@ -1,29 +1,29 @@
-#/bin/sh
+#!/bin/sh
 
 ## Stop and remove application
-sudo /Library/Ossec/bin/ossec-control stop
-sudo /bin/rm -r /Library/Ossec*
+/Library/Ossec/bin/ossec-control stop
+/bin/rm -r /Library/Ossec*
 
 ## stop and unload dispatcher
-#sudo /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+/bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 # remove launchdaemons
-sudo /bin/rm -f /Library/LaunchDaemons/com.wazuh.agent.plist
+/bin/rm -f /Library/LaunchDaemons/com.wazuh.agent.plist
 
 ## remove StartupItems
-sudo /bin/rm -rf /Library/StartupItems/WAZUH
+/bin/rm -rf /Library/StartupItems/WAZUH
 
 ## Remove User and Groups
-sudo /usr/bin/dscl . -delete "/Users/wazuh"
-sudo /usr/bin/dscl . -delete "/Groups/wazuh"
+/usr/bin/dscl . -delete "/Users/wazuh"
+/usr/bin/dscl . -delete "/Groups/wazuh"
 
-sudo /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent
-sudo /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent-etc
+/usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent
+/usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent-etc
 
 # In case it was installed via Puppet pkgdmg provider
 
 if [ -e /var/db/.puppet_pkgdmg_installed_wazuh-agent ]; then
-    sudo rm -f /var/db/.puppet_pkgdmg_installed_wazuh-agent
+    rm -f /var/db/.puppet_pkgdmg_installed_wazuh-agent
 fi
 
 echo


### PR DESCRIPTION
|Related issue|
|---|
|#1965 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The function previously removed all scripts inside `macos/package-files` which are part of the repository and are not changed during the generation of packages. 

Uninstall function is called as root, so there is no necessity of calling all lines with `sudo`. The uncommented line is necessary according to the [documentation](https://documentation.wazuh.com/current/installation-guide/wazuh-agent/wazuh-agent-package-macos.html#uninstall-a-wazuh-agent).

## Tests
Tested for macOS package creation with and without errors, and it gives no problem.