### PR TITLE
Added new function checkFilebeatURL

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -175,7 +175,7 @@ def test_check_wazuh_manager_apid():
 
 @pytest.mark.wazuh_cluster
 def test_check_wazuh_manager_clusterd():
-    assert check_call("ps -xa | grep wazuh-clusterd | grep -v grep", shell=True) != ""
+    assert check_call("ps -xa | grep clusterd.py | grep -v grep", shell=True) != ""
 
 @pytest.mark.wazuh
 def test_check_filebeat_process():

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -255,6 +255,9 @@ function builder_main() {
     if [ -n "${installer}" ]; then
         buildInstaller
         chmod 500 ${output_script_path}
+        if [ -n "${change_filebeat_url}" ]; then
+            sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=\"https://raw.githubusercontent.com/wazuh/wazuh/\${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json\"|g" "${resources_installer}/installVariables.sh"
+        fi
     fi
 
     if [ -n "${passwordsTool}" ]; then
@@ -286,6 +289,7 @@ function checkFilebeatURL() {
         else
             echo -e "Changing Filebeat URL..."
             sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=${new_filebeat_url}|g" "${resources_installer}/installVariables.sh"
+            change_filebeat_url=1
         fi
     fi
 }

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -274,7 +274,7 @@ function builder_main() {
 function checkFilebeatURL() {
 
     # Import variables
-    . ${resources_installer}/installVariables.sh
+    eval "$(grep -E "filebeat_wazuh_template=" "unattended_installer/install_functions/installVariables.sh")"
     new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 
     # Get the response of the URL and check it

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -276,16 +276,16 @@ function checkFilebeatURL() {
 
     # Get the response of the URL and check it
     response=$(curl --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
-    if [ $response != "200" ]; then
+    if [ "${response}" != "200" ]; then
        	response=$(curl --write-out '%{http_code}' --silent --output /dev/null $new_filebeat_url)
 
         # Display error if both URLs do not get the resource
-        if [ $response != "200" ]; then
+        if [ "${response}" != "200" ]; then
             echo -e "Error: Could not get the Filebeat Wazuh template. "
         # If matches, replace the variable of installVariables to the new one
         else
             echo -e "Changing Filebeat URL..."
-            sed -i -E "s/http.+\\$\\{wazuh_major\\}.+wazuh-template.json/https:\/\/raw.githubusercontent.com\/wazuh\/wazuh\/master\/extensions\/elasticsearch\/7.x\/wazuh-template.json/" ${resources_installer}/installVariables.sh
+            sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=${new_filebeat_url}|g" "${resources_installer}/installVariables.sh"
         fi
     fi
 }

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -9,13 +9,13 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-readonly base_path="$(dirname "$(readlink -f "$0")")"
-readonly resources_installer="${base_path}/install_functions"
-readonly resources_config="${base_path}/config"
-readonly resources_certs="${base_path}/cert_tool"
-readonly resources_passwords="${base_path}/passwords_tool"
-readonly resources_common="${base_path}/common_functions"
-readonly resources_download="${base_path}/downloader"
+readonly base_path_builder="$(dirname "$(readlink -f "$0")")"
+readonly resources_installer="${base_path_builder}/install_functions"
+readonly resources_config="${base_path_builder}/config"
+readonly resources_certs="${base_path_builder}/cert_tool"
+readonly resources_passwords="${base_path_builder}/passwords_tool"
+readonly resources_common="${base_path_builder}/common_functions"
+readonly resources_download="${base_path_builder}/downloader"
 readonly source_branch="4.4"
 
 function getHelp() {
@@ -50,7 +50,7 @@ function buildInstaller() {
 
     checkFilebeatURL
 
-    output_script_path="${base_path}/wazuh-install.sh"
+    output_script_path="${base_path_builder}/wazuh-install.sh"
 
     ## Create installer script
     echo -n > "${output_script_path}"
@@ -134,7 +134,7 @@ function buildInstaller() {
 }
 
 function buildPasswordsTool() {
-    output_script_path="${base_path}/wazuh-passwords-tool.sh"
+    output_script_path="${base_path_builder}/wazuh-passwords-tool.sh"
 
     ## Create installer script
     echo -n > "${output_script_path}"
@@ -174,7 +174,7 @@ function buildPasswordsTool() {
 }
 
 function buildCertsTool() {
-    output_script_path="${base_path}/wazuh-certs-tool.sh"
+    output_script_path="${base_path_builder}/wazuh-certs-tool.sh"
 
     ## Create installer script
     echo -n > "${output_script_path}"

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -270,21 +270,21 @@ function builder_main() {
 
 function checkFilebeatURL() {
 
-	# Import variables
-	. ${resources_installer}/installVariables.sh
-	new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
+    # Import variables
+    . ${resources_installer}/installVariables.sh
+    new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 
-	# Get the response of the URL and check it
-	response=$(curl --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
-	if [ $response != "200" ]; then
+    # Get the response of the URL and check it
+    response=$(curl --write-out '%{http_code}' --silent --output /dev/null $filebeat_wazuh_template)
+    if [ $response != "200" ]; then
        	response=$(curl --write-out '%{http_code}' --silent --output /dev/null $new_filebeat_url)
 
         # Display error if both URLs do not get the resource
         if [ $response != "200" ]; then
-        	echo -e "Error: Could not get the Filebeat Wazuh template. "
+            echo -e "Error: Could not get the Filebeat Wazuh template. "
         # If matches, replace the variable of installVariables to the new one
         else
-         	echo -e "Changing Filebeat URL..."
+            echo -e "Changing Filebeat URL..."
             sed -i -E "s/http.+\\$\\{wazuh_major\\}.+wazuh-template.json/https:\/\/raw.githubusercontent.com\/wazuh\/wazuh\/master\/extensions\/elasticsearch\/7.x\/wazuh-template.json/" ${resources_installer}/installVariables.sh
         fi
     fi

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -256,7 +256,7 @@ function builder_main() {
         buildInstaller
         chmod 500 ${output_script_path}
         if [ -n "${change_filebeat_url}" ]; then
-            sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=\"https://raw.githubusercontent.com/wazuh/wazuh/\${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json\"|g" "${resources_installer}/installVariables.sh"
+            sed -i -E "s|(https.+)master(.+wazuh-template.json)|\1\\$\\{wazuh_major\\}\2|"  "${resources_installer}/installVariables.sh"
         fi
     fi
 
@@ -288,7 +288,7 @@ function checkFilebeatURL() {
         # If matches, replace the variable of installVariables to the new one
         else
             echo -e "Changing Filebeat URL..."
-            sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=${new_filebeat_url}|g" "${resources_installer}/installVariables.sh"
+            sed -i -E "s|filebeat_wazuh_template=.*|filebeat_wazuh_template=\"${new_filebeat_url}\"|g" "${resources_installer}/installVariables.sh"
             change_filebeat_url=1
         fi
     fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2000|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR modifies the `builder.sh` script of the unattended installer, adding a new function, `checkFilebeatURL`, that changes the URL of the Filebeat Wazuh template in case of the URL does not work. This is compulsory when `major` is the same branch as the `master` branch, and that `major` branch is not created in the bucket.

The function is:
https://github.com/wazuh/wazuh-packages/blob/5a42d306d9e5f105464a475f38ea546a0a4834b4/unattended_installer/builder.sh#L271-L291

<!--
Add a clear description of how the problem has been solved.
-->

