### PR TITLE
Remove parameter `-b` to `depothelper`

### DIFF
--- a/hp-ux/generate_wazuh_packages.sh
+++ b/hp-ux/generate_wazuh_packages.sh
@@ -44,7 +44,7 @@ build_environment() {
 
     if [ -n "${ftp_ip}" ] && [ -n "${ftp_port}" ] && [ -n "${ftp_user}" ] && [ -n "${ftp_pass}" ]
     then
-        fpt_connection="-b 64 -p ${ftp_ip}:${ftp_port}:${ftp_user}:${ftp_pass}"
+        fpt_connection="-p ${ftp_ip}:${ftp_port}:${ftp_user}:${ftp_pass}"
     fi
 
     echo "fpt_connection: $fpt_connection"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-jenkins/issues/4486

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Need to remove the parameter `-b 64` to  `depothelper`.

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests
https://ci.wazuh.info/job/Packages_builder_special/644

