### PR TITLE
Disable expanded header by default in Wazuh dashboard to  4.4

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -93,15 +93,12 @@ sed -i 's|OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK="https://github.com/opensear
 sed -i 's|OPENSEARCH_DASHBOARDS_FEEDBACK_LINK="https://github.com/opensearch-project"|OPENSEARCH_DASHBOARDS_FEEDBACK_LINK="https://wazuh.com/community/join-us-on-slack"|' ./src/core/target/public/core.entry.js
 ## Help link - Open an issue in GitHub
 sed -i 's|GITHUB_CREATE_ISSUE_LINK="https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose"|GITHUB_CREATE_ISSUE_LINK="https://github.com/wazuh/wazuh/issues/new/choose"|' ./src/core/target/public/core.entry.js
+# Replace home logo
+sed -i 's|DEFAULT_MARK="opensearch_mark_default_mode.svg"|DEFAULT_MARK="home.svg"|g' ./src/core/target/public/core.entry.js
+sed -i 's|DEFAULT_DARK_MARK="opensearch_mark_dark_mode.svg"|DEFAULT_DARK_MARK="home_dark_mode.svg"|g' ./src/core/target/public/core.entry.js
 # Build the compressed files
 gzip -c ./src/core/target/public/core.entry.js > ./src/core/target/public/core.entry.js.gz
 brotli -c ./src/core/target/public/core.entry.js > ./src/core/target/public/core.entry.js.br
-# Replace home logo
-sed -i 's|opensearch_mark_default_mode.svg|home.svg|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
-sed -i 's|opensearch_mark_dark_mode.svg|home_dark_mode.svg|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
-# Build the compressed files
-gzip -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.br
-brotli -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.gz
 # Remove Overview plugin from the OpenSearch Dashboards menu.
 # Remove "updater" property and set the plugin "status" as inaccesible (status:1)
 sed -i 's|updater\$:appUpdater\$|status:1|' ./src/plugins/opensearch_dashboards_overview/target/public/opensearchDashboardsOverview.plugin.js
@@ -124,6 +121,9 @@ sed -i 's|Log in to OpenSearch Dashboards||g' ./plugins/securityDashboards/targe
 sed -i 's|If you have forgotten your username or password, contact your system administrator.||g' ./plugins/securityDashboards/target/public/securityDashboards.chunk.5.js
 # Disable first time pop-up tenant selector
 sed -i 's|setShouldShowTenantPopup(shouldShowTenantPopup)|setShouldShowTenantPopup(false)|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
+# Replace home logo
+sed -i 's|DEFAULT_MARK="opensearch_mark_default_mode.svg"|DEFAULT_MARK="home.svg"|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
+sed -i 's|DEFAULT_DARK_MARK="opensearch_mark_dark_mode.svg"|DEFAULT_DARK_MARK="home_dark_mode.svg"|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
 gzip -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.gz
 brotli -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.br
 # Generate compressed files

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -59,6 +59,8 @@ cp ./etc/custom_welcome/light_theme.style.css ./src/core/server/core_app/assets/
 cp ./etc/custom_welcome/*svg ./src/core/server/core_app/assets/
 cp ./etc/custom_welcome/Assets/default_branding/logo_full_alpha.svg ./src/core/server/core_app/assets/default_branding/opensearch_logo_default_mode.svg
 cp ./etc/custom_welcome/Assets/default_branding/logo_full_alpha.svg ./src/core/server/core_app/assets/default_branding/opensearch_logo_dark_mode.svg
+cp ./etc/custom_welcome/Assets/default_branding/home.svg ./src/core/server/core_app/assets/default_branding/
+cp ./etc/custom_welcome/Assets/default_branding/home_dark_mode.svg ./src/core/server/core_app/assets/default_branding/
 cp ./etc/custom_welcome/Assets/Favicons/* ./src/core/server/core_app/assets/favicons/
 cp ./etc/custom_welcome/Assets/Favicons/favicon.ico ./src/core/server/core_app/assets/favicons/favicon.ico
 cp ./etc/http_service.js ./src/core/server/http/http_service.js
@@ -66,6 +68,7 @@ cp ./etc/template.js ./src/core/server/rendering/views/template.js
 cp ./etc/styles.js ./src/core/server/rendering/views/styles.js
 # Replace App Title
 sed -i "s|defaultValue: ''|defaultValue: \'Wazuh\'|g" ./src/core/server/opensearch_dashboards_config.js
+sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensearch_dashboards_config.js
 # Replace config path
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-keystore
@@ -93,6 +96,12 @@ sed -i 's|GITHUB_CREATE_ISSUE_LINK="https://github.com/opensearch-project/OpenSe
 # Build the compressed files
 gzip -c ./src/core/target/public/core.entry.js > ./src/core/target/public/core.entry.js.gz
 brotli -c ./src/core/target/public/core.entry.js > ./src/core/target/public/core.entry.js.br
+# Replace home logo
+sed -i 's|opensearch_mark_default_mode.svg|home.svg|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
+sed -i 's|opensearch_mark_dark_mode.svg|home_dark_mode.svg|g' ./plugins/securityDashboards/target/public/securityDashboards.plugin.js
+# Build the compressed files
+gzip -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.br
+brotli -c ./plugins/securityDashboards/target/public/securityDashboards.plugin.js > ./plugins/securityDashboards/target/public/securityDashboards.plugin.js.gz
 # Remove Overview plugin from the OpenSearch Dashboards menu.
 # Remove "updater" property and set the plugin "status" as inaccesible (status:1)
 sed -i 's|updater\$:appUpdater\$|status:1|' ./src/plugins/opensearch_dashboards_overview/target/public/opensearchDashboardsOverview.plugin.js

--- a/stack/dashboard/base/files/etc/custom_welcome/Assets/default_branding/home.svg
+++ b/stack/dashboard/base/files/etc/custom_welcome/Assets/default_branding/home.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="i0e4112b0-8781-11ed-96c4-b9592c9b3cea" class="euiIcon euiIcon--medium logoImage"
+	 width="16" height="16" viewBox="0 0 16 16" focusable="false" role="img" data-test-subj="homeIcon" data-test-image-url="home">
+	<tittle id="ief9b20a0-8783-11ed-a154-178a006c1c67">Wazuh home</tittle>
+	<path d="M8.13 1.229l5.5 4.47a1 1 0 01.37.777V14a1 1 0 01-1 1H2a1 1 0 01-1-1V6.476a1 1 0 01.37-.776l5.5-4.471a1 1 0 011.26 0zM13 6.476L7.5 2.005 2 6.475V14h11V6.476z"/>
+</svg>

--- a/stack/dashboard/base/files/etc/custom_welcome/Assets/default_branding/home_dark_mode.svg
+++ b/stack/dashboard/base/files/etc/custom_welcome/Assets/default_branding/home_dark_mode.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="i0e4112b0-8781-11ed-96c4-b9592c9b3cea" class="euiIcon euiIcon--medium logoImage"
+	 width="16" height="16" viewBox="0 0 16 16" focusable="false" role="img" data-test-subj="homeIcon" data-test-image-url="home"
+	 fill="#000000">
+	<tittle id="ief9b20a0-8783-11ed-a154-178a006c1c67">Wazuh home</tittle>
+	<path d="M8.13 1.229l5.5 4.47a1 1 0 01.37.777V14a1 1 0 01-1 1H2a1 1 0 01-1-1V6.476a1 1 0 01.37-.776l5.5-4.471a1 1 0 011.26 0zM13 6.476L7.5 2.005 2 6.475V14h11V6.476z" fill="#fff"/>
+</svg>

--- a/stack/dashboard/base/files/etc/opensearch_dashboards.yml
+++ b/stack/dashboard/base/files/etc/opensearch_dashboards.yml
@@ -12,4 +12,3 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh
-

--- a/stack/dashboard/base/files/etc/opensearch_dashboards.yml
+++ b/stack/dashboard/base/files/etc/opensearch_dashboards.yml
@@ -12,3 +12,4 @@ server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh
+


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2011|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The default configuration is modified so that the header is hidden by default, and in turn the Home icon that is displayed when the header is disabled is modified

## Logs example

<!--
Paste here related logs
-->

### Chrome:
![Screenshot_20221230_122421](https://user-images.githubusercontent.com/64099752/210086340-621de77f-02d6-4696-a955-5b6b3b8c7c49.png)
![Screenshot_20221230_122500](https://user-images.githubusercontent.com/64099752/210086386-d0231acc-3ee1-4952-bd39-8d28d71f605e.png)
### Opera:
![Screenshot_20221230_122531](https://user-images.githubusercontent.com/64099752/210086423-8a7aa8f4-2dfe-42f4-ba59-30b7f36fbd66.png)
![Screenshot_20221230_122557](https://user-images.githubusercontent.com/64099752/210086455-338e11c0-d011-48a4-aad6-5ef4a3973677.png)
### Brave:
![Screenshot_20221230_122625](https://user-images.githubusercontent.com/64099752/210086496-b09d06f2-7aeb-4c09-bf1e-20875867ff73.png)
![Screenshot_20221230_122649](https://user-images.githubusercontent.com/64099752/210086529-5eb066b7-a329-4b12-bce9-cbc7e4acc046.png)
### Firefox.
![Screenshot_20221230_122714](https://user-images.githubusercontent.com/64099752/210086573-51b5f364-3cb6-4327-877b-0dcdfe975a9a.png)
![Screenshot_20221230_122745](https://user-images.githubusercontent.com/64099752/210086608-f48f1a31-88e3-43ce-aecf-ba1627bdf2d7.png)


## Tests
Centos 7: https://ci.wazuh.info/view/Tests/job/Test_stack/213/console
Ubuntu Focal: https://ci.wazuh.info/view/Tests/job/Test_stack/214/console

Packages:
RPM:
- Wazuh dashboard: https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/wazuh-dashboard-4.4.0-0.0.0.2011.x86_64.rpm
- Wazuh indexer: https://packages-dev.wazuh.com/warehouse/test/4.4/rpm/wazuh-indexer-4.4.0-0.0.0.2011.x86_64.rpm
DEB:
- Wazuh dashboard: https://packages-dev.wazuh.com/warehouse/test/4.4/deb/wazuh-dashboard_4.4.0-0.0.0.2011_amd64.deb
- Wazuh indexer: https://packages-dev.wazuh.com/warehouse/test/4.4/deb/wazuh-indexer_4.4.0-0.0.0.2011_amd64.deb

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
