### PR TITLE
Removed errors logs from OVA to 4.4

### DIFF
--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -40,7 +40,7 @@ preInstall
 # Install
 bash ${RESOURCES_PATH}/${INSTALLER} ${INSTALL_ARGS}
 
-systemctl stop wazuh-dashboard filebeat wazuh-indexer
+systemctl stop wazuh-dashboard filebeat wazuh-indexer wazuh-manager
 systemctl enable wazuh-manager
 
 clean

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -40,7 +40,7 @@ preInstall
 # Install
 bash ${RESOURCES_PATH}/${INSTALLER} ${INSTALL_ARGS}
 
-systemctl stop wazuh-manager wazuh-indexer filebeat wazuh-dashboard
+systemctl stop wazuh-dashboard filebeat wazuh-indexer wazuh-manager
 systemctl enable wazuh-manager
 
 clean

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -40,7 +40,7 @@ preInstall
 # Install
 bash ${RESOURCES_PATH}/${INSTALLER} ${INSTALL_ARGS}
 
-systemctl stop wazuh-dashboard filebeat wazuh-indexer wazuh-manager
+systemctl stop wazuh-manager wazuh-indexer filebeat wazuh-dashboard
 systemctl enable wazuh-manager
 
 clean


### PR DESCRIPTION
|Related issue|
|---|
|close https://github.com/wazuh/wazuh-packages/issues/1971|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
After various tests, I was able to detect that the fact that wazuh-manager service was active before the VM was exported generated this error in the logs.
I managed to avoid this error in the logs by adding this service to the provision.sh

## Logs example

<!--
Paste here related logs
-->
```console
[wazuh-user@wazuh-server ~]$ journalctl -r -u wazuh-indexer.service | grep -i -E "error|critical|warning|fatal" 
ene 04 16:00:35 wazuh-server systemd-entrypoint[965]: WARNING: System::setSecurityManager will be removed in a future release
ene 04 16:00:35 wazuh-server systemd-entrypoint[965]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
ene 04 16:00:35 wazuh-server systemd-entrypoint[965]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.4.1.jar)
ene 04 16:00:35 wazuh-server systemd-entrypoint[965]: WARNING: A terminally deprecated method in java.lang.System has been called
ene 04 16:00:34 wazuh-server systemd-entrypoint[965]: WARNING: System::setSecurityManager will be removed in a future release
ene 04 16:00:34 wazuh-server systemd-entrypoint[965]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
ene 04 16:00:34 wazuh-server systemd-entrypoint[965]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.4.1.jar)
ene 04 16:00:34 wazuh-server systemd-entrypoint[965]: WARNING: A terminally deprecated method in java.lang.System has been called
[wazuh-user@wazuh-server ~]$ 

```

## Tests
https://ci.wazuh.info/view/Packages/job/Packages_Builder_OVA/186/console

OVA: https://packages-dev.wazuh.com/trash/vm/wazuh-4.4.0.ova

