### PR TITLE
Change the relative path used in checkFilebeat for a defined path variable

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -274,7 +274,7 @@ function builder_main() {
 function checkFilebeatURL() {
 
     # Import variables
-    eval "$(grep -E "filebeat_wazuh_template=" "unattended_installer/install_functions/installVariables.sh")"
+    eval "$(grep -E "filebeat_wazuh_template=" "${resources_installer}/installVariables.sh")"
     new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 
     # Get the response of the URL and check it


### PR DESCRIPTION
|Related issue|
|---|
| #2025 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR changes a relative path for variable `resources_installer` to avoid errors coming from where the `builder.sh` is called.

```
readonly base_path_builder="$(dirname "$(readlink -f "$0")")"
readonly resources_installer="${base_path_builder}/install_functions"
```

## Logs example

<!--
Paste here related logs
-->

#### Before the PR
```
[verdx@pop-os unattended_installer]$ bash builder.sh -i 
grep: unattended_installer/install_functions/installVariables.sh: No such file or directory
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
Changing Filebeat URL...
```

#### After the PR
```
[verdx@pop-os unattended_installer]$ bash builder.sh -i 
Changing Filebeat URL...
[verdx@pop-os unattended_installer]$ 

```