### PR TITLE
Avoid doing Wazuh Indexer backup if not necessary

### DIFF
--- a/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer.service
+++ b/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer.service
@@ -58,7 +58,7 @@ SendSIGKILL=no
 SuccessExitStatus=143
 
 # Allow a slow startup before the systemd notifier module kicks in to extend the timeout
-TimeoutStartSec=75
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -126,10 +126,6 @@ function indexer_initialize() {
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /etc/wazuh-indexer/opensearch-security -icl -p 9200 -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
     fi
 
-    if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then
-        installCommon_changePasswords
-    fi
-
     common_logger "Wazuh indexer cluster initialized."
 
 }

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -176,7 +176,7 @@ function indexer_startCluster() {
         fi
     done
     eval "wazuh_indexer_ip=( $(cat /etc/wazuh-indexer/opensearch.yml | grep network.host | sed 's/network.host:\s//') )"
-    eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -p 9200 -cd /etc/wazuh-indexer/opensearch-security -icl -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${wazuh_indexer_ip} ${debug}"
+    eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /etc/wazuh-indexer/opensearch-security -icl -p 9200 -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h ${wazuh_indexer_ip} ${debug}"
     if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "The Wazuh indexer cluster security configuration could not be initialized."
         exit 1

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -126,6 +126,10 @@ function indexer_initialize() {
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /etc/wazuh-indexer/opensearch-security -icl -p 9200 -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
     fi
 
+    if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then
+        installCommon_changePasswords
+    fi
+
     common_logger "Wazuh indexer cluster initialized."
 
 }

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -194,6 +194,8 @@ function installCommon_changePasswords() {
         if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
             changeall=1
             passwords_readUsers
+        else
+            nobackup=1
         fi
         if { [ -n "${wazuh}" ] || [ -n "${AIO}" ]; } && { [ "${server_node_types[pos]}" == "master" ] || [ "${#server_node_names[@]}" -eq 1 ]; }; then
             passwords_getApiToken

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -195,7 +195,7 @@ function installCommon_changePasswords() {
             changeall=1
             passwords_readUsers
         else
-            nobackup=1
+            no_indexer_backup=1
         fi
         if { [ -n "${wazuh}" ] || [ -n "${AIO}" ]; } && { [ "${server_node_types[pos]}" == "master" ] || [ "${#server_node_names[@]}" -eq 1 ]; }; then
             passwords_getApiToken

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -297,7 +297,7 @@ function main() {
 
     fi
 
-# -------------- Wazuh case  ---------------------------------------
+# -------------- Wazuh server case  ---------------------------------------
 
     if [ -n "${wazuh}" ]; then
         common_logger "--- Wazuh server ---"

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -8,13 +8,9 @@
 
 function passwords_changePassword() {
 
-    if [ -n "${indexer}" ] || [ -z "${api}" ]; then
+    if [ -n "${changeall}" ]; then
         eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
         eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
-    fi
-
-
-    if [ -n "${changeall}" ]; then
         for i in "${!passwords[@]}"
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
@@ -29,6 +25,8 @@ function passwords_changePassword() {
 
         done
     else
+        eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
+        eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
         if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
             awk -v new="$hash" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
         fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -9,8 +9,10 @@
 function passwords_changePassword() {
 
     if [ -n "${changeall}" ]; then
-        eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
-        eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+        if [ -n "${indexer_installed}" ]; then
+            eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
+            eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+        fi
         for i in "${!passwords[@]}"
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
@@ -25,8 +27,10 @@ function passwords_changePassword() {
 
         done
     else
-        eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
-        eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+        if [ -z "${api}" ] && [ -n "${indexer_installed}" ]; then
+            eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
+            eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+        fi
         if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
             awk -v new="$hash" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
         fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -8,7 +8,7 @@
 
 function passwords_changePassword() {
 
-    if [ -n "${indexer}" || -z "${api}" ]; then
+    if [ -n "${indexer}" ] || [ -z "${api}" ]; then
         eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
         eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
     fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -9,7 +9,7 @@
 function passwords_changePassword() {
 
     if [ -n "${changeall}" ]; then
-        if [ -n "${indexer_installed}" ]; then
+        if [ -n "${indexer_installed}" ] && [ -z ${nobackup} ]; then
             eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
             eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
         fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -9,7 +9,7 @@
 function passwords_changePassword() {
 
     if [ -n "${changeall}" ]; then
-        if [ -n "${indexer_installed}" ] && [ -z ${nobackup} ]; then
+        if [ -n "${indexer_installed}" ] && [ -z ${no_indexer_backup} ]; then
             eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
             eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
         fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -8,8 +8,11 @@
 
 function passwords_changePassword() {
 
-    eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
-    eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+    if [ -n "${indexer}" || -z "${api}" ]; then
+        eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
+        eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+    fi
+
 
     if [ -n "${changeall}" ]; then
         for i in "${!passwords[@]}"


### PR DESCRIPTION
|Related issue|
|---|
| #1962 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
To fix the error explained in #1962, this PR adds a new variable `no_indexer_backup` that specifies that the function `passwords_changePassword()` is being called from script `wazuh-install.sh`, but for an action that won't imply running the Indexer Security administrator. That way we isolate the cases in which `passwords_changePassword()` is called from `wazuh-install.sh` but function `passwords_runSecurityAdmin()` is not being called. In this cases, file `/etc/wazuh-indexer/backup` would be created with owner `root:root` and left after the action. If that file exists with those permissions, the Wazuh Indexer service would be unable to start.

## Logs example

<!--
Paste here related logs
-->
All logs are written along the tests in the Issue.

## Tests

- [x] [AIO using `-a` on RPM (Amazon Linux 2)](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1378670667)
- [x] [AIO using `-a` on DEB(Ubuntu 22)](https://github.com/wazuh/wazuh-packages/issues/1962)
- [x] [AIO component by component on RPM (Amazon Linux 2)](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1378670667)
- [x] [AIO component by component on DEB(Ubuntu 22)](https://github.com/wazuh/wazuh-packages/issues/1962)
- [x] [Pasword tool tests](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1378638928)
- [x] [Distributed with CentOS, Debian and RHEL](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1378670667)
- [x] [Distributed multi-node clusters](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1380207010)
- [x] [Pair combination testing](https://github.com/wazuh/wazuh-packages/issues/1962#issuecomment-1380379229)
