### PR TITLE
Create backup before changing password

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -12,6 +12,7 @@ function passwords_changePassword() {
         if [ -n "${indexer_installed}" ] && [ -z ${no_indexer_backup} ]; then
             eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
             eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+            passwords_createBackUp
         fi
         for i in "${!passwords[@]}"
         do
@@ -30,9 +31,10 @@ function passwords_changePassword() {
         if [ -z "${api}" ] && [ -n "${indexer_installed}" ]; then
             eval "mkdir /etc/wazuh-indexer/backup/ 2>/dev/null"
             eval "cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null"
+            passwords_createBackUp
         fi
         if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
-            awk -v new="$hash" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+            awk -v new="${hash}" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
         fi
 
         if [ "${nuser}" == "admin" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#2034|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR  fixes an error that caused the passwords other users to be modified when changing a single password using the password tool.

## Logs example

<!--
Paste here related logs
-->
```
[root@amazon2 vagrant]# cat wazuh-install-files/wazuh-passwords.txt
# Admin user for the web user interface and Wazuh indexer. Use this user to log in to Wazuh dashboard
  indexer_username: 'admin'
  indexer_password: '6G7Gxz1kDLNIhsxO2Fn7LXituguj.u*6'

# Wazuh dashboard user for establishing the connection with Wazuh indexer
  indexer_username: 'kibanaserver'
  indexer_password: 'E80.zMnk3uBnTF29pW3Dp4yMJ+?29f5j'

# Regular Dashboard user, only has read permissions to all indices and all permissions on the .kibana index
  indexer_username: 'kibanaro'
  indexer_password: '16x6El*aew2is?t0zjXbaZC6A5AN59uA'

# Filebeat user for CRUD operations on Wazuh indices
  indexer_username: 'logstash'
  indexer_password: 'kuqH9dyhL4YX?V.WIx*6ZWNWRRj8776g'

# User with READ access to all indices
  indexer_username: 'readall'
  indexer_password: '9u35?Clwbg.jzBq2OzQV6Kg+6+a6KofM'

# User with permissions to perform snapshot and restore operations
  indexer_username: 'snapshotrestore'
  indexer_password: '.ViUXN4yss*?KzTNokpwdEaNbQWhvFil'

# Password for wazuh API user
  api_username: 'wazuh'
  api_password: 'f.vi4K1oBWtASBmwSYFzjWhOstRFz9lu'

# Password for wazuh-wui API user
  api_username: 'wazuh-wui'
  api_password: '2zuN2j*01SUZLE8aQj29gS**b4y+trDf'

[root@amazon2 vagrant]# bash ./wazuh-passwords-tool.sh -u admin -p Pass-1234
12/01/2023 14:39:13 INFO: Generating password hash
12/01/2023 14:39:18 WARNING: Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
[root@amazon2 vagrant]# curl -k -u kibanaserver:kibanaserver https://127.0.0.1:9200/
Unauthorized[root@amazon2 vagrant]# 
[root@amazon2 vagrant]# curl -k -u kibanaserver:E80.zMnk3uBnTF29pW3Dp4yMJ+?29f5j https://127.0.0.1:9200/
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "Ygu_iAGPRR2fDLexJLoGZA",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "f2f809ea280ffba217451da894a5899f1cec02ab",
    "build_date" : "2022-12-12T22:17:42.341124910Z",
    "build_snapshot" : false,
    "lucene_version" : "9.4.2",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```