### PR TITLE
Remove references to the deprecated folder var/db/agents

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -54,7 +54,7 @@ case "$1" in
     # Remove/relocate existing SQLite databases
     rm -f ${DIR}/var/db/cluster.db* || true
     rm -f ${DIR}/var/db/.profile.db* || true
-    rm -f ${DIR}/var/db/agents/* || true
+    rm -rf ${DIR}/var/db/agents || true
 
     if [ -f ${DIR}/var/db/global.db ]; then
         mv ${DIR}/var/db/global.db ${DIR}/queue/db/

--- a/debs/SPECS/wazuh-manager/debian/preinst
+++ b/debs/SPECS/wazuh-manager/debian/preinst
@@ -133,7 +133,7 @@ case "$1" in
         fi
 
         if [ -d ${DIR}/var/db/agents ]; then
-            rm -f ${DIR}/var/db/agents/*
+            rm -rf ${DIR}/var/db/agents
         fi
 
         # Remove plain-text agent information if exists

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -214,7 +214,7 @@ fi
 # Remove/relocate existing SQLite databases
 rm -f %{_localstatedir}/var/db/cluster.db* || true
 rm -f %{_localstatedir}/var/db/.profile.db* || true
-rm -f %{_localstatedir}/var/db/agents/* || true
+rm -rf %{_localstatedir}/var/db/agents || true
 
 if [ -f %{_localstatedir}/var/db/global.db ]; then
   mv %{_localstatedir}/var/db/global.db %{_localstatedir}/queue/db/
@@ -815,7 +815,6 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/var
 %dir %attr(770, root, wazuh) %{_localstatedir}/var/db
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/db/agents
 %attr(660, root, wazuh) %{_localstatedir}/var/db/mitre.db
 %dir %attr(770, root, wazuh) %{_localstatedir}/var/download
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/var/multigroups


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15437|

This is part of an issue which aims to improve the performance of the database synchronization process (database module).

## Description

In recent versions of Wazuh, the agent's databases are located in the `queue/db` folder.

This PR aims to remove all references to the `var/db/agents` folder in the Wazuh manager. 

It also ensures that the deprecated folder will no longer exist in the Wazuh manager.

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
