### PR TITLE
Preserved securityconfig files upon upgrade of the Wazuh indexer - 4.4

### DIFF
--- a/.github/actions/upgrade-indexer/common.sh
+++ b/.github/actions/upgrade-indexer/common.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+FILES_OLD="/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig"
+FILES_NEW="/etc/wazuh-indexer/opensearch-security"
+declare -A files_old
+declare -A files_new
+PACKAGE_NAME="${1}"
+MAJOR_MINOR_RELEASE=$((${2}))
+
+# Check the system to differ between DEB and RPM
+function check_system() {
+
+    if [ -n "$(command -v yum)" ]; then
+        sys_type="rpm"
+    elif [ -n "$(command -v apt-get)" ]; then
+        sys_type="deb"
+    else
+        echo "Error: could not detect the system."
+        exit 1
+    fi
+
+}
+
+# Checks the version of Wazuh with 4.3 version, where path is different.
+function check_version() {
+
+    if [ -z "${MAJOR_MINOR_RELEASE}" ]; then
+        echo "Error: second argument expected."
+        exit 1
+    fi
+
+    # 43 represents the threshold where the path of the securityconfig
+    # files changes (major and minor)
+    if [ "${MAJOR_MINOR_RELEASE}" -gt "43" ]; then
+        FILES_OLD="${FILES_NEW}"
+        echo "New path detected (/etc)."
+    else
+        echo "Old path detected (/usr/share)."
+    fi
+
+}
+
+# Compare the arrays, the loop ends if a different checksum is detected
+function compare_arrays() {
+
+    for file in "${!files_old[@]}"; do
+        echo "Comparing $file file checksum..."
+        echo "Old: ${files_old[$file]}"
+        echo "New: ${files_new[$file]}"
+        if [[ "${files_old[$file]}" == "${files_new[$file]}" ]]; then
+            echo "${file} - Same checksum."
+        else
+            echo "${file} - Different checksum."
+            exit 1
+        fi
+    done
+
+}
+
+# Steps before installing the RPM release package.
+function add_production_repository() {
+
+    rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
+    echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/4.x/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo
+
+}
+
+# Reads the files passed by param and store their checksum in the array
+function read_files() {
+
+    if [ ! -d "${1}" ]; then
+        echo "Error: the directory does not exist. ${1}."
+        exit 1
+    fi
+
+    for file in ${1}/*; do
+        if [ -f "${file}" ]; then
+            echo "Processing ${file} file..."
+
+            # Change only the old files
+            if [ "${2}" == "old" ]; then
+                echo "# Adding a new line to force changed checksum" >> ${f}
+                echo "Changed file."
+            fi
+            checksum=`md5sum ${file} | cut -d " " -f1`
+            basename=`basename ${file}`
+            if [ "${2}" == "old" ]; then
+                files_old["${basename}"]="${checksum}"
+            elif [ "${2}" == "new" ]; then
+                files_new["${basename}"]="${checksum}"
+            fi
+        fi
+    done
+
+}
+
+# Prints associative array of the files passed by params
+function print_files() {
+
+    aux=$(declare -p "$1")
+    eval "declare -A arr="${aux#*=}
+
+    if [ "${#arr[@]}" -eq 0 ]; then
+        echo "Error: the array didn't scan correctly."
+        exit 1
+    fi
+
+    for KEY in "${!arr[@]}"; do
+        echo "Key: ${KEY}"
+        echo "Value: ${arr[${KEY}]}"
+    done
+
+}

--- a/.github/actions/upgrade-indexer/upgrade-indexer.sh
+++ b/.github/actions/upgrade-indexer/upgrade-indexer.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Gets the absolute path of the script, used to load the common.sh file
+ABSOLUTE_PATH="$( cd $(dirname ${0}) ; pwd -P )"
+. ${ABSOLUTE_PATH}/common.sh
+
+check_system
+check_version
+
+echo "Installing old version of Wazuh indexer..."
+if [ ${sys_type} == "deb" ]; then
+    apt-get -y install wazuh-indexer
+elif [ ${sys_type} == "rpm" ]; then
+    add_production_repository
+    yum -y install wazuh-indexer
+else
+    echo "Error: No system detected."
+    exit 1
+fi
+
+read_files "${FILES_OLD}" "old"
+echo "Old files..."
+print_files "files_old"
+
+echo "Installing new version of Wazuh indexer..."
+if [ ${sys_type} == "deb" ]; then
+    apt-get install $PACKAGE_NAME
+elif [ ${sys_type} == "rpm" ]; then
+    yum -y localinstall $PACKAGE_NAME
+fi
+
+read_files "${FILES_NEW}" "new"
+echo "New files..."
+print_files "files_new"
+
+compare_arrays
+if [ "$?" -eq 0 ]; then
+    echo "Same checksums - Test passed correctly."
+    exit 0
+fi
+echo "Error: different checksums detected."
+exit 1

--- a/.github/workflows/test-indexer-debian.yml
+++ b/.github/workflows/test-indexer-debian.yml
@@ -1,0 +1,36 @@
+name: Test the preserving of security config files upon upgrade - Wazuh indexer - Debian
+on:
+  pull_request:
+    paths:
+      - 'stack/indexer/deb/debian/*'
+  workflow_dispatch:
+
+jobs:
+  Test-security-config-files-preservation-Debian:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Preinstall the latest stable version of the Wazuh indexer package
+        run: |
+          curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
+          echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | sudo tee -a /etc/apt/sources.list.d/wazuh.list
+          sudo apt-get update
+
+      - name: Get the latest stable Wazuh version (all components)
+        run: echo "LATEST_STABLE_VERSION=$(jq -r 'map(select(.prerelease == false and .draft == false)) | .[] | .tag_name' <<< $(curl --silent https://api.github.com/repos/wazuh/wazuh/releases) | sed "s|v||g" | sort -rV | head -n 1)" >> $GITHUB_ENV
+
+      - name: Get the major and minor of the latest stable version
+        run: echo "MAJOR_MINOR=$(echo $LATEST_STABLE_VERSION | cut -d '.' -f1-2 | sed "s|\.||")" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+      - name: Build the Wazuh indexer package and set environment variable
+        working-directory: ./stack/indexer/deb
+        run: |
+          sudo ./build_package.sh
+          echo "PACKAGE_NAME=$(ls ./output | grep .deb | head -n 1)" >> $GITHUB_ENV
+
+      - name: Move the built package
+        working-directory: ./stack/indexer/deb
+        run: sudo cp ./output/$PACKAGE_NAME $GITHUB_WORKSPACE/$PACKAGE_NAME
+
+      - name: Run script
+        run: sudo bash $GITHUB_WORKSPACE/.github/actions/upgrade-indexer/upgrade-indexer.sh $GITHUB_WORKSPACE/$PACKAGE_NAME $MAJOR_MINOR

--- a/.github/workflows/test-indexer-rpm.yml
+++ b/.github/workflows/test-indexer-rpm.yml
@@ -1,0 +1,32 @@
+name: Test the preserving of security config files upon upgrade - Wazuh indexer - RPM
+on:
+  pull_request:
+    paths:
+      - 'stack/indexer/rpm/wazuh-indexer.spec'
+  workflow_dispatch:
+
+jobs:
+  Test-security-config-files-preservation-RPM:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the latest stable Wazuh version (all components)
+        run: echo "LATEST_STABLE_VERSION=$(jq -r 'map(select(.prerelease == false and .draft == false)) | .[] | .tag_name' <<< $(curl --silent https://api.github.com/repos/wazuh/wazuh/releases) | sed "s|v||g" | sort -rV | head -n 1)" >> $GITHUB_ENV
+
+      - name: Get the major and minor of the latest stable version
+        run: echo "MAJOR_MINOR=$(echo $LATEST_STABLE_VERSION | cut -d '.' -f1-2 | sed "s|\.||")" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+      - name: Build the Wazuh indexer package and set environment variable
+        working-directory: ./stack/indexer/rpm
+        run: |
+          sudo ./build_package.sh
+          echo "PACKAGE_NAME=$(ls ./output | grep .rpm | head -n 1)" >> $GITHUB_ENV
+
+      - name: Move the built package
+        working-directory: ./stack/indexer/rpm
+        run: |
+          mkdir $GITHUB_WORKSPACE/packages
+          sudo cp ./output/$PACKAGE_NAME $GITHUB_WORKSPACE/packages/$PACKAGE_NAME
+
+      - name: Launch docker
+        run: sudo docker run -v $GITHUB_WORKSPACE/.github/actions/upgrade-indexer/:/tests -v $GITHUB_WORKSPACE/packages/:/packages centos:centos7 bash /tests/upgrade-indexer.sh /packages/$PACKAGE_NAME $MAJOR_MINOR

--- a/stack/indexer/deb/debian/postinst
+++ b/stack/indexer/deb/debian/postinst
@@ -14,12 +14,13 @@ export USER=${NAME}
 export GROUP=${NAME}
 export CONFIG_DIR=/etc/${NAME}
 export INSTALLATION_DIR=/usr/share/${NAME}
+export BACKUP_DIR="${CONFIG_DIR}/upgrade_backup"
 export LOG_DIR=/var/log/${NAME}
 export PID_DIR=/run/${NAME}
 export LIB_DIR=/var/lib/${NAME}
 export SYS_DIR=/usr/lib
 
-set -e 
+set -e
 
 #
 # This script is executed in the post-installation phase
@@ -44,7 +45,7 @@ case "$1" in
         # The codeblock below is using the fact that postinst script is called with the most-recently configured version.
         # In other words, a fresh installed will be called like "postinst configure" with no previous version ($2 is null)
         if [ -z "$2" ]; then
-          # If $2 is null, this is an install	
+          # If $2 is null, this is an install
 
           # Setting owner and group
           chown -R ${USER}:${GROUP} ${CONFIG_DIR}
@@ -81,6 +82,13 @@ case "$1" in
           echo "${USER} soft nofile 65535" >> /etc/security/limits.conf
 
         else # Otherwise it is an upgrade
+
+            # If the backup of securityconfig files is done (4.3.x), restore them
+            if [ -d "${BACKUP_DIR}/securityconfig" ]; then
+                cp "${BACKUP_DIR}"/securityconfig/* "${CONFIG_DIR}/opensearch-security"
+                rm -rf "${BACKUP_DIR}"
+            fi
+
             if [ -f "${INSTALLATION_DIR}/${NAME}.restart" ]; then
                 echo -n "Restarting wazuh-indexer service..."
                 rm -f "${INSTALLATION_DIR}/${NAME}.restart"

--- a/stack/indexer/deb/debian/postrm
+++ b/stack/indexer/deb/debian/postrm
@@ -7,7 +7,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -e 
+set -e
 
 export NAME=wazuh-indexer
 export CONFIG_DIR="/etc/${NAME}"
@@ -46,7 +46,7 @@ case "$1" in
         REMOVE_USER_AND_GROUP=true
     ;;
 
-    failed-upgrade|abort-install|abort-upgrade|disappear|upgrade|disappear)
+    failed-upgrade|abort-install|abort-upgrade|upgrade|disappear)
     ;;
 
     *)

--- a/stack/indexer/deb/debian/preinst
+++ b/stack/indexer/deb/debian/preinst
@@ -7,10 +7,11 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -e 
+set -e
 
 export NAME=wazuh-indexer
 export CONFIG_DIR="/etc/${NAME}"
+export BACKUP_DIR="${CONFIG_DIR}/upgrade_backup"
 export INSTALLATION_DIR="/usr/share/${NAME}"
 
 #
@@ -60,6 +61,12 @@ case "$1" in
     ;;
 
     upgrade)
+        # Move the securityconfig files if they exist (4.3.x versions)
+        if [ -d "${INSTALLATION_DIR}/plugins/opensearch-security/securityconfig" ]; then
+            mkdir "${BACKUP_DIR}"
+            cp -r "${INSTALLATION_DIR}/plugins/opensearch-security/securityconfig/" "${BACKUP_DIR}"
+        fi
+
         # Stop the services to upgrade
         if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet "${NAME}" > /dev/null 2>&1; then
             systemctl stop "${NAME}".service > /dev/null 2>&1

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -170,6 +170,18 @@ if [ -f /etc/os-release ]; then
   fi
 fi
 
+# If is an upgrade, move the securityconfig files if they exist (4.3.x versions)
+if [ ${1} = 2 ]; then
+    if [ -d "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig ]; then
+
+        if [ ! -d "%{CONFIG_DIR}"/opensearch-security ]; then
+            mkdir "%{CONFIG_DIR}"/opensearch-security
+        fi
+
+        cp -r "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig/* "%{CONFIG_DIR}"/opensearch-security
+    fi
+fi
+
 # -----------------------------------------------------------------------------
 
 %preun
@@ -453,17 +465,17 @@ rm -fr %{buildroot}
 %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-performance-analyzer/rca_idle_cluster_manager.conf
 %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-performance-analyzer/supervisord.conf
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/action_groups.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/audit.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/config.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/internal_users.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/nodes_dn.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/opensearch.yml.example
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/roles.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/roles_mapping.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/tenants.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/whitelist.yml
-%attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/allowlist.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/action_groups.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/audit.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/config.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/internal_users.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/nodes_dn.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/opensearch.yml.example
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/roles.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/roles_mapping.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/tenants.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/whitelist.yml
+%config(noreplace) %attr(640, %{USER}, %{GROUP}) %{CONFIG_DIR}/opensearch-security/allowlist.yml
 %attr(440, %{USER}, %{GROUP}) %{INSTALL_DIR}/VERSION
 %dir %attr(750, %{USER}, %{GROUP}) %{CONFIG_DIR}/jvm.options.d
 %config(noreplace) %attr(660, %{USER}, %{GROUP}) %{CONFIG_DIR}/log4j2.properties
@@ -1364,6 +1376,8 @@ rm -fr %{buildroot}
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/jdk/lib/security/blocked.certs
 
 %changelog
+* Fri May 05 2023 support <info@wazuh.com> - %{version}
+- More info: https://documentation.wazuh.com/current/release-notes/
 * Wed Jan 18 2023 support <info@wazuh.com> - 4.4.0
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu Nov 10 2022 support <info@wazuh.com> - 4.3.10

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -1376,7 +1376,7 @@ rm -fr %{buildroot}
 %attr(640, %{USER}, %{GROUP}) %{INSTALL_DIR}/jdk/lib/security/blocked.certs
 
 %changelog
-* Fri May 05 2023 support <info@wazuh.com> - %{version}
+* Mon Apr 17 2023 support <info@wazuh.com> - 4.4.1
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Wed Jan 18 2023 support <info@wazuh.com> - 4.4.0
 - More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2155|

## Description

This PR is the backport of https://github.com/wazuh/wazuh-packages/pull/1998 to `4.4`.

To summarize, the SPEC files of the Wazuh indexer of Debian and RPM have changed to preserve the securityconfig files upon upgrade.
Due to the lack of automatic tests, some GitHub Actions have been added, too.

<!--
Add a clear description of how the problem has been solved.
-->

