### PR TITLE
The Wazuh dashboard build_number is updated with the Wazuh app parameters  to 4.4

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -47,6 +47,10 @@ if [ "${repository}" ];then
     valid_url='(https?|ftp|file)://[-[:alnum:]\+&@#/%?=~_|!:,.;]*[-[:alnum:]\+&@#/%=~_|]'
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
+        if ! curl --output /dev/null --silent --head --fail "${url}"; then
+        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+        exit 1
+        fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"
     fi
@@ -149,10 +153,10 @@ wazuh_plugin="if (plugin.includes(\'wazuh\')) {\n    return plugin;\n  } else {\
 sed -i "s|return \`\${LATEST_PLUGIN_BASE_URL}\/\${version}\/latest\/\${platform}\/\${arch}\/tar\/builds\/opensearch-dashboards\/plugins\/\${plugin}-\${version}.zip\`;|$wazuh_plugin|" ./src/cli_plugin/install/settings.js
 # Generate build number for package.json
 curl -sO ${url}
-unzip wazuh-${version}-${revision}.zip 'opensearch-dashboards/wazuh/package.json'
+unzip *.zip 'opensearch-dashboards/wazuh/package.json'
 build_number=$(jq -r '.version' ./opensearch-dashboards/wazuh/package.json | tr -d '.')$(jq -r '.revision' ./opensearch-dashboards/wazuh/package.json)
 rm -rf ./opensearch-dashboards
-rm -f ./wazuh-${version}-${revision}.zip
+rm -f ./*.zip
 jq ".build.number=${build_number}" ./package.json > ./package.json.tmp
 mv ./package.json.tmp ./package.json
 

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -14,7 +14,8 @@ set -e
 architecture="$1"
 revision="$2"
 future="$3"
-reference="$4"
+repository=$4
+reference="$5"
 opensearch_version="2.4.1"
 base_dir=/opt/wazuh-dashboard-base
 
@@ -40,6 +41,18 @@ if [ "${future}" = "yes" ];then
     version="99.99.0"
 fi
 wazuh_minor=$(echo ${version} | cut -c1-3)
+
+# Obtain Wazuh plugin URL
+if [ "${repository}" ];then
+    valid_url='(https?|ftp|file)://[-[:alnum:]\+&@#/%?=~_|!:,.;]*[-[:alnum:]\+&@#/%=~_|]'
+    if [[ $repository =~ $valid_url ]];then
+        url="${repository}"
+    else
+        url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"
+    fi
+else
+    url="https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-${version}-${revision}.zip"
+fi
 
 # -----------------------------------------------------------------------------
 
@@ -134,9 +147,15 @@ cp /root/VERSION .
 # Add exception for wazuh plugin install
 wazuh_plugin="if (plugin.includes(\'wazuh\')) {\n    return plugin;\n  } else {\n    return \`\${LATEST_PLUGIN_BASE_URL}\/\${version}\/latest\/\${platform}\/\${arch}\/tar\/builds\/opensearch-dashboards\/plugins\/\${plugin}-\${version}.zip\`;\n  }"
 sed -i "s|return \`\${LATEST_PLUGIN_BASE_URL}\/\${version}\/latest\/\${platform}\/\${arch}\/tar\/builds\/opensearch-dashboards\/plugins\/\${plugin}-\${version}.zip\`;|$wazuh_plugin|" ./src/cli_plugin/install/settings.js
-# Changed package.json build number
-jq ".build.number=$(cat /root/VERSION | tr -d '.')" ./package.json > ./package.json.tmp
+# Generate build number for package.json
+curl -sO ${url}
+unzip wazuh-${version}-${revision}.zip 'opensearch-dashboards/wazuh/package.json'
+build_number=$(jq -r '.version' ./opensearch-dashboards/wazuh/package.json | tr -d '.')$(jq -r '.revision' ./opensearch-dashboards/wazuh/package.json)
+rm -f ./opensearch-dashboards/wazuh/package.json
+rm -f ./wazuh-${version}-${revision}.zip
+jq ".build.number=${build_number}" ./package.json > ./package.json.tmp
 mv ./package.json.tmp ./package.json
+
 
 # Remove plugins
 /bin/bash ./bin/opensearch-dashboards-plugin remove queryWorkbenchDashboards --allow-root

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -14,7 +14,7 @@ set -e
 architecture="$1"
 revision="$2"
 future="$3"
-repository=$4
+repository="$4"
 reference="$5"
 opensearch_version="2.4.1"
 base_dir=/opt/wazuh-dashboard-base

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -151,7 +151,7 @@ sed -i "s|return \`\${LATEST_PLUGIN_BASE_URL}\/\${version}\/latest\/\${platform}
 curl -sO ${url}
 unzip wazuh-${version}-${revision}.zip 'opensearch-dashboards/wazuh/package.json'
 build_number=$(jq -r '.version' ./opensearch-dashboards/wazuh/package.json | tr -d '.')$(jq -r '.revision' ./opensearch-dashboards/wazuh/package.json)
-rm -f ./opensearch-dashboards/wazuh/package.json
+rm -rf ./opensearch-dashboards
 rm -f ./wazuh-${version}-${revision}.zip
 jq ".build.number=${build_number}" ./package.json > ./package.json.tmp
 mv ./package.json.tmp ./package.json

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -48,8 +48,8 @@ if [ "${repository}" ];then
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
         if ! curl --output /dev/null --silent --head --fail "${url}"; then
-        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
-        exit 1
+            echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+            exit 1
         fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"

--- a/stack/dashboard/base/docker/Dockerfile
+++ b/stack/dashboard/base/docker/Dockerfile
@@ -16,14 +16,13 @@ RUN yum install -y \
     autoconf \
     automake \
     libtool \
-    jq
+    jq \
+    unzip
 
 RUN git clone https://github.com/google/brotli.git
 
-RUN cd brotli && ./bootstrap && ./configure --prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib64/brotli --libdir=/usr/lib64/brotli --datarootdir=/usr/share --mandir=/usr/share/man/man1 --docdir=/usr/share/doc \
+RUN cd brotli && chmod +x ./bootstrap && ./bootstrap && ./configure --prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib64/brotli --libdir=/usr/lib64/brotli --datarootdir=/usr/share --mandir=/usr/share/man/man1 --docdir=/usr/share/doc \
     && make && make install
-
-    
 
 # Add the scripts to build the RPM package
 ADD builder.sh /usr/local/bin/builder

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -38,6 +38,10 @@ build_deb() {
     container_name="$1"
     dockerfile_path="$2"
 
+    if [ "${repository}" ];then
+        url="${repository}"
+    fi
+
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
@@ -48,11 +52,10 @@ build_deb() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
-
-    if [ "${repository}" ];then
-        url="${repository}"
+    if [ "${url}" ];then
+        base_cmd+="--app-url ${url}"
     fi
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -98,6 +101,7 @@ help() {
     echo "Usage: $0 [OPTIONS]"
     echo
     echo "    -a, --architecture <arch>  [Optional] Target architecture of the package [amd64]."
+    echo "    --app-url <url>            [Optional] Set the repository from where the Wazuh plugin should be downloaded. By default, will be used pre-release."
     echo "    -r, --revision <rev>       [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
@@ -119,6 +123,14 @@ main() {
         "-a"|"--architecture")
             if [ -n "${2}" ]; then
                 architecture="${2}"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--app-url")
+            if [ -n "$2" ]; then
+                repository="$2"
                 shift 2
             else
                 help 1
@@ -151,14 +163,6 @@ main() {
         "-s"|"--store")
             if [ -n "${2}" ]; then
                 outdir="${2}"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "--app-url")
-            if [ -n "$2" ]; then
-                repository="$2"
                 shift 2
             else
                 help 1

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -18,6 +18,7 @@ deb_builder_dockerfile="${current_path}/docker"
 future="no"
 base_cmd=""
 url=""
+build_base="yes"
 
 trap ctrl_c INT
 
@@ -45,17 +46,19 @@ build_deb() {
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
-    # Base generation
-    if [ "${future}" == "yes" ];then
-        base_cmd+="--future "
+    if [ "${build_base}" == "yes" ];then
+        # Base generation
+        if [ "${future}" == "yes" ];then
+            base_cmd+="--future "
+        fi
+        if [ "${reference}" ];then
+            base_cmd+="--reference ${reference}"
+        fi
+        if [ "${url}" ];then
+            base_cmd+="--app-url ${url}"
+        fi
+        ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     fi
-    if [ "${reference}" ];then
-        base_cmd+="--reference ${reference}"
-    fi
-    if [ "${url}" ];then
-        base_cmd+="--app-url ${url}"
-    fi
-    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -102,6 +105,7 @@ help() {
     echo
     echo "    -a, --architecture <arch>  [Optional] Target architecture of the package [amd64]."
     echo "    --app-url <url>            [Optional] Set the repository from where the Wazuh plugin should be downloaded. By default, will be used pre-release."
+    echo "    -b, --build-base <yes/no>  [Optional] Build a new base or use a existing one. By default, yes."
     echo "    -r, --revision <rev>       [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
@@ -131,6 +135,14 @@ main() {
         "--app-url")
             if [ -n "$2" ]; then
                 repository="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "-b"|"--build-base")
+            if [ -n "${2}" ]; then
+                build_base="${2}"
                 shift 2
             else
                 help 1

--- a/stack/dashboard/deb/builder.sh
+++ b/stack/dashboard/deb/builder.sh
@@ -37,8 +37,8 @@ if [ "${repository}" ];then
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
         if ! curl --output /dev/null --silent --head --fail "${url}"; then
-        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
-        exit 1
+            echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+            exit 1
         fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"

--- a/stack/dashboard/deb/builder.sh
+++ b/stack/dashboard/deb/builder.sh
@@ -36,6 +36,10 @@ if [ "${repository}" ];then
     valid_url='(https?|ftp|file)://[-[:alnum:]\+&@#/%?=~_|!:,.;]*[-[:alnum:]\+&@#/%=~_|]'
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
+        if ! curl --output /dev/null --silent --head --fail "${url}"; then
+        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+        exit 1
+        fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"
     fi

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -38,6 +38,10 @@ build_rpm() {
     container_name="$1"
     dockerfile_path="$2"
 
+    if [ "${repository}" ];then
+        url="${repository}"
+    fi
+
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
 
@@ -48,11 +52,10 @@ build_rpm() {
     if [ "${reference}" ];then
         base_cmd+="--reference ${reference}"
     fi
-    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
-
-    if [ "${repository}" ];then
-        url="${repository}"
+    if [ "${url}" ];then
+        base_cmd+="--app-url ${url}"
     fi
+    ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
 
     # Build the Docker image
     if [[ ${build_docker} == "yes" ]]; then
@@ -98,6 +101,7 @@ help() {
     echo "Usage: $0 [OPTIONS]"
     echo
     echo "    -a, --architecture <arch>  [Optional] Target architecture of the package [x86_64]."
+    echo "    --app-url <url>            [Optional] Set the repository from where the Wazuh plugin should be downloaded. By default, will be used pre-release."
     echo "    -r, --revision <rev>       [Optional] Package revision. By default: 1."
     echo "    -s, --store <path>         [Optional] Set the destination path of package. By default, an output folder will be created."
     echo "    --reference <ref>          [Optional] wazuh-packages branch to download SPECs, not used by default."
@@ -120,6 +124,14 @@ main() {
         "-a"|"--architecture")
             if [ -n "$2" ]; then
                 architecture="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
+        "--app-url")
+            if [ -n "$2" ]; then
+                repository="$2"
                 shift 2
             else
                 help 1
@@ -152,14 +164,6 @@ main() {
         "-s"|"--store")
             if [ -n "$2" ]; then
                 outdir="$2"
-                shift 2
-            else
-                help 1
-            fi
-            ;;
-        "--app-url")
-            if [ -n "$2" ]; then
-                repository="$2"
                 shift 2
             else
                 help 1

--- a/stack/dashboard/rpm/builder.sh
+++ b/stack/dashboard/rpm/builder.sh
@@ -37,8 +37,8 @@ if [ "${repository}" ];then
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
         if ! curl --output /dev/null --silent --head --fail "${url}"; then
-        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
-        exit 1
+            echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+            exit 1
         fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"

--- a/stack/dashboard/rpm/builder.sh
+++ b/stack/dashboard/rpm/builder.sh
@@ -36,6 +36,10 @@ if [ "${repository}" ];then
     valid_url='(https?|ftp|file)://[-[:alnum:]\+&@#/%?=~_|!:,.;]*[-[:alnum:]\+&@#/%=~_|]'
     if [[ $repository =~ $valid_url ]];then
         url="${repository}"
+        if ! curl --output /dev/null --silent --head --fail "${url}"; then
+        echo "The given URL to download the Wazuh plugin zip does not exist: ${url}"
+        exit 1
+        fi
     else
         url="https://packages-dev.wazuh.com/${repository}/ui/dashboard/wazuh-${version}-${revision}.zip"
     fi


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2012|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
A modification is made in the construction of the base so that the Wazuh dashboard package has the corresponding build_number included in its packages.json according to the Wazuh plugin that is installed in the package itself

## Logs example

<!--
Paste here related logs
-->
```console
[root@centos7-1 ~]# cat /usr/share/wazuh-dashboard/package.json 
{
  "name": "opensearch-dashboards",
  "description": "OpenSearch Dashboards is a browser based analytics and search dashboard for OpenSearch. OpenSearch Dashboards is a snap to setup and start using. OpenSearch Dashboards strives to be easy to get started with, while also being flexible and powerful, just like OpenSearch.",
  "keywords": [
    "opensearch-dashboards",
    "opensearch",
    "logstash",
    "analytics",
    "visualizations",
    "dashboards",
    "dashboarding"
  ],
  "version": "2.4.1",
  "branch": "2.4",
  "build": {
    "number": 44001,
    "sha": "ea36827cdedf1e726e7cb8315ffc49f73f9b4eb7",
    "distributable": true,
    "release": true
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/opensearch-project/opensearch-dashboards.git"
  },
  "engines": {
    "node": "14.20.0"
  }
}
```
4.3.0:
![image](https://user-images.githubusercontent.com/64099752/213495734-cd9547de-bfcb-46fc-a7d6-764cd548d5bb.png)

4.4.0:
![image](https://user-images.githubusercontent.com/64099752/213495800-a27c922c-33d3-4a83-8062-5c4f64ee0575.png)


## Tests

Centos 7: https://devel.ci.wazuh.info/view/Tests/job/Test_stack/412/console
Ubuntu Focal: https://devel.ci.wazuh.info/view/Tests/job/Test_stack/413/console

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
