### PR TITLE
Updated loading page message

### DIFF
--- a/stack/dashboard/base/files/etc/template.js
+++ b/stack/dashboard/base/files/etc/template.js
@@ -255,7 +255,7 @@ const Template = ({
       defaultMessage: `${injectedMetadata.branding.applicationTitle} did not load properly. Check the server output for more information.`
     })
   }, i18n('core.ui.welcomeMessage', {
-    defaultMessage: `Loading ${injectedMetadata.branding.applicationTitle}`
+    defaultMessage: `Loading ...`
   })), renderBrandingEnabledOrDisabledLoadingBar())), /*#__PURE__*/_react.default.createElement("div", {
     className: "osdWelcomeView",
     id: "osd_legacy_browser_error",


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2052|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
An override is made so that the loading page message is "Loading ..." instead of "Loading <title>"
![image](https://user-images.githubusercontent.com/64099752/213718359-34f09a12-51b1-4d6f-9315-a1bec3dcb028.png)


## Logs example

<!--
Paste here related logs
-->

## Tests
Builders:
- rpm: https://ci.wazuh.info/job/Packages_builder/127760/console
- deb: https://ci.wazuh.info/job/Packages_builder/127759/console

Tests:
- Centos 7: https://ci.wazuh.info/job/Test_stack/357/
- Ubuntu Focal: https://ci.wazuh.info/job/Test_stack/358/

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
