### PR TITLE
Fix Alpine package ossec.conf creation

### DIFF
--- a/alpine/SPECS/wazuh-agent/APKBUILD
+++ b/alpine/SPECS/wazuh-agent/APKBUILD
@@ -68,5 +68,6 @@ package() {
   cp -a /wazuh-wazuh*/src/VERSION "${package_files_dir}/src"
   cp -a /wazuh-wazuh*/src/REVISION "${package_files_dir}/src"
   cp -a /wazuh-wazuh*/etc/templates/config/generic/* "${package_files_dir}/etc/templates/config/generic"
+  cp -a /wazuh-wazuh*/etc/templates/config/alpine/* "${package_files_dir}/etc/templates/config/alpine"
 }
 

--- a/alpine/SPECS/wazuh-agent/APKBUILD
+++ b/alpine/SPECS/wazuh-agent/APKBUILD
@@ -59,6 +59,7 @@ package() {
   package_files_dir="${pkgdir}${directory_base}/packages_files"
   mkdir -p "${pkgdir}${directory_base}/packages_files/src/init"
   mkdir -p "${pkgdir}${directory_base}/packages_files/etc/templates/config/generic/localfile-logs"
+  mkdir -p "${pkgdir}${directory_base}/packages_files/etc/templates/config/alpine"
   cp -a /wazuh-wazuh*/gen_ossec.sh "${package_files_dir}"
   cp -a /wazuh-wazuh*/add_localfiles.sh "${package_files_dir}"
   cp -a /wazuh-wazuh*/src/init/dist-detect.sh "${package_files_dir}/src/init"

--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
@@ -14,4 +14,6 @@ ${directory_base}/packages_files/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER
 # Add default local_files to ossec.conf
 ${directory_base}/packages_files/add_localfiles.sh ${directory_base} >> ${directory_base}/etc/ossec.conf
 
+rm -rf ${directory_base}/packages_files
+
 exit 0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/15858|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
With the new support of Alpine Linux in 4.4, it has been needed to add a new template, `wazuh/wazuh/etc/templates/config/alpine/rootcheck.agent.template` for the `ossec.conf` creation in this SO in order to prevent false positive Trojans detection. First, it was tested with a compilation from sources and the expected changes were applied correctly, but when trying to create packages to install in Alpine Linux, the resulting package did not apply these changes as we wanted to. 

After researching the problem, it was detected that the `wazuh-packages/alpine/SPECS/wazuh-agent/APKBUILD` was missing some lines to correctly detect the new folder containing the Alpine template. Now, the built packages work properly and apply the correct template.

When checking the correct formation of the `ossec.conf` before the changes the result was:
```
alpine3:/home/vagrant# cat /var/ossec/etc/ossec.conf | grep check_trojans
    <check_trojans>yes</check_trojans>
```
Now the needed changes take place in the `ossec.conf` creation:
```
alpine3:/home/vagrant# cat /var/ossec/etc/ossec.conf | grep check_trojans
    <check_trojans>no</check_trojans>
```
<!--
Add a clear description of how the problem has been solved.
-->

## Tests
<!-- Minimum checks required -->
- Correct formation of `ossec.conf`
  - [x] Alpine Linux 3.17 (package installation)
  - [x] Alpine Linux 3.17 (sources installation)
 