### PR TITLE
Disabled proxy in Installation Assistant

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -137,7 +137,8 @@ function common_checkWazuhConfigYaml() {
 # Retries even if the --retry-connrefused is not available
 function common_curl() {
 
-    curl="curl $@ ${curl_noproxy}"
+    curl="curl $@ ${noproxy}"
+
     if [ -n "${curl_has_connrefused}" ]; then
         eval "${curl} --retry-connrefused"
         e_code="${PIPESTATUS[0]}"

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -137,17 +137,18 @@ function common_checkWazuhConfigYaml() {
 # Retries even if the --retry-connrefused is not available
 function common_curl() {
 
+    curl="curl $@ ${curl_noproxy}"
     if [ -n "${curl_has_connrefused}" ]; then
-        eval "curl $@ --retry-connrefused ${curl_noproxy}"
+        eval "${curl} --retry-connrefused"
         e_code="${PIPESTATUS[0]}"
     else
         retries=0
-        eval "curl $@ ${curl_noproxy}"
+        eval "${curl}"
         e_code="${PIPESTATUS[0]}"
         while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
             retries=$((retries+1))
             sleep 5
-            eval "curl $@ ${curl_noproxy}"
+            eval "${curl}"
             e_code="${PIPESTATUS[0]}"
         done
     fi

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -138,16 +138,16 @@ function common_checkWazuhConfigYaml() {
 function common_curl() {
 
     if [ -n "${curl_has_connrefused}" ]; then
-        eval "curl $@ --retry-connrefused --noproxy '*'"
+        eval "curl $@ --retry-connrefused ${curl_noproxy}"
         e_code="${PIPESTATUS[0]}"
     else
         retries=0
-        eval "curl $@ --noproxy '*'"
+        eval "curl $@ ${curl_noproxy}"
         e_code="${PIPESTATUS[0]}"
         while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
             retries=$((retries+1))
             sleep 5
-            eval "curl $@ --noproxy '*'"
+            eval "curl $@ ${curl_noproxy}"
             e_code="${PIPESTATUS[0]}"
         done
     fi

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -138,16 +138,16 @@ function common_checkWazuhConfigYaml() {
 function common_curl() {
 
     if [ -n "${curl_has_connrefused}" ]; then
-        eval "curl $@ --retry-connrefused"
+        eval "curl $@ --retry-connrefused --noproxy '*'"
         e_code="${PIPESTATUS[0]}"
     else
         retries=0
-        eval "curl $@"
+        eval "curl $@ --noproxy '*'"
         e_code="${PIPESTATUS[0]}"
         while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
             retries=$((retries+1))
             sleep 5
-            eval "curl $@"
+            eval "curl $@ --noproxy '*'"
             e_code="${PIPESTATUS[0]}"
         done
     fi

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -175,6 +175,11 @@ function check_curlVersion() {
         curl_has_connrefused=0
     fi
 
+    curl_noproxy=""
+    if [ $(check_versions ${curl_version} 7.19.4) == "0" ]; then
+        curl_noproxy=" --noproxy '*'"
+    fi
+
 }
 
 function check_dist() {

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -166,7 +166,7 @@ function checks_arguments() {
 
 }
 
-# Checks if the --retry-connrefused is available in curl
+# Checks if some parameters are available in curl
 function check_curlVersion() {
 
     # --retry-connrefused was added in 7.52.0
@@ -175,6 +175,7 @@ function check_curlVersion() {
         curl_has_connrefused=0
     fi
 
+    # --noproxy was added in 7.19.4
     curl_noproxy=""
     if [ $(check_versions ${curl_version} 7.19.4) == "0" ]; then
         curl_noproxy=" --noproxy '*'"

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -176,9 +176,9 @@ function check_curlVersion() {
     fi
 
     # --noproxy was added in 7.19.4
-    curl_noproxy=""
+    noproxy=""
     if [ $(check_versions ${curl_version} 7.19.4) == "0" ]; then
-        curl_noproxy=" --noproxy '*'"
+        noproxy=" --noproxy '*'"
     fi
 
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2066|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR modifies all the `curl` commands performed in the Installation Assistant, avoiding the use of the proxy. This is achieved by adding the `--noproxy '*'` parameter.

<!--
Add a clear description of how the problem has been solved.
-->



