### PR TITLE
Avoid error caused by the removal of `packages_files` directory in Alpine Linux packages

### DIFF
--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
@@ -14,6 +14,4 @@ ${directory_base}/packages_files/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER
 # Add default local_files to ossec.conf
 ${directory_base}/packages_files/add_localfiles.sh ${directory_base} >> ${directory_base}/etc/ossec.conf
 
-rm -rf ${directory_base}/packages_files
-
 exit 0


### PR DESCRIPTION
|Related issue|
|---|
|#2081|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes the database error caused by removing the `packages_files` directory in the post-install script of the Alpine Linux packages.

## Logs example

<!--
Paste here related logs
-->
```
/packages # apk add --allow-untrusted wazuh-agent-4.4.0-r1.apk
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/8) Installing libintl (0.21-r2)
(2/8) Installing ncurses-terminfo-base (6.3_p20220521-r0)
(3/8) Installing ncurses-libs (6.3_p20220521-r0)
(4/8) Installing libproc (3.3.17-r1)
(5/8) Installing procps (3.3.17-r1)
(6/8) Installing libgcc (11.2.1_git20220219-r2)
(7/8) Installing libstdc++ (11.2.1_git20220219-r2)
(8/8) Installing wazuh-agent (4.4.0-r1)
Executing wazuh-agent-4.4.0-r1.pre-install
Executing wazuh-agent-4.4.0-r1.post-install
Executing busybox-1.35.0-r17.trigger
OK: 25 MiB in 22 packages
```
## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Alpine
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md
