### PR TITLE
Added installCommon_installCheckDependencies function

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -202,11 +202,13 @@ function main() {
 
 # -------------- Uninstall case  ------------------------------------
 
+    common_checkSystem
+    installCommon_installCheckDependencies
+    
     if [ -z "${download}" ]; then
         check_dist
     fi
 
-    common_checkSystem
     common_checkInstalled
     checks_arguments
     if [ -n "${uninstall}" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2047|
|https://github.com/wazuh/wazuh-packages/issues/2067|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR modifies how the Installation Assistant installs the necessary dependencies, differentiating between the installation dependencies and the check dependencies. Every tool used in the checks will be installed to ensure the system has every needed tool.
This is performed by the `installCommon_installCheckDependencies` function.


