### PR TITLE
Fixed Debian expired keys in Dockerfiles

### DIFF
--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
+    apt-get update && apt-get install -y --force-yes apt-utils && \
     apt-get install -y --force-yes \
     curl gcc make sudo wget expect gnupg perl-base=5.14.2-21+deb7u3 perl \
     libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev build-essential \

--- a/debs/Debian/amd64/Dockerfile
+++ b/debs/Debian/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.1=5.1.29-5 libdb5.1-dev libssl1.0.0=1.0.1e-2+deb7u20 procps gawk libsigsegv2
 
-RUN apt-get update && apt-get build-dep python3.2 -y
+RUN apt-get update && apt-get build-dep python3.2 -y --force-yes
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 12
-RUN apt-get update &&  apt-get build-dep python3.5 -y
+RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install --allow-change-held-packages -y nodejs
 

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt apt-utils  \
+    apt-get update && apt-get install -y --allow-change-held-packages apt apt-utils  \
     curl gcc g++ make sudo expect gnupg \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
@@ -15,7 +15,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
 # Add Debian's source repository and, Install NodeJS 12
 RUN apt-get update &&  apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install --allow-change-held-packages -y nodejs
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils \
+    apt-get update && apt-get install -y --allow-change-held-packages apt-utils \
     curl gcc make wget sudo expect gnupg perl-base \
     perl libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
@@ -15,7 +15,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
 # Add Debian's source repository and, Install NodeJS 12
 RUN apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y --allow-change-held-packages nodejs
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
     libssl1.1 libssl-dev gawk libsigsegv2 procps libc6-armel-cross g++
 
 # Add Debian's source repository and, Install NodeJS 12
-RUN apt-get build-dep python3.5 -y
+RUN apt-get build-dep python3.5 -y --allow-change-held-packages
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y --allow-change-held-packages nodejs
 

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
     libssl1.0.0=1.0.1e-2+deb7u20 gawk libsigsegv2 procps
 
 # Add Debian's source repository
-RUN apt-get update && apt-get build-dep python3.2 -y
+RUN apt-get update && apt-get build-dep python3.2 -y --force-yes
 RUN sed -i "s;/\* To add :#define SO_REUSEPORT 15 \*/;#define SO_REUSEPORT 15;g" /usr/include/asm-generic/socket.h
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \

--- a/debs/Debian/i386/Dockerfile
+++ b/debs/Debian/i386/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
+    apt-get update && apt-get install -y --force-yes apt-utils && \
     apt-get install -y --force-yes \
     curl gcc-multilib make wget sudo expect gnupg perl-base=5.14.2-21+deb7u3 \
     perl libc-bin=2.13-38+deb7u10 libc6=2.13-38+deb7u10 libc6-dev \

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /et
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
-RUN apt-get update && apt-get build-dep python3.5 -y
+RUN apt-get update && apt-get build-dep python3.5 -y --allow-change-held-packages
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -2,11 +2,13 @@ FROM ppc64le/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get -v
+
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y --force-yes \
+    apt-get update && apt-get install -y --allow-change-held-packages apt-utils && \
+    apt-get install -y --allow-change-held-packages \
     curl gcc make sudo expect gnupg perl-base perl wget \
     libc-bin libc6 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \

--- a/stack/dashboard/deb/docker/amd64/Dockerfile
+++ b/stack/dashboard/deb/docker/amd64/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:10
 ENV DEBIAN_FRONTEND noninteractive
 
 # Installing necessary packages
-RUN apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y \
+RUN apt-get update && apt-get install -y --allow-change-held-packages apt-utils && \
+    apt-get install -y --allow-change-held-packages \
     curl sudo wget expect gnupg build-essential \
     devscripts equivs selinux-basics procps gawk
 

--- a/stack/indexer/deb/docker/amd64/Dockerfile
+++ b/stack/indexer/deb/docker/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:8
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y apt-utils && \
+RUN apt-get update && apt-get install -y --force-yes apt-utils && \
     apt-get install -y --force-yes \
     curl sudo wget expect gnupg build-essential \
     devscripts equivs selinux-basics procps gawk

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Installing necessary packages
 RUN apt-get update && \
-    apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
+    apt-get install -y --allow-change-held-packages gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
     curl perl binutils zip libssl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \

--- a/wpk/common/Dockerfile
+++ b/wpk/common/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:9
 
 RUN apt-get update && \
-    apt-get -y install python git curl jq python3 python3-pip libffi-dev && \
+    apt-get -y install --allow-change-held-packages python git curl jq python3 python3-pip libffi-dev && \
     pip3 install --upgrade cryptography==2.9.2 awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1964|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR is a backport of the related issue to the `4.4` branch.
It fixes the generation of the Docker images based on Debian systems due to expired keys.

The changes are:
- Add `--force-yes` option to the `apt install` command in systems where the `apt` package is under `1.1` version.
- Add `--allow-change-held-packages` option to the `apt install` command in systems where the `apt` package is over `1.1` version. This change is to avoid the warning of the deprecated option `--force-yes` in versions over `1.1`

In other words, the new option `--allow-change-held-packages` is included in the Dockerfiles that use:
- Debian 9 system.
- Debian 10 system.
- Ubuntu 22.04 system.
## Tests

The generation of the affected images are in https://github.com/wazuh/wazuh-packages/issues/1964#issuecomment-1432997233.

## Logs

:green_circle: Package generator - Amd64 dockerfile
<details><summary>Show log</summary>

```
Setting up setools (3.3.7-3) ...
Setting up strace (4.5.20-2.3) ...
Setting up sudo (1.8.5p2-1+nmu3+deb7u1) ...
Setting up unzip (6.0-8+deb7u5) ...
Setting up wdiff (1.1.2-1) ...
Setting up x11-utils (7.7~1) ...
Setting up xauth (1:1.0.7-1) ...
Setting up xbitmaps (1.1.1-1) ...
Setting up xterm (278-4) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/uxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up libaudit-dev (1:1.7.18-1.1) ...
Setting up libdb5.1-dev (5.1.29-5) ...
Setting up python-magic (5.11-2+deb7u8) ...
Setting up g++-4.7 (4.7.2-5) ...
Setting up g++ (4:4.7.2-1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libswitch-perl (2.16-2) ...
Setting up perl-modules (5.14.2-21+deb7u3) ...
Setting up libstdc++6-4.7-dev (4.7.2-5) ...
Setting up perl (5.14.2-21+deb7u3) ...
update-alternatives: using /usr/bin/prename to provide /usr/bin/rename (rename) in auto mode
Setting up libtimedate-perl (1.2000-1) ...
Setting up libmailtools-perl (2.09-1) ...
Setting up libdigest-hmac-perl (1.03+dfsg-1) ...
Setting up libnet-ip-perl (1.25-3) ...
Setting up libnet-dns-perl (0.66-2+b2) ...
Setting up libnet-domain-tld-perl (1.69-1) ...
Setting up libemail-valid-perl (0.190-1) ...
Setting up sgml-base (1.26+nmu4) ...
Setting up autoconf (2.69-1) ...
Setting up automake (1:1.11.6-1) ...
update-alternatives: using /usr/bin/automake-1.11 to provide /usr/bin/automake (automake) in auto mode
Setting up liberror-perl (0.17-1) ...
Setting up git (1:1.7.10.4-1+wheezy3) ...
Setting up autopoint (0.18.1.1-9) ...
Setting up libdpkg-perl (1.16.18) ...
Setting up dpkg-dev (1.16.18) ...
Setting up build-essential (11.5) ...
Setting up intltool-debian (0.35.0+20060710.1) ...
Setting up po-debconf (1.0.16+nmu2) ...
Setting up debhelper (9.20120909) ...
Setting up devscripts (2.12.6+deb7u2) ...
Setting up hardening-includes (2.2) ...
Setting up libalgorithm-diff-perl (1.19.02-2) ...
Setting up libalgorithm-diff-xs-perl (0.04-2+b1) ...
Setting up libalgorithm-merge-perl (0.08-2) ...
Setting up libarchive-zip-perl (1.30-6) ...
Setting up libsub-name-perl (0.05-1+b2) ...
Setting up libclass-accessor-perl (0.34-1) ...
Setting up libclass-inspector-perl (1.27-1) ...
Setting up libclone-perl (0.31-1+b2) ...
Setting up libcommon-sense-perl (3.6-1) ...
Setting up libconvert-binhex-perl (1.119+pristine-3) ...
Setting up libcrypt-ssleay-perl (0.58-1) ...
Setting up libdistro-info-perl (0.10) ...
Setting up libencode-locale-perl (1.03-1) ...
Setting up libexporter-lite-perl (0.02-2) ...
Setting up libfcgi-perl (0.74-1+b1) ...
Setting up libfile-fcntllock-perl (0.14-2) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libfont-afm-perl (1.20-1) ...
Setting up liburi-perl (1.60-1) ...
Setting up libhtml-tagset-perl (3.20-2) ...
Setting up libhtml-parser-perl (3.69-2) ...
Setting up liblwp-mediatypes-perl (6.02-1) ...
Setting up libhttp-message-perl (6.03-1) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libhtml-tree-perl (5.02-1) ...
Setting up libhtml-format-perl (2.10-1) ...
Setting up libhtml-template-perl (2.91-1) ...
Setting up libhttp-cookies-perl (6.00-2) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libio-pty-perl (1:1.08-1+b2) ...
Setting up libsocket-perl (2.002-1) ...
Setting up libio-socket-ip-perl (0.16-2) ...
Setting up libnet-ssleay-perl (1.48-1+b1) ...
Setting up libio-socket-ssl-perl (1.76-2) ...
Setting up libio-string-perl (1.08-2) ...
Setting up libio-stringy-perl (2.110-5) ...
Setting up libipc-run-perl (0.92-1) ...
Setting up libjson-perl (2.53-1) ...
Setting up libjson-xs-perl (2.320-1+b1) ...
Setting up libnet-http-perl (6.03-2) ...
Setting up libwww-robotrules-perl (6.01-1) ...
Setting up liblwp-protocol-https-perl (6.03-1) ...
Setting up libsys-hostname-long-perl (1.4-2) ...
Setting up libmail-sendmail-perl (0.79.16-1) ...
Setting up libmime-tools-perl (5.503-1) ...
Setting up libossp-uuid-perl (1.6.2-1.3) ...
Setting up libparse-debianchangelog-perl (1.2.0-1) ...
Setting up libtask-weaken-perl (1.03-1) ...
Setting up libtie-ixhash-perl (1.21-2) ...
Setting up libxml-namespacesupport-perl (1.09-3) ...
Setting up libxml-sax-base-perl (1.07-1) ...
Setting up libxml-sax-perl (0.99+dfsg-2) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::PurePerl with priority 10...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up patchutils (0.3.2-1.1) ...
Setting up lintian (2.5.10.4) ...
Setting up xml-core (0.13+nmu2) ...
Setting up equivs (2.0.9) ...
Setting up libwww-perl (6.04-1) ...
Setting up libparse-debcontrol-perl (2.005-3) ...
Setting up libxml-parser-perl (2.41-1+b1) ...
Setting up libsoap-lite-perl (0.714-1) ...
Setting up libxml-sax-expat-perl (0.40-2) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::Expat with priority 50...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Replacing config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up libxml-simple-perl (2.20-1) ...
Processing triggers for ca-certificates ...
Updating certificates in /etc/ssl/certs... 171 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Processing triggers for sgml-base ...
```
</details>

<br>
:green_circle: Package generator - Arm64 dockerfile
<details><summary>Show log</summary>

```
Setting up tcpd (7.6.q-26) ...
Setting up libpod-constants-perl (0.19-1) ...
Setting up libkrb5support0:amd64 (1.15-1+deb9u3) ...
Setting up libsort-versions-perl (1.62-1) ...
Setting up libio-socket-ssl-perl (2.044-1) ...
Setting up gcc-6 (6.3.0-18+deb9u1) ...
Setting up libcroco3:amd64 (0.6.11-3) ...
Setting up libsub-exporter-perl (0.986-1) ...
Setting up g++-6 (6.3.0-18+deb9u1) ...
Setting up libpython-stdlib:amd64 (2.7.13-2) ...
Setting up libalgorithm-merge-perl (0.08-3) ...
Setting up libdrm-intel1:amd64 (2.4.74-1) ...
Setting up dpkg-dev (1.18.26) ...
Setting up libalgorithm-diff-xs-perl (0.04-4+b2) ...
Setting up tcl-expect:amd64 (5.45-7+deb9u1) ...
Setting up guile-2.0-libs:amd64 (2.0.13+1-4) ...
Setting up libp11-kit0:amd64 (0.23.3-2+deb9u1) ...
Setting up tcl8.6 (8.6.6+dfsg-1+b1) ...
Setting up libstring-copyright-perl (0.003005-1) ...
Setting up libhtml-parser-perl (3.72-3) ...
Setting up libpython2.7:amd64 (2.7.13-2+deb9u6) ...
Setting up automake (1:1.15-6) ...
update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
Setting up libipc-run-perl (0.94-1+deb9u1) ...
Setting up libcgi-pm-perl (4.35-1) ...
Setting up libdevel-globaldestruction-perl (0.14-1) ...
Setting up libice6:amd64 (2:1.0.9-2) ...
Setting up libparse-debianchangelog-perl (1.2.0-12) ...
Setting up man-db (2.7.6.1-2) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Building database of manual pages ...
Setting up shared-mime-info (1.8-1+deb9u1) ...
Setting up pinentry-curses (1.0.0-2) ...
Setting up gnupg-agent (2.1.18-8~deb9u4) ...
Setting up libkyotocabinet16v5:amd64 (1.2.76-4.2+b1) ...
Setting up libxcb1:amd64 (1.12-1) ...
Setting up python (2.7.13-2) ...
Setting up libfile-stripnondeterminism-perl (0.034-1) ...
Setting up liblist-moreutils-perl (0.416-1+b1) ...
Setting up libtool (2.4.6-2) ...
Setting up python3.5 (3.5.3-1+deb9u5) ...
Setting up libpython3-stdlib:amd64 (3.5.3-1) ...
Setting up libxcb-present0:amd64 (1.12-1) ...
Setting up libfontconfig1:amd64 (2.11.0-6.7+b1) ...
Setting up libxcb-dri2-0:amd64 (1.12-1) ...
Setting up libsm6:amd64 (2:1.2.2-1+b3) ...
Setting up expect (5.45-7+deb9u1) ...
Setting up libxcb-dri3-0:amd64 (1.12-1) ...
Setting up libk5crypto3:amd64 (1.15-1+deb9u3) ...
Setting up libxcb-glx0:amd64 (1.12-1) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libnet-smtp-ssl-perl (1.04-1) ...
Setting up libimport-into-perl (1.002005-1) ...
Setting up libmodule-implementation-perl (0.09-1) ...
Setting up gettext (0.19.8.1-2+deb9u1) ...
Setting up gnupg (2.1.18-8~deb9u4) ...
Setting up libgnutls30:amd64 (3.5.8-5+deb9u6) ...
Setting up libx11-6:amd64 (2:1.6.4-3+deb9u4) ...
Setting up libgl1-mesa-dri:amd64 (13.0.6-1+b2) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-1+b1) ...
Setting up gcc (4:6.3.0-4) ...
Setting up python-pkg-resources (33.1.1-1) ...
Setting up libxmuu1:amd64 (2:1.1.2-2) ...
Setting up libcgi-fast-perl (1:2.12-1) ...
Setting up libhtml-tree-perl (5.03-2) ...
Setting up libparams-validate-perl (1.26-1) ...
Setting up libgpgme11:amd64 (1.8.0-3+b2) ...
Setting up libxcb-sync1:amd64 (1.12-1) ...
Setting up intltool-debian (0.35.0+20060710.4) ...
Setting up python-six (1.10.0-3) ...
Setting up libldap-2.4-2:amd64 (2.4.44+dfsg-5+deb9u9) ...
Setting up wget (1.18-5+deb9u3) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libxcomposite1:amd64 (1:0.4.4-2) ...
Setting up libxpm4:amd64 (1:3.5.12-1) ...
Setting up libxt6:amd64 (1:1.1.5-1) ...
Setting up libxcb-shape0:amd64 (1.12-1) ...
Setting up libxrender1:amd64 (1:0.9.10-1) ...
Setting up libmoo-perl (2.002005-1) ...
Setting up libhttp-message-perl (6.11-1) ...
Setting up g++ (4:6.3.0-4) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libkrb5-3:amd64 (1.15-1+deb9u3) ...
Setting up libb-hooks-endofscope-perl (0.21-1) ...
Setting up exim4-daemon-light (4.89-2+deb9u8) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Initializing GnuTLS DH parameter file
Setting up libxft2:amd64 (2.3.2-1+b2) ...
Setting up dirmngr (2.1.18-8~deb9u4) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libpackage-stash-perl (0.37-1) ...
Setting up python-gpg (1.8.0-3+b2) ...
Setting up libmailtools-perl (2.18-1) ...
Setting up libgetopt-long-descriptive-perl (0.100-1) ...
Setting up libhtml-format-perl (2.12-1) ...
Setting up libemail-valid-perl (1.202-1) ...
Setting up python-chardet (2.3.0-2) ...
Setting up libxext6:amd64 (2:1.3.3-1+b2) ...
Setting up libxfixes3:amd64 (1:5.0.3-1) ...
Setting up po-debconf (1.0.20) ...
Setting up libhttp-cookies-perl (6.01-1) ...
Setting up build-essential (12.3) ...
Setting up libxss1:amd64 (1:1.2.2-1) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libxmu6:amd64 (2:1.1.2-2) ...
Setting up libgssapi-krb5-2:amd64 (1.15-1+deb9u3) ...
Setting up xauth (1:1.0.9-1+b2) ...
Setting up python-debian (0.1.30) ...
Setting up libxxf86dga1:amd64 (2:1.1.4-1+b3) ...
Setting up dput (0.12.1) ...
Setting up lintian (2.5.50.4) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libxv1:amd64 (2:1.0.11-1) ...
Setting up libxxf86vm1:amd64 (1:1.1.4-1+b2) ...
Setting up libnamespace-clean-perl (0.27-1) ...
Setting up python-apt (1.4.3) ...
Setting up openssh-client (1:7.4p1-10+deb9u7) ...
Setting up libxrandr2:amd64 (2:1.5.1-1) ...
Setting up libmime-tools-perl (5.508-1) ...
Setting up libxi6:amd64 (2:1.7.9-1) ...
Setting up libgsasl7 (1.8.0-8+b2) ...
Setting up libxaw7:amd64 (2:1.0.13-1+b2) ...
Setting up libmailutils5:amd64 (1:3.1.1-1) ...
Setting up licensecheck (3.0.29-1) ...
Setting up libxinerama1:amd64 (2:1.1.3-1+b3) ...
Setting up libxdamage1:amd64 (1:1.1.4-2+b3) ...
Setting up libcurl3:amd64 (7.52.1-5+deb9u16) ...
Setting up libcurl3-gnutls:amd64 (7.52.1-5+deb9u16) ...
Setting up libtk8.6:amd64 (8.6.6-1+b1) ...
Setting up xterm (327-2+deb9u3) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up mailutils (1:3.1.1-1) ...
update-alternatives: using /usr/bin/frm.mailutils to provide /usr/bin/frm (frm) in auto mode
update-alternatives: using /usr/bin/from.mailutils to provide /usr/bin/from (from) in auto mode
update-alternatives: using /usr/bin/messages.mailutils to provide /usr/bin/messages (messages) in auto mode
update-alternatives: using /usr/bin/movemail.mailutils to provide /usr/bin/movemail (movemail) in auto mode
update-alternatives: using /usr/bin/readmsg.mailutils to provide /usr/bin/readmsg (readmsg) in auto mode
update-alternatives: using /usr/bin/dotlock.mailutils to provide /usr/bin/dotlock (dotlock) in auto mode
update-alternatives: using /usr/bin/mail.mailutils to provide /usr/bin/mailx (mailx) in auto mode
Setting up libxtst6:amd64 (2:1.2.3-1) ...
Setting up libgl1-mesa-glx:amd64 (13.0.6-1+b2) ...
Setting up git (1:2.11.0-3+deb9u7) ...
Setting up libgit-wrapper-perl (0.047-1) ...
Setting up tk8.6 (8.6.6-1+b1) ...
Setting up curl (7.52.1-5+deb9u16) ...
Setting up x11-utils (7.7+3+b1) ...
Setting up dh-autoreconf (14) ...
Setting up python3 (3.5.3-1) ...
running python rtupdate hooks for python3.5...
running python post-rtupdate hooks for python3.5...
Setting up python3-selinux (2.6-3+b3) ...
Setting up python3-numpy (1:1.12.1-3) ...
Setting up python3-magic (1:5.30-1+deb9u3) ...
Setting up liblwp-protocol-https-perl (6.06-2) ...
Setting up python3-six (1.10.0-3) ...
Setting up devscripts (2.17.6+deb9u2) ...
Setting up python3-pkg-resources (33.1.1-1) ...
Setting up lsb-release (9.20161125) ...
Setting up dh-strip-nondeterminism (0.034-1) ...
Setting up python3-chardet (2.3.0-2) ...
Setting up python3-semanage (2.6-2) ...
Setting up dh-python (2.20170125) ...
Setting up python3-decorator (4.0.11-1) ...
Setting up python3-debian (0.1.30) ...
Setting up libwww-perl (6.15-1) ...
Setting up python3-audit (1:2.6.7-2) ...
Setting up python3-ipy (1:0.83-1) ...
Setting up python3-yaml (3.12-1) ...
Setting up debhelper (10.2.5) ...
Setting up equivs (2.0.9+nmu1) ...
Setting up python3-scipy (0.18.1-2) ...
Setting up python3-apt (1.4.3) ...
Setting up selinux-basics (0.5.6) ...
Setting up python3-networkx (1.11-2) ...
Setting up libxml-parser-perl (2.44-2+b1) ...
Setting up python3-setools (4.0.1-6) ...
Setting up setools (4.0.1-6) ...
Setting up python3-sepolgen (2.6-3) ...
Setting up libsoap-lite-perl (1.20-1) ...
Setting up python3-sepolicy (2.6-3) ...
Setting up libxmlrpc-lite-perl (0.717-1) ...
Setting up policycoreutils-python-utils (2.6-3) ...
Setting up policycoreutils-dev (2.6-3) ...
Setting up selinux-policy-dev (2:2.20161023.1-9) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Processing triggers for sgml-base (1.29) ...
Processing triggers for ca-certificates (20200601~deb9u2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```
</details>

<br>
:green_circle: Package generator - Armhf
<details><summary>Show log</summary>

```
Setting up mime-support (3.60) ...
Setting up sudo (1.8.19p1-2.1+deb9u3) ...
Setting up iso-codes (3.75-1) ...
Setting up libpng16-16:amd64 (1.6.28-1+deb9u1) ...
Setting up libgpm2:amd64 (1.20.4-6.2+b1) ...
Setting up libldap-common (2.4.44+dfsg-5+deb9u9) ...
Setting up fonts-dejavu-core (2.37-1) ...
Setting up xbitmaps (1.1.1-2) ...
Setting up libcilkrts5:amd64 (6.3.0-18+deb9u1) ...
Setting up apt-utils (1.4.11) ...
Setting up perl-openssl-defaults:amd64 (3) ...
Setting up libblas-common (3.7.0-2) ...
Setting up bash-completion (1:2.1-4.3) ...
Setting up libubsan0:amd64 (6.3.0-18+deb9u1) ...
Setting up libtsan0:amd64 (6.3.0-18+deb9u1) ...
Setting up libssl-dev:amd64 (1.1.0l-1~deb9u6) ...
Setting up libgfortran3:amd64 (6.3.0-18+deb9u1) ...
Setting up groff-base (1.22.3-9) ...
Setting up mysql-common (5.8+1.0.2) ...
update-alternatives: using /etc/mysql/my.cnf.fallback to provide /etc/mysql/my.cnf (my.cnf) in auto mode
Setting up libxshmfence1:amd64 (1.2-1+b2) ...
Setting up libossp-uuid16:amd64 (1.6.2-1.5+b4) ...
Setting up libsasl2-modules-db:amd64 (2.1.27~101-g0780600+dfsg-3+deb9u2) ...
Setting up libcap-ng-dev (0.7.7-3+b1) ...
Setting up unzip (6.0-21+deb9u2) ...
Setting up linux-libc-dev:amd64 (4.9.320-2) ...
Setting up libsasl2-2:amd64 (2.1.27~101-g0780600+dfsg-3+deb9u2) ...
Setting up libgc1c2:amd64 (1:7.4.2-8+deb9u1) ...
Setting up dctrl-tools (2.24-2+b1) ...
Setting up distro-info-data (0.36) ...
Setting up gettext-base (0.19.8.1-2+deb9u1) ...
Setting up libtxc-dxtn-s2tc:amd64 (1.0+git20151227-2) ...
update-alternatives: using /usr/lib/x86_64-linux-gnu/s2tc/libtxc_dxtn.so to provide /usr/lib/x86_64-linux-gnu/libtxc_dxtn.so (libtxc-dxtn-x86_64-linux-gnu) in auto mode
Setting up libpipeline1:amd64 (1.4.1-2) ...
Setting up libksba8:amd64 (1.3.5-2) ...
Setting up libmariadbclient18:amd64 (10.1.48-0+deb9u2) ...
Setting up libglapi-mesa:amd64 (13.0.6-1+b2) ...
Setting up m4 (1.4.18-1) ...
Setting up sgml-base (1.29) ...
Setting up at (3.1.20-3) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up gawk (1:4.1.4+dfsg-1) ...
Setting up libicu57:amd64 (57.1-6+deb9u5) ...
Setting up libbsd0:amd64 (0.8.3-1+deb9u1) ...
Setting up libprocps6:amd64 (2:3.3.12-3+deb9u1) ...
Setting up ucf (3.0036) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up libxml2:amd64 (2.9.4+dfsg1-2.2+deb9u7) ...
Setting up libutempter0:amd64 (1.1.6-3) ...
Setting up libfreetype6:amd64 (2.6.3-3.2+deb9u2) ...
Setting up libtasn1-6:amd64 (4.10-1.1+deb9u1) ...
Setting up libmagic-mgc (1:5.30-1+deb9u3) ...
Setting up gnupg-l10n (2.1.18-8~deb9u4) ...
Setting up libdrm2:amd64 (2.4.74-1) ...
Setting up bzip2 (1.0.6-8.1) ...
Setting up libaudit-dev:amd64 (1:2.6.7-2) ...
Setting up libmagic1:amd64 (1:5.30-1+deb9u3) ...
Setting up libhogweed4:amd64 (3.3-1+deb9u1) ...
Setting up rsync (3.1.2-1+deb9u3) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of restart.
Setting up liblsan0:amd64 (6.3.0-18+deb9u1) ...
Setting up procps (2:3.3.12-3+deb9u1) ...
update-alternatives: using /usr/bin/w.procps to provide /usr/bin/w (w) in auto mode
Setting up perl (5.24.1-3+deb9u7) ...
update-alternatives: using /usr/bin/prename to provide /usr/bin/rename (rename) in auto mode
Setting up selinux-utils (2.6-3+b3) ...
Setting up libfile-chdir-perl (0.1008-1) ...
Setting up libsys-hostname-long-perl (1.5-1) ...
Setting up libfile-fcntllock-perl (0.22-3+b2) ...
Setting up libssl1.0.2:amd64 (1.0.2u-1~deb9u7) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up libtext-glob-perl (0.10-1) ...
Setting up libpackage-stash-xs-perl (0.28-3+b1) ...
Setting up libstrictures-perl (2.000003-1) ...
Setting up libmpx2:amd64 (6.3.0-18+deb9u1) ...
Setting up libisl15:amd64 (0.18-1) ...
Setting up libyaml-0-2:amd64 (0.1.7-2) ...
Setting up libx11-xcb1:amd64 (2:1.6.4-3+deb9u4) ...
Setting up libntlm0:amd64 (1.4-8+deb9u1) ...
Setting up libblas3 (3.7.0-2) ...
update-alternatives: using /usr/lib/libblas/libblas.so.3 to provide /usr/lib/libblas.so.3 (libblas.so.3) in auto mode
Setting up libssh2-1:amd64 (1.7.0-1+deb9u2) ...
Setting up patch (2.7.5-1+deb9u2) ...
Setting up libglib2.0-data (2.50.3-2+deb9u3) ...
Setting up liblwp-mediatypes-perl (6.02-1) ...
Setting up libmail-sendmail-perl (0.79.16-2) ...
Setting up krb5-locales (1.15-1+deb9u3) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Setting up libsocket6-perl (0.27-1+b1) ...
Setting up patchutils (0.3.4-2) ...
Setting up publicsuffix (20190415.1030-0+deb9u1) ...
Setting up autotools-dev (20161112.1) ...
Setting up libunistring0:amd64 (0.9.6+really0.9.3-0.1) ...
Setting up liburi-perl (1.71-1) ...
Setting up t1utils (1.39-2) ...
Setting up xz-utils (5.2.2-1.2+deb9u1) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
Setting up libfakeroot:amd64 (1.21-3.1) ...
Setting up libc6-armel-cross (2.24-10cross1) ...
Setting up libscalar-list-utils-perl (1:1.47-1) ...
Setting up libltdl7:amd64 (2.4.6-2) ...
Setting up openssl (1.1.0l-1~deb9u6) ...
Setting up libsqlite3-0:amd64 (3.16.2-5+deb9u3) ...
Setting up libfontenc1:amd64 (1:1.1.3-1+b2) ...
Setting up libdigest-hmac-perl (1.03+dfsg-1) ...
Setting up libio-string-perl (1.08-3) ...
Setting up libalgorithm-diff-perl (1.19.03-1) ...
Setting up libfribidi0:amd64 (0.19.7-1+deb9u2) ...
Setting up liblocale-gettext-perl (1.07-3+b1) ...
Setting up libclone-perl (0.38-2+b1) ...
Setting up wdiff (1.2.2-2) ...
Setting up libpciaccess0:amd64 (0.13.4-1+b2) ...
Setting up libclass-xsaccessor-perl (1.19-2+b7) ...
Setting up libsensors4:amd64 (1:3.4.0-4) ...
Setting up libnet-http-perl (6.12-1) ...
Setting up libnumber-compare-perl (0.03-1) ...
Setting up libmpc3:amd64 (1.0.3-1+b2) ...
Setting up binutils (2.28-5) ...
Setting up libffi6:amd64 (3.2.1-6) ...
Setting up cpp-6 (6.3.0-18+deb9u1) ...
Setting up libssl-doc (1.1.0l-1~deb9u6) ...
Setting up libc-dev-bin (2.24-11+deb9u4) ...
Setting up libdrm-radeon1:amd64 (2.4.74-1) ...
Setting up libunicode-utf8-perl (0.60-1+b3) ...
Setting up libtcl8.6:amd64 (8.6.6+dfsg-1+b1) ...
Setting up libxdmcp6:amd64 (1:1.1.2-3) ...
Setting up xml-core (0.17) ...
Setting up libkeyutils1:amd64 (1.5.9-9) ...
Setting up libdrm-nouveau2:amd64 (2.4.74-1) ...
Setting up bsdmainutils (9.0.12+nmu1) ...
update-alternatives: using /usr/bin/bsd-write to provide /usr/bin/write (write) in auto mode
update-alternatives: using /usr/bin/bsd-from to provide /usr/bin/from (from) in auto mode
Setting up libsasl2-modules:amd64 (2.1.27~101-g0780600+dfsg-3+deb9u2) ...
Setting up libconvert-binhex-perl (1.125-1) ...
Setting up libio-sessiondata-perl (1.03-1) ...
Setting up libparams-util-perl (1.07-3+b1) ...
Setting up x11-common (1:7.7+19) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up libsub-name-perl (0.21-1) ...
Setting up ca-certificates (20200601~deb9u2) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Updating certificates in /etc/ssl/certs...
137 added, 0 removed; done.
Setting up manpages-dev (4.10-2) ...
Setting up libyaml-libyaml-perl (0.63-2) ...
Setting up libc6-dev:amd64 (2.24-11+deb9u4) ...
Setting up cron (3.0pl1-128+deb9u2) ...
Adding group `crontab' (GID 102) ...
Done.
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up libparams-classify-perl (0.013-6+b1) ...
Setting up libassuan0:amd64 (2.4.3-2) ...
Setting up libfcgi-perl (0.78-2) ...
Setting up xdg-user-dirs (0.15-2+b1) ...
Setting up libwww-robotrules-perl (6.01-1) ...
Setting up policycoreutils (2.6-3) ...
Setting up libauthen-sasl-perl (2.1600-1) ...
Setting up libitm1:amd64 (6.3.0-18+deb9u1) ...
Setting up libx11-data (2:1.6.4-3+deb9u4) ...
Setting up libpython2.7-stdlib:amd64 (2.7.13-2+deb9u6) ...
Setting up diffstat (1.61-1+b1) ...
Setting up libxau6:amd64 (1:1.0.8-1) ...
Setting up autopoint (0.19.8.1-2+deb9u1) ...
Setting up libmpdec2:amd64 (2.4.2-1) ...
Setting up libclass-accessor-perl (0.34-1) ...
Setting up libsort-key-perl (1.33-1+b3) ...
Setting up libclass-inspector-perl (1.31-1) ...
Setting up liblzo2-2:amd64 (2.08-1.2+b2) ...
Setting up libwrap0:amd64 (7.6.q-26) ...
Setting up mailutils-common (1:3.1.1-1) ...
Setting up libtask-weaken-perl (1.04-1) ...
Setting up netbase (5.4) ...
Setting up libhtml-tagset-perl (3.20-3) ...
Setting up libpath-tiny-perl (0.100-1) ...
Setting up libedit2:amd64 (3.1-20160903-3) ...
Setting up libnet-domain-tld-perl (1.75-1) ...
Setting up cpp (4:6.3.0-4) ...
Setting up libsub-install-perl (0.928-1) ...
Setting up libdata-optlist-perl (0.110-1) ...
Setting up libio-stringy-perl (2.111-2) ...
Setting up libsub-exporter-progressive-perl (0.001013-1) ...
Setting up libtry-tiny-perl (0.28-1) ...
Setting up libclass-method-modifiers-perl (2.12-1) ...
Setting up libfont-afm-perl (1.20-2) ...
Setting up fontconfig-config (2.11.0-6.7) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up libidn2-0:amd64 (0.16-1+deb9u1) ...
Setting up libgcc-6-dev:amd64 (6.3.0-18+deb9u1) ...
Setting up libstdc++-6-dev:amd64 (6.3.0-18+deb9u1) ...
Setting up libarchive-zip-perl (1.59-1+deb9u1) ...
Setting up libltdl-dev:amd64 (2.4.6-2) ...
Setting up libdistro-info-perl (0.14) ...
Setting up libio-socket-inet6-perl (2.72-2) ...
Setting up libio-pty-perl (1:1.08-1.1+b2) ...
Setting up libdrm-amdgpu1:amd64 (2.4.74-1) ...
Setting up libfile-which-perl (1.21-1) ...
Setting up libencode-locale-perl (1.05-1) ...
Setting up libperlio-gzip-perl (0.19-1+b2) ...
Setting up libtext-levenshtein-perl (0.13-1) ...
Setting up liberror-perl (0.17024-1) ...
Setting up libvariable-magic-perl (0.61-1) ...
Setting up libtimedate-perl (2.3000-2+deb9u1) ...
Setting up libnet-ip-perl (1.26-1) ...
Setting up rename (0.20-4) ...
update-alternatives: using /usr/bin/file-rename to provide /usr/bin/rename (rename) in auto mode
Setting up librole-tiny-perl (2.000005-1) ...
Setting up libnet-ssleay-perl (1.80-1) ...
Setting up selinux-policy-default (2:2.20161023.1-9) ...
Updating selinux default policy (this step might take a moment)...libsemanage.add_user: user system_u not in password file
 done.
Setting up libmodule-runtime-perl (0.014-2) ...
Setting up libpsl5:amd64 (0.17.0-3) ...
Setting up libfile-homedir-perl (1.00-1) ...
Setting up libipc-system-simple-perl (1.25-3) ...
Setting up libfile-basedir-perl (0.07-1) ...
Setting up libstring-escape-perl (2010.002-1) ...
Setting up liblapack3 (3.7.0-2) ...
update-alternatives: using /usr/lib/lapack/liblapack.so.3 to provide /usr/lib/liblapack.so.3 (liblapack.so.3) in auto mode
Setting up libglib2.0-0:amd64 (2.50.3-2+deb9u3) ...
No schema files found: doing nothing.
Setting up libpython3.5-stdlib:amd64 (3.5.3-1+deb9u5) ...
Setting up libio-html-perl (1.001-1) ...
Setting up libexporter-tiny-perl (0.042-1) ...
Setting up libllvm3.9:amd64 (1:3.9.1-9) ...
Setting up libossp-uuid-perl (1.6.2-1.5+b4) ...
Setting up libdpkg-perl (1.18.26) ...
Setting up python2.7 (2.7.13-2+deb9u6) ...
Setting up libnumber-range-perl (0.12-1) ...
Setting up liblist-compare-perl (0.53-1) ...
Setting up autoconf (2.69-10) ...
Setting up libpath-iterator-rule-perl (1.009-1) ...
Setting up libnet-dns-perl (1.07-1) ...
Setting up exim4-base (4.89-2+deb9u8) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
exim: DB upgrade, deleting hints-db
Setting up file (1:5.30-1+deb9u3) ...
Setting up libsub-identify-perl (0.12-2+b1) ...
Setting up fakeroot (1.21-3.1) ...
update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
Setting up tcpd (7.6.q-26) ...
Setting up libpod-constants-perl (0.19-1) ...
Setting up libkrb5support0:amd64 (1.15-1+deb9u3) ...
Setting up libsort-versions-perl (1.62-1) ...
Setting up libio-socket-ssl-perl (2.044-1) ...
Setting up gcc-6 (6.3.0-18+deb9u1) ...
Setting up libcroco3:amd64 (0.6.11-3) ...
Setting up libsub-exporter-perl (0.986-1) ...
Setting up g++-6 (6.3.0-18+deb9u1) ...
Setting up libpython-stdlib:amd64 (2.7.13-2) ...
Setting up libalgorithm-merge-perl (0.08-3) ...
Setting up libdrm-intel1:amd64 (2.4.74-1) ...
Setting up dpkg-dev (1.18.26) ...
Setting up libalgorithm-diff-xs-perl (0.04-4+b2) ...
Setting up tcl-expect:amd64 (5.45-7+deb9u1) ...
Setting up guile-2.0-libs:amd64 (2.0.13+1-4) ...
Setting up libp11-kit0:amd64 (0.23.3-2+deb9u1) ...
Setting up tcl8.6 (8.6.6+dfsg-1+b1) ...
Setting up libstring-copyright-perl (0.003005-1) ...
Setting up libhtml-parser-perl (3.72-3) ...
Setting up libpython2.7:amd64 (2.7.13-2+deb9u6) ...
Setting up automake (1:1.15-6) ...
update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
Setting up libipc-run-perl (0.94-1+deb9u1) ...
Setting up libcgi-pm-perl (4.35-1) ...
Setting up libdevel-globaldestruction-perl (0.14-1) ...
Setting up libice6:amd64 (2:1.0.9-2) ...
Setting up libparse-debianchangelog-perl (1.2.0-12) ...
Setting up man-db (2.7.6.1-2) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Building database of manual pages ...
Setting up shared-mime-info (1.8-1+deb9u1) ...
Setting up pinentry-curses (1.0.0-2) ...
Setting up gnupg-agent (2.1.18-8~deb9u4) ...
Setting up libkyotocabinet16v5:amd64 (1.2.76-4.2+b1) ...
Setting up libxcb1:amd64 (1.12-1) ...
Setting up python (2.7.13-2) ...
Setting up libfile-stripnondeterminism-perl (0.034-1) ...
Setting up liblist-moreutils-perl (0.416-1+b1) ...
Setting up libtool (2.4.6-2) ...
Setting up python3.5 (3.5.3-1+deb9u5) ...
Setting up libpython3-stdlib:amd64 (3.5.3-1) ...
Setting up libxcb-present0:amd64 (1.12-1) ...
Setting up libfontconfig1:amd64 (2.11.0-6.7+b1) ...
Setting up libxcb-dri2-0:amd64 (1.12-1) ...
Setting up libsm6:amd64 (2:1.2.2-1+b3) ...
Setting up expect (5.45-7+deb9u1) ...
Setting up libxcb-dri3-0:amd64 (1.12-1) ...
Setting up libk5crypto3:amd64 (1.15-1+deb9u3) ...
Setting up libxcb-glx0:amd64 (1.12-1) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libnet-smtp-ssl-perl (1.04-1) ...
Setting up libimport-into-perl (1.002005-1) ...
Setting up libmodule-implementation-perl (0.09-1) ...
Setting up gettext (0.19.8.1-2+deb9u1) ...
Setting up gnupg (2.1.18-8~deb9u4) ...
Setting up libgnutls30:amd64 (3.5.8-5+deb9u6) ...
Setting up libx11-6:amd64 (2:1.6.4-3+deb9u4) ...
Setting up libgl1-mesa-dri:amd64 (13.0.6-1+b2) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-1+b1) ...
Setting up gcc (4:6.3.0-4) ...
Setting up python-pkg-resources (33.1.1-1) ...
Setting up libxmuu1:amd64 (2:1.1.2-2) ...
Setting up libcgi-fast-perl (1:2.12-1) ...
Setting up libhtml-tree-perl (5.03-2) ...
Setting up libparams-validate-perl (1.26-1) ...
Setting up libgpgme11:amd64 (1.8.0-3+b2) ...
Setting up libxcb-sync1:amd64 (1.12-1) ...
Setting up intltool-debian (0.35.0+20060710.4) ...
Setting up python-six (1.10.0-3) ...
Setting up libldap-2.4-2:amd64 (2.4.44+dfsg-5+deb9u9) ...
Setting up wget (1.18-5+deb9u3) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libxcomposite1:amd64 (1:0.4.4-2) ...
Setting up libxpm4:amd64 (1:3.5.12-1) ...
Setting up libxt6:amd64 (1:1.1.5-1) ...
Setting up libxcb-shape0:amd64 (1.12-1) ...
Setting up libxrender1:amd64 (1:0.9.10-1) ...
Setting up libmoo-perl (2.002005-1) ...
Setting up libhttp-message-perl (6.11-1) ...
Setting up g++ (4:6.3.0-4) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libkrb5-3:amd64 (1.15-1+deb9u3) ...
Setting up libb-hooks-endofscope-perl (0.21-1) ...
Setting up exim4-daemon-light (4.89-2+deb9u8) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Initializing GnuTLS DH parameter file
Setting up libxft2:amd64 (2.3.2-1+b2) ...
Setting up dirmngr (2.1.18-8~deb9u4) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libpackage-stash-perl (0.37-1) ...
Setting up python-gpg (1.8.0-3+b2) ...
Setting up libmailtools-perl (2.18-1) ...
Setting up libgetopt-long-descriptive-perl (0.100-1) ...
Setting up libhtml-format-perl (2.12-1) ...
Setting up libemail-valid-perl (1.202-1) ...
Setting up python-chardet (2.3.0-2) ...
Setting up libxext6:amd64 (2:1.3.3-1+b2) ...
Setting up libxfixes3:amd64 (1:5.0.3-1) ...
Setting up po-debconf (1.0.20) ...
Setting up libhttp-cookies-perl (6.01-1) ...
Setting up build-essential (12.3) ...
Setting up libxss1:amd64 (1:1.2.2-1) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libxmu6:amd64 (2:1.1.2-2) ...
Setting up libgssapi-krb5-2:amd64 (1.15-1+deb9u3) ...
Setting up xauth (1:1.0.9-1+b2) ...
Setting up python-debian (0.1.30) ...
Setting up libxxf86dga1:amd64 (2:1.1.4-1+b3) ...
Setting up dput (0.12.1) ...
Setting up lintian (2.5.50.4) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libxv1:amd64 (2:1.0.11-1) ...
Setting up libxxf86vm1:amd64 (1:1.1.4-1+b2) ...
Setting up libnamespace-clean-perl (0.27-1) ...
Setting up python-apt (1.4.3) ...
Setting up openssh-client (1:7.4p1-10+deb9u7) ...
Setting up libxrandr2:amd64 (2:1.5.1-1) ...
Setting up libmime-tools-perl (5.508-1) ...
Setting up libxi6:amd64 (2:1.7.9-1) ...
Setting up libgsasl7 (1.8.0-8+b2) ...
Setting up libxaw7:amd64 (2:1.0.13-1+b2) ...
Setting up libmailutils5:amd64 (1:3.1.1-1) ...
Setting up licensecheck (3.0.29-1) ...
Setting up libxinerama1:amd64 (2:1.1.3-1+b3) ...
Setting up libxdamage1:amd64 (1:1.1.4-2+b3) ...
Setting up libcurl3:amd64 (7.52.1-5+deb9u16) ...
Setting up libcurl3-gnutls:amd64 (7.52.1-5+deb9u16) ...
Setting up libtk8.6:amd64 (8.6.6-1+b1) ...
Setting up xterm (327-2+deb9u3) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up mailutils (1:3.1.1-1) ...
update-alternatives: using /usr/bin/frm.mailutils to provide /usr/bin/frm (frm) in auto mode
update-alternatives: using /usr/bin/from.mailutils to provide /usr/bin/from (from) in auto mode
update-alternatives: using /usr/bin/messages.mailutils to provide /usr/bin/messages (messages) in auto mode
update-alternatives: using /usr/bin/movemail.mailutils to provide /usr/bin/movemail (movemail) in auto mode
update-alternatives: using /usr/bin/readmsg.mailutils to provide /usr/bin/readmsg (readmsg) in auto mode
update-alternatives: using /usr/bin/dotlock.mailutils to provide /usr/bin/dotlock (dotlock) in auto mode
update-alternatives: using /usr/bin/mail.mailutils to provide /usr/bin/mailx (mailx) in auto mode
Setting up libxtst6:amd64 (2:1.2.3-1) ...
Setting up libgl1-mesa-glx:amd64 (13.0.6-1+b2) ...
Setting up git (1:2.11.0-3+deb9u7) ...
Setting up libgit-wrapper-perl (0.047-1) ...
Setting up tk8.6 (8.6.6-1+b1) ...
Setting up curl (7.52.1-5+deb9u16) ...
Setting up x11-utils (7.7+3+b1) ...
Setting up dh-autoreconf (14) ...
Setting up python3 (3.5.3-1) ...
running python rtupdate hooks for python3.5...
running python post-rtupdate hooks for python3.5...
Setting up python3-selinux (2.6-3+b3) ...
Setting up python3-numpy (1:1.12.1-3) ...
Setting up python3-magic (1:5.30-1+deb9u3) ...
Setting up liblwp-protocol-https-perl (6.06-2) ...
Setting up python3-six (1.10.0-3) ...
Setting up devscripts (2.17.6+deb9u2) ...
Setting up python3-pkg-resources (33.1.1-1) ...
Setting up lsb-release (9.20161125) ...
Setting up dh-strip-nondeterminism (0.034-1) ...
Setting up python3-chardet (2.3.0-2) ...
Setting up python3-semanage (2.6-2) ...
Setting up dh-python (2.20170125) ...
Setting up python3-decorator (4.0.11-1) ...
Setting up python3-debian (0.1.30) ...
Setting up libwww-perl (6.15-1) ...
Setting up python3-audit (1:2.6.7-2) ...
Setting up python3-ipy (1:0.83-1) ...
Setting up python3-yaml (3.12-1) ...
Setting up debhelper (10.2.5) ...
Setting up equivs (2.0.9+nmu1) ...
Setting up python3-scipy (0.18.1-2) ...
Setting up python3-apt (1.4.3) ...
Setting up selinux-basics (0.5.6) ...
Setting up python3-networkx (1.11-2) ...
Setting up libxml-parser-perl (2.44-2+b1) ...
Setting up python3-setools (4.0.1-6) ...
Setting up setools (4.0.1-6) ...
Setting up python3-sepolgen (2.6-3) ...
Setting up libsoap-lite-perl (1.20-1) ...
Setting up python3-sepolicy (2.6-3) ...
Setting up libxmlrpc-lite-perl (0.717-1) ...
Setting up policycoreutils-python-utils (2.6-3) ...
Setting up policycoreutils-dev (2.6-3) ...
Setting up selinux-policy-dev (2:2.20161023.1-9) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Processing triggers for sgml-base (1.29) ...
Processing triggers for ca-certificates (20200601~deb9u2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```
</details>

<br>
:green_circle: Windows dockefile
<details><summary>Show log</summary>

```
Setting up libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Setting up gcc-11-base:amd64 (11.3.0-1ubuntu1~22.04) ...
Setting up libxau6:amd64 (1:1.0.9-1build5) ...
Setting up libpsl5:amd64 (0.21.0-1.2build2) ...
Setting up wget (1.21.2-2ubuntu1) ...
Setting up manpages (5.10-1ubuntu1) ...
Setting up unzip (6.0-26ubuntu3.1) ...
Setting up libbrotli1:amd64 (1.0.9-2build6) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up binutils-common:amd64 (2.38-4ubuntu2.1) ...
Setting up libnghttp2-14:amd64 (1.43.0-1build3) ...
Setting up nsis-common (3.08-2) ...
Setting up libdeflate0:amd64 (1.10-2) ...
Setting up linux-libc-dev:amd64 (5.15.0-60.66) ...
Setting up libctf-nobfd0:amd64 (2.38-4ubuntu2.1) ...
Setting up gcc-mingw-w64-base:amd64 (10.3.0-14ubuntu1+24.3) ...
Setting up libgomp1:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up perl-modules-5.34 (5.34.0-3ubuntu1.1) ...
Setting up libldap-common (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up libjbig0:amd64 (2.1-3.1ubuntu0.22.04.1) ...
Setting up libasan6:amd64 (11.3.0-1ubuntu1~22.04) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up zip (3.0-12build2) ...
Setting up gcc-mingw-w64-i686-posix-runtime (10.3.0-14ubuntu1+24.3) ...
Setting up libtirpc-dev:amd64 (1.3.2-2ubuntu0.1) ...
Setting up rpcsvc-proto (1.4.2-0ubuntu6) ...
Setting up libx11-data (2:1.7.5-1) ...
Setting up make (4.3-4.1build1) ...
Setting up libmpfr6:amd64 (4.1.0-3build3) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Setting up libquadmath0:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up libssl-dev:amd64 (3.0.2-0ubuntu1.8) ...
Setting up libpng16-16:amd64 (1.6.37-3build5) ...
Setting up libmpc3:amd64 (1.2.1-2build1) ...
Setting up libatomic1:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up fonts-dejavu-core (2.37-2build1) ...
Setting up ucf (3.0043) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Setting up binutils-mingw-w64-i686 (2.38-3ubuntu1+9build1) ...
Setting up libjpeg-turbo8:amd64 (2.1.2-0ubuntu1) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libssh-4:amd64 (0.9.6-2build1) ...
Setting up libwebp7:amd64 (1.2.2-2) ...
Setting up libubsan1:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up gcc-mingw-w64-x86-64-win32-runtime (10.3.0-14ubuntu1+24.3) ...
Setting up libmd0:amd64 (1.0.4-1build1) ...
Setting up libnsl-dev:amd64 (1.3.0-2build2) ...
Setting up gcc-mingw-w64-i686-win32-runtime (10.3.0-14ubuntu1+24.3) ...
Setting up libcrypt-dev:amd64 (1:4.4.27-1) ...
Setting up netbase (6.3) ...
Setting up mingw-w64-common (8.0.0-1) ...
Setting up libbinutils:amd64 (2.38-4ubuntu2.1) ...
Setting up libisl23:amd64 (0.24-2build1) ...
Setting up libc-dev-bin (2.35-0ubuntu3.1) ...
Setting up openssl (3.0.2-0ubuntu1.8) ...
Setting up libbsd0:amd64 (0.11.5-1) ...
Setting up publicsuffix (20211207.1025-1) ...
Setting up libcc1-0:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up liblsan0:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up libitm1:amd64 (12.1.0-2ubuntu1~22.04) ...
Setting up libgdbm6:amd64 (1.23-1) ...
Setting up libtsan0:amd64 (11.3.0-1ubuntu1~22.04) ...
Setting up libctf0:amd64 (2.38-4ubuntu2.1) ...
Setting up libjpeg8:amd64 (8c-2ubuntu10) ...
Setting up cpp-11 (11.3.0-1ubuntu1~22.04) ...
Setting up mingw-w64-x86-64-dev (8.0.0-1) ...
Setting up manpages-dev (5.10-1ubuntu1) ...
Setting up libxdmcp6:amd64 (1:1.1.3-0ubuntu5) ...
Setting up libxcb1:amd64 (1.14-3ubuntu3) ...
Setting up binutils-mingw-w64-x86-64 (2.38-3ubuntu1+9build1) ...
Setting up fontconfig-config (2.13.1-4.2ubuntu5) ...
Setting up gcc-mingw-w64-x86-64-posix-runtime (10.3.0-14ubuntu1+24.3) ...
Setting up nsis (3.08-2) ...
Setting up libldap-2.5-0:amd64 (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up gcc-mingw-w64-x86-64-posix (10.3.0-14ubuntu1+24.3) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-gcc-posix to provide /usr/bin/x86_64-w64-mingw32-gcc (x86_64-w64-mingw32-gcc) in auto mode
Setting up ca-certificates (20211016ubuntu0.22.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Updating certificates in /etc/ssl/certs...
124 added, 0 removed; done.
Setting up gcc-mingw-w64-x86-64-win32 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-gcc-win32 to provide /usr/bin/x86_64-w64-mingw32-gcc (x86_64-w64-mingw32-gcc) in auto mode
Setting up libfreetype6:amd64 (2.11.1+dfsg-1ubuntu0.1) ...
Setting up gcc-mingw-w64-x86-64 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: warning: forcing reinstallation of alternative /usr/bin/x86_64-w64-mingw32-gcc-win32 because link group x86_64-w64-mingw32-gcc is broken
update-alternatives: warning: skip creation of /usr/bin/x86_64-w64-mingw32-gcc-8 because associated file /usr/bin/x86_64-w64-mingw32-gcc-8.3-win32 (of link group x86_64-w64-mingw32-gcc) doesn't exist
Setting up libgdbm-compat4:amd64 (1.23-1) ...
Setting up libgcc-11-dev:amd64 (11.3.0-1ubuntu1~22.04) ...
Setting up cpp (4:11.2.0-1ubuntu1) ...
Setting up mingw-w64-i686-dev (8.0.0-1) ...
Setting up libcurl4:amd64 (7.81.0-1ubuntu1.7) ...
Setting up libc6-dev:amd64 (2.35-0ubuntu3.1) ...
Setting up libx11-6:amd64 (2:1.7.5-1) ...
Setting up libtiff5:amd64 (4.3.0-6ubuntu0.3) ...
Setting up curl (7.81.0-1ubuntu1.7) ...
Setting up libfontconfig1:amd64 (2.13.1-4.2ubuntu5) ...
Setting up binutils-x86-64-linux-gnu (2.38-4ubuntu2.1) ...
Setting up gcc-mingw-w64-i686-win32 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: using /usr/bin/i686-w64-mingw32-gcc-win32 to provide /usr/bin/i686-w64-mingw32-gcc (i686-w64-mingw32-gcc) in auto mode
Setting up libperl5.34:amd64 (5.34.0-3ubuntu1.1) ...
Setting up libxpm4:amd64 (1:3.5.12-1ubuntu0.22.04.1) ...
Setting up g++-mingw-w64-i686-win32 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: using /usr/bin/i686-w64-mingw32-g++-win32 to provide /usr/bin/i686-w64-mingw32-g++ (i686-w64-mingw32-g++) in auto mode
Setting up g++-mingw-w64-x86-64-win32 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-g++-win32 to provide /usr/bin/x86_64-w64-mingw32-g++ (x86_64-w64-mingw32-g++) in auto mode
Setting up gcc-mingw-w64-i686-posix (10.3.0-14ubuntu1+24.3) ...
Setting up g++-mingw-w64-x86-64-posix (10.3.0-14ubuntu1+24.3) ...
Setting up binutils (2.38-4ubuntu2.1) ...
Setting up gcc-mingw-w64-i686 (10.3.0-14ubuntu1+24.3) ...
update-alternatives: warning: forcing reinstallation of alternative /usr/bin/i686-w64-mingw32-gcc-win32 because link group i686-w64-mingw32-gcc is broken
update-alternatives: warning: skip creation of /usr/bin/i686-w64-mingw32-gcc-8 because associated file /usr/bin/i686-w64-mingw32-gcc-8.3-win32 (of link group i686-w64-mingw32-gcc) doesn't exist
Setting up perl (5.34.0-3ubuntu1.1) ...
Setting up g++-mingw-w64-x86-64 (10.3.0-14ubuntu1+24.3) ...
Setting up libgd3:amd64 (2.3.0-2ubuntu2) ...
Setting up libstdc++-11-dev:amd64 (11.3.0-1ubuntu1~22.04) ...
Setting up gcc-11 (11.3.0-1ubuntu1~22.04) ...
Setting up gcc-mingw-w64 (10.3.0-14ubuntu1+24.3) ...
Setting up g++-mingw-w64-i686-posix (10.3.0-14ubuntu1+24.3) ...
Setting up libc-devtools (2.35-0ubuntu3.1) ...
Setting up g++-11 (11.3.0-1ubuntu1~22.04) ...
Setting up gcc (4:11.2.0-1ubuntu1) ...
Setting up g++-mingw-w64-i686 (10.3.0-14ubuntu1+24.3) ...
Setting up g++ (4:11.2.0-1ubuntu1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/c++.1.gz because associated file /usr/share/man/man1/g++.1.gz (of link group c++) doesn't exist
Setting up g++-mingw-w64 (10.3.0-14ubuntu1+24.3) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Processing triggers for ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```
</details>

<br>
:green_circle: WPK dockerfile
<details><summary>Show log</summary>

```
Collecting cryptography==2.9.2
  Downloading https://files.pythonhosted.org/packages/58/95/f1282ca55649b60afcf617e1e2ca384a2a3e7a5cf91f724cf83c8fbe76a1/cryptography-2.9.2-cp35-abi3-manylinux1_x86_64.whl (2.7MB)
Collecting awscli
  Downloading https://files.pythonhosted.org/packages/61/6e/0536697825b514b3b9e69d3ae3beb0f4abcdd6d04a047c1f715f2a5e0bec/awscli-1.18.223-py2.py3-none-any.whl (3.5MB)
Collecting cffi!=1.11.3,>=1.8 (from cryptography==2.9.2)
  Downloading https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz (508kB)
Collecting six>=1.4.1 (from cryptography==2.9.2)
  Downloading https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
Collecting s3transfer<0.4.0,>=0.3.0 (from awscli)
  Downloading https://files.pythonhosted.org/packages/00/89/0cb4e92c239e6425b9b0035227b8cdf9d3d098a5c9e95632c3815df63a09/s3transfer-0.3.7-py2.py3-none-any.whl (73kB)
Collecting PyYAML<5.4,>=3.10; python_version != "3.4" (from awscli)
  Downloading https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz (269kB)
Collecting botocore==1.19.63 (from awscli)
  Downloading https://files.pythonhosted.org/packages/2c/05/0a955f0c92bec7da076fbbc73926dfb13fab8e2b88de7f8eb17c443f28f0/botocore-1.19.63-py2.py3-none-any.whl (7.2MB)
Collecting docutils<0.16,>=0.10 (from awscli)
  Downloading https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl (547kB)
Collecting rsa<=4.5.0,>=3.1.2; python_version != "3.4" (from awscli)
  Downloading https://files.pythonhosted.org/packages/26/f8/8127fdda0294f044121d20aac7785feb810e159098447967a6103dedfb96/rsa-4.5-py2.py3-none-any.whl
Collecting colorama<0.4.4,>=0.2.5; python_version != "3.4" (from awscli)
  Downloading https://files.pythonhosted.org/packages/c9/dc/45cdef1b4d119eb96316b3117e6d5708a08029992b2fee2c143c7a0a5cc5/colorama-0.4.3-py2.py3-none-any.whl
Collecting pycparser (from cffi!=1.11.3,>=1.8->cryptography==2.9.2)
  Downloading https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl (118kB)
Collecting jmespath<1.0.0,>=0.7.1 (from botocore==1.19.63->awscli)
  Downloading https://files.pythonhosted.org/packages/07/cb/5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/jmespath-0.10.0-py2.py3-none-any.whl
Collecting urllib3<1.27,>=1.25.4; python_version != "3.4" (from botocore==1.19.63->awscli)
  Downloading https://files.pythonhosted.org/packages/ec/03/062e6444ce4baf1eac17a6a0ebfe36bb1ad05e1df0e20b110de59c278498/urllib3-1.26.9-py2.py3-none-any.whl (138kB)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore==1.19.63->awscli)
  Downloading https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl (247kB)
Collecting pyasn1>=0.1.3 (from rsa<=4.5.0,>=3.1.2; python_version != "3.4"->awscli)
  Downloading https://files.pythonhosted.org/packages/62/1e/a94a8d635fa3ce4cfc7f506003548d0a2447ae76fd5ca53932970fe3053f/pyasn1-0.4.8-py2.py3-none-any.whl (77kB)
Building wheels for collected packages: cffi, PyYAML
  Running setup.py bdist_wheel for cffi: started
  Running setup.py bdist_wheel for cffi: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/2a/63/34/2d00df575488c28abba6b0abd4013fa1fe54499814e7f7a6f1
  Running setup.py bdist_wheel for PyYAML: started
  Running setup.py bdist_wheel for PyYAML: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/a7/c1/ea/cf5bd31012e735dc1dfea3131a2d5eae7978b251083d6247bd
Successfully built cffi PyYAML
Installing collected packages: pycparser, cffi, six, cryptography, jmespath, urllib3, python-dateutil, botocore, s3transfer, PyYAML, docutils, pyasn1, rsa, colorama, awscli
  Found existing installation: six 1.10.0
    Not uninstalling six at /usr/lib/python3/dist-packages, outside environment /usr
  Found existing installation: cryptography 1.7.1
    Not uninstalling cryptography at /usr/lib/python3/dist-packages, outside environment /usr
  Found existing installation: pyasn1 0.1.9
    Not uninstalling pyasn1 at /usr/lib/python3/dist-packages, outside environment /usr
Successfully installed PyYAML-5.3.1 awscli-1.18.223 botocore-1.19.63 cffi-1.15.1 colorama-0.4.3 cryptography-2.9.2 docutils-0.15.2 jmespath-0.10.0 pyasn1-0.4.8 pycparser-2.21 python-dateutil-2.8.2 rsa-4.5 s3transfer-0.3.7 six-1.16.0 urllib3-1.26.9
```
</details>

<br>
:green_circle: Package generator - i386 dockerfile
<details><summary>Show log</summary>

```
Setting up patch (2.6.1-3) ...
Setting up python-apt-common (0.8.8.2) ...
Setting up python-apt (0.8.8.2) ...
Setting up autotools-dev (20120608.1) ...
Setting up git-man (1:1.7.10.4-1+wheezy3) ...
Setting up binutils (2.22-8+deb7u2) ...
Setting up libc-dev-bin (2.13-38+deb7u10) ...
Setting up linux-libc-dev:amd64 (3.2.78-1) ...
Setting up libc6-dev:amd64 (2.13-38+deb7u10) ...
Setting up cpp-4.7 (4.7.2-5) ...
Setting up cpp (4:4.7.2-1) ...
Setting up gcc-4.7 (4.7.2-5) ...
Setting up gcc (4:4.7.2-1) ...
Setting up make (3.81-8.2) ...
Setting up tcl8.5 (8.5.11-2) ...
update-alternatives: using /usr/bin/tclsh8.5 to provide /usr/bin/tclsh (tclsh) in auto mode
Setting up tk8.5 (8.5.11-2) ...
update-alternatives: using /usr/bin/wish8.5 to provide /usr/bin/wish (wish) in auto mode
Setting up tcl (8.5.0-2.1) ...
update-alternatives: using /usr/bin/tclsh-default to provide /usr/bin/tclsh (tclsh) in auto mode
Setting up tk (8.5.0-2.1) ...
update-alternatives: using /usr/bin/wish-default to provide /usr/bin/wish (wish) in auto mode
Setting up bwidget (1.9.5-1) ...
Setting up openssl (1.0.1e-2+deb7u20) ...
Setting up ca-certificates (20130119+deb7u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up cdbs (0.4.115+deb7u1) ...
Setting up checkpolicy (2.1.8-2) ...
Setting up curl (7.26.0-1+wheezy13) ...
Setting up dbus (1.6.8-1+deb7u6) ...
invoke-rc.d: policy-rc.d denied execution of start.
Setting up dctrl-tools (2.22.2) ...
Setting up html2text (1.3.2a-15) ...
Setting up gettext (0.18.1.1-9) ...
Setting up debian-keyring (2013.04.21) ...
Setting up diffstat (1.55-3) ...
Setting up distro-info-data (0.17~deb7u1) ...
Setting up dput (0.9.6.3+nmu2) ...
Setting up expect (5.45-2) ...
Setting up fakeroot (1.18.4-2) ...
update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
Setting up libc6-i386 (2.13-38+deb7u10) ...
Setting up libc6-dev-i386 (2.13-38+deb7u10) ...
Setting up lib32gcc1 (1:4.7.2-5) ...
Setting up lib32gomp1 (4.7.2-5) ...
Setting up lib32itm1 (4.7.2-5) ...
Setting up lib32quadmath0 (4.7.2-5) ...
Setting up gcc-4.7-multilib (4.7.2-5) ...
Setting up gcc-multilib (4:4.7.2-1) ...
Setting up heirloom-mailx (12.5-2+deb7u1) ...
update-alternatives: using /usr/bin/heirloom-mailx to provide /usr/bin/mailx (mailx) in auto mode
Setting up hicolor-icon-theme (0.12-1) ...
Setting up iso-codes (3.41-1) ...
Setting up libapt-pkg-perl (0.1.26+b1) ...
Setting up libgl1-mesa-dri:amd64 (8.0.5-4+deb7u2) ...
Setting up libglade2-0 (1:2.6.4-1) ...
Setting up libglib2.0-data (2.33.12+really2.32.4-5) ...
Setting up libgtk2.0-bin (2.24.10-2) ...
Setting up libltdl-dev:amd64 (2.4.2-1.1) ...
Setting up libossp-uuid16 (1.6.2-1.3) ...
Setting up libsasl2-modules:amd64 (2.1.25.dfsg1-6+deb7u1) ...
Setting up libsetools-tcl (3.3.7-3) ...
Setting up libtool (2.4.2-1.1) ...
Setting up libutempter0 (1.1.5-4) ...
Creating utempter group...
Setting up lsb-release (4.1+Debian8+deb7u1) ...
Setting up manpages-dev (3.44-1) ...
Setting up python-chardet (2.0.1-2) ...
Setting up python-debian (0.1.21) ...
Setting up rsync (3.0.9-4) ...
update-rc.d: using dependency based boot sequencing
invoke-rc.d: policy-rc.d denied execution of restart.
Setting up selinux-utils (2.1.9-5) ...
Setting up selinux-basics (0.5.0) ...
Setting up selinux-policy-default (2:2.20110726-12) ...
Notice: Trying to link (but not load) a default policy.
This process may fail -- you should check the results, and 
you need to switch to this policy yourself anyway.

Locating modules
Ordering modules based on dependencies
Selecting modules based on installed packages
Loaded modules  dbus netutils ssh apache git ptchown tzdata sudo gpg rsync
Setting up setools (3.3.7-3) ...
Setting up strace (4.5.20-2.3) ...
Setting up sudo (1.8.5p2-1+nmu3+deb7u1) ...
Setting up unzip (6.0-8+deb7u5) ...
Setting up wdiff (1.1.2-1) ...
Setting up x11-utils (7.7~1) ...
Setting up xauth (1:1.0.7-1) ...
Setting up xbitmaps (1.1.1-1) ...
Setting up xterm (278-4) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/uxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up libaudit-dev (1:1.7.18-1.1) ...
Setting up libdb5.1-dev (5.1.29-5) ...
Setting up python-magic (5.11-2+deb7u8) ...
Setting up g++-4.7 (4.7.2-5) ...
Setting up g++ (4:4.7.2-1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libswitch-perl (2.16-2) ...
Setting up perl-modules (5.14.2-21+deb7u3) ...
Setting up libstdc++6-4.7-dev (4.7.2-5) ...
Setting up perl (5.14.2-21+deb7u3) ...
update-alternatives: using /usr/bin/prename to provide /usr/bin/rename (rename) in auto mode
Setting up libtimedate-perl (1.2000-1) ...
Setting up libmailtools-perl (2.09-1) ...
Setting up libdigest-hmac-perl (1.03+dfsg-1) ...
Setting up libnet-ip-perl (1.25-3) ...
Setting up libnet-dns-perl (0.66-2+b2) ...
Setting up libnet-domain-tld-perl (1.69-1) ...
Setting up libemail-valid-perl (0.190-1) ...
Setting up sgml-base (1.26+nmu4) ...
Setting up autoconf (2.69-1) ...
Setting up automake (1:1.11.6-1) ...
update-alternatives: using /usr/bin/automake-1.11 to provide /usr/bin/automake (automake) in auto mode
Setting up liberror-perl (0.17-1) ...
Setting up git (1:1.7.10.4-1+wheezy3) ...
Setting up autopoint (0.18.1.1-9) ...
Setting up libdpkg-perl (1.16.18) ...
Setting up dpkg-dev (1.16.18) ...
Setting up build-essential (11.5) ...
Setting up intltool-debian (0.35.0+20060710.1) ...
Setting up po-debconf (1.0.16+nmu2) ...
Setting up debhelper (9.20120909) ...
Setting up devscripts (2.12.6+deb7u2) ...
Setting up hardening-includes (2.2) ...
Setting up libalgorithm-diff-perl (1.19.02-2) ...
Setting up libalgorithm-diff-xs-perl (0.04-2+b1) ...
Setting up libalgorithm-merge-perl (0.08-2) ...
Setting up libarchive-zip-perl (1.30-6) ...
Setting up libsub-name-perl (0.05-1+b2) ...
Setting up libclass-accessor-perl (0.34-1) ...
Setting up libclass-inspector-perl (1.27-1) ...
Setting up libclone-perl (0.31-1+b2) ...
Setting up libcommon-sense-perl (3.6-1) ...
Setting up libconvert-binhex-perl (1.119+pristine-3) ...
Setting up libcrypt-ssleay-perl (0.58-1) ...
Setting up libdistro-info-perl (0.10) ...
Setting up libencode-locale-perl (1.03-1) ...
Setting up libexporter-lite-perl (0.02-2) ...
Setting up libfcgi-perl (0.74-1+b1) ...
Setting up libfile-fcntllock-perl (0.14-2) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libfont-afm-perl (1.20-1) ...
Setting up liburi-perl (1.60-1) ...
Setting up libhtml-tagset-perl (3.20-2) ...
Setting up libhtml-parser-perl (3.69-2) ...
Setting up liblwp-mediatypes-perl (6.02-1) ...
Setting up libhttp-message-perl (6.03-1) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libhtml-tree-perl (5.02-1) ...
Setting up libhtml-format-perl (2.10-1) ...
Setting up libhtml-template-perl (2.91-1) ...
Setting up libhttp-cookies-perl (6.00-2) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libio-pty-perl (1:1.08-1+b2) ...
Setting up libsocket-perl (2.002-1) ...
Setting up libio-socket-ip-perl (0.16-2) ...
Setting up libnet-ssleay-perl (1.48-1+b1) ...
Setting up libio-socket-ssl-perl (1.76-2) ...
Setting up libio-string-perl (1.08-2) ...
Setting up libio-stringy-perl (2.110-5) ...
Setting up libipc-run-perl (0.92-1) ...
Setting up libjson-perl (2.53-1) ...
Setting up libjson-xs-perl (2.320-1+b1) ...
Setting up libnet-http-perl (6.03-2) ...
Setting up libwww-robotrules-perl (6.01-1) ...
Setting up liblwp-protocol-https-perl (6.03-1) ...
Setting up libsys-hostname-long-perl (1.4-2) ...
Setting up libmail-sendmail-perl (0.79.16-1) ...
Setting up libmime-tools-perl (5.503-1) ...
Setting up libossp-uuid-perl (1.6.2-1.3) ...
Setting up libparse-debianchangelog-perl (1.2.0-1) ...
Setting up libtask-weaken-perl (1.03-1) ...
Setting up libtie-ixhash-perl (1.21-2) ...
Setting up libxml-namespacesupport-perl (1.09-3) ...
Setting up libxml-sax-base-perl (1.07-1) ...
Setting up libxml-sax-perl (0.99+dfsg-2) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::PurePerl with priority 10...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up patchutils (0.3.2-1.1) ...
Setting up lintian (2.5.10.4) ...
Setting up xml-core (0.13+nmu2) ...
Setting up equivs (2.0.9) ...
Setting up libwww-perl (6.04-1) ...
Setting up libparse-debcontrol-perl (2.005-3) ...
Setting up libxml-parser-perl (2.41-1+b1) ...
Setting up libsoap-lite-perl (0.714-1) ...
Setting up libxml-sax-expat-perl (0.40-2) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::Expat with priority 50...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Replacing config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up libxml-simple-perl (2.20-1) ...
Processing triggers for ca-certificates ...
Updating certificates in /etc/ssl/certs... 171 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Processing triggers for sgml-base ...
```
</details>

<br>
:green_circle: Package generator - ppc64le dockerfile
<details><summary>Show log</summary>

```
Setting up tcpd (7.6.q-26) ...
Setting up libpod-constants-perl (0.19-1) ...
Setting up libkrb5support0:amd64 (1.15-1+deb9u3) ...
Setting up libsort-versions-perl (1.62-1) ...
Setting up libio-socket-ssl-perl (2.044-1) ...
Setting up gcc-6 (6.3.0-18+deb9u1) ...
Setting up libcroco3:amd64 (0.6.11-3) ...
Setting up libsub-exporter-perl (0.986-1) ...
Setting up g++-6 (6.3.0-18+deb9u1) ...
Setting up libpython-stdlib:amd64 (2.7.13-2) ...
Setting up libalgorithm-merge-perl (0.08-3) ...
Setting up libdrm-intel1:amd64 (2.4.74-1) ...
Setting up dpkg-dev (1.18.26) ...
Setting up libalgorithm-diff-xs-perl (0.04-4+b2) ...
Setting up tcl-expect:amd64 (5.45-7+deb9u1) ...
Setting up guile-2.0-libs:amd64 (2.0.13+1-4) ...
Setting up libp11-kit0:amd64 (0.23.3-2+deb9u1) ...
Setting up tcl8.6 (8.6.6+dfsg-1+b1) ...
Setting up libstring-copyright-perl (0.003005-1) ...
Setting up libhtml-parser-perl (3.72-3) ...
Setting up libpython2.7:amd64 (2.7.13-2+deb9u6) ...
Setting up automake (1:1.15-6) ...
update-alternatives: using /usr/bin/automake-1.15 to provide /usr/bin/automake (automake) in auto mode
Setting up libipc-run-perl (0.94-1+deb9u1) ...
Setting up libcgi-pm-perl (4.35-1) ...
Setting up libdevel-globaldestruction-perl (0.14-1) ...
Setting up libice6:amd64 (2:1.0.9-2) ...
Setting up libparse-debianchangelog-perl (1.2.0-12) ...
Setting up man-db (2.7.6.1-2) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Building database of manual pages ...
Setting up shared-mime-info (1.8-1+deb9u1) ...
Setting up pinentry-curses (1.0.0-2) ...
Setting up gnupg-agent (2.1.18-8~deb9u4) ...
Setting up libkyotocabinet16v5:amd64 (1.2.76-4.2+b1) ...
Setting up libxcb1:amd64 (1.12-1) ...
Setting up python (2.7.13-2) ...
Setting up libfile-stripnondeterminism-perl (0.034-1) ...
Setting up liblist-moreutils-perl (0.416-1+b1) ...
Setting up libtool (2.4.6-2) ...
Setting up python3.5 (3.5.3-1+deb9u5) ...
Setting up libpython3-stdlib:amd64 (3.5.3-1) ...
Setting up libxcb-present0:amd64 (1.12-1) ...
Setting up libfontconfig1:amd64 (2.11.0-6.7+b1) ...
Setting up libxcb-dri2-0:amd64 (1.12-1) ...
Setting up libsm6:amd64 (2:1.2.2-1+b3) ...
Setting up expect (5.45-7+deb9u1) ...
Setting up libxcb-dri3-0:amd64 (1.12-1) ...
Setting up libk5crypto3:amd64 (1.15-1+deb9u3) ...
Setting up libxcb-glx0:amd64 (1.12-1) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libnet-smtp-ssl-perl (1.04-1) ...
Setting up libimport-into-perl (1.002005-1) ...
Setting up libmodule-implementation-perl (0.09-1) ...
Setting up gettext (0.19.8.1-2+deb9u1) ...
Setting up gnupg (2.1.18-8~deb9u4) ...
Setting up libgnutls30:amd64 (3.5.8-5+deb9u6) ...
Setting up libx11-6:amd64 (2:1.6.4-3+deb9u4) ...
Setting up libgl1-mesa-dri:amd64 (13.0.6-1+b2) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-1+b1) ...
Setting up gcc (4:6.3.0-4) ...
Setting up python-pkg-resources (33.1.1-1) ...
Setting up libxmuu1:amd64 (2:1.1.2-2) ...
Setting up libcgi-fast-perl (1:2.12-1) ...
Setting up libhtml-tree-perl (5.03-2) ...
Setting up libparams-validate-perl (1.26-1) ...
Setting up libgpgme11:amd64 (1.8.0-3+b2) ...
Setting up libxcb-sync1:amd64 (1.12-1) ...
Setting up intltool-debian (0.35.0+20060710.4) ...
Setting up python-six (1.10.0-3) ...
Setting up libldap-2.4-2:amd64 (2.4.44+dfsg-5+deb9u9) ...
Setting up wget (1.18-5+deb9u3) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libxcomposite1:amd64 (1:0.4.4-2) ...
Setting up libxpm4:amd64 (1:3.5.12-1) ...
Setting up libxt6:amd64 (1:1.1.5-1) ...
Setting up libxcb-shape0:amd64 (1.12-1) ...
Setting up libxrender1:amd64 (1:0.9.10-1) ...
Setting up libmoo-perl (2.002005-1) ...
Setting up libhttp-message-perl (6.11-1) ...
Setting up g++ (4:6.3.0-4) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libkrb5-3:amd64 (1.15-1+deb9u3) ...
Setting up libb-hooks-endofscope-perl (0.21-1) ...
Setting up exim4-daemon-light (4.89-2+deb9u8) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Initializing GnuTLS DH parameter file
Setting up libxft2:amd64 (2.3.2-1+b2) ...
Setting up dirmngr (2.1.18-8~deb9u4) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libpackage-stash-perl (0.37-1) ...
Setting up python-gpg (1.8.0-3+b2) ...
Setting up libmailtools-perl (2.18-1) ...
Setting up libgetopt-long-descriptive-perl (0.100-1) ...
Setting up libhtml-format-perl (2.12-1) ...
Setting up libemail-valid-perl (1.202-1) ...
Setting up python-chardet (2.3.0-2) ...
Setting up libxext6:amd64 (2:1.3.3-1+b2) ...
Setting up libxfixes3:amd64 (1:5.0.3-1) ...
Setting up po-debconf (1.0.20) ...
Setting up libhttp-cookies-perl (6.01-1) ...
Setting up build-essential (12.3) ...
Setting up libxss1:amd64 (1:1.2.2-1) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libxmu6:amd64 (2:1.1.2-2) ...
Setting up libgssapi-krb5-2:amd64 (1.15-1+deb9u3) ...
Setting up xauth (1:1.0.9-1+b2) ...
Setting up python-debian (0.1.30) ...
Setting up libxxf86dga1:amd64 (2:1.1.4-1+b3) ...
Setting up dput (0.12.1) ...
Setting up lintian (2.5.50.4) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libxv1:amd64 (2:1.0.11-1) ...
Setting up libxxf86vm1:amd64 (1:1.1.4-1+b2) ...
Setting up libnamespace-clean-perl (0.27-1) ...
Setting up python-apt (1.4.3) ...
Setting up openssh-client (1:7.4p1-10+deb9u7) ...
Setting up libxrandr2:amd64 (2:1.5.1-1) ...
Setting up libmime-tools-perl (5.508-1) ...
Setting up libxi6:amd64 (2:1.7.9-1) ...
Setting up libgsasl7 (1.8.0-8+b2) ...
Setting up libxaw7:amd64 (2:1.0.13-1+b2) ...
Setting up libmailutils5:amd64 (1:3.1.1-1) ...
Setting up licensecheck (3.0.29-1) ...
Setting up libxinerama1:amd64 (2:1.1.3-1+b3) ...
Setting up libxdamage1:amd64 (1:1.1.4-2+b3) ...
Setting up libcurl3:amd64 (7.52.1-5+deb9u16) ...
Setting up libcurl3-gnutls:amd64 (7.52.1-5+deb9u16) ...
Setting up libtk8.6:amd64 (8.6.6-1+b1) ...
Setting up xterm (327-2+deb9u3) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up mailutils (1:3.1.1-1) ...
update-alternatives: using /usr/bin/frm.mailutils to provide /usr/bin/frm (frm) in auto mode
update-alternatives: using /usr/bin/from.mailutils to provide /usr/bin/from (from) in auto mode
update-alternatives: using /usr/bin/messages.mailutils to provide /usr/bin/messages (messages) in auto mode
update-alternatives: using /usr/bin/movemail.mailutils to provide /usr/bin/movemail (movemail) in auto mode
update-alternatives: using /usr/bin/readmsg.mailutils to provide /usr/bin/readmsg (readmsg) in auto mode
update-alternatives: using /usr/bin/dotlock.mailutils to provide /usr/bin/dotlock (dotlock) in auto mode
update-alternatives: using /usr/bin/mail.mailutils to provide /usr/bin/mailx (mailx) in auto mode
Setting up libxtst6:amd64 (2:1.2.3-1) ...
Setting up libgl1-mesa-glx:amd64 (13.0.6-1+b2) ...
Setting up git (1:2.11.0-3+deb9u7) ...
Setting up libgit-wrapper-perl (0.047-1) ...
Setting up tk8.6 (8.6.6-1+b1) ...
Setting up curl (7.52.1-5+deb9u16) ...
Setting up x11-utils (7.7+3+b1) ...
Setting up dh-autoreconf (14) ...
Setting up python3 (3.5.3-1) ...
running python rtupdate hooks for python3.5...
running python post-rtupdate hooks for python3.5...
Setting up python3-selinux (2.6-3+b3) ...
Setting up python3-numpy (1:1.12.1-3) ...
Setting up python3-magic (1:5.30-1+deb9u3) ...
Setting up liblwp-protocol-https-perl (6.06-2) ...
Setting up python3-six (1.10.0-3) ...
Setting up devscripts (2.17.6+deb9u2) ...
Setting up python3-pkg-resources (33.1.1-1) ...
Setting up lsb-release (9.20161125) ...
Setting up dh-strip-nondeterminism (0.034-1) ...
Setting up python3-chardet (2.3.0-2) ...
Setting up python3-semanage (2.6-2) ...
Setting up dh-python (2.20170125) ...
Setting up python3-decorator (4.0.11-1) ...
Setting up python3-debian (0.1.30) ...
Setting up libwww-perl (6.15-1) ...
Setting up python3-audit (1:2.6.7-2) ...
Setting up python3-ipy (1:0.83-1) ...
Setting up python3-yaml (3.12-1) ...
Setting up debhelper (10.2.5) ...
Setting up equivs (2.0.9+nmu1) ...
Setting up python3-scipy (0.18.1-2) ...
Setting up python3-apt (1.4.3) ...
Setting up selinux-basics (0.5.6) ...
Setting up python3-networkx (1.11-2) ...
Setting up libxml-parser-perl (2.44-2+b1) ...
Setting up python3-setools (4.0.1-6) ...
Setting up setools (4.0.1-6) ...
Setting up python3-sepolgen (2.6-3) ...
Setting up libsoap-lite-perl (1.20-1) ...
Setting up python3-sepolicy (2.6-3) ...
Setting up libxmlrpc-lite-perl (0.717-1) ...
Setting up policycoreutils-python-utils (2.6-3) ...
Setting up policycoreutils-dev (2.6-3) ...
Setting up selinux-policy-dev (2:2.20161023.1-9) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Processing triggers for sgml-base (1.29) ...
Processing triggers for ca-certificates (20200601~deb9u2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:2 and /etc/apt/sources.list:7
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:2 and /etc/apt/sources.list:7
```
</details>

<br>
:green_circle: Indexer amd64 dockerfile
<details><summary>Show log</summary>

```
Setting up bzip2 (1.0.6-7+deb8u2) ...
Setting up file (1:5.22+15-2+deb8u7) ...
Setting up gettext-base (0.19.3-2) ...
Setting up krb5-locales (1.12.1+dfsg-19+deb8u5) ...
Setting up patch (2.7.5-1+deb8u3) ...
Setting up xz-utils (5.1.1alpha+20120614-2+b3) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
Setting up autopoint (0.19.3-2) ...
Setting up binutils (2.25-5+deb8u1) ...
Setting up libc-dev-bin (2.19-18+deb8u10) ...
Setting up linux-libc-dev:amd64 (3.16.84-1) ...
Setting up libc6-dev:amd64 (2.19-18+deb8u10) ...
Setting up cpp-4.9 (4.9.2-10+deb8u2) ...
Setting up cpp (4:4.9.2-2) ...
Setting up libgcc-4.9-dev:amd64 (4.9.2-10+deb8u2) ...
Setting up gcc-4.9 (4.9.2-10+deb8u2) ...
Setting up gcc (4:4.9.2-2) ...
Setting up libstdc++-4.9-dev:amd64 (4.9.2-10+deb8u2) ...
Setting up g++-4.9 (4.9.2-10+deb8u2) ...
Setting up g++ (4:4.9.2-2) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up make (4.0-8.1) ...
Setting up libtimedate-perl (2.3000-2) ...
Setting up libdpkg-perl (1.17.27) ...
Setting up dpkg-dev (1.17.27) ...
Setting up build-essential (11.7) ...
Setting up openssl (1.0.1t-1+deb8u12) ...
Setting up ca-certificates (20141019+deb8u4) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Updating certificates in /etc/ssl/certs... 152 added, 0 removed; done.
Setting up checkpolicy (2.3-1) ...
Setting up curl (7.38.0-4+deb8u16) ...
Setting up dbus (1.8.22-0+deb8u3) ...
invoke-rc.d: policy-rc.d denied execution of start.
Setting up dctrl-tools (2.23) ...
Setting up gettext (0.19.3-2) ...
Setting up intltool-debian (0.35.0+20060710.1) ...
Setting up po-debconf (1.0.16+nmu3) ...
Setting up debhelper (9.20150101+deb8u2) ...
Setting up debian-keyring (2015.04.10) ...
Setting up python3.4 (3.4.2-1+deb8u7) ...
Setting up python3-minimal (3.4.2-2) ...
Setting up libpython3-stdlib:amd64 (3.4.2-2) ...
Setting up diffstat (1.58-1) ...
Setting up distro-info-data (0.26) ...
Setting up dput (0.9.6.4+deb8u1) ...
Setting up tcl-expect:amd64 (5.45-6) ...
Setting up expect (5.45-6) ...
Setting up libfakeroot:amd64 (1.20.2-1) ...
Setting up fakeroot (1.20.2-1) ...
update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
Setting up hardening-includes (2.6) ...
Setting up iso-codes (3.57-1) ...
Setting up libalgorithm-c3-perl (0.09-1) ...
Setting up libalgorithm-diff-perl (1.19.02-3) ...
Setting up libalgorithm-diff-xs-perl (0.04-3+b1) ...
Setting up libalgorithm-merge-perl (0.08-2) ...
Setting up libapt-pkg-perl (0.1.29+b2) ...
Setting up libarchive-extract-perl (0.72-1) ...
Setting up libarchive-zip-perl (1.39-1+deb8u1) ...
Setting up libasprintf-dev:amd64 (0.19.3-2) ...
Setting up libauthen-sasl-perl (2.1600-1) ...
Setting up libcgi-pm-perl (4.09-1) ...
Setting up libfcgi-perl (0.77-1+deb8u1) ...
Setting up libcgi-fast-perl (1:2.04-1) ...
Setting up libsub-name-perl (0.12-1) ...
Setting up libclass-accessor-perl (0.34-1) ...
Setting up libclass-c3-perl (0.26-1) ...
Setting up libclass-c3-xs-perl (0.13-2+b1) ...
Setting up libclass-inspector-perl (1.28-1) ...
Setting up libclone-perl (0.37-1+b1) ...
Setting up libcommon-sense-perl (3.73-2+b3) ...
Setting up libconvert-binhex-perl (1.123-2) ...
Setting up libcpan-meta-perl (2.142690-1) ...
Setting up libcrypt-ssleay-perl (0.58-1+b2) ...
Setting up libparams-util-perl (1.07-2+b1) ...
Setting up libsub-install-perl (0.928-1) ...
Setting up libdata-optlist-perl (0.109-1) ...
Setting up libmro-compat-perl (0.12-1) ...
Setting up libsub-exporter-perl (0.986-1) ...
Setting up libdata-section-perl (0.200006-1) ...
Setting up libdigest-hmac-perl (1.03+dfsg-1) ...
Setting up libdistro-info-perl (0.14) ...
Setting up libnet-ssleay-perl (1.65-1+deb8u1) ...
Setting up libio-socket-ssl-perl (2.002-2+deb8u3) ...
Setting up libnet-smtp-ssl-perl (1.01-3) ...
Setting up libmailtools-perl (2.13-1) ...
Setting up libsocket6-perl (0.25-1+b1) ...
Setting up libio-socket-inet6-perl (2.72-1) ...
Setting up libnet-ip-perl (1.26-1) ...
Setting up libnet-dns-perl (0.81-2+deb8u1) ...
Setting up libnet-domain-tld-perl (1.72-1) ...
Setting up libemail-valid-perl (1.195-1) ...
Setting up libencode-locale-perl (1.03-1) ...
Setting up liberror-perl (0.17-1.1) ...
Setting up libexporter-lite-perl (0.06-1) ...
Setting up libfile-basedir-perl (0.03-1) ...
Setting up libfile-fcntllock-perl (0.22-1+b1) ...
Setting up libhttp-date-perl (6.02-1) ...
Setting up libfile-listing-perl (6.04-1) ...
Setting up libfont-afm-perl (1.20-1) ...
Setting up libgettextpo-dev:amd64 (0.19.3-2) ...
Setting up libglib2.0-data (2.42.1-1+deb8u3) ...
Setting up liburi-perl (1.64-1) ...
Setting up libhtml-tagset-perl (3.20-2) ...
Setting up libhtml-parser-perl (3.71-1+b3) ...
Setting up libio-html-perl (1.001-1) ...
Setting up liblwp-mediatypes-perl (6.02-1) ...
Setting up libhttp-message-perl (6.06-1) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up libhtml-tree-perl (5.03-1) ...
Setting up libhtml-format-perl (2.11-1) ...
Setting up libhttp-cookies-perl (6.01-1) ...
Setting up libhttp-daemon-perl (6.01-1) ...
Setting up libhttp-negotiate-perl (6.00-2) ...
Setting up libio-pty-perl (1:1.08-1+b4) ...
Setting up libio-sessiondata-perl (1.03-1) ...
Setting up libio-string-perl (1.08-3) ...
Setting up libio-stringy-perl (2.110-5) ...
Setting up libipc-run-perl (0.92-1+deb8u1) ...
Setting up libjson-perl (2.61-1) ...
Setting up libjson-xs-perl (2.340-1+b2) ...
Setting up liblist-moreutils-perl (0.33-2+b1) ...
Setting up liblog-message-perl (0.8-1) ...
Setting up liblog-message-simple-perl (0.10-2) ...
Setting up libnet-http-perl (6.07-1) ...
Setting up libwww-robotrules-perl (6.01-1) ...
Setting up libsys-hostname-long-perl (1.4-3) ...
Setting up libmail-sendmail-perl (0.79.16-1) ...
Setting up libmime-tools-perl (5.505-1) ...
Setting up libmodule-build-perl (0.421000-2+deb8u1) ...
Setting up libmodule-pluggable-perl (5.1-1) ...
Setting up libmodule-signature-perl (0.73-1+deb8u2) ...
Setting up libossp-uuid-perl (1.6.2-1.5+b1) ...
Setting up libpackage-constants-perl (0.04-1) ...
Setting up libparse-debianchangelog-perl (1.2.0-1.1) ...
Setting up libperlio-gzip-perl (0.18-3+b1) ...
Setting up libpod-latex-perl (0.61-1) ...
Setting up libregexp-common-perl (2013031301-1) ...
Setting up libpod-readme-perl (0.11-1) ...
Setting up libsasl2-modules:amd64 (2.1.26.dfsg1-13+deb8u2) ...
Setting up libtask-weaken-perl (1.04-1) ...
Setting up libtext-template-perl (1.46-1) ...
Setting up libsoftware-license-perl (0.103010-3) ...
Setting up libterm-ui-perl (0.42-1) ...
Setting up libtext-levenshtein-perl (0.11-1) ...
Setting up libtext-soundex-perl (3.4-1+b2) ...
Setting up libtie-ixhash-perl (1.23-1) ...
Setting up libutempter0 (1.1.5-4) ...
Creating utempter group...
Setting up patchutils (0.3.3-1) ...
Setting up t1utils (1.38-4) ...
Setting up lintian (2.5.30+deb8u4) ...
Setting up lsb-release (4.1+Debian13+nmu1) ...
Setting up manpages-dev (3.74-1) ...
Setting up psmisc (22.21-2) ...
Setting up python-ipy (1:0.81-1) ...
Setting up python-selinux (2.3-2) ...
Setting up python-semanage (2.3-1+b1) ...
Setting up python-setools (3.3.8-3.1) ...
Setting up python-sepolgen (1.2.1-1) ...
Setting up python-sepolicy (2.3-1) ...
Setting up selinux-utils (2.3-2) ...
Setting up policycoreutils (2.3-1) ...
invoke-rc.d: policy-rc.d denied execution of start.
invoke-rc.d: policy-rc.d denied execution of start.
Setting up python-apt-common (0.9.3.13) ...
Setting up rename (0.20-3) ...
update-alternatives: using /usr/bin/file-rename to provide /usr/bin/rename (rename) in auto mode
Setting up selinux-basics (0.5.2) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Setting up setools (3.3.8-3.1) ...
Setting up shared-mime-info (1.3-1) ...
Setting up strace (4.9-2) ...
Setting up sudo (1.8.10p3-1+deb8u7) ...
Setting up tcl8.6 (8.6.2+dfsg-2) ...
Setting up tk8.6 (8.6.2-1) ...
Setting up unzip (6.0-16+deb8u6) ...
Setting up wdiff (1.2.2-1) ...
Setting up x11-utils (7.7+2) ...
Setting up xbitmaps (1.1.1-2) ...
Setting up xdg-user-dirs (0.15-2) ...
Setting up xml-core (0.13+nmu2) ...
Setting up xterm (312-2) ...
update-alternatives: using /usr/bin/xterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
update-alternatives: using /usr/bin/lxterm to provide /usr/bin/x-terminal-emulator (x-terminal-emulator) in auto mode
Setting up equivs (2.0.9) ...
Setting up python-audit (1:2.4-1+b1) ...
Setting up python3 (3.4.2-2) ...
running python rtupdate hooks for python3.4...
running python post-rtupdate hooks for python3.4...
Setting up devscripts (2.15.3+deb8u1) ...
Setting up liblwp-protocol-https-perl (6.06-2) ...
Setting up python3-apt (0.9.3.13) ...
Setting up python3-pkg-resources (5.5.1-1) ...
Setting up python3-chardet (2.3.0-1) ...
Setting up python3-six (1.8.0-1) ...
Setting up python3-debian (0.1.27) ...
Setting up python3-magic (1:5.22+15-2+deb8u7) ...
Setting up dh-python (1.20141111-2) ...
Setting up libwww-perl (6.08-1) ...
Setting up libparse-debcontrol-perl (2.005-4) ...
Setting up libxml-parser-perl (2.41-3) ...
Setting up libsoap-lite-perl (1.11-1) ...
Setting up libxmlrpc-lite-perl (0.717-1) ...
Processing triggers for systemd (215-17+deb8u13) ...
Processing triggers for libc-bin (2.19-18+deb8u10) ...
Processing triggers for ca-certificates (20141019+deb8u4) ...
Updating certificates in /etc/ssl/certs... 0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Processing triggers for sgml-base (1.26+nmu4) ...
```
</details>

<br>
:green_circle: Dashboard amd64 dockerfile
<details><summary>Show log</summary>

```
Setting up libltdl-dev:amd64 (2.4.6-9) ...
Setting up libxml-sax-base-perl (1.09-1) ...
Setting up libio-string-perl (1.08-3) ...
Setting up libreadonly-perl (2.050-1) ...
Setting up python3-chardet (3.0.4-3) ...
Setting up libstring-copyright-perl (0.003006-1) ...
Setting up python3-debian (0.1.35) ...
Setting up python3-requests (2.21.0-1) ...
Setting up libdata-optlist-perl (0.110-1) ...
Setting up libipc-run-perl (20180523.0-1) ...
Setting up git (1:2.20.1-2+deb10u7) ...
Setting up python3-numpy (1:1.16.2-1) ...
Setting up libcontextual-return-perl (0.004014-2) ...
Setting up libwww-robotrules-perl (6.02-1) ...
Setting up libtypes-serialiser-perl (1.0-1) ...
Setting up g++ (4:8.3.0-1) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up libhtml-parser-perl (3.72-3+b3) ...
Setting up libgit-wrapper-perl (0.048-1) ...
Setting up liblog-any-adapter-screen-perl (0.140-1) ...
Setting up librole-tiny-perl (2.000006-1) ...
Setting up build-essential (12.6) ...
Setting up libfile-homedir-perl (1.004-1) ...
Setting up libalgorithm-diff-xs-perl (0.04-5+b1) ...
Setting up libio-socket-ssl-perl (2.060-3) ...
Setting up libsub-exporter-perl (0.987-1) ...
Setting up libalgorithm-merge-perl (0.08-3) ...
Setting up libhttp-message-perl (6.18-1) ...
Setting up libhtml-form-perl (6.03-1) ...
Setting up python3-setools (4.2.0-1) ...
Setting up libfile-stripnondeterminism-perl (1.1.2-1) ...
Setting up libjson-xs-perl (3.040-1+b1) ...
Setting up libhttp-negotiate-perl (6.01-1) ...
Setting up python3-scipy (1.1.0-7) ...
Setting up libio-prompter-perl (0.004015-1) ...
Setting up libhttp-cookies-perl (6.04-1) ...
Setting up po-debconf (1.0.21) ...
Setting up libhtml-tree-perl (5.07-2) ...
Setting up libparams-classify-perl (0.015-1+b1) ...
Setting up libcgi-pm-perl (4.40-1) ...
Setting up libpath-iterator-rule-perl (1.014-1) ...
Setting up libnet-dns-sec-perl (1.11-1) ...
Setting up setools (4.2.0-1) ...
Setting up libsereal-perl (4.005-1) ...
Setting up libhtml-format-perl (2.12-1) ...
Setting up libxml-sax-perl (1.00+dfsg-1) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::PurePerl with priority 10...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline

Creating config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up dput (1.0.3) ...
Setting up libnet-smtp-ssl-perl (1.04-1) ...
Setting up libmodule-runtime-perl (0.016-1) ...
Setting up libmailtools-perl (2.18-1) ...
Setting up libparse-debianchangelog-perl (1.2.0-13) ...
Setting up libxml-libxml-perl (2.0134+dfsg-1) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::LibXML::SAX::Parser with priority 50...
update-perl-sax-parsers: Registering Perl SAX parser XML::LibXML::SAX with priority 50...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Replacing config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up libconst-fast-perl (0.014-1) ...
Setting up libhttp-daemon-perl (6.01-3+deb10u1) ...
Setting up python3-sepolgen (2.8-3) ...
Setting up python3-sepolicy (2.8-3) ...
Setting up libmodule-implementation-perl (0.09-1) ...
Setting up libemail-valid-perl (1.202-1) ...
Setting up libcgi-fast-perl (1:2.13-1) ...
Setting up libpackage-stash-perl (0.38-1) ...
Setting up libimport-into-perl (1.002005-1) ...
Setting up libmoo-perl (2.003004-2) ...
Setting up libmime-tools-perl (5.509-1) ...
Setting up libxml-simple-perl (2.25-1) ...
Setting up libparams-validate-perl (1.29-1+b1) ...
Setting up libb-hooks-endofscope-perl (0.24-1) ...
Setting up policycoreutils-python-utils (2.8-3) ...
Setting up policycoreutils-dev (2.8-3) ...
Setting up selinux-policy-dev (2:2.20190201-2) ...
Setting up lintian (2.15.0) ...
Setting up libnamespace-clean-perl (0.27-1) ...
Setting up libgetopt-long-descriptive-perl (0.103-2) ...
Setting up licensecheck (3.0.31-3) ...
Setting up libgitlab-api-v4-perl (0.16-1) ...
Setting up liblwp-protocol-https-perl (6.07-2) ...
Setting up odbcinst (2.3.6-0.1) ...
Setting up libwww-perl (6.36-2) ...
Setting up debhelper (12.1.1) ...
Setting up dh-autoreconf (19) ...
Setting up devscripts (2.19.5+deb10u1) ...
Setting up dh-strip-nondeterminism (1.1.2-1) ...
Setting up equivs (2.2.0) ...
Setting up odbcinst1debian2:amd64 (2.3.6-0.1) ...
Setting up libgdal20 (2.4.0+dfsg-1+deb10u1) ...
Setting up python3-gdal (2.4.0+dfsg-1+deb10u1) ...
Setting up libxml-parser-perl (2.44-4) ...
Setting up libxml-sax-expat-perl (0.51-1) ...
update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::Expat with priority 50...
update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Replacing config file /etc/perl/XML/SAX/ParserDetails.ini with new version
Setting up libsoap-lite-perl (1.27-1) ...
Setting up libxmlrpc-lite-perl (0.717-2) ...
Processing triggers for libc-bin (2.28-10+deb10u2) ...
Processing triggers for ca-certificates (20200601~deb10u2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```
</details>