### PR TITLE
Checking the `dist-detect` curl in the Installation Assistant builder

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -48,6 +48,7 @@ function getHelp() {
 
 function buildInstaller() {
 
+    checkDistDetectURL
     checkFilebeatURL
 
     output_script_path="${base_path_builder}/wazuh-install.sh"

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -280,7 +280,7 @@ function checkDistDetectURL() {
     while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
         retries=$((retries+1))
         sleep 5
-        eval "curl -s -o /dev/null 'https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh' --retry 5 --retry-delay 5 --max-time 300 --fail" 
+        eval "curl -s -o /dev/null 'https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh' --fail" 
         e_code="${PIPESTATUS[0]}"
     done
 

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -285,7 +285,7 @@ function checkDistDetectURL() {
     done
 
     if [[ "${retries}" -eq 12 ]] || [[ "${e_code}" -ne 0 ]]; then
-        echo -e "Error: Could not get the Filebeat Wazuh template. "
+        echo -e "Error: Could not get the dist-detect file."
         exit 1
     fi
 

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -271,6 +271,25 @@ function builder_main() {
     fi
 }
 
+function checkDistDetectURL() {
+
+    retries=0
+    eval "curl -s -o /dev/null 'https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh' --retry 5 --retry-delay 5 --max-time 300 --fail" 
+    e_code="${PIPESTATUS[0]}"
+    while [ "${e_code}" -eq 7 ] && [ "${retries}" -ne 12 ]; do
+        retries=$((retries+1))
+        sleep 5
+        eval "curl -s -o /dev/null 'https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh' --retry 5 --retry-delay 5 --max-time 300 --fail" 
+        e_code="${PIPESTATUS[0]}"
+    done
+
+    if [[ "${retries}" -eq 12 ]] || [[ "${e_code}" -ne 0 ]]; then
+        echo -e "Error: Could not get the Filebeat Wazuh template. "
+        exit 1
+    fi
+
+}
+
 function checkFilebeatURL() {
 
     # Import variables


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2031|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR modifies the builder of the Installation Assitant, adding a new function, `checkDistDetectURL`, which test the `curl` command of the `dist-detect.sh` file before adding it to the Installation Assistant.

This avoids adding the wrong content to the Installation Assistant in case the curl fails.

## Logs example

Logs are in the related issue https://github.com/wazuh/wazuh-packages/issues/2031#issuecomment-1432712317.

## Tests

Logs are in the related issue https://github.com/wazuh/wazuh-packages/issues/2031#issuecomment-1432712317.
