### PR TITLE
Fix error with wazuh-indexer logs permissions in OVA

### DIFF
--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -44,6 +44,5 @@ systemctl stop wazuh-dashboard filebeat wazuh-indexer wazuh-manager
 systemctl enable wazuh-manager
 rm -f /var/log/wazuh-indexer/*
 rm -f /var/log/filebeat/*
-rm -rf /var/ossec/logs/*
 
 clean

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -42,5 +42,8 @@ bash ${RESOURCES_PATH}/${INSTALLER} ${INSTALL_ARGS}
 
 systemctl stop wazuh-dashboard filebeat wazuh-indexer wazuh-manager
 systemctl enable wazuh-manager
+rm -f /var/log/wazuh-indexer/*
+rm -f /var/log/filebeat/*
+rm -rf /var/ossec/logs/*
 
 clean


### PR DESCRIPTION
|Related issue|
|---|
|#1971|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes an error that caused the logs from the Wazuh indexer to not be accessible after importing the OVA.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the OVA package
  - [x] Test services
  - [x] Test wazuh-dashboard conectivity 
