### PR TITLE
Calls to the dashboard api now use the port defined as a variable

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -98,7 +98,7 @@ function dashboard_initialize() {
         print_ip="${nodes_dashboard_ip}"
     fi
 
-    if [ "$(common_curl -XGET https://"${nodes_dashboard_ip}"/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)" -eq "200" ]; then
+    if [ "$(common_curl -XGET https://"${nodes_dashboard_ip}":"${wazuh_dashboard_port}"/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)" -eq "200" ]; then
         if [ "${#server_node_names[@]}" -eq 1 ]; then
             wazuh_api_address=${server_node_ips[0]}
         else
@@ -158,7 +158,7 @@ function dashboard_initializeAIO() {
 
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    if [ "$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)" -ne "200" ]; then
+    if [ "$(common_curl -XGET https://localhost:"${wazuh_dashboard_port}"/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)" -ne "200" ]; then
         common_logger -e "Cannot connect to Wazuh dashboard."
         installCommon_rollBack
         exit 1

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -244,7 +244,7 @@ function main() {
     fi
 
     if [ -n "${dashboard}" ]; then
-        checks_ports "${wazuh_dashboard_ports[@]}"
+        checks_ports "${wazuh_dashboard_port}"
     fi
 
 

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -51,4 +51,4 @@ adminPassword="wazuh"
 readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 443)
 readonly wazuh_indexer_ports=( 9200 9300 )
 readonly wazuh_manager_ports=( 1514 1515 1516 55000 )
-readonly wazuh_dashboard_ports=( 443 )
+readonly wazuh_dashboard_port=443


### PR DESCRIPTION
|Related issue|
|---|
| #2078 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

All calls to the dashboard API now use explicitly the dashboard port defined in variable `wazuh_dashboard_port`, instead on relying on the fact that it uses the default https port, 443.


## Logs example

<!--
Paste here related logs
-->

## Tests

- [x] CentOS 7
- [ ] Amazon Linux 2
- [ ] Red Hat Enterprise Linux 8
- [ ] Ubuntu 20