### PR TITLE
Fix error when running `wazuh-install.sh` after canceling the execution

### DIFF
--- a/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.post-install
@@ -14,6 +14,4 @@ ${directory_base}/packages_files/gen_ossec.sh conf agent ${DIST_NAME} ${DIST_VER
 # Add default local_files to ossec.conf
 ${directory_base}/packages_files/add_localfiles.sh ${directory_base} >> ${directory_base}/etc/ossec.conf
 
-rm -rf ${directory_base}/packages_files
-
 exit 0

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 12
-RUN apt-get update &&  apt-get build-dep python3.5 -y
+RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install --allow-change-held-packages -y nodejs
 

--- a/debs/Debian/arm64/Dockerfile
+++ b/debs/Debian/arm64/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt apt-utils  \
+    apt-get update && apt-get install -y --allow-change-held-packages apt apt-utils  \
     curl gcc g++ make sudo expect gnupg \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
@@ -15,7 +15,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
 # Add Debian's source repository and, Install NodeJS 12
 RUN apt-get update &&  apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install --allow-change-held-packages -y nodejs
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils \
+    apt-get update && apt-get install -y --allow-change-held-packages apt-utils \
     curl gcc make wget sudo expect gnupg perl-base \
     perl libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
@@ -15,7 +15,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
 # Add Debian's source repository and, Install NodeJS 12
 RUN apt-get build-dep python3.5 -y
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y --allow-change-held-packages nodejs
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/armhf/Dockerfile
+++ b/debs/Debian/armhf/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://deb.debian.org/debian stretch contrib non-free" >> /etc/apt
     libssl1.1 libssl-dev gawk libsigsegv2 procps libc6-armel-cross g++
 
 # Add Debian's source repository and, Install NodeJS 12
-RUN apt-get build-dep python3.5 -y
+RUN apt-get build-dep python3.5 -y --allow-change-held-packages
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y --allow-change-held-packages nodejs
 

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /et
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
-RUN apt-get update && apt-get build-dep python3.5 -y
+RUN apt-get update && apt-get build-dep python3.5 -y --allow-change-held-packages
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \

--- a/debs/Debian/ppc64le/Dockerfile
+++ b/debs/Debian/ppc64le/Dockerfile
@@ -2,11 +2,13 @@ FROM ppc64le/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get -v
+
 # Installing necessary packages
 RUN echo "deb http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian stretch main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y --force-yes \
+    apt-get update && apt-get install -y --allow-change-held-packages apt-utils && \
+    apt-get install -y --allow-change-held-packages \
     curl gcc make sudo expect gnupg perl-base perl wget \
     libc-bin libc6 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \

--- a/stack/dashboard/deb/docker/amd64/Dockerfile
+++ b/stack/dashboard/deb/docker/amd64/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:10
 ENV DEBIAN_FRONTEND noninteractive
 
 # Installing necessary packages
-RUN apt-get update && apt-get install -y apt-utils && \
-    apt-get install -y \
+RUN apt-get update && apt-get install -y --allow-change-held-packages apt-utils && \
+    apt-get install -y --allow-change-held-packages \
     curl sudo wget expect gnupg build-essential \
     devscripts equivs selinux-basics procps gawk
 

--- a/stack/indexer/deb/docker/amd64/Dockerfile
+++ b/stack/indexer/deb/docker/amd64/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:8
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Installing necessary packages
 RUN apt-get update && apt-get install -y --force-yes apt-utils && \
     apt-get install -y --force-yes \
     curl sudo wget expect gnupg build-essential \

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -21,6 +21,7 @@ function installCommon_cleanExit() {
     if [[ "${rollback_conf}" =~ [N|n] ]]; then
         exit 1
     else
+        common_checkInstalled
         installCommon_rollBack
         exit 1
     fi

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Installing necessary packages
 RUN apt-get update && \
-    apt-get install -y gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
+    apt-get install -y --allow-change-held-packages gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
     curl perl binutils zip libssl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \

--- a/wpk/common/Dockerfile
+++ b/wpk/common/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:9
 
 RUN apt-get update && \
-    apt-get -y install python git curl jq python3 python3-pip libffi-dev && \
+    apt-get -y install --allow-change-held-packages python git curl jq python3 python3-pip libffi-dev && \
     pip3 install --upgrade cryptography==2.9.2 awscli
 
 ADD wpkpack.py /usr/local/bin/wpkpack


### PR DESCRIPTION
|Related issue|
|---|
|#2024|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error in the wazuh-install.sh script that caused it to fail if we had previously canceled the execution of the script.

The error could appear because of two reasons:
1. Some files from the wazuh-indexer were not deleted in the rollback function.
2. After canceling the execution some packages were installed but the script did not know it.

