### PR TITLE
Fix the errors in the dashboard for the AIO installation 

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -156,17 +156,31 @@ function dashboard_initialize() {
 
 function dashboard_initializeAIO() {
 
+    set -ex
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    if [ "$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)" -ne "200" ]; then
-        common_logger -e "Cannot connect to Wazuh dashboard."
+    echo "Before curl"
+    e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+    retries=0
+    max_dashboard_initialize_retries=5
+    read -p "Press enter to continue"
+    while [ "${e_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
+    do
+        echo "Before retry"
+        e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+        echo "After retry"
+        retries=$((retries+1))
+    done
+    if [ "${e_code}" -eq "200" ]; then
+        common_logger "Wazuh dashboard web application initialized."
+        common_logger -nl "--- Summary ---"
+        common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
+    else
+        common_logger -e "Wazuh dashboard installation failed."
         installCommon_rollBack
         exit 1
     fi
-
-    common_logger "Wazuh dashboard web application initialized."
-    common_logger -nl "--- Summary ---"
-    common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
+    set +ex
 }
 
 function dashboard_install() {

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -156,22 +156,18 @@ function dashboard_initialize() {
 
 function dashboard_initializeAIO() {
 
-    set -ex
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    echo "Before curl"
-    e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+    http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
     retries=0
     max_dashboard_initialize_retries=5
-    read -p "Press enter to continue"
-    while [ "${e_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
+    while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
-        echo "Before retry"
-        e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
-        echo "After retry"
+        http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
         retries=$((retries+1))
+        sleep 1
     done
-    if [ "${e_code}" -eq "200" ]; then
+    if [ "${http_code}" -eq "200" ]; then
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"
         common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
@@ -180,7 +176,6 @@ function dashboard_initializeAIO() {
         installCommon_rollBack
         exit 1
     fi
-    set +ex
 }
 
 function dashboard_install() {

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -301,13 +301,14 @@ function passwords_generatePasswordFile() {
 function passwords_getApiToken() {
 
     retries=0
-    max_internal_error_retries=5
+    max_internal_error_retries=10
 
-    TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+    TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
-        TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+        TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
         retries=$((retries+1))
+        sleep 1
     done
     if [[ ${TOKEN_API} =~ "Wazuh Internal Error" ]]; then
         common_logger -e "There was an error while trying to get the API token."

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -300,11 +300,25 @@ function passwords_generatePasswordFile() {
 
 function passwords_getApiToken() {
 
+    retries=0
+    max_internal_error_retries=5
+
     TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
-    if [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
+    while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
+    do
+        TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+        retries=$((retries+1))
+    done
+    if [[ ${TOKEN_API} =~ "Wazuh Internal Error" ]]; then
+        common_logger -e "There was an error while trying to get the API token."
+        if [[ $(type -t installCommon_rollBack) == "function" ]]; then
+            installCommon_rollBack
+        fi
+        exit 1
+    elif [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
         common_logger -e "Invalid admin user credentials"
         if [[ $(type -t installCommon_rollBack) == "function" ]]; then
-                installCommon_rollBack
+            installCommon_rollBack
         fi
         exit 1
     fi


### PR DESCRIPTION
|Related issue|
|---|
| #2111 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR aims to fix the errors seen in the dashboard installation when an All-in-one installation is done in a system with less capabilities than the recommended ones. This errors have discovered some issues on the error treatment of the installation.

For now, function `passwords_getApiToken` now detects one more possible error and retries the Token downloading some number of times.