### PR TITLE
Fix the errors in the dashboard for the AIO installation 

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -34,8 +34,8 @@ function getHelp() {
     echo -e "        -c,  --cert-tool"
     echo -e "                Builds the certificate creation tool cert-tool.sh"
     echo -e ""
-    echo -e "        -d [staging],  --development"
-    echo -e "                Use development repos. By default it uses pre-release. If staging is specified, it will be used"
+    echo -e "        -d [pre-release|staging],  --development"
+    echo -e "                Use development repositories. By default it uses the pre-release package repository. If staging is specified, it will use that repository."
     echo -e ""
     echo -e "        -p,  --password-tool"
     echo -e "                Builds the password creation and modification tool password-tool.sh"
@@ -230,6 +230,9 @@ function builder_main() {
                 development=1
                 if [ -n "${2}" ] && [ "${2}" = "staging" ]; then
                     devrepo="staging"
+                    shift 2
+                elif [ -n "${2}" ] && [ "${2}" = "pre-release" ]; then
+                    devrepo="pre-release"
                     shift 2
                 else
                     devrepo="pre-release"

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -34,8 +34,8 @@ function getHelp() {
     echo -e "        -c,  --cert-tool"
     echo -e "                Builds the certificate creation tool cert-tool.sh"
     echo -e ""
-    echo -e "        -d,  --development"
-    echo -e "                Use development repos"
+    echo -e "        -d [staging],  --development"
+    echo -e "                Use development repos. By default it uses pre-release. If staging is specified, it will be used"
     echo -e ""
     echo -e "        -p,  --password-tool"
     echo -e "                Builds the password creation and modification tool password-tool.sh"
@@ -68,11 +68,11 @@ function buildInstaller() {
     if [ -n "${development}" ]; then
         echo 'readonly development=1' >> "${output_script_path}"
         echo 'readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
-        echo 'readonly repobaseurl="https://packages-dev.wazuh.com/pre-release"' >> "${output_script_path}"
+        echo 'readonly repobaseurl="https://packages-dev.wazuh.com/'${devrepo}'"' >> "${output_script_path}"
         echo 'readonly reporelease="unstable"' >> "${output_script_path}"
         echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
-        echo 'readonly repository="pre-release"' >> "${output_script_path}"
+        echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -228,7 +228,13 @@ function builder_main() {
                 ;;
             "-d"|"--development")
                 development=1
-                shift 1
+                if [ -n "${2}" ] && [ "${2}" = "staging" ]; then
+                    devrepo="staging"
+                    shift 2
+                else
+                    devrepo="pre-release"
+                    shift 1
+                fi
                 ;;
             "-p"|"--password-tool")
                 passwordsTool=1

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -162,22 +162,18 @@ function dashboard_initialize() {
 
 function dashboard_initializeAIO() {
 
-    set -ex
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    echo "Before curl"
-    e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+    http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
     retries=0
     max_dashboard_initialize_retries=5
-    read -p "Press enter to continue"
-    while [ "${e_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
+    while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
-        echo "Before retry"
-        e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
-        echo "After retry"
+        http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
         retries=$((retries+1))
+        sleep 1
     done
-    if [ "${e_code}" -eq "200" ]; then
+    if [ "${http_code}" -eq "200" ]; then
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"
         common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
@@ -186,7 +182,6 @@ function dashboard_initializeAIO() {
         installCommon_rollBack
         exit 1
     fi
-    set +ex
 }
 
 function dashboard_install() {

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -169,7 +169,7 @@ function dashboard_initializeAIO() {
     max_dashboard_initialize_retries=5
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
-        common_logger -w "Wazuh dashboard web application not yet initialized. Waiting..."
+        common_logger "Wazuh dashboard web application not yet initialized. Waiting..."
         http_code="$(curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null)"
         retries=$((retries+1))
         sleep 1

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -164,13 +164,13 @@ function dashboard_initializeAIO() {
 
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
+    http_code="$(curl -XGET https://localhost/status -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null )"
     retries=0
     max_dashboard_initialize_retries=5
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
         common_logger "Wazuh dashboard web application not yet initialized. Waiting..."
-        http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
+        http_code="$(curl -XGET https://localhost/status -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)"
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -162,21 +162,31 @@ function dashboard_initialize() {
 
 function dashboard_initializeAIO() {
 
+    set -ex
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    until [ "$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)" -eq "200" ] || [ "${i}" -eq 12 ]; do
-        sleep 10
-        i=$((i+1))
+    echo "Before curl"
+    e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+    retries=0
+    max_dashboard_initialize_retries=5
+    read -p "Press enter to continue"
+    while [ "${e_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
+    do
+        echo "Before retry"
+        e_code="$(common_curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+        echo "After retry"
+        retries=$((retries+1))
     done
-    if [ ${i} -eq 12 ]; then
-        common_logger -e "Cannot connect to Wazuh dashboard."
+    if [ "${e_code}" -eq "200" ]; then
+        common_logger "Wazuh dashboard web application initialized."
+        common_logger -nl "--- Summary ---"
+        common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
+    else
+        common_logger -e "Wazuh dashboard installation failed."
         installCommon_rollBack
         exit 1
     fi
-
-    common_logger "Wazuh dashboard web application initialized."
-    common_logger -nl "--- Summary ---"
-    common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
+    set +ex
 }
 
 function dashboard_install() {

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -166,13 +166,13 @@ function dashboard_initializeAIO() {
     installCommon_getPass "admin"
     http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
     retries=0
-    max_dashboard_initialize_retries=5
+    max_dashboard_initialize_retries=20
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
         common_logger "Wazuh dashboard web application not yet initialized. Waiting..."
         http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
         retries=$((retries+1))
-        sleep 1
+        sleep 15
     done
     if [ "${http_code}" -eq "200" ]; then
         common_logger "Wazuh dashboard web application initialized."

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -164,13 +164,13 @@ function dashboard_initializeAIO() {
 
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    http_code="$(curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null)"
+    http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
     retries=0
     max_dashboard_initialize_retries=5
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
         common_logger "Wazuh dashboard web application not yet initialized. Waiting..."
-        http_code="$(curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null)"
+        http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -164,13 +164,13 @@ function dashboard_initializeAIO() {
 
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    http_code="$(curl -XGET https://localhost/status -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null )"
+    http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
     retries=0
     max_dashboard_initialize_retries=5
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
         common_logger "Wazuh dashboard web application not yet initialized. Waiting..."
-        http_code="$(curl -XGET https://localhost/status -uadmin:${u_pass} -k -w %{http_code} -s -o /dev/null)"
+        http_code=$(curl -XGET https://localhost/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -164,12 +164,13 @@ function dashboard_initializeAIO() {
 
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
-    http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+    http_code="$(curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null)"
     retries=0
     max_dashboard_initialize_retries=5
     while [ "${http_code}" -ne "200" ] && [ "${retries}" -lt "${max_dashboard_initialize_retries}" ]
     do
-        http_code="$(common_curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null --max-time 300 --retry 12 --retry-delay 10 --fail)"
+        common_logger -w "Wazuh dashboard web application not yet initialized. Waiting..."
+        http_code="$(curl -XGET https://localhost/status -uadmin:\"${u_pass}\" -k -w %\"{http_code}\" -s -o /dev/null)"
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -294,7 +294,7 @@ function passwords_generatePasswordFile() {
 function passwords_getApiToken() {
 
     retries=0
-    max_internal_error_retries=10
+    max_internal_error_retries=20
 
     TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
@@ -302,7 +302,7 @@ function passwords_getApiToken() {
         common_logger "There was an error accessing the API. Retrying..."
         TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
         retries=$((retries+1))
-        sleep 1
+        sleep 10
     done
     if [[ ${TOKEN_API} =~ "Wazuh Internal Error" ]]; then
         common_logger -e "There was an error while trying to get the API token."

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -296,11 +296,11 @@ function passwords_getApiToken() {
     retries=0
     max_internal_error_retries=10
 
-    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X GET \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
         common_logger "There was an error accessing the API. Retrying..."
-        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X GET \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -296,11 +296,11 @@ function passwords_getApiToken() {
     retries=0
     max_internal_error_retries=10
 
-    TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\")"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
-        common_logger -w "There was an error accessing the API. Retrying..."
-        TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+        common_logger "There was an error accessing the API. Retrying..."
+        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\")"
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -299,6 +299,7 @@ function passwords_getApiToken() {
     TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
+        common_logger -w "There was an error accessing the API. Retrying..."
         TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
         retries=$((retries+1))
         sleep 1

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -309,7 +309,8 @@ function passwords_getApiToken() {
             installCommon_rollBack
         fi
         exit 1
-    elif [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
+    fi
+    if [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
         common_logger -e "Invalid admin user credentials"
         if [[ $(type -t installCommon_rollBack) == "function" ]]; then
             installCommon_rollBack

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -293,11 +293,25 @@ function passwords_generatePasswordFile() {
 
 function passwords_getApiToken() {
 
-    TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
-    if [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
+    retries=0
+    max_internal_error_retries=5
+
+    TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+    while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
+    do
+        TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+        retries=$((retries+1))
+    done
+    if [[ ${TOKEN_API} =~ "Wazuh Internal Error" ]]; then
+        common_logger -e "There was an error while trying to get the API token."
+        if [[ $(type -t installCommon_rollBack) == "function" ]]; then
+            installCommon_rollBack
+        fi
+        exit 1
+    elif [[ ${TOKEN_API} =~ "Invalid credentials" ]]; then
         common_logger -e "Invalid admin user credentials"
         if [[ $(type -t installCommon_rollBack) == "function" ]]; then
-                installCommon_rollBack
+            installCommon_rollBack
         fi
         exit 1
     fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -296,11 +296,11 @@ function passwords_getApiToken() {
     retries=0
     max_internal_error_retries=10
 
-    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\")"
+    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
         common_logger "There was an error accessing the API. Retrying..."
-        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\")"
+        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
         retries=$((retries+1))
         sleep 1
     done

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -294,13 +294,14 @@ function passwords_generatePasswordFile() {
 function passwords_getApiToken() {
 
     retries=0
-    max_internal_error_retries=5
+    max_internal_error_retries=10
 
-    TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+    TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
-        TOKEN_API=$(common_curl -s -u "${adminUser}":"${adminPassword}" -k -X POST "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
+        TOKEN_API="$(common_curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X POST \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
         retries=$((retries+1))
+        sleep 1
     done
     if [[ ${TOKEN_API} =~ "Wazuh Internal Error" ]]; then
         common_logger -e "There was an error while trying to get the API token."

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -296,11 +296,11 @@ function passwords_getApiToken() {
     retries=0
     max_internal_error_retries=10
 
-    TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X GET \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+    TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
     while [[ "${TOKEN_API}" =~ "Wazuh Internal Error" ]] && [ "${retries}" -lt "${max_internal_error_retries}" ]
     do
         common_logger "There was an error accessing the API. Retrying..."
-        TOKEN_API="$(curl -s -u \"${adminUser}\":\"${adminPassword}\" -k -X GET \"https://localhost:55000/security/user/authenticate?raw=true\" --max-time 300 --retry 5 --retry-delay 5)"
+        TOKEN_API=$(curl -s -u "${adminUser}":"${adminPassword}" -k -X GET "https://localhost:55000/security/user/authenticate?raw=true" --max-time 300 --retry 5 --retry-delay 5)
         retries=$((retries+1))
         sleep 1
     done


### PR DESCRIPTION
|Related issue|
|---|
| #2111 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR aims to fix the errors seen in the dashboard installation when an All-in-one installation is done in a system with less capabilities than the recommended ones. This errors have discovered some issues on the error treatment of the installation.

For now, function `passwords_getApiToken` now detects one more possible error and retries the Token downloading some number of times.

## Testing
#### Test AIO on machines with minimum requirements(4GB and 2 cores):
<details>
<summary> :green_circle: Ubuntu 18</summary>

```
root@ubuntu18:/home/vagrant# bash wazuh-install.sh -a 
08/03/2023 16:37:20 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:37:20 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:37:41 INFO: Wazuh development repository added.
08/03/2023 16:37:41 INFO: --- Configuration files ---
08/03/2023 16:37:42 INFO: Generating configuration files.
08/03/2023 16:37:42 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:37:42 INFO: --- Wazuh indexer ---
08/03/2023 16:37:42 INFO: Starting Wazuh indexer installation.
08/03/2023 16:38:40 INFO: Wazuh indexer installation finished.
08/03/2023 16:38:40 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:38:40 INFO: Starting service wazuh-indexer.
08/03/2023 16:39:02 INFO: wazuh-indexer service started.
08/03/2023 16:39:02 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:39:15 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:39:15 INFO: --- Wazuh server ---
08/03/2023 16:39:15 INFO: Starting the Wazuh manager installation.
08/03/2023 16:40:49 INFO: Wazuh manager installation finished.
08/03/2023 16:40:49 INFO: Starting service wazuh-manager.
08/03/2023 16:41:09 INFO: wazuh-manager service started.
08/03/2023 16:41:09 INFO: Starting Filebeat installation.
08/03/2023 16:41:37 INFO: Filebeat installation finished.
08/03/2023 16:41:50 INFO: Filebeat post-install configuration finished.
08/03/2023 16:41:50 INFO: Starting service filebeat.
08/03/2023 16:41:51 INFO: filebeat service started.
08/03/2023 16:41:51 INFO: --- Wazuh dashboard ---
08/03/2023 16:41:51 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:43:51 INFO: Wazuh dashboard installation finished.
08/03/2023 16:43:54 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:43:54 INFO: Starting service wazuh-dashboard.
08/03/2023 16:43:57 INFO: wazuh-dashboard service started.
08/03/2023 16:44:56 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:44:57 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:44:57 INFO: --- Summary ---
08/03/2023 16:44:57 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: dB6NmE.L5QgE3BGomPlM4.KsRIe*gvTn
08/03/2023 16:44:57 INFO: Installation finished.
root@ubuntu18:/home/vagrant# 
```
</details>

<details>
<summary> :green_circle: Ubuntu 20</summary>

```
root@ubuntu20:/home/vagrant# bash wazuh-install.sh -a 
08/03/2023 16:42:20 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:42:20 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:42:53 INFO: --- Dependencies ----
08/03/2023 16:42:53 INFO: Installing apt-transport-https.
08/03/2023 16:43:12 INFO: Wazuh development repository added.
08/03/2023 16:43:12 INFO: --- Configuration files ---
08/03/2023 16:43:12 INFO: Generating configuration files.
08/03/2023 16:43:13 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:43:13 INFO: --- Wazuh indexer ---
08/03/2023 16:43:13 INFO: Starting Wazuh indexer installation.
08/03/2023 16:44:40 INFO: Wazuh indexer installation finished.
08/03/2023 16:44:40 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:44:40 INFO: Starting service wazuh-indexer.
08/03/2023 16:44:59 INFO: wazuh-indexer service started.
08/03/2023 16:44:59 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:45:08 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:45:08 INFO: --- Wazuh server ---
08/03/2023 16:45:08 INFO: Starting the Wazuh manager installation.
08/03/2023 16:46:29 INFO: Wazuh manager installation finished.
08/03/2023 16:46:29 INFO: Starting service wazuh-manager.
08/03/2023 16:46:42 INFO: wazuh-manager service started.
08/03/2023 16:46:42 INFO: Starting Filebeat installation.
08/03/2023 16:47:15 INFO: Filebeat installation finished.
08/03/2023 16:47:18 INFO: Filebeat post-install configuration finished.
08/03/2023 16:47:18 INFO: Starting service filebeat.
08/03/2023 16:47:19 INFO: filebeat service started.
08/03/2023 16:47:19 INFO: --- Wazuh dashboard ---
08/03/2023 16:47:19 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:50:03 INFO: Wazuh dashboard installation finished.
08/03/2023 16:50:04 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:50:04 INFO: Starting service wazuh-dashboard.
08/03/2023 16:50:05 INFO: wazuh-dashboard service started.
08/03/2023 16:51:06 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:51:08 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:51:08 INFO: --- Summary ---
08/03/2023 16:51:08 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: cA3FCqEPB+mzlTb2v0girbYtE*Hh*bBe
08/03/2023 16:51:08 INFO: Installation finished.
root@ubuntu20:/home/vagrant# 
```
</details>

<details>
<summary> :green_circle: Ubuntu 22</summary>

```
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a
08/03/2023 17:01:02 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 17:01:02 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 17:01:13 INFO: Wazuh development repository added.
08/03/2023 17:01:13 INFO: --- Configuration files ---
08/03/2023 17:01:13 INFO: Generating configuration files.
08/03/2023 17:01:15 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 17:01:15 INFO: --- Wazuh indexer ---
08/03/2023 17:01:15 INFO: Starting Wazuh indexer installation.
08/03/2023 17:02:08 INFO: Wazuh indexer installation finished.
08/03/2023 17:02:08 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 17:02:08 INFO: Starting service wazuh-indexer.
08/03/2023 17:02:27 INFO: wazuh-indexer service started.
08/03/2023 17:02:27 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 17:02:36 INFO: Wazuh indexer cluster initialized.
08/03/2023 17:02:36 INFO: --- Wazuh server ---
08/03/2023 17:02:36 INFO: Starting the Wazuh manager installation.
08/03/2023 17:04:01 INFO: Wazuh manager installation finished.
08/03/2023 17:04:01 INFO: Starting service wazuh-manager.
08/03/2023 17:04:27 INFO: wazuh-manager service started.
08/03/2023 17:04:27 INFO: Starting Filebeat installation.
08/03/2023 17:04:47 INFO: Filebeat installation finished.
08/03/2023 17:04:49 INFO: Filebeat post-install configuration finished.
08/03/2023 17:04:49 INFO: Starting service filebeat.
08/03/2023 17:04:50 INFO: filebeat service started.
08/03/2023 17:04:50 INFO: --- Wazuh dashboard ---
08/03/2023 17:04:50 INFO: Starting Wazuh dashboard installation.
08/03/2023 17:06:16 INFO: Wazuh dashboard installation finished.
08/03/2023 17:06:16 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 17:06:16 INFO: Starting service wazuh-dashboard.
08/03/2023 17:06:18 INFO: wazuh-dashboard service started.
08/03/2023 17:07:33 INFO: Initializing Wazuh dashboard web application.
08/03/2023 17:07:34 INFO: Wazuh dashboard web application initialized.
08/03/2023 17:07:34 INFO: --- Summary ---
08/03/2023 17:07:34 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: JNXaq+E9Wgm4C?WZTGtzg4zTq.uX?506
08/03/2023 17:07:34 INFO: Installation finished.
root@ubuntu22:/home/vagrant# 
```
</details>

<details>
<summary> :green_circle: CentOS 7</summary>

```
[root@centos7 vagrant]# bash wazuh-install.sh -a
08/03/2023 17:09:50 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 17:09:50 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 17:09:58 INFO: Wazuh development repository added.
08/03/2023 17:09:58 INFO: --- Configuration files ---
08/03/2023 17:09:58 INFO: Generating configuration files.
08/03/2023 17:10:00 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 17:10:00 INFO: --- Wazuh indexer ---
08/03/2023 17:10:00 INFO: Starting Wazuh indexer installation.
08/03/2023 17:11:56 INFO: Wazuh indexer installation finished.
08/03/2023 17:11:56 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 17:11:56 INFO: Starting service wazuh-indexer.
08/03/2023 17:12:13 INFO: wazuh-indexer service started.
08/03/2023 17:12:13 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 17:12:21 INFO: Wazuh indexer cluster initialized.
08/03/2023 17:12:21 INFO: --- Wazuh server ---
08/03/2023 17:12:21 INFO: Starting the Wazuh manager installation.
08/03/2023 17:13:28 INFO: Wazuh manager installation finished.
08/03/2023 17:13:28 INFO: Starting service wazuh-manager.
08/03/2023 17:13:44 INFO: wazuh-manager service started.
08/03/2023 17:13:44 INFO: Starting Filebeat installation.
08/03/2023 17:13:58 INFO: Filebeat installation finished.
08/03/2023 17:13:59 INFO: Filebeat post-install configuration finished.
08/03/2023 17:13:59 INFO: Starting service filebeat.
08/03/2023 17:13:59 INFO: filebeat service started.
08/03/2023 17:13:59 INFO: --- Wazuh dashboard ---
08/03/2023 17:13:59 INFO: Starting Wazuh dashboard installation.
08/03/2023 17:15:39 INFO: Wazuh dashboard installation finished.
08/03/2023 17:15:40 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 17:15:40 INFO: Starting service wazuh-dashboard.
08/03/2023 17:15:43 INFO: wazuh-dashboard service started.
08/03/2023 17:16:26 INFO: Initializing Wazuh dashboard web application.
08/03/2023 17:16:26 INFO: Wazuh dashboard web application initialized.
08/03/2023 17:16:26 INFO: --- Summary ---
08/03/2023 17:16:26 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: 5xmia.y1QOToqpdLhOvBFT3Rn52stGt3
08/03/2023 17:16:26 INFO: Installation finished.
[root@centos7 vagrant]# 
```
</details>

<details>
<summary> :green_circle: CentOS 8</summary>

```
[root@centos8 vagrant]# bash wazuh-install.sh -a
08/03/2023 17:08:47 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 17:08:47 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 17:08:53 INFO: Wazuh development repository added.
08/03/2023 17:08:53 INFO: --- Configuration files ---
08/03/2023 17:08:53 INFO: Generating configuration files.
08/03/2023 17:08:53 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 17:08:54 INFO: --- Wazuh indexer ---
08/03/2023 17:08:54 INFO: Starting Wazuh indexer installation.
08/03/2023 17:10:43 INFO: Wazuh indexer installation finished.
08/03/2023 17:10:44 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 17:10:44 INFO: Starting service wazuh-indexer.
08/03/2023 17:11:05 INFO: wazuh-indexer service started.
08/03/2023 17:11:05 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 17:11:18 INFO: Wazuh indexer cluster initialized.
08/03/2023 17:11:18 INFO: --- Wazuh server ---
08/03/2023 17:11:18 INFO: Starting the Wazuh manager installation.
08/03/2023 17:12:53 INFO: Wazuh manager installation finished.
08/03/2023 17:12:53 INFO: Starting service wazuh-manager.
08/03/2023 17:13:09 INFO: wazuh-manager service started.
08/03/2023 17:13:09 INFO: Starting Filebeat installation.
08/03/2023 17:13:20 INFO: Filebeat installation finished.
08/03/2023 17:13:22 INFO: Filebeat post-install configuration finished.
08/03/2023 17:13:22 INFO: Starting service filebeat.
08/03/2023 17:13:22 INFO: filebeat service started.
08/03/2023 17:13:22 INFO: --- Wazuh dashboard ---
08/03/2023 17:13:22 INFO: Starting Wazuh dashboard installation.
08/03/2023 17:15:11 INFO: Wazuh dashboard installation finished.
08/03/2023 17:15:11 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 17:15:11 INFO: Starting service wazuh-dashboard.
08/03/2023 17:15:12 INFO: wazuh-dashboard service started.
08/03/2023 17:16:00 INFO: Initializing Wazuh dashboard web application.
08/03/2023 17:16:01 INFO: Wazuh dashboard web application initialized.
08/03/2023 17:16:01 INFO: --- Summary ---
08/03/2023 17:16:01 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: uKDP0XtKD8sn0DStvvdUY8Z.mEVpi0+g
08/03/2023 17:16:01 INFO: Installation finished.
[root@centos8 vagrant]# 
```
</details>

<details>
<summary> :green_circle: Amazon Linux 2</summary>

```
[root@amazonlinux2 vagrant]# bash wazuh-install.sh -a
08/03/2023 09:19:06 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 09:19:06 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 09:19:10 INFO: Wazuh development repository added.
08/03/2023 09:19:10 INFO: --- Configuration files ---
08/03/2023 09:19:10 INFO: Generating configuration files.
08/03/2023 09:19:11 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 09:19:11 INFO: --- Wazuh indexer ---
08/03/2023 09:19:11 INFO: Starting Wazuh indexer installation.
08/03/2023 09:20:43 INFO: Wazuh indexer installation finished.
08/03/2023 09:20:43 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 09:20:43 INFO: Starting service wazuh-indexer.
08/03/2023 09:21:01 INFO: wazuh-indexer service started.
08/03/2023 09:21:01 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 09:21:08 INFO: Wazuh indexer cluster initialized.
08/03/2023 09:21:08 INFO: --- Wazuh server ---
08/03/2023 09:21:08 INFO: Starting the Wazuh manager installation.
08/03/2023 09:21:43 INFO: Wazuh manager installation finished.
08/03/2023 09:21:43 INFO: Starting service wazuh-manager.
08/03/2023 09:21:59 INFO: wazuh-manager service started.
08/03/2023 09:21:59 INFO: Starting Filebeat installation.
08/03/2023 09:22:07 INFO: Filebeat installation finished.
08/03/2023 09:22:10 INFO: Filebeat post-install configuration finished.
08/03/2023 09:22:10 INFO: Starting service filebeat.
08/03/2023 09:22:10 INFO: filebeat service started.
08/03/2023 09:22:10 INFO: --- Wazuh dashboard ---
08/03/2023 09:22:10 INFO: Starting Wazuh dashboard installation.
08/03/2023 09:23:56 INFO: Wazuh dashboard installation finished.
08/03/2023 09:23:57 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 09:23:57 INFO: Starting service wazuh-dashboard.
08/03/2023 09:23:58 INFO: wazuh-dashboard service started.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:wazuh -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDUyLCJleHAiOjE2NzgyNjgzNTIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ade6n-UHdWaDhOEYPW5YVm3cu19TvepVW-Elz1gUjzcSxM2l0MO1kWak2MKpP9jUwP2tTBZ2bb07MUnxUBAyVzHrAANjq9WEPeAqrdgKCsEP6-9rg1LDCMuWl2u2AbEAo_hSeNvdDJKmvAgXoQ8cj46lNAc1OguzmmLOcjiONb26WzDE
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDUyLCJleHAiOjE2NzgyNjgzNTIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ade6n-UHdWaDhOEYPW5YVm3cu19TvepVW-Elz1gUjzcSxM2l0MO1kWak2MKpP9jUwP2tTBZ2bb07MUnxUBAyVzHrAANjq9WEPeAqrdgKCsEP6-9rg1LDCMuWl2u2AbEAo_hSeNvdDJKmvAgXoQ8cj46lNAc1OguzmmLOcjiONb26WzDE =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDUyLCJleHAiOjE2NzgyNjgzNTIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ade6n-UHdWaDhOEYPW5YVm3cu19TvepVW-Elz1gUjzcSxM2l0MO1kWak2MKpP9jUwP2tTBZ2bb07MUnxUBAyVzHrAANjq9WEPeAqrdgKCsEP6-9rg1LDCMuWl2u2AbEAo_hSeNvdDJKmvAgXoQ8cj46lNAc1OguzmmLOcjiONb26WzDE =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDUyLCJleHAiOjE2NzgyNjgzNTIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ade6n-UHdWaDhOEYPW5YVm3cu19TvepVW-Elz1gUjzcSxM2l0MO1kWak2MKpP9jUwP2tTBZ2bb07MUnxUBAyVzHrAANjq9WEPeAqrdgKCsEP6-9rg1LDCMuWl2u2AbEAo_hSeNvdDJKmvAgXoQ8cj46lNAc1OguzmmLOcjiONb26WzDE =~ Invalid credentials ]]
+ set +ex
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u 'wazuh:tO4GGf7j+TvTl+fdNV1Ww575?Ny+kf7*' -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDkxLCJleHAiOjE2NzgyNjgzOTEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AHyZAG6B6gcJtg6BGubsxkTaVD6EyZ6yBAUOJtKTxipQ8wY2fa87C8U1DUIG3jVd6cx4H32_ZgO7X2X34Jc0SfvMAaspwZUnT1_Dzfn3xV3rQ2WBEKB86yZIP19bkMRG10LrM-Amvs3Y98P2L6V_S8Y_VhIgSG3R3_jSI3HVyS1jhNeH
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDkxLCJleHAiOjE2NzgyNjgzOTEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AHyZAG6B6gcJtg6BGubsxkTaVD6EyZ6yBAUOJtKTxipQ8wY2fa87C8U1DUIG3jVd6cx4H32_ZgO7X2X34Jc0SfvMAaspwZUnT1_Dzfn3xV3rQ2WBEKB86yZIP19bkMRG10LrM-Amvs3Y98P2L6V_S8Y_VhIgSG3R3_jSI3HVyS1jhNeH =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDkxLCJleHAiOjE2NzgyNjgzOTEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AHyZAG6B6gcJtg6BGubsxkTaVD6EyZ6yBAUOJtKTxipQ8wY2fa87C8U1DUIG3jVd6cx4H32_ZgO7X2X34Jc0SfvMAaspwZUnT1_Dzfn3xV3rQ2WBEKB86yZIP19bkMRG10LrM-Amvs3Y98P2L6V_S8Y_VhIgSG3R3_jSI3HVyS1jhNeH =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjY3NDkxLCJleHAiOjE2NzgyNjgzOTEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AHyZAG6B6gcJtg6BGubsxkTaVD6EyZ6yBAUOJtKTxipQ8wY2fa87C8U1DUIG3jVd6cx4H32_ZgO7X2X34Jc0SfvMAaspwZUnT1_Dzfn3xV3rQ2WBEKB86yZIP19bkMRG10LrM-Amvs3Y98P2L6V_S8Y_VhIgSG3R3_jSI3HVyS1jhNeH =~ Invalid credentials ]]
+ set +ex
+ common_logger 'Initializing Wazuh dashboard web application.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 09:24:56'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ case ${1} in
+ message='Initializing Wazuh dashboard web application.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ tee -a /var/log/wazuh-install.log
+ printf '%s\n' '08/03/2023 09:24:56 INFO: Initializing Wazuh dashboard web application.'
08/03/2023 09:24:56 INFO: Initializing Wazuh dashboard web application.
+ installCommon_getPass admin
+ for i in '"${!users[@]}"'
+ '[' admin == admin ']'
+ u_pass=qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3
+ for i in '"${!users[@]}"'
+ '[' kibanaserver == admin ']'
+ for i in '"${!users[@]}"'
+ '[' kibanaro == admin ']'
+ for i in '"${!users[@]}"'
+ '[' logstash == admin ']'
+ for i in '"${!users[@]}"'
+ '[' readall == admin ']'
+ for i in '"${!users[@]}"'
+ '[' snapshotrestore == admin ']'
++ curl -XGET https://localhost/status -uadmin:qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3 -k -w '%{http_code}' -s -o /dev/null
+ http_code=200
+ retries=0
+ max_dashboard_initialize_retries=5
+ '[' 200 -ne 200 ']'
+ '[' 200 -eq 200 ']'
+ common_logger 'Wazuh dashboard web application initialized.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 09:24:57'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ case ${1} in
+ message='Wazuh dashboard web application initialized.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 09:24:57 INFO: Wazuh dashboard web application initialized.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 09:24:57 INFO: Wazuh dashboard web application initialized.
+ common_logger -nl '--- Summary ---'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 09:24:57'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n '--- Summary ---' ']'
+ case ${1} in
+ message='--- Summary ---'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 09:24:57 INFO: --- Summary ---'
08/03/2023 09:24:57 INFO: --- Summary ---
+ common_logger -nl 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 09:24:57'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3' ']'
+ case ${1} in
+ message='You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 09:24:57 INFO: You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3'
08/03/2023 09:24:57 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: qUmrc+rxDfPlpmQ.l5sSX4h9omVgCY+3
+ set +ex
08/03/2023 09:24:57 INFO: Installation finished.
```
</details>

<details>
<summary> :green_circle: RHEL 7</summary>

```
[root@redhat7 vagrant]# bash wazuh-install.sh -a 
08/03/2023 15:35:39 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 15:35:39 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 15:35:49 INFO: Wazuh development repository added.
08/03/2023 15:35:49 INFO: --- Configuration files ---
08/03/2023 15:35:49 INFO: Generating configuration files.
08/03/2023 15:35:50 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 15:35:50 INFO: --- Wazuh indexer ---
08/03/2023 15:35:50 INFO: Starting Wazuh indexer installation.
08/03/2023 15:37:39 INFO: Wazuh indexer installation finished.
08/03/2023 15:37:39 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 15:37:39 INFO: Starting service wazuh-indexer.
08/03/2023 15:37:55 INFO: wazuh-indexer service started.
08/03/2023 15:37:55 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 15:38:05 INFO: Wazuh indexer cluster initialized.
08/03/2023 15:38:05 INFO: --- Wazuh server ---
08/03/2023 15:38:05 INFO: Starting the Wazuh manager installation.
08/03/2023 15:39:33 INFO: Wazuh manager installation finished.
08/03/2023 15:39:33 INFO: Starting service wazuh-manager.
08/03/2023 15:39:50 INFO: wazuh-manager service started.
08/03/2023 15:39:50 INFO: Starting Filebeat installation.
08/03/2023 15:40:12 INFO: Filebeat installation finished.
08/03/2023 15:40:54 INFO: Filebeat post-install configuration finished.
08/03/2023 15:40:54 INFO: Starting service filebeat.
08/03/2023 15:40:55 INFO: filebeat service started.
08/03/2023 15:40:55 INFO: --- Wazuh dashboard ---
08/03/2023 15:40:55 INFO: Starting Wazuh dashboard installation.
08/03/2023 15:43:41 INFO: Wazuh dashboard installation finished.
08/03/2023 15:43:42 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 15:43:42 INFO: Starting service wazuh-dashboard.
08/03/2023 15:43:44 INFO: wazuh-dashboard service started.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:wazuh -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMjI4LCJleHAiOjE2NzgyOTExMjgsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AXfiBLEWACD83SagKyYVP38y0L3a8rwlX50rh-ey5X5XBrT3My5uqMxZ6CAErXkK5TkXmUxNXIiYxprfQEYHwpXNAdjui0t0JukK_gOlbShl5O_M4pnZ45AsaNP-0P6mGtgDcxM7eZc2ThbbwURC3wZqKdN4Feei5iaeRb4C-2ZwrLvy
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMjI4LCJleHAiOjE2NzgyOTExMjgsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AXfiBLEWACD83SagKyYVP38y0L3a8rwlX50rh-ey5X5XBrT3My5uqMxZ6CAErXkK5TkXmUxNXIiYxprfQEYHwpXNAdjui0t0JukK_gOlbShl5O_M4pnZ45AsaNP-0P6mGtgDcxM7eZc2ThbbwURC3wZqKdN4Feei5iaeRb4C-2ZwrLvy =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMjI4LCJleHAiOjE2NzgyOTExMjgsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AXfiBLEWACD83SagKyYVP38y0L3a8rwlX50rh-ey5X5XBrT3My5uqMxZ6CAErXkK5TkXmUxNXIiYxprfQEYHwpXNAdjui0t0JukK_gOlbShl5O_M4pnZ45AsaNP-0P6mGtgDcxM7eZc2ThbbwURC3wZqKdN4Feei5iaeRb4C-2ZwrLvy =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMjI4LCJleHAiOjE2NzgyOTExMjgsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AXfiBLEWACD83SagKyYVP38y0L3a8rwlX50rh-ey5X5XBrT3My5uqMxZ6CAErXkK5TkXmUxNXIiYxprfQEYHwpXNAdjui0t0JukK_gOlbShl5O_M4pnZ45AsaNP-0P6mGtgDcxM7eZc2ThbbwURC3wZqKdN4Feei5iaeRb4C-2ZwrLvy =~ Invalid credentials ]]
+ set +ex
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u 'wazuh:R*KUUwxkiaFKP+cpb1yeirioX6YCr8r0' -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMzI3LCJleHAiOjE2NzgyOTEyMjcsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Aa5EOh1r5orzN2HR54JBew9A0Q7uMEViBXnc1h4-E9PnlJKCSBwaL6fAiRTBSH-npTXq-AWK49WKwgOl67ByLi3YARJK1q0HsQ3NjT3iJk694fPuPmofhbEEdrfnGdL2b1ha6iHBtt2TPVtcFKygL7CtfNlAsIZ730dBAtP6oFcAG7Ul
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMzI3LCJleHAiOjE2NzgyOTEyMjcsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Aa5EOh1r5orzN2HR54JBew9A0Q7uMEViBXnc1h4-E9PnlJKCSBwaL6fAiRTBSH-npTXq-AWK49WKwgOl67ByLi3YARJK1q0HsQ3NjT3iJk694fPuPmofhbEEdrfnGdL2b1ha6iHBtt2TPVtcFKygL7CtfNlAsIZ730dBAtP6oFcAG7Ul =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMzI3LCJleHAiOjE2NzgyOTEyMjcsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Aa5EOh1r5orzN2HR54JBew9A0Q7uMEViBXnc1h4-E9PnlJKCSBwaL6fAiRTBSH-npTXq-AWK49WKwgOl67ByLi3YARJK1q0HsQ3NjT3iJk694fPuPmofhbEEdrfnGdL2b1ha6iHBtt2TPVtcFKygL7CtfNlAsIZ730dBAtP6oFcAG7Ul =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4MjkwMzI3LCJleHAiOjE2NzgyOTEyMjcsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Aa5EOh1r5orzN2HR54JBew9A0Q7uMEViBXnc1h4-E9PnlJKCSBwaL6fAiRTBSH-npTXq-AWK49WKwgOl67ByLi3YARJK1q0HsQ3NjT3iJk694fPuPmofhbEEdrfnGdL2b1ha6iHBtt2TPVtcFKygL7CtfNlAsIZ730dBAtP6oFcAG7Ul =~ Invalid credentials ]]
+ set +ex
+ common_logger 'Initializing Wazuh dashboard web application.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:45:37'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ case ${1} in
+ message='Initializing Wazuh dashboard web application.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ tee -a /var/log/wazuh-install.log
+ printf '%s\n' '08/03/2023 15:45:37 INFO: Initializing Wazuh dashboard web application.'
08/03/2023 15:45:37 INFO: Initializing Wazuh dashboard web application.
+ installCommon_getPass admin
+ for i in '"${!users[@]}"'
+ '[' admin == admin ']'
+ u_pass='hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz'
+ for i in '"${!users[@]}"'
+ '[' kibanaserver == admin ']'
+ for i in '"${!users[@]}"'
+ '[' kibanaro == admin ']'
+ for i in '"${!users[@]}"'
+ '[' logstash == admin ']'
+ for i in '"${!users[@]}"'
+ '[' readall == admin ']'
+ for i in '"${!users[@]}"'
+ '[' snapshotrestore == admin ']'
++ curl -XGET https://localhost/status '-uadmin:hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz' -k -w '%{http_code}' -s -o /dev/null
+ http_code=200
+ retries=0
+ max_dashboard_initialize_retries=5
+ '[' 200 -ne 200 ']'
+ '[' 200 -eq 200 ']'
+ common_logger 'Wazuh dashboard web application initialized.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:45:39'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ case ${1} in
+ message='Wazuh dashboard web application initialized.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 15:45:39 INFO: Wazuh dashboard web application initialized.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 15:45:39 INFO: Wazuh dashboard web application initialized.
+ common_logger -nl '--- Summary ---'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:45:39'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n '--- Summary ---' ']'
+ case ${1} in
+ message='--- Summary ---'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 15:45:39 INFO: --- Summary ---'
08/03/2023 15:45:39 INFO: --- Summary ---
+ common_logger -nl 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:45:39'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz' ']'
+ case ${1} in
+ message='You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 15:45:39 INFO: You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz'
08/03/2023 15:45:39 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: hJXm.db1nBi.+*lsg9bxp9BQ3s7?SdDz
+ set +ex
08/03/2023 15:45:39 INFO: Installation finished.
[root@redhat7 vagrant]# 
```
</details>

<details>
<summary> :green_circle: RHEL 8</summary>

```
[root@redhat8 vagrant]# bash wazuh-install.sh -a -o
08/03/2023 14:54:23 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 14:54:23 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 14:54:30 INFO: --- Removing existing Wazuh installation ---
08/03/2023 14:54:30 INFO: Wazuh GPG key not found in the system
08/03/2023 14:54:30 INFO: Installation cleaned.
08/03/2023 14:54:36 INFO: Wazuh development repository added.
08/03/2023 14:54:36 INFO: --- Configuration files ---
08/03/2023 14:54:36 INFO: Generating configuration files.
08/03/2023 14:54:37 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 14:54:38 INFO: --- Wazuh indexer ---
08/03/2023 14:54:38 INFO: Starting Wazuh indexer installation.
08/03/2023 14:57:09 INFO: Wazuh indexer installation finished.
08/03/2023 14:57:09 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 14:57:09 INFO: Starting service wazuh-indexer.
08/03/2023 14:57:29 INFO: wazuh-indexer service started.
08/03/2023 14:57:29 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 14:57:42 INFO: Wazuh indexer cluster initialized.
08/03/2023 14:57:42 INFO: --- Wazuh server ---
08/03/2023 14:57:42 INFO: Starting the Wazuh manager installation.
08/03/2023 14:59:39 INFO: Wazuh manager installation finished.
08/03/2023 14:59:39 INFO: Starting service wazuh-manager.
08/03/2023 14:59:58 INFO: wazuh-manager service started.
08/03/2023 14:59:58 INFO: Starting Filebeat installation.
08/03/2023 15:00:17 INFO: Filebeat installation finished.
08/03/2023 15:00:19 INFO: Filebeat post-install configuration finished.
08/03/2023 15:00:19 INFO: Starting service filebeat.
08/03/2023 15:00:19 INFO: filebeat service started.
08/03/2023 15:00:19 INFO: --- Wazuh dashboard ---
08/03/2023 15:00:19 INFO: Starting Wazuh dashboard installation.
08/03/2023 15:02:30 INFO: Wazuh dashboard installation finished.
08/03/2023 15:02:30 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 15:02:30 INFO: Starting service wazuh-dashboard.
08/03/2023 15:02:31 INFO: wazuh-dashboard service started.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:wazuh -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3NzU5LCJleHAiOjE2NzgyODg2NTksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYTUaIfTiQj7Ahxq_9zlTn-po3MboECXiR0GrKo4nubaujFu6fz_Y-AFeWxn1ONajbNNh5zaZAFK09alENeUZBCCAJmN8iWqsGHtcnDh2DDxatNnEGvNDNVpJkb02n5xy9zHlomF_TPEqId4reMPLxlxWsUX9nGWeUZO0cMVAfbPPY9y
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3NzU5LCJleHAiOjE2NzgyODg2NTksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYTUaIfTiQj7Ahxq_9zlTn-po3MboECXiR0GrKo4nubaujFu6fz_Y-AFeWxn1ONajbNNh5zaZAFK09alENeUZBCCAJmN8iWqsGHtcnDh2DDxatNnEGvNDNVpJkb02n5xy9zHlomF_TPEqId4reMPLxlxWsUX9nGWeUZO0cMVAfbPPY9y =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3NzU5LCJleHAiOjE2NzgyODg2NTksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYTUaIfTiQj7Ahxq_9zlTn-po3MboECXiR0GrKo4nubaujFu6fz_Y-AFeWxn1ONajbNNh5zaZAFK09alENeUZBCCAJmN8iWqsGHtcnDh2DDxatNnEGvNDNVpJkb02n5xy9zHlomF_TPEqId4reMPLxlxWsUX9nGWeUZO0cMVAfbPPY9y =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3NzU5LCJleHAiOjE2NzgyODg2NTksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYTUaIfTiQj7Ahxq_9zlTn-po3MboECXiR0GrKo4nubaujFu6fz_Y-AFeWxn1ONajbNNh5zaZAFK09alENeUZBCCAJmN8iWqsGHtcnDh2DDxatNnEGvNDNVpJkb02n5xy9zHlomF_TPEqId4reMPLxlxWsUX9nGWeUZO0cMVAfbPPY9y =~ Invalid credentials ]]
+ set +ex
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:qTij8P25cZmPwcW.FCbiPjodh9PTnAuJ -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3ODEwLCJleHAiOjE2NzgyODg3MTAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ae-gXrnkg0PkDK8BR-UoJouugwneviPxYSsBu_dEsHYMtGW4nRmpE5_0MUdS7iQkIgUqh6K-V2uRlNBPnlD5c4hgAImmGWAknk2dzLYkl1vM3Eu2_6zWrnTKc-494C8hfsyCjjtmxV-BBTFZHzx-J3yQw5_9JR5xNg4q9xY1tG6OVP_9
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3ODEwLCJleHAiOjE2NzgyODg3MTAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ae-gXrnkg0PkDK8BR-UoJouugwneviPxYSsBu_dEsHYMtGW4nRmpE5_0MUdS7iQkIgUqh6K-V2uRlNBPnlD5c4hgAImmGWAknk2dzLYkl1vM3Eu2_6zWrnTKc-494C8hfsyCjjtmxV-BBTFZHzx-J3yQw5_9JR5xNg4q9xY1tG6OVP_9 =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3ODEwLCJleHAiOjE2NzgyODg3MTAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ae-gXrnkg0PkDK8BR-UoJouugwneviPxYSsBu_dEsHYMtGW4nRmpE5_0MUdS7iQkIgUqh6K-V2uRlNBPnlD5c4hgAImmGWAknk2dzLYkl1vM3Eu2_6zWrnTKc-494C8hfsyCjjtmxV-BBTFZHzx-J3yQw5_9JR5xNg4q9xY1tG6OVP_9 =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg3ODEwLCJleHAiOjE2NzgyODg3MTAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ae-gXrnkg0PkDK8BR-UoJouugwneviPxYSsBu_dEsHYMtGW4nRmpE5_0MUdS7iQkIgUqh6K-V2uRlNBPnlD5c4hgAImmGWAknk2dzLYkl1vM3Eu2_6zWrnTKc-494C8hfsyCjjtmxV-BBTFZHzx-J3yQw5_9JR5xNg4q9xY1tG6OVP_9 =~ Invalid credentials ]]
+ set +ex
+ common_logger 'Initializing Wazuh dashboard web application.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:03:36'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ case ${1} in
+ message='Initializing Wazuh dashboard web application.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 15:03:36 INFO: Initializing Wazuh dashboard web application.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 15:03:36 INFO: Initializing Wazuh dashboard web application.
+ installCommon_getPass admin
+ for i in "${!users[@]}"
+ '[' admin == admin ']'
+ u_pass='rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV'
+ for i in "${!users[@]}"
+ '[' kibanaserver == admin ']'
+ for i in "${!users[@]}"
+ '[' kibanaro == admin ']'
+ for i in "${!users[@]}"
+ '[' logstash == admin ']'
+ for i in "${!users[@]}"
+ '[' readall == admin ']'
+ for i in "${!users[@]}"
+ '[' snapshotrestore == admin ']'
++ curl -XGET https://localhost/status '-uadmin:rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV' -k -w '%{http_code}' -s -o /dev/null
+ http_code=200
+ retries=0
+ max_dashboard_initialize_retries=5
+ '[' 200 -ne 200 ']'
+ '[' 200 -eq 200 ']'
+ common_logger 'Wazuh dashboard web application initialized.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:03:38'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ case ${1} in
+ message='Wazuh dashboard web application initialized.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 15:03:38 INFO: Wazuh dashboard web application initialized.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 15:03:38 INFO: Wazuh dashboard web application initialized.
+ common_logger -nl '--- Summary ---'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:03:38'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n '--- Summary ---' ']'
+ case ${1} in
+ message='--- Summary ---'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 15:03:38 INFO: --- Summary ---'
08/03/2023 15:03:38 INFO: --- Summary ---
+ common_logger -nl 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 15:03:38'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV' ']'
+ case ${1} in
+ message='You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 15:03:38 INFO: You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV'
08/03/2023 15:03:38 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: rTMtLNDBJ*5nrT2jfVVgxy4J+4PlkhmV
+ set +ex
08/03/2023 15:03:38 INFO: Installation finished.
```
</details>

<details>
<summary>:green_circle: RHEL 9</summary>

```
[root@redhat9 vagrant]# bash wazuh-install.sh -a -i -o
08/03/2023 16:21:45 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:21:45 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:21:49 INFO: --- Removing existing Wazuh installation ---
08/03/2023 16:21:49 INFO: Removing Wazuh manager.
08/03/2023 16:22:17 INFO: Wazuh manager removed.
08/03/2023 16:22:17 INFO: Removing Wazuh indexer.
08/03/2023 16:22:21 INFO: Wazuh indexer removed.
08/03/2023 16:22:21 INFO: Removing Filebeat.
08/03/2023 16:22:24 INFO: Filebeat removed.
08/03/2023 16:22:24 INFO: Removing Wazuh dashboard.
08/03/2023 16:22:38 INFO: Wazuh dashboard removed.
08/03/2023 16:22:38 INFO: Installation cleaned.
08/03/2023 16:22:38 WARNING: Hardware and system checks ignored.
08/03/2023 16:22:43 INFO: Wazuh development repository added.
08/03/2023 16:22:43 INFO: --- Configuration files ---
08/03/2023 16:22:43 INFO: Generating configuration files.
08/03/2023 16:22:46 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:22:46 INFO: --- Wazuh indexer ---
08/03/2023 16:22:46 INFO: Starting Wazuh indexer installation.
08/03/2023 16:24:34 INFO: Wazuh indexer installation finished.
08/03/2023 16:24:34 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:24:34 INFO: Starting service wazuh-indexer.
08/03/2023 16:24:51 INFO: wazuh-indexer service started.
08/03/2023 16:24:51 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:25:05 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:25:05 INFO: --- Wazuh server ---
08/03/2023 16:25:05 INFO: Starting the Wazuh manager installation.
08/03/2023 16:27:25 INFO: Wazuh manager installation finished.
08/03/2023 16:27:25 INFO: Starting service wazuh-manager.
08/03/2023 16:27:36 INFO: wazuh-manager service started.
08/03/2023 16:27:36 INFO: Starting Filebeat installation.
08/03/2023 16:27:53 INFO: Filebeat installation finished.
08/03/2023 16:27:57 INFO: Filebeat post-install configuration finished.
08/03/2023 16:27:57 INFO: Starting service filebeat.
08/03/2023 16:27:57 INFO: filebeat service started.
08/03/2023 16:27:57 INFO: --- Wazuh dashboard ---
08/03/2023 16:27:57 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:30:05 INFO: Wazuh dashboard installation finished.
08/03/2023 16:30:06 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:30:06 INFO: Starting service wazuh-dashboard.
08/03/2023 16:30:06 INFO: wazuh-dashboard service started.
08/03/2023 16:31:44 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:31:53 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:31:54 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:31:55 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:31:57 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:31:58 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:31:59 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:31:59 INFO: --- Summary ---
08/03/2023 16:31:59 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: NF9Dn4ytOoAD3cwVnb3Ajt.e?Ikn90Zu
08/03/2023 16:31:59 INFO: Installation finished.
[root@redhat9 vagrant]# 
```
</details>

#### Test AIO on machines with limited resources (2GB and 1 cores):
<details>
<summary> :green_circle: CentOS 9 Stream</summary>

```
[root@centos9stream vagrant]# bash wazuh-install.sh -a -i -o -v
08/03/2023 14:27:14 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 14:27:14 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 14:27:18 INFO: --- Removing existing Wazuh installation ---
08/03/2023 14:27:18 INFO: Wazuh GPG key not found in the system
08/03/2023 14:27:18 INFO: Installation cleaned.
08/03/2023 14:27:18 WARNING: Hardware and system checks ignored.
08/03/2023 14:27:22 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/pre-release/yum/
protect=1
08/03/2023 14:27:23 INFO: Wazuh development repository added.
08/03/2023 14:27:23 INFO: --- Configuration files ---
08/03/2023 14:27:23 INFO: Generating configuration files.
08/03/2023 14:27:23 DEBUG: Creating the root certificate.
..................+....+..+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+.......+......+..+.......+...+...+..................+......+...+...............+...+...+.....+....+...............+......+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.......+.....+.+..+.....................+.+...+...+..+...+.......+......+...........+......+....+...........+...................+.....+..........+......+.......................+......+....+.........+..+....+.........+.....+.............+...+.....+......+...+................+..+...+.+...+...+..............+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.....+....+..+.......+...+.......................+....+........+.........+...+...+.............+..+....+...+...+...............+........+.+...+...+........+.+.....+.+.................+.....................+.........+.+......+......+..................+..+.......+.....+...+.........+.+...+.....+....+......+..+.........+....+.........+...+..+.+..+.........+...+.+......+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.................+.........+..................+...........+.+...+..+....+.....+.......+........+.........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+...+..+...+.......+.........+.....+....+.........+.....+...+...+....+......+..+..........+....................+...+.+...+...+..+................+...............+..+............+..........+..+......+...+......+.+..+...+....+........+.+.....................+........+.+......+........+......+...................+..+.............+.................+.............+...+...+.....+....+..+.+.................+.+...........+.+..+......+.+..............+....+............+.....+...+...+.......+...+...+..+....+........+.......+.....+......+...+.......+.....+...+......+.............+......+..+....+........+.+.........+........+...+.+...+..+....+............+..+......+.........+...+...+....+......+..+...+.......+..............+....+......+...+.....+......+....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
08/03/2023 14:27:24 DEBUG: Creating the Wazuh indexer certificates.
Ignoring -days without -x509; not generating a certificate
.+..+...+......+.+..............+.+..............+...+...+....+.....+....+..+.........................+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+......+......+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
..........+.+.....+............+.......+......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*......+.....+.+...........+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+..........+.....+.+.....+............+..........+................................+...+.......+.....+.+.....+....+...+........+.........+......+.........+......+.+...+..+...+...+....+...........+...............+....+...+......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-indexer
08/03/2023 14:27:25 DEBUG: Creating the Wazuh server certificates.
Ignoring -days without -x509; not generating a certificate
....+.....+.........+.......+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..........+..+..........+...+..+......+.........+.+..+.+..+.........+.............+...........+.+......+...............+..+...+...+.......+............+...+........+....+..+...............+...+...+...+.......+..+............+...+.+......+.....+...+.+......+.....+.........+.+.....+....+.........+......+..............+......+.......+........+....+...+..+.+...........+......+.......+.....+............+.+...............+.....+....+.........+..............+...+....+...+..+..........+......+..+.......+...+...+..+......+....+...+...+.....+....+..+....+.........+..+..........+...+.....+...+..........+.........+.....+..........+.....+...+.......+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
..+......+.....+......+.......+...+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*......+.......+...+......+..+...+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+....+........+.+.....+.+......+....................+.......+...+........+....+............+.........+..+...+.......+.....+.........+.+..+.......+.....+.+.....+.........+.............+..+.....................+....+.....+...+.+......+........+......+..........+..............+..........+..+..........+...........+.......+...+..+.+..............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-server
08/03/2023 14:27:25 DEBUG: Creating the Wazuh dashboard certificates.
Ignoring -days without -x509; not generating a certificate
........+......+..+.......+........+.......+.....+.........+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+..+...+....+.....+.........+.+.........+..+....+........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+.....+......+.........+......+....+.....+......+.........+..........+..+...+.........+...............+.+..+...+.+..............+......+.+..+.......+........+..................+..........+............+...+.....+....+.........+.........+...+..+.+......+...+..+..........+........+...+.........+.........+....+........+...+....+..+.+..............+.........+.+......+..+......+.+......+..+.......+...............+.....+.........+....+..+.+............+.....+.+..+...............+.......+......+.....+......+...+......+.+.........+..+...............+...+..........+.........+...+..+..........+....................+...+.......+......+...........+....+..+....+...........+....+.....+.+...+..+.......+..+...+.+.........+......+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.....+.+.....+.........+......+.......+........+....+......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..........+....+...+......+..............+.....................+.......+..+...+...+.+.....+....+...............+..+..........+..+............+....+...............+......+...........+....+......+.....+...+....+.....+......+.+.....+....+..+....+........+...+..................+..........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+..................+......+..+............+.+...........+.........+.......+.....+....+...+............+.....+...+...+...+....+............+........................+..+.......+..+....+..+...+.+....................+...+............+...+.............+........+.+......+...+..............+..................+............+.+..+...+.+.....+.+........+.......+.....+.......+...+..+...+...+....+..+.+...+..+.......+...+.....+.........+...+......+.......+.....+...+.+.....+.+...+...........+...+.+.....+...................+........+.......+.....+...+.......+......+...............+.....+......+.+..............+....+.........+.................+....+..+.........+...+.....................+.........+...+.......+..+.+........+......+..........+...+.....+......+......+......+..........+...+......+.....+...+.+..+.......+...+.........+...+.....+............+.+............+............+...........+...+.......+..+.......+.....+......+..........+..+......+.......+..+.+.....................+...+..+.+..+...+...+...............+.......+....................+.......+.....+...+.......+.................+.........+.+..............+..........+..+.......+...+.....+.........+.........+....+...........+....+..+...+............+...+......+.+......+..+...+....+.....+......+...................+........+.+............+..+................+.....+......+....+.....+.+...+...+.....+...+....+...+.....+...+........................+.+.....+............+..........+...+......+.........+..+...+.......+........+....+........+.......+...+...+.........+..+....+..+.............+......+........+............+...+.+.....+.+.....+.+..+................+.........+............+.....+...+...+...+....+...+...+.....+....+...+.........+......+..+...+...+.+...+..+..........+...+...........+.......+..+...+.......+..+.........+.+........................+......+........+............................+...............+.....+..................+.+.........+.....+......+...............+.+.....+.......+...+..+..........+..+......+...+......+....+......+...+..+.............+........+...+......+...+......+.......+..+.......+........+.......+......+..................+...............+.....+.........+............+.+..+.+..............+..........+..+...+................+..............+..........+............+...+......+..+...+......+.........+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-dashboard
08/03/2023 14:27:27 DEBUG: Generating random passwords.
08/03/2023 14:27:27 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 14:27:27 INFO: --- Wazuh indexer ---
08/03/2023 14:27:27 INFO: Starting Wazuh indexer installation.
Extra Packages for Enterprise Linux 9 - x86_64  3.3 kB/s |  29 kB     00:08    
Extra Packages for Enterprise Linux 9 - Next -   14 kB/s |  28 kB     00:02    
EL-9 - Wazuh                                    2.6 kB/s | 3.4 kB     00:01    
Dependencies resolved.
================================================================================
 Package                Architecture    Version            Repository      Size
================================================================================
Installing:
 wazuh-indexer          x86_64          4.3.10-1           wazuh          361 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 361 M
Installed size: 614 M
Downloading Packages:
wazuh-indexer-4.3.10-1.x86_64.rpm               3.3 MB/s | 361 MB     01:49    
--------------------------------------------------------------------------------
Total                                           3.3 MB/s | 361 MB     01:49     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Running scriptlet: wazuh-indexer-4.3.10-1.x86_64                          1/1 
  Installing       : wazuh-indexer-4.3.10-1.x86_64                          1/1 
  Running scriptlet: wazuh-indexer-4.3.10-1.x86_64                          1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore

Couldn't write '64' to 'kernel/random/read_wakeup_threshold', ignoring: No such file or directory

  Verifying        : wazuh-indexer-4.3.10-1.x86_64                          1/1 

Installed:
  wazuh-indexer-4.3.10-1.x86_64                                                 

Complete!
08/03/2023 14:30:24 INFO: Wazuh indexer installation finished.
08/03/2023 14:30:24 DEBUG: Configuring Wazuh indexer.
08/03/2023 14:30:25 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 14:30:25 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /usr/lib/systemd/system/wazuh-indexer.service.
08/03/2023 14:30:49 INFO: wazuh-indexer service started.
08/03/2023 14:30:49 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
08/03/2023 14:31:04 INFO: Wazuh indexer cluster initialized.
08/03/2023 14:31:04 INFO: --- Wazuh server ---
08/03/2023 14:31:04 INFO: Starting the Wazuh manager installation.
Extra Packages for Enterprise Linux 9 - x86_64   96 kB/s |  29 kB     00:00    
Extra Packages for Enterprise Linux 9 - Next -  105 kB/s |  28 kB     00:00    
EL-9 - Wazuh                                    2.7 kB/s | 3.4 kB     00:01    
Dependencies resolved.
================================================================================
 Package                Architecture    Version            Repository      Size
================================================================================
Installing:
 wazuh-manager          x86_64          4.3.10-1           wazuh          115 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 115 M
Installed size: 438 M
Downloading Packages:
wazuh-manager-4.3.10-1.x86_64.rpm               4.4 MB/s | 115 MB     00:25    
--------------------------------------------------------------------------------
Total                                           4.4 MB/s | 115 MB     00:25     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Running scriptlet: wazuh-manager-4.3.10-1.x86_64                          1/1 
  Installing       : wazuh-manager-4.3.10-1.x86_64                          1/1 
  Running scriptlet: wazuh-manager-4.3.10-1.x86_64                          1/1 
  Verifying        : wazuh-manager-4.3.10-1.x86_64                          1/1 

Installed:
  wazuh-manager-4.3.10-1.x86_64                                                 

Complete!
08/03/2023 14:33:02 INFO: Wazuh manager installation finished.
08/03/2023 14:33:02 INFO: Starting service wazuh-manager.
Synchronizing state of wazuh-manager.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable wazuh-manager
Failed to execute /usr/lib/systemd/systemd-sysv-install: No such file or directory
08/03/2023 14:33:27 INFO: wazuh-manager service started.
08/03/2023 14:33:27 INFO: Starting Filebeat installation.

Installed:
  filebeat-7.10.2-1.x86_64                                                      

08/03/2023 14:34:10 INFO: Filebeat installation finished.
wazuh/
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
08/03/2023 14:34:12 INFO: Filebeat post-install configuration finished.
08/03/2023 14:34:12 INFO: Starting service filebeat.
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /usr/lib/systemd/system/filebeat.service.
08/03/2023 14:34:14 INFO: filebeat service started.
08/03/2023 14:34:14 INFO: --- Wazuh dashboard ---
08/03/2023 14:34:14 INFO: Starting Wazuh dashboard installation.
Extra Packages for Enterprise Linux 9 - x86_64   17 kB/s |  29 kB     00:01    
Extra Packages for Enterprise Linux 9 - Next -   55 kB/s |  28 kB     00:00    
EL-9 - Wazuh                                    2.8 kB/s | 3.4 kB     00:01    
Dependencies resolved.
================================================================================
 Package                 Architecture   Version             Repository     Size
================================================================================
Installing:
 wazuh-dashboard         x86_64         4.3.10-1            wazuh         150 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 150 M
Installed size: 587 M
Downloading Packages:
wazuh-dashboard-4.3.10-1.x86_64.rpm             4.7 MB/s | 150 MB     00:31    
--------------------------------------------------------------------------------
Total                                           4.7 MB/s | 150 MB     00:31     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Running scriptlet: wazuh-dashboard-4.3.10-1.x86_64                        1/1 
  Installing       : wazuh-dashboard-4.3.10-1.x86_64                        1/1 
  Running scriptlet: wazuh-dashboard-4.3.10-1.x86_64                        1/1 
  Verifying        : wazuh-dashboard-4.3.10-1.x86_64                        1/1 

Installed:
  wazuh-dashboard-4.3.10-1.x86_64                                               

Complete!
08/03/2023 14:36:49 INFO: Wazuh dashboard installation finished.
08/03/2023 14:36:49 DEBUG: Wazuh dashboard certificate setup finished.
08/03/2023 14:36:49 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 14:36:49 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
08/03/2023 14:36:50 INFO: wazuh-dashboard service started.
08/03/2023 14:36:50 DEBUG: Setting Wazuh indexer cluster passwords.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:wazuh -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MjMzLCJleHAiOjE2NzgyODcxMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AfxYls4dbi2F_SewFbeYRL5ESsEugqc4itQqvZ8P7NRn6T8g3w3GAzd6ZxYaiEJ3HUNusA5Uoy0Gxoh_yp9pdN-nAXLk87pQSZER6iIo4RHihhf_71DreshKeNovKKV6ntpB69TSgxbVhKXRhbki9VkbZfILnLQRviDdDdFKA6EIDSTv
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MjMzLCJleHAiOjE2NzgyODcxMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AfxYls4dbi2F_SewFbeYRL5ESsEugqc4itQqvZ8P7NRn6T8g3w3GAzd6ZxYaiEJ3HUNusA5Uoy0Gxoh_yp9pdN-nAXLk87pQSZER6iIo4RHihhf_71DreshKeNovKKV6ntpB69TSgxbVhKXRhbki9VkbZfILnLQRviDdDdFKA6EIDSTv =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MjMzLCJleHAiOjE2NzgyODcxMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AfxYls4dbi2F_SewFbeYRL5ESsEugqc4itQqvZ8P7NRn6T8g3w3GAzd6ZxYaiEJ3HUNusA5Uoy0Gxoh_yp9pdN-nAXLk87pQSZER6iIo4RHihhf_71DreshKeNovKKV6ntpB69TSgxbVhKXRhbki9VkbZfILnLQRviDdDdFKA6EIDSTv =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MjMzLCJleHAiOjE2NzgyODcxMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AfxYls4dbi2F_SewFbeYRL5ESsEugqc4itQqvZ8P7NRn6T8g3w3GAzd6ZxYaiEJ3HUNusA5Uoy0Gxoh_yp9pdN-nAXLk87pQSZER6iIo4RHihhf_71DreshKeNovKKV6ntpB69TSgxbVhKXRhbki9VkbZfILnLQRviDdDdFKA6EIDSTv =~ Invalid credentials ]]
+ set +ex
08/03/2023 14:37:22 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '_doc/config' into /usr/share/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /usr/share/wazuh-indexer/backup/config.yml
Will retrieve '_doc/roles' into /usr/share/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /usr/share/wazuh-indexer/backup/roles.yml
Will retrieve '_doc/rolesmapping' into /usr/share/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /usr/share/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '_doc/internalusers' into /usr/share/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /usr/share/wazuh-indexer/backup/internal_users.yml
Will retrieve '_doc/actiongroups' into /usr/share/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /usr/share/wazuh-indexer/backup/action_groups.yml
Will retrieve '_doc/tenants' into /usr/share/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /usr/share/wazuh-indexer/backup/tenants.yml
Will retrieve '_doc/nodesdn' into /usr/share/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /usr/share/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '_doc/whitelist' into /usr/share/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /usr/share/wazuh-indexer/backup/whitelist.yml
Will retrieve '_doc/audit' into /usr/share/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /usr/share/wazuh-indexer/backup/audit.yml
08/03/2023 14:37:56 DEBUG: Password backup created in /usr/share/wazuh-indexer/backup.
08/03/2023 14:37:56 DEBUG: Generating password hashes.
08/03/2023 14:38:06 DEBUG: Password hashes generated.
Successfully updated the keystore
08/03/2023 14:38:08 DEBUG: filebeat started.
08/03/2023 14:38:10 DEBUG: wazuh-dashboard started.
08/03/2023 14:38:10 DEBUG: Loading new passwords changes.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
08/03/2023 14:38:36 DEBUG: Passwords changed.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u 'wazuh:g2FL43qE6ZRL85ix8s.yLFIxMpnC?9Db' -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MzIwLCJleHAiOjE2NzgyODcyMjAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYte6xTo6WzMa4RQEXV0O4sIG-zB_ttQ51Xr1brO9n9lf_ot1kY6WG2cjEVNjVvJhnyP5wbd2YWMyCp7A4-tpCs3AaW3W0gnVT6ZiwK0RzdZpbkxzSi4b9hq72EDFYeYi2JXeYzqdC8notp5p7WR9I5sY0j5KYy1wbmPyzhdcWpVDZ1Y
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MzIwLCJleHAiOjE2NzgyODcyMjAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYte6xTo6WzMa4RQEXV0O4sIG-zB_ttQ51Xr1brO9n9lf_ot1kY6WG2cjEVNjVvJhnyP5wbd2YWMyCp7A4-tpCs3AaW3W0gnVT6ZiwK0RzdZpbkxzSi4b9hq72EDFYeYi2JXeYzqdC8notp5p7WR9I5sY0j5KYy1wbmPyzhdcWpVDZ1Y =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MzIwLCJleHAiOjE2NzgyODcyMjAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYte6xTo6WzMa4RQEXV0O4sIG-zB_ttQ51Xr1brO9n9lf_ot1kY6WG2cjEVNjVvJhnyP5wbd2YWMyCp7A4-tpCs3AaW3W0gnVT6ZiwK0RzdZpbkxzSi4b9hq72EDFYeYi2JXeYzqdC8notp5p7WR9I5sY0j5KYy1wbmPyzhdcWpVDZ1Y =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MzIwLCJleHAiOjE2NzgyODcyMjAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AYte6xTo6WzMa4RQEXV0O4sIG-zB_ttQ51Xr1brO9n9lf_ot1kY6WG2cjEVNjVvJhnyP5wbd2YWMyCp7A4-tpCs3AaW3W0gnVT6ZiwK0RzdZpbkxzSi4b9hq72EDFYeYi2JXeYzqdC8notp5p7WR9I5sY0j5KYy1wbmPyzhdcWpVDZ1Y =~ Invalid credentials ]]
+ set +ex
+ common_logger 'Initializing Wazuh dashboard web application.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:38:47'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ case ${1} in
+ message='Initializing Wazuh dashboard web application.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 14:38:47 INFO: Initializing Wazuh dashboard web application.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 14:38:47 INFO: Initializing Wazuh dashboard web application.
+ installCommon_getPass admin
+ for i in "${!users[@]}"
+ '[' admin == admin ']'
+ u_pass='aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj'
+ for i in "${!users[@]}"
+ '[' kibanaserver == admin ']'
+ for i in "${!users[@]}"
+ '[' kibanaro == admin ']'
+ for i in "${!users[@]}"
+ '[' logstash == admin ']'
+ for i in "${!users[@]}"
+ '[' readall == admin ']'
+ for i in "${!users[@]}"
+ '[' snapshotrestore == admin ']'
++ curl -XGET https://localhost/status '-uadmin:aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj' -k -w '%{http_code}' -s -o /dev/null
+ http_code=200
+ retries=0
+ max_dashboard_initialize_retries=5
+ '[' 200 -ne 200 ']'
+ '[' 200 -eq 200 ']'
+ common_logger 'Wazuh dashboard web application initialized.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:38:48'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ case ${1} in
+ message='Wazuh dashboard web application initialized.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 14:38:48 INFO: Wazuh dashboard web application initialized.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 14:38:48 INFO: Wazuh dashboard web application initialized.
+ common_logger -nl '--- Summary ---'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:38:48'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n '--- Summary ---' ']'
+ case ${1} in
+ message='--- Summary ---'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 14:38:48 INFO: --- Summary ---'
08/03/2023 14:38:48 INFO: --- Summary ---
+ common_logger -nl 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:38:48'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj' ']'
+ case ${1} in
+ message='You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 14:38:48 INFO: You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj'
08/03/2023 14:38:48 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: aM9ftmy.eowV5wVPLK8DMDzEpxYE?Hmj
+ set +ex
08/03/2023 14:38:49 INFO: Installation finished.
[root@centos9stream vagrant]# exit
```
</details>

<details>
<summary> :green_circle: Ubuntu 22</summary>

```
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -v -o
08/03/2023 14:24:00 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 14:24:00 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 14:24:01 INFO: --- Removing existing Wazuh installation ---
08/03/2023 14:24:01 INFO: Removing Wazuh manager.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-manager*
0 upgraded, 0 newly installed, 1 to remove and 58 not upgraded.
After this operation, 460 MB disk space will be freed.
(Reading database ... 154136 files and directories currently installed.)... 
Removing wazuh-manager (4.3.10-1) ...
(Reading database ... 135463 files and directories currently installed.)
Purging configuration files for wazuh-manager (4.3.10-1) ...
08/03/2023 14:25:45 INFO: Wazuh manager removed.
08/03/2023 14:25:45 INFO: Removing Wazuh indexer.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 58 not upgraded.
After this operation, 639 MB disk space will be freed.
(Reading database ... 135445 files and directories currently installed.)... 
Removing wazuh-indexer (4.3.10-1) ...
Stopping wazuh-indexer service... OK
(Reading database ... 134513 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.3.10-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/usr/lib/systemd/system' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
08/03/2023 14:25:56 INFO: Wazuh indexer removed.
08/03/2023 14:25:56 INFO: Removing Filebeat.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  filebeat*
0 upgraded, 0 newly installed, 1 to remove and 58 not upgraded.
After this operation, 73.6 MB disk space will be freed.
(Reading database ... 134500 files and directories currently installed.) ... 
Removing filebeat (7.10.2) ...
(Reading database ... 134208 files and directories currently installed.)
Purging configuration files for filebeat (7.10.2) ...
dpkg: warning: while removing filebeat, directory '/etc/filebeat' not empty so not removed
dpkg: warning: while removing filebeat, directory '/usr/share/filebeat/module' not empty so not removed
08/03/2023 14:25:59 INFO: Filebeat removed.
08/03/2023 14:25:59 INFO: Removing Wazuh dashboard.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-dashboard*
0 upgraded, 0 newly installed, 1 to remove and 58 not upgraded.
After this operation, 635 MB disk space will be freed.
(Reading database ... 134181 files and directories currently installed.)... 
Removing wazuh-dashboard (4.3.10-1) ...
Stopping wazuh-dashboard service... OK
Deleting PID directory... OK
Deleting installation directory... OK
(Reading database ... 75657 files and directories currently installed.)
Purging configuration files for wazuh-dashboard (4.3.10-1) ...
 OK
08/03/2023 14:26:06 INFO: Wazuh dashboard removed.
08/03/2023 14:26:09 INFO: Installation cleaned.
08/03/2023 14:26:09 WARNING: Hardware and system checks ignored.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Reading package lists...
Building dependency tree...
Reading state information...
58 packages can be upgraded. Run 'apt list --upgradable' to see them.
08/03/2023 14:26:22 DEBUG: Adding the Wazuh repository.
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [26.6 kB]
Fetched 43.8 kB in 2s (26.3 kB/s)
Reading package lists...
W: https://packages-dev.wazuh.com/pre-release/apt/dists/unstable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
08/03/2023 14:26:28 INFO: Wazuh development repository added.
08/03/2023 14:26:28 INFO: --- Configuration files ---
08/03/2023 14:26:28 INFO: Generating configuration files.
08/03/2023 14:26:28 DEBUG: Creating the root certificate.
.....+.+...+..+.......+..+......+...+......+....+.........+...+...+......+.....+....+............+.....+....+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+...+.......+.....+...+.......+..+.......+......+.....+...............+...+....+..+...............+....+..+....+........+.+..+.......+........+.........+.........+.+.....+.........+....+...........+....+......+..+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+........................+...+.+.....+.+...+..+...+................+.........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
........+..........+......+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*......+.........+.....+.........+......+....+...+........+............+...+.+.....+...+.......+...+...+...+...........+...............+...+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+.....+.........+.+..+.........+....+.....+.+......+..+......+................+....................+.+............+.....+.+..+.......+...+........+......+.+..+.............+.....+....+.....+......+...+.+.........+.....+............+............+...+...+.......+..+.+......+...+...+..+............+.+...+..+...+.+........+...............................+.................+............+...+...+..........+..............+.+.....+.+.....+...+.............+....................+....+...............+...+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
08/03/2023 14:26:29 DEBUG: Creating the Wazuh indexer certificates.
Ignoring -days without -x509; not generating a certificate
.+..............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+.+.....+.+......+...+.....+.+......+..+......+.........+......+.......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+...+..................+.........+...+...........+.........+............+.+...+.....+..........+..+.......+..+.+..+.......+...+..+....+............+.....+.......+..+......+.......+...........+.........+.......+.....+...+.......+......+..+...+...+.+......+...+.....+........................+.+.....+...................+..+.+...............+..+.+..+..........+..+......+....+...........+....+..+....+......+...+.....................+..+....+.....+....+............+.....+...+....+..+.........+......+....+..............+...............+.............+.....+...+....+.....+......+......+...+......+.+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+......+...+...+...+......+.........+.......+...........................+...+.....+...+....+.................+.+............+..+...+.......+......+.....+.......+..+.+....................+...+.+.....................+..+......+.+...........+.........+......+...+....+...............+.....+..........+..+..........+...+...+...+..............+............+...+.+...........+...+.......+...+..+.+...+.....+....+..+.+.........+...+......+.................+.........+.+...............+..+.+.....+......+...+..................+............+...............+.+..+...+.+.......................+.+...........+......+...+....+...+..+......+.+...+..+.+............+..+......+......................+...+..+......+.......+...+......+.....+....+...........+..........+..............+..........+......+.....+...+..........+.....+...+.......+..+...+.+.....+..........+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-indexer
08/03/2023 14:26:30 DEBUG: Creating the Wazuh server certificates.
Ignoring -days without -x509; not generating a certificate
....+.+..+.+..+.......+...+..+.......+..................+..+.+.........+.........+...............+.....+.......+..+............+....+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+.......+...+...............+...+..+.+.....+......+.+..+......+.+.....+.+.....+...+.+......+........+....+.....+................+......+......+...+......+...+.....+.+...........+.............+...+........+............+............+.......+........+.+..+...+.......+.....+.......+.....+......+.........+......+....+........+...+.....................+.+............+..+...+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
...+.......+...+...+..............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.............+.........+.+.....+...+...+.......+...+.....+...+......+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*............+.+.........+..+....+......+.........+.....+......+.+.........+.....+......+...+.+........+.......+...+..+.+...+..+...+.......+.....+.............+..+...+.+......+...+......+...+..+.+..............+...+...+...+......................+...+..+..........+..+..........+.....+.+......+...............+.....+...............+...+...+....+...........+.......+......+.........+........+....+........+.+.........+...+........+.+...+..+.+.................+.+............+.....+...+.+...+........+.........+......+.......+..+.........+.+...+...+...+......+.....+...+.+.................+....+...+..+.........+....+..+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-server
08/03/2023 14:26:30 DEBUG: Creating the Wazuh dashboard certificates.
Ignoring -days without -x509; not generating a certificate
...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+...+...+...+....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+...........+....+.....+.+...+.....+......+......+.+............+..+....+..+....+...........+..........+..+.+...........+....+...........+....+.........+...+..+...+...+....+......+.....+......+......+.............+..+....+........+.+.....+......+.+..+............................+.........+..............+.....................+...+...+...+.+...............+........+.+.....+.+...........+.........+......+....+.....+....+..+...................+.....+................+..+.+..+..........+..+...............+......+....+...+........+....+...+.....+.............+.........+.....+.............+.....+...+....+...+........+................+...+.....+......+......+....+...........+....+..+.......+......+.....+.+...+............+.....................+..+...+...+....+...+.....+....+.........+.....+.......+...+..+.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
...+.....+...+..................+.......+..+.+...........+....+.........+...+...+.....+......+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+......+......+...+..+..........+........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.......+...+....+......+..+......+.+.....+.+..+.......+..............+......+......+.......+..+.+...+..+..................+....+.....+.+.........+..+.+..+......+......+......+.......+...+........+.+...........+.......+...+.........+........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-dashboard
08/03/2023 14:26:31 DEBUG: Generating random passwords.
08/03/2023 14:26:31 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 14:26:31 INFO: --- Wazuh indexer ---
08/03/2023 14:26:31 INFO: Starting Wazuh indexer installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 58 not upgraded.
                                                               Need to get 0 B/357 MB of archives.
                                                                                                  After this operation, 639 MB of additional disk space will be used.
                                                                                                                                                                     Selecting previously unselected package wazuh-indexer.
(Reading database ... 75648 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.3.10-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.3.10-1) ...
Setting up wazuh-indexer (4.3.10-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
NEEDRESTART-VER: 3.5
NEEDRESTART-KCUR: 5.15.0-58-generic
NEEDRESTART-KEXP: 5.15.0-58-generic
NEEDRESTART-KSTA: 1
NEEDRESTART-SVC: filebeat.service
08/03/2023 14:27:28 INFO: Wazuh indexer installation finished.
08/03/2023 14:27:28 DEBUG: Configuring Wazuh indexer.
08/03/2023 14:27:28 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 14:27:28 INFO: Starting service wazuh-indexer.
Synchronizing state of wazuh-indexer.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
08/03/2023 14:27:59 INFO: wazuh-indexer service started.
08/03/2023 14:27:59 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
08/03/2023 14:28:14 INFO: Wazuh indexer cluster initialized.
08/03/2023 14:28:14 INFO: --- Wazuh server ---
08/03/2023 14:28:14 INFO: Starting the Wazuh manager installation.
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 59 not upgraded.
                                                               Need to get 0 B/120 MB of archives.
                                                                                                  After this operation, 460 MB of additional disk space will be used.
                                                                                                                                                                     Selecting previously unselected package wazuh-manager.
(Reading database ... 76593 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.3.10-1_amd64.deb ...
Unpacking wazuh-manager (4.3.10-1) ...
Setting up wazuh-manager (4.3.10-1) ...
NEEDRESTART-VER: 3.5
NEEDRESTART-KCUR: 5.15.0-58-generic
NEEDRESTART-KEXP: 5.15.0-58-generic
NEEDRESTART-KSTA: 1
NEEDRESTART-SVC: filebeat.service
08/03/2023 14:29:26 INFO: Wazuh manager installation finished.
08/03/2023 14:29:26 INFO: Starting service wazuh-manager.
Synchronizing state of wazuh-manager.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable wazuh-manager
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
08/03/2023 14:29:55 INFO: wazuh-manager service started.
08/03/2023 14:29:55 INFO: Starting Filebeat installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  filebeat
0 upgraded, 1 newly installed, 0 to remove and 60 not upgraded.
                                                               Need to get 0 B/22.1 MB of archives.
                                                                                                   After this operation, 73.6 MB of additional disk space will be used.
                                                                                                                                                                       Selecting previously unselected package filebeat.
(Reading database ... 95284 files and directories currently installed.)
Preparing to unpack .../filebeat_7.10.2_amd64.deb ...
Unpacking filebeat (7.10.2) ...
Setting up filebeat (7.10.2) ...
NEEDRESTART-VER: 3.5
NEEDRESTART-KCUR: 5.15.0-58-generic
NEEDRESTART-KEXP: 5.15.0-58-generic
NEEDRESTART-KSTA: 1
NEEDRESTART-SVC: filebeat.service
08/03/2023 14:30:38 INFO: Filebeat installation finished.
wazuh/
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
08/03/2023 14:30:48 INFO: Filebeat post-install configuration finished.
08/03/2023 14:30:48 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
08/03/2023 14:30:50 INFO: filebeat service started.
08/03/2023 14:30:50 INFO: --- Wazuh dashboard ---
08/03/2023 14:30:50 INFO: Starting Wazuh dashboard installation.
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  wazuh-dashboard
0 upgraded, 1 newly installed, 0 to remove and 60 not upgraded.
                                                               Need to get 0 B/130 MB of archives.
                                                                                                  After this operation, 635 MB of additional disk space will be used.
                                                                                                                                                                     Selecting previously unselected package wazuh-dashboard.
(Reading database ... 95603 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.3.10-1_amd64.deb ...
Creating wazuh-dashboard group... OK
Creating wazuh-dashboard user... OK
Unpacking wazuh-dashboard (4.3.10-1) ...
Setting up wazuh-dashboard (4.3.10-1) ...
NEEDRESTART-VER: 3.5
NEEDRESTART-KCUR: 5.15.0-58-generic
NEEDRESTART-KEXP: 5.15.0-58-generic
NEEDRESTART-KSTA: 1
NEEDRESTART-SVC: filebeat.service
08/03/2023 14:32:13 INFO: Wazuh dashboard installation finished.
08/03/2023 14:32:13 DEBUG: Wazuh dashboard certificate setup finished.
08/03/2023 14:32:13 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 14:32:13 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
08/03/2023 14:32:15 INFO: wazuh-dashboard service started.
08/03/2023 14:32:15 DEBUG: Setting Wazuh indexer cluster passwords.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u wazuh:wazuh -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg1OTQ5LCJleHAiOjE2NzgyODY4NDksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ACtyJL9DI2MbFruhZrKM9_iCmIKG1LYlja4elD6Gg6OakkRVjc9VlW5UYsKBroKZf0u2xpsqZqfnusyaYFdL0jNqAKPuiN-_BsT4hcbjzN3j4fDvvSylBHDZZycEqqAZ7itOYZs49AVtfV0HiICbZ0KXmK5DOXZH1tq5hod6gj4z5Oth
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg1OTQ5LCJleHAiOjE2NzgyODY4NDksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ACtyJL9DI2MbFruhZrKM9_iCmIKG1LYlja4elD6Gg6OakkRVjc9VlW5UYsKBroKZf0u2xpsqZqfnusyaYFdL0jNqAKPuiN-_BsT4hcbjzN3j4fDvvSylBHDZZycEqqAZ7itOYZs49AVtfV0HiICbZ0KXmK5DOXZH1tq5hod6gj4z5Oth =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg1OTQ5LCJleHAiOjE2NzgyODY4NDksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ACtyJL9DI2MbFruhZrKM9_iCmIKG1LYlja4elD6Gg6OakkRVjc9VlW5UYsKBroKZf0u2xpsqZqfnusyaYFdL0jNqAKPuiN-_BsT4hcbjzN3j4fDvvSylBHDZZycEqqAZ7itOYZs49AVtfV0HiICbZ0KXmK5DOXZH1tq5hod6gj4z5Oth =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg1OTQ5LCJleHAiOjE2NzgyODY4NDksInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ACtyJL9DI2MbFruhZrKM9_iCmIKG1LYlja4elD6Gg6OakkRVjc9VlW5UYsKBroKZf0u2xpsqZqfnusyaYFdL0jNqAKPuiN-_BsT4hcbjzN3j4fDvvSylBHDZZycEqqAZ7itOYZs49AVtfV0HiICbZ0KXmK5DOXZH1tq5hod6gj4z5Oth =~ Invalid credentials ]]
+ set +ex
08/03/2023 14:32:34 DEBUG: Creating password backup.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '_doc/config' into /usr/share/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /usr/share/wazuh-indexer/backup/config.yml
Will retrieve '_doc/roles' into /usr/share/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /usr/share/wazuh-indexer/backup/roles.yml
Will retrieve '_doc/rolesmapping' into /usr/share/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /usr/share/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '_doc/internalusers' into /usr/share/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /usr/share/wazuh-indexer/backup/internal_users.yml
Will retrieve '_doc/actiongroups' into /usr/share/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /usr/share/wazuh-indexer/backup/action_groups.yml
Will retrieve '_doc/tenants' into /usr/share/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /usr/share/wazuh-indexer/backup/tenants.yml
Will retrieve '_doc/nodesdn' into /usr/share/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /usr/share/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '_doc/whitelist' into /usr/share/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /usr/share/wazuh-indexer/backup/whitelist.yml
Will retrieve '_doc/audit' into /usr/share/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /usr/share/wazuh-indexer/backup/audit.yml
08/03/2023 14:33:14 DEBUG: Password backup created in /usr/share/wazuh-indexer/backup.
08/03/2023 14:33:14 DEBUG: Generating password hashes.
08/03/2023 14:33:24 DEBUG: Password hashes generated.
Successfully updated the keystore
08/03/2023 14:33:32 DEBUG: filebeat started.
08/03/2023 14:33:36 DEBUG: wazuh-dashboard started.
08/03/2023 14:33:36 DEBUG: Loading new passwords changes.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
Connected as CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US
OpenSearch Version: 1.2.4
OpenSearch Security Version: 1.2.4.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/
Will update '_doc/config' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '_doc/roles' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '_doc/rolesmapping' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '_doc/internalusers' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '_doc/actiongroups' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '_doc/tenants' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '_doc/nodesdn' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '_doc/whitelist' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '_doc/audit' with /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Done with success
08/03/2023 14:33:56 DEBUG: Passwords changed.
+ retries=0
+ max_internal_error_retries=10
++ curl -s -u 'wazuh:mw+ZZK0FVTZO9pLVRxOfcTTZVWO8oev*' -k -X GET 'https://localhost:55000/security/user/authenticate?raw=true' --max-time 300 --retry 5 --retry-delay 5
+ TOKEN_API=eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MDQwLCJleHAiOjE2NzgyODY5NDAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AApK1nwXKNpMnDOCetoPIpDl9TUUTD7IH1-Nr6V6ldU4V6665NPM-qBEf_IrPNIujPDK_lTJg7Ehd13e8BHgNiaGAUGMDEBaJEifFW-6GbrK5d9Ze1EIqbDSLkp3cTWg-gxMcvoYiRcFsRK1upDEstT3tg44ht6SBeb29nfsXfOKUbcX
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MDQwLCJleHAiOjE2NzgyODY5NDAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AApK1nwXKNpMnDOCetoPIpDl9TUUTD7IH1-Nr6V6ldU4V6665NPM-qBEf_IrPNIujPDK_lTJg7Ehd13e8BHgNiaGAUGMDEBaJEifFW-6GbrK5d9Ze1EIqbDSLkp3cTWg-gxMcvoYiRcFsRK1upDEstT3tg44ht6SBeb29nfsXfOKUbcX =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MDQwLCJleHAiOjE2NzgyODY5NDAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AApK1nwXKNpMnDOCetoPIpDl9TUUTD7IH1-Nr6V6ldU4V6665NPM-qBEf_IrPNIujPDK_lTJg7Ehd13e8BHgNiaGAUGMDEBaJEifFW-6GbrK5d9Ze1EIqbDSLkp3cTWg-gxMcvoYiRcFsRK1upDEstT3tg44ht6SBeb29nfsXfOKUbcX =~ Wazuh Internal Error ]]
+ [[ eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjc4Mjg2MDQwLCJleHAiOjE2NzgyODY5NDAsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AApK1nwXKNpMnDOCetoPIpDl9TUUTD7IH1-Nr6V6ldU4V6665NPM-qBEf_IrPNIujPDK_lTJg7Ehd13e8BHgNiaGAUGMDEBaJEifFW-6GbrK5d9Ze1EIqbDSLkp3cTWg-gxMcvoYiRcFsRK1upDEstT3tg44ht6SBeb29nfsXfOKUbcX =~ Invalid credentials ]]
+ set +ex
+ common_logger 'Initializing Wazuh dashboard web application.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:34:13'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ '[' -n 'Initializing Wazuh dashboard web application.' ']'
+ case ${1} in
+ message='Initializing Wazuh dashboard web application.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ printf '%s\n' '08/03/2023 14:34:13 INFO: Initializing Wazuh dashboard web application.'
+ tee -a /var/log/wazuh-install.log
08/03/2023 14:34:13 INFO: Initializing Wazuh dashboard web application.
+ installCommon_getPass admin
+ for i in "${!users[@]}"
+ '[' admin == admin ']'
+ u_pass='GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls'
+ for i in "${!users[@]}"
+ '[' kibanaserver == admin ']'
+ for i in "${!users[@]}"
+ '[' kibanaro == admin ']'
+ for i in "${!users[@]}"
+ '[' logstash == admin ']'
+ for i in "${!users[@]}"
+ '[' readall == admin ']'
+ for i in "${!users[@]}"
+ '[' snapshotrestore == admin ']'
++ curl -XGET https://localhost/status '-uadmin:GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls' -k -w '%{http_code}' -s -o /dev/null
+ http_code=200
+ retries=0
+ max_dashboard_initialize_retries=5
+ '[' 200 -ne 200 ']'
+ '[' 200 -eq 200 ']'
+ common_logger 'Wazuh dashboard web application initialized.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:34:15'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ '[' -n 'Wazuh dashboard web application initialized.' ']'
+ case ${1} in
+ message='Wazuh dashboard web application initialized.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z '' ']'
+ tee -a /var/log/wazuh-install.log
+ printf '%s\n' '08/03/2023 14:34:15 INFO: Wazuh dashboard web application initialized.'
08/03/2023 14:34:15 INFO: Wazuh dashboard web application initialized.
+ common_logger -nl '--- Summary ---'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:34:15'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n '--- Summary ---' ']'
+ case ${1} in
+ message='--- Summary ---'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 14:34:15 INFO: --- Summary ---'
08/03/2023 14:34:15 INFO: --- Summary ---
+ common_logger -nl 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='08/03/2023 14:34:15'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -nl ']'
+ '[' -n -nl ']'
+ case ${1} in
+ nolog=1
+ shift 1
+ '[' -n 'You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls' ']'
+ case ${1} in
+ message='You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls'
+ shift 1
+ '[' -n '' ']'
+ '[' -z '' ']'
+ '[' 0 -eq 0 ']'
+ '[' -z 1 ']'
+ printf '%b\n' '08/03/2023 14:34:15 INFO: You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls'
08/03/2023 14:34:15 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: GP9*dVXlYxQOxAY9hEpozMTFlvqI9uls
+ set +ex
08/03/2023 14:34:16 INFO: Installation finished.
```
</details>

<details>
<summary>:green_circle: Amazon Linux 2</summary>

```
[root@amazon2 vagrant]# ./wazuh-install.sh -a
08/03/2023 16:56:27 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:56:27 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:56:28 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
[root@amazon2 vagrant]# ./wazuh-install.sh -a -i
08/03/2023 16:56:30 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:56:30 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:56:32 WARNING: Hardware and system checks ignored.
08/03/2023 16:56:34 INFO: Wazuh repository added.
08/03/2023 16:56:34 INFO: --- Configuration files ---
08/03/2023 16:56:34 INFO: Generating configuration files.
08/03/2023 16:56:35 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:56:35 INFO: --- Wazuh indexer ---
08/03/2023 16:56:35 INFO: Starting Wazuh indexer installation.
08/03/2023 16:58:11 INFO: Wazuh indexer installation finished.
08/03/2023 16:58:11 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:58:11 INFO: Starting service wazuh-indexer.
08/03/2023 16:58:46 INFO: wazuh-indexer service started.
08/03/2023 16:58:46 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:58:59 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:58:59 INFO: --- Wazuh server ---
08/03/2023 16:58:59 INFO: Starting the Wazuh manager installation.
08/03/2023 16:59:22 INFO: Wazuh manager installation finished.
08/03/2023 16:59:22 INFO: Starting service wazuh-manager.
08/03/2023 16:59:45 INFO: wazuh-manager service started.
08/03/2023 16:59:45 INFO: Starting Filebeat installation.
08/03/2023 16:59:58 INFO: Filebeat installation finished.
08/03/2023 16:59:59 INFO: Filebeat post-install configuration finished.
08/03/2023 16:59:59 INFO: Starting service filebeat.
08/03/2023 16:59:59 INFO: filebeat service started.
08/03/2023 16:59:59 INFO: --- Wazuh dashboard ---
08/03/2023 17:00:00 INFO: Starting Wazuh dashboard installation.
08/03/2023 17:01:06 INFO: Wazuh dashboard installation finished.
08/03/2023 17:01:06 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 17:01:06 INFO: Starting service wazuh-dashboard.
08/03/2023 17:01:07 INFO: wazuh-dashboard service started.
08/03/2023 17:02:14 INFO: Initializing Wazuh dashboard web application.
08/03/2023 17:02:14 INFO: Wazuh dashboard web application initialized.
08/03/2023 17:02:14 INFO: --- Summary ---
08/03/2023 17:02:14 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: Lhac56rS881+LUAuh2x9VtoLW?tJtS8p
08/03/2023 17:02:14 INFO: Installation finished.
[root@amazon2 vagrant]# 
```
</details>

<details>
<summary>:green_circle:CentOS 7</summary>

```
[root@centos7 vagrant]# ./wazuh-install.sh -a
08/03/2023 16:51:59 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:51:59 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:52:02 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
[root@centos7 vagrant]# ./wazuh-install.sh -a -i
08/03/2023 16:52:05 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:52:05 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:52:08 WARNING: Hardware and system checks ignored.
08/03/2023 16:52:11 INFO: Wazuh repository added.
08/03/2023 16:52:11 INFO: --- Configuration files ---
08/03/2023 16:52:11 INFO: Generating configuration files.
08/03/2023 16:52:13 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:52:13 INFO: --- Wazuh indexer ---
08/03/2023 16:52:13 INFO: Starting Wazuh indexer installation.
08/03/2023 16:53:48 INFO: Wazuh indexer installation finished.
08/03/2023 16:53:49 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:53:49 INFO: Starting service wazuh-indexer.
08/03/2023 16:54:23 INFO: wazuh-indexer service started.
08/03/2023 16:54:23 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:54:38 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:54:38 INFO: --- Wazuh server ---
08/03/2023 16:54:38 INFO: Starting the Wazuh manager installation.
08/03/2023 16:55:32 INFO: Wazuh manager installation finished.
08/03/2023 16:55:32 INFO: Starting service wazuh-manager.
08/03/2023 16:55:50 INFO: wazuh-manager service started.
08/03/2023 16:55:50 INFO: Starting Filebeat installation.
08/03/2023 16:56:31 INFO: Filebeat installation finished.
08/03/2023 16:56:33 INFO: Filebeat post-install configuration finished.
08/03/2023 16:56:33 INFO: Starting service filebeat.
08/03/2023 16:56:33 INFO: filebeat service started.
08/03/2023 16:56:33 INFO: --- Wazuh dashboard ---
08/03/2023 16:56:33 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:58:38 INFO: Wazuh dashboard installation finished.
08/03/2023 16:58:38 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:58:38 INFO: Starting service wazuh-dashboard.
08/03/2023 16:58:38 INFO: wazuh-dashboard service started.
08/03/2023 16:59:43 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:59:45 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:59:45 INFO: --- Summary ---
08/03/2023 16:59:45 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: *PQbDtTe?Zk7Ziz0L*kH72Jqz2NW6657
08/03/2023 16:59:45 INFO: Installation finished.

```
</details>

<details>
<summary>:green_circle:  CentOS 8</summary>

```
[root@centos8 vagrant]# ./wazuh-install.sh -a
08/03/2023 16:51:53 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:51:53 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:51:55 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
[root@centos8 vagrant]# ./wazuh-install.sh -a -i
08/03/2023 16:52:02 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:52:02 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:52:04 WARNING: Hardware and system checks ignored.
08/03/2023 16:52:08 INFO: Wazuh repository added.
08/03/2023 16:52:08 INFO: --- Configuration files ---
08/03/2023 16:52:08 INFO: Generating configuration files.
08/03/2023 16:52:10 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:52:10 INFO: --- Wazuh indexer ---
08/03/2023 16:52:10 INFO: Starting Wazuh indexer installation.
08/03/2023 16:54:02 INFO: Wazuh indexer installation finished.
08/03/2023 16:54:02 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:54:02 INFO: Starting service wazuh-indexer.
08/03/2023 16:54:34 INFO: wazuh-indexer service started.
08/03/2023 16:54:34 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:54:49 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:54:49 INFO: --- Wazuh server ---
08/03/2023 16:54:49 INFO: Starting the Wazuh manager installation.
08/03/2023 16:56:04 INFO: Wazuh manager installation finished.
08/03/2023 16:56:04 INFO: Starting service wazuh-manager.
08/03/2023 16:56:23 INFO: wazuh-manager service started.
08/03/2023 16:56:23 INFO: Starting Filebeat installation.
08/03/2023 16:56:40 INFO: Filebeat installation finished.
08/03/2023 16:56:42 INFO: Filebeat post-install configuration finished.
08/03/2023 16:56:42 INFO: Starting service filebeat.
08/03/2023 16:56:43 INFO: filebeat service started.
08/03/2023 16:56:43 INFO: --- Wazuh dashboard ---
08/03/2023 16:56:44 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:58:41 INFO: Wazuh dashboard installation finished.
08/03/2023 16:58:41 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:58:41 INFO: Starting service wazuh-dashboard.
08/03/2023 16:58:42 INFO: wazuh-dashboard service started.
08/03/2023 16:59:47 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:59:48 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:59:49 INFO: Wazuh dashboard web application not yet initialized. Waiting...
08/03/2023 16:59:51 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:59:51 INFO: --- Summary ---
08/03/2023 16:59:51 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: QDZHtmTELKCy*DM*xzDPVREP8OiFW3?2
08/03/2023 16:59:51 INFO: Installation finished.

```
</details>

<details>
<summary> :green_circle: RHEL 9</summary>

```
[root@rhel9 vagrant]# ./wazuh-install.sh -a
08/03/2023 16:36:59 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:36:59 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:37:03 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
[root@rhel9 vagrant]# ./wazuh-install.sh -a -i
08/03/2023 16:37:43 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:37:43 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:37:47 WARNING: Hardware and system checks ignored.
08/03/2023 16:37:50 INFO: Wazuh repository added.
08/03/2023 16:37:50 INFO: --- Configuration files ---
08/03/2023 16:37:50 INFO: Generating configuration files.
08/03/2023 16:37:53 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:37:53 INFO: --- Wazuh indexer ---
08/03/2023 16:37:53 INFO: Starting Wazuh indexer installation.
08/03/2023 16:39:24 INFO: Wazuh indexer installation finished.
08/03/2023 16:39:24 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:39:24 INFO: Starting service wazuh-indexer.
08/03/2023 16:39:50 INFO: wazuh-indexer service started.
08/03/2023 16:39:50 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:40:04 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:40:04 INFO: --- Wazuh server ---
08/03/2023 16:40:04 INFO: Starting the Wazuh manager installation.
08/03/2023 16:40:58 INFO: Wazuh manager installation finished.
08/03/2023 16:40:58 INFO: Starting service wazuh-manager.
08/03/2023 16:41:15 INFO: wazuh-manager service started.
08/03/2023 16:41:15 INFO: Starting Filebeat installation.
08/03/2023 16:41:37 INFO: Filebeat installation finished.
08/03/2023 16:41:38 INFO: Filebeat post-install configuration finished.
08/03/2023 16:41:38 INFO: Starting service filebeat.
08/03/2023 16:41:39 INFO: filebeat service started.
08/03/2023 16:41:39 INFO: --- Wazuh dashboard ---
08/03/2023 16:41:39 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:43:25 INFO: Wazuh dashboard installation finished.
08/03/2023 16:43:26 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:43:26 INFO: Starting service wazuh-dashboard.
08/03/2023 16:43:26 INFO: wazuh-dashboard service started.
08/03/2023 16:44:40 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:44:41 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:44:41 INFO: --- Summary ---
08/03/2023 16:44:41 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: o.c.Ng21Squ97J7mio.iTrpiFpn.Y5F0
08/03/2023 16:44:41 INFO: Installation finished.

```
</details>

<details>
<summary> :green_circle: Ubuntu18LTS</summary>

```
root@ubuntu18LTS:/home/vagrant# ./wazuh-install.sh -a
08/03/2023 15:47:17 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 15:47:17 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 15:47:19 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
root@ubuntu18LTS:/home/vagrant# ./wazuh-install.sh -a -i
08/03/2023 15:50:21 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 15:50:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 15:50:22 WARNING: Hardware and system checks ignored.
08/03/2023 15:50:29 INFO: --- Dependencies ----
08/03/2023 15:50:29 INFO: Installing apt-transport-https.
08/03/2023 15:50:36 INFO: Wazuh repository added.
08/03/2023 15:50:36 INFO: --- Configuration files ---
08/03/2023 15:50:36 INFO: Generating configuration files.
08/03/2023 15:50:37 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 15:50:37 INFO: --- Wazuh indexer ---
08/03/2023 15:50:37 INFO: Starting Wazuh indexer installation.
08/03/2023 15:51:31 INFO: Wazuh indexer installation finished.
08/03/2023 15:51:31 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 15:51:31 INFO: Starting service wazuh-indexer.
08/03/2023 15:52:01 INFO: wazuh-indexer service started.
08/03/2023 15:52:01 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 15:52:16 INFO: Wazuh indexer cluster initialized.
08/03/2023 15:52:16 INFO: --- Wazuh server ---
08/03/2023 15:52:16 INFO: Starting the Wazuh manager installation.
08/03/2023 15:53:05 INFO: Wazuh manager installation finished.
08/03/2023 15:53:05 INFO: Starting service wazuh-manager.
08/03/2023 15:53:26 INFO: wazuh-manager service started.
08/03/2023 15:53:26 INFO: Starting Filebeat installation.
08/03/2023 15:53:42 INFO: Filebeat installation finished.
08/03/2023 15:53:43 INFO: Filebeat post-install configuration finished.
08/03/2023 15:53:43 INFO: Starting service filebeat.
08/03/2023 15:53:45 INFO: filebeat service started.
08/03/2023 15:53:45 INFO: --- Wazuh dashboard ---
08/03/2023 15:53:45 INFO: Starting Wazuh dashboard installation.
08/03/2023 15:54:28 INFO: Wazuh dashboard installation finished.
08/03/2023 15:54:28 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 15:54:28 INFO: Starting service wazuh-dashboard.
08/03/2023 15:54:29 INFO: wazuh-dashboard service started.
08/03/2023 15:56:05 INFO: Initializing Wazuh dashboard web application.
08/03/2023 15:56:06 INFO: Wazuh dashboard web application initialized.
08/03/2023 15:56:06 INFO: --- Summary ---
08/03/2023 15:56:06 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: 4BB7fZLdICBIm*IwoFWh*D9Dx358PZKV
08/03/2023 15:56:06 INFO: Installation finished.
```
</details>

<details>
<summary> :green_circle: Ubuntu20LTS</summary>

```
root@ubuntu20LTS:/home/vagrant# ./wazuh-install.sh -a
08/03/2023 16:10:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:10:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:10:59 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
root@ubuntu20LTS:/home/vagrant# ./wazuh-install.sh -a -i
08/03/2023 16:12:54 INFO: Starting Wazuh installation assistant. Wazuh version: 4.3.10
08/03/2023 16:12:54 INFO: Verbose logging redirected to /var/log/wazuh-install.log
08/03/2023 16:12:55 WARNING: Hardware and system checks ignored.
08/03/2023 16:13:02 INFO: --- Dependencies ----
08/03/2023 16:13:02 INFO: Installing apt-transport-https.
08/03/2023 16:13:09 INFO: Wazuh repository added.
08/03/2023 16:13:09 INFO: --- Configuration files ---
08/03/2023 16:13:09 INFO: Generating configuration files.
08/03/2023 16:13:09 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
08/03/2023 16:13:09 INFO: --- Wazuh indexer ---
08/03/2023 16:13:09 INFO: Starting Wazuh indexer installation.
08/03/2023 16:14:08 INFO: Wazuh indexer installation finished.
08/03/2023 16:14:08 INFO: Wazuh indexer post-install configuration finished.
08/03/2023 16:14:08 INFO: Starting service wazuh-indexer.
08/03/2023 16:14:41 INFO: wazuh-indexer service started.
08/03/2023 16:14:41 INFO: Initializing Wazuh indexer cluster security settings.
08/03/2023 16:14:55 INFO: Wazuh indexer cluster initialized.
08/03/2023 16:14:55 INFO: --- Wazuh server ---
08/03/2023 16:14:55 INFO: Starting the Wazuh manager installation.
08/03/2023 16:15:41 INFO: Wazuh manager installation finished.
08/03/2023 16:15:41 INFO: Starting service wazuh-manager.
08/03/2023 16:16:03 INFO: wazuh-manager service started.
08/03/2023 16:16:03 INFO: Starting Filebeat installation.
08/03/2023 16:16:26 INFO: Filebeat installation finished.
08/03/2023 16:16:27 INFO: Filebeat post-install configuration finished.
08/03/2023 16:16:27 INFO: Starting service filebeat.
08/03/2023 16:16:29 INFO: filebeat service started.
08/03/2023 16:16:29 INFO: --- Wazuh dashboard ---
08/03/2023 16:16:29 INFO: Starting Wazuh dashboard installation.
08/03/2023 16:17:19 INFO: Wazuh dashboard installation finished.
08/03/2023 16:17:19 INFO: Wazuh dashboard post-install configuration finished.
08/03/2023 16:17:19 INFO: Starting service wazuh-dashboard.
08/03/2023 16:17:20 INFO: wazuh-dashboard service started.
08/03/2023 16:18:35 INFO: Initializing Wazuh dashboard web application.
08/03/2023 16:18:36 INFO: Wazuh dashboard web application initialized.
08/03/2023 16:18:36 INFO: --- Summary ---
08/03/2023 16:18:36 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: fSjxZmF*Mv+3NLHxBAKiT+qf2U.8ZXAH
08/03/2023 16:18:36 INFO: Installation finished.

```
</details>

#### Test AIO on machines with limited resources (T2.micro EC2 instances):

- :red_circle: Ubuntu 22 t2.micro
- :red_circle: RHEL 9 t2.micro

<details>
<summary> :red_circle: Amazon Linux 2 t2.micro </summary>

```
08/03/2023 10:02:12 INFO: Initializing Wazuh indexer cluster security settings.
Security Admin v7
Will connect to 127.0.0.1:9300 ... done
ERR: Cannot connect to OpenSearch. Please refer to opensearch logfile for more information
Trace:
NoNodeAvailableException[None of the configured nodes are available: [{#transport#-1}{XpFlu3voShSbt93-XRVQ2w}{127.0.0.1}{127.0.0.1:9300}]]
	at org.opensearch.client.transport.TransportClientNodesService.ensureNodesAreAvailable(TransportClientNodesService.java:381)
	at org.opensearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:272)
	at org.opensearch.client.transport.TransportProxyClient.execute(TransportProxyClient.java:79)
	at org.opensearch.client.transport.TransportClient.doExecute(TransportClient.java:484)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:433)
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:419)
	at org.opensearch.security.tools.SecurityAdmin.execute(SecurityAdmin.java:524)
	at org.opensearch.security.tools.SecurityAdmin.main(SecurityAdmin.java:157)
```
</details

With the EC2 t2.micro tests it has been proved that t2.micro machines do not support an AIO installation. Both the RHEL 9 machine and the Ubuntu 22 one have just frozen from the installation and the Amazon Linux 2 has not been able to install the indexer, as seen in the error.



#### Jenkins tests:
  - :green_circle: Distributed installation: https://ci.wazuh.info/job/Test_unattended_distributed/450/
  - :green_circle: AIO tests: https://ci.wazuh.info/job/Test_unattended_tier/8/ 

