### PR TITLE
Add Archives repository to Debian Stretch tests

### DIFF
--- a/.github/actions/test-install-components/install_component.sh
+++ b/.github/actions/test-install-components/install_component.sh
@@ -7,6 +7,11 @@ if [ -f /etc/os-release ]; then
         find /etc/yum.repos.d/ -type f -exec sed -i 's/mirrorlist/#mirrorlist/g' {} \;
         find /etc/yum.repos.d/ -type f -exec sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' {} \;
     fi
+
+    if [ "$ID" = "debian" ] && [ "$VERSION_ID" = "9" ]; then
+        echo "deb http://archive.debian.org/debian stretch contrib main non-free" > /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+    fi
 fi
 
 if [ -f /etc/redhat-release ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#2177|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

In this PR we add the Archives repository to the Debian Stretch tests in GH actions.
