### PR TITLE
Fix 4.3.11 changelog date

### DIFF
--- a/aix/SPECS/wazuh-agent-aix.spec
+++ b/aix/SPECS/wazuh-agent-aix.spec
@@ -290,7 +290,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 
 %changelog
-* Thu Dec 08 2022 support <info@wazuh.com> - 4.3.11
+* Mon Apr 24 2023 support <info@wazuh.com> - 4.3.11
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu Nov 10 2022 support <info@wazuh.com> - 4.3.10
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/debs/SPECS/wazuh-agent/debian/changelog
+++ b/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,7 +2,7 @@ wazuh-agent (4.3.11-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 08 Dec 2022 15:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 24 Apr 2023 15:00:00 +0000
 
 wazuh-agent (4.3.10-RELEASE) stable; urgency=low
 

--- a/debs/SPECS/wazuh-manager/debian/changelog
+++ b/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,7 +2,7 @@ wazuh-manager (4.3.11-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 08 Dec 2022 15:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 24 Apr 2023 15:00:00 +0000
 
 wazuh-manager (4.3.10-RELEASE) stable; urgency=low
 

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -615,7 +615,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Thu Dec 08 2022 support <info@wazuh.com> - 4.3.11
+* Mon Apr 24 2023 2022 support <info@wazuh.com> - 4.3.11
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu Nov 10 2022 support <info@wazuh.com> - 4.3.10
 - More info: https://documentation.wazuh.com/current/release-notes/

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -832,7 +832,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Thu Dec 08 2022 support <info@wazuh.com> - 4.3.11
+* Mon Apr 24 2023 support <info@wazuh.com> - 4.3.11
 - More info: https://documentation.wazuh.com/current/release-notes/
 * Thu Nov 10 2022 support <info@wazuh.com> - 4.3.10
 - More info: https://documentation.wazuh.com/current/release-notes/


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-packages/pull/2187|

This PR fixes the release date of version 4.3.11 in the 4.3 branch

- https://ci.wazuh.info/view/Packages/job/Packages_builder_tier/2947/
  - Debian Wazuh manager/agent
  - RPM Wazuh manager/agent

```
[root@centos7 vagrant]# rpm -q --changelog wazuh-agent 
* Mon Apr 24 2023 2022 support <info@wazuh.com> - 4.3.11
- More info: https://documentation.wazuh.com/current/release-notes/

* Thu Nov 10 2022 support <info@wazuh.com> - 4.3.10
- More info: https://documentation.wazuh.com/current/release-notes/
```

```
root@debian11:/home/vagrant# apt changelog wazuh-manager
Get:1 store: wazuh-manager 4.3.11-0.0.0.todelete Changelog
Fetched 15.6 kB in 0s (0 B/s)
...
wazuh-manager (4.3.11-0.0.0.todelete) stable; urgency=low

  * More info: https://documentation.wazuh.com/current/release-notes/

 -- Wazuh, Inc <info@wazuh.com>  Mon, 24 Apr 2023 15:00:00 +0000

wazuh-manager (4.3.10-0.0.0.todelete) stable; urgency=low

```
