### PR TITLE
Fix 2196, support empty ruleset/sca directories

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -95,8 +95,9 @@ case "$1" in
         fi
 
         # Set correct permissions, owner and group
-        chmod 640 ${DIR}/ruleset/sca/*
-        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # There may not be any sca rules, so avoid wildcards
+        chmod -R u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+        chown -R root:${GROUP} ${DIR}/ruleset/sca/
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -218,9 +218,9 @@ case "$1" in
             done
         fi
 
-        # Set correct permissions, owner and group
-        chmod 640 ${DIR}/ruleset/sca/*
-        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # Set correct permissions, owner and group. ruleset directory may be empty.
+        chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+        chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 


### PR DESCRIPTION
Fixes #2196

Alter the chmod and chown lines to not assume there are files in the directory.

Impact if there are files is unchanged.

|Related issue|
|---|
|#2196|