### PR TITLE
Fixed macOS post-install user and group check

### DIFF
--- a/macos/package_files/postinstall.sh
+++ b/macos/package_files/postinstall.sh
@@ -124,14 +124,6 @@ if [[ $(dscl . -read /Groups/ossec) ]]; then
     find ${DIR}/ -group ossec -user ossec -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
     sudo /usr/bin/dscl . -delete "/Users/ossec"
   fi
-  if [[ $(dscl . -read /Users/ossecm) ]]; then
-    find ${DIR}/ -group ossec -user ossecm -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
-    sudo /usr/bin/dscl . -delete "/Users/ossecm"
-  fi
-  if [[ $(dscl . -read /Users/ossecr) ]]; then
-    find ${DIR}/ -group ossec -user ossecr -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
-    sudo /usr/bin/dscl . -delete "/Users/ossecr"
-  fi
   sudo /usr/bin/dscl . -delete "/Groups/ossec"
 fi
 

--- a/macos/package_files/postinstall.sh
+++ b/macos/package_files/postinstall.sh
@@ -120,15 +120,15 @@ rm -rf ${DIR}/packages_files
 
 if [[ $(dscl . -read /Groups/ossec) ]]; then
   find ${DIR}/ -group ossec -user root -exec chown root:wazuh {} \ > /dev/null 2>&1 || true
-  if [ $(dscl . -read /Users/ossec) ]]; then
+  if [[ $(dscl . -read /Users/ossec) ]]; then
     find ${DIR}/ -group ossec -user ossec -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
     sudo /usr/bin/dscl . -delete "/Users/ossec"
   fi
-  if [ $(dscl . -read /Users/ossecm) ]]; then
+  if [[ $(dscl . -read /Users/ossecm) ]]; then
     find ${DIR}/ -group ossec -user ossecm -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
     sudo /usr/bin/dscl . -delete "/Users/ossecm"
   fi
-  if [ $(dscl . -read /Users/ossecr) ]]; then
+  if [[ $(dscl . -read /Users/ossecr) ]]; then
     find ${DIR}/ -group ossec -user ossecr -exec chown wazuh:wazuh {} \ > /dev/null 2>&1 || true
     sudo /usr/bin/dscl . -delete "/Users/ossecr"
   fi


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2210|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This pull request fixes the `if` statements so that the encapsulation is correct, it also eliminates two if statements without use since the user `ossecr` and the user `ossecm` have never been part of the macOS agent installation

## Logs example

- See https://github.com/wazuh/wazuh-packages/issues/2210#issuecomment-1557641605

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [x] Package upgrade
- [ ] Package downgrade
- [x] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package (macOS Catalina)
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
