### PR TITLE
Replace launchctl variables from macOS installation scripts

### DIFF
--- a/macos/package_files/postinstall.sh
+++ b/macos/package_files/postinstall.sh
@@ -18,13 +18,17 @@ if [ -f "${DIR}/WAZUH_PKG_UPGRADE" ]; then
   upgrade="true"
 fi
 
-rm -f ${DIR}/WAZUH_PKG_UPGRADE
+if [ -f "${DIR}/WAZUH_PKG_UPGRADE" ]; then
+  rm -f ${DIR}/WAZUH_PKG_UPGRADE
+fi
 
 if [ -f "${DIR}/WAZUH_RESTART" ]; then
   restart="true"
 fi
 
-rm -f ${DIR}/WAZUH_RESTART
+if [ -f "${DIR}/WAZUH_RESTART" ]; then
+  rm -f ${DIR}/WAZUH_RESTART
+fi
 
 if [ -n "${upgrade}" ]; then
     rm -rf ${DIR}/etc/{ossec.conf,client.keys,local_internal_options.conf,shared}

--- a/macos/package_files/preinstall.sh
+++ b/macos/package_files/preinstall.sh
@@ -11,16 +11,20 @@
 
 DIR="/Library/Ossec"
 
-if [ -d ${DIR} ]; then
-    rm -f ${DIR}/WAZUH_PKG_UPGRADE
-    rm -f ${DIR}/WAZUH_RESTART
-    touch ${DIR}/WAZUH_PKG_UPGRADE
+if [ -d "${DIR}" ]; then
+    if [ -f "${DIR}/WAZUH_PKG_UPGRADE" ]; then
+        rm -f "${DIR}/WAZUH_PKG_UPGRADE"
+    fi
+    if [ -f "${DIR}/WAZUH_RESTART" ]; then
+        rm -f "${DIR}/WAZUH_RESTART"
+    fi
+    touch "${DIR}/WAZUH_PKG_UPGRADE"
     upgrade="true"
     if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
-        touch ${DIR}/WAZUH_RESTART
+        touch "${DIR}/WAZUH_RESTART"
         restart="true"
     elif ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
-        touch ${DIR}/WAZUH_RESTART
+        touch "${DIR}/WAZUH_RESTART"
         restart="true"
     fi
 fi

--- a/macos/package_files/preinstall.sh
+++ b/macos/package_files/preinstall.sh
@@ -11,16 +11,17 @@
 
 DIR="/Library/Ossec"
 
-if [ ! -d ${DIR} ]; then
-    launchctl setenv WAZUH_PKG_UPGRADE false
-else
-    launchctl setenv WAZUH_PKG_UPGRADE true
+if [ -d ${DIR} ]; then
+    rm -f ${DIR}/WAZUH_PKG_UPGRADE
+    rm -f ${DIR}/WAZUH_RESTART
+    touch ${DIR}/WAZUH_PKG_UPGRADE
+    upgrade="true"
     if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
-        launchctl setenv WAZUH_RESTART true
+        touch ${DIR}/WAZUH_RESTART
+        restart="true"
     elif ${DIR}/bin/ossec-control status | grep "is running" > /dev/null 2>&1; then
-        launchctl setenv WAZUH_RESTART true
-    else
-        launchctl setenv WAZUH_RESTART false
+        touch ${DIR}/WAZUH_RESTART
+        restart="true"
     fi
 fi
 
@@ -31,7 +32,7 @@ elif [ -f ${DIR}/bin/ossec-control ]; then
     ${DIR}/bin/ossec-control stop
 fi
 
-if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
+if [ -n "${upgrade}" ]; then
     mkdir -p ${DIR}/config_files/
     cp -r ${DIR}/etc/{ossec.conf,client.keys,local_internal_options.conf,shared} ${DIR}/config_files/
 
@@ -44,7 +45,7 @@ if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
     fi
 fi
 
-if [ $(launchctl getenv WAZUH_PKG_UPGRADE) = true ]; then
+if [ -n "${upgrade}" ]; then
     if pkgutil --pkgs | grep -i wazuh-agent-etc > /dev/null 2>&1 ; then
         pkgutil --forget com.wazuh.pkg.wazuh-agent-etc
     fi


### PR DESCRIPTION
|Related issue|
|---|
|#2205|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR removes the execution of launchctl commands from macOS installation scripts.

This PR must be merged in combination with:
https://github.com/wazuh/wazuh/pull/17195


## Logs example

<!--
Paste here related logs
-->

## Tests
https://github.com/wazuh/wazuh-packages/issues/2205#issuecomment-1560753346
