### PR TITLE
Fix winagent signing for new certs

### DIFF
--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -7,7 +7,7 @@ DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
 TRUST_VERIFICATION="1"
-CA_NAME="DigiCert High Assurance EV Root CA"
+CA_NAME="DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1"
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -37,7 +37,7 @@ help() {
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: 1 (only warnings)."
-    echo "    -c, --ca_name <CA name>   [Optional] CA name to be used to verify the trust of the agent. By default: DigiCert High Assurance EV Root CA."
+    echo "    -c, --ca_name <CA name>   [Optional] CA name to be used to verify the trust of the agent. By default: DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/windows/generate_compiled_windows_agent.sh
+++ b/windows/generate_compiled_windows_agent.sh
@@ -7,7 +7,7 @@ DEBUG="no"
 OUTDIR="$(pwd)"
 REVISION="1"
 TRUST_VERIFICATION="1"
-CA_NAME="DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1"
+CA_NAME="DigiCert Assured ID Root CA"
 
 DOCKERFILE_PATH="./"
 DOCKER_IMAGE_NAME="compile_windows_agent"
@@ -37,7 +37,7 @@ help() {
     echo "    -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
     echo "    -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -t, --trust_verification  [Optional] Build the binaries with trust load images verification. By default: 1 (only warnings)."
-    echo "    -c, --ca_name <CA name>   [Optional] CA name to be used to verify the trust of the agent. By default: DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1."
+    echo "    -c, --ca_name <CA name>   [Optional] CA name to be used to verify the trust of the agent. By default: DigiCert Assured ID Root CA."
     echo "    -h, --help                Show this help."
     echo
     exit $1

--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -73,16 +73,16 @@ function BuildWazuhMsi(){
     if($SIGN -eq "yes"){
         # Sign .exe files and the InstallerScripts.vbs
         Write-Host "Signing .exe files..."
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\*.exe"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 ".\*.exe"
         Write-Host "Signing .vbs files..."
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\InstallerScripts.vbs"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 ".\InstallerScripts.vbs"
         Write-Host "Signing .dll files..."
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\*.dll"
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 ".\*.dll"
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\data_provider\build\bin\sysinfo.dll"
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /td SHA256 "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\*.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 ".\*.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\data_provider\build\bin\sysinfo.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
     }
 
     Write-Host "Building MSI installer..."
@@ -92,7 +92,7 @@ function BuildWazuhMsi(){
 
     if($SIGN -eq "yes"){
         Write-Host "Signing $MSI_NAME..."
-        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /d $MSI_NAME /td SHA256 $MSI_NAME
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /d $MSI_NAME /fd SHA256 /td SHA256 $MSI_NAME
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#2227|

## Description

This PR aims to include the fixes needed by the new Wazuh certificates used during winagent signing procedure

## Logs example

Manual execution with Signing enabled https://ci.wazuh.info/job/Packages_builder_win/14161/
Package: https://packages-dev.wazuh.com/trash/windows/wazuh-agent-4.4.4-0.0.1.winsign.msi

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
