### PR TITLE
Support empty ruleset/sca directories

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -94,10 +94,11 @@ case "$1" in
             done
         fi
 
-        # Set correct permissions, owner and group
-        # There may not be any sca rules, so avoid wildcards
-        chmod -R u=rwX,g=rX,o= ${DIR}/ruleset/sca/
-        chown -R root:${GROUP} ${DIR}/ruleset/sca/
+        # Set correct permissions, owner and group. ruleset directory may be empty.
+        if [ -z "$(ls -A ${DIR}/ruleset/sca/)" ]; then
+            chmod -R u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+            chown -R root:${GROUP} ${DIR}/ruleset/sca/
+        fi
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 

--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -96,8 +96,8 @@ case "$1" in
 
         # Set correct permissions, owner and group. ruleset directory may be empty.
         if [ -z "$(ls -A ${DIR}/ruleset/sca/)" ]; then
-            chmod -R u=rwX,g=rX,o= ${DIR}/ruleset/sca/
-            chown -R root:${GROUP} ${DIR}/ruleset/sca/
+            chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+            chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
         fi
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}

--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -95,8 +95,9 @@ case "$1" in
         fi
 
         # Set correct permissions, owner and group
-        chmod 640 ${DIR}/ruleset/sca/*
-        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # There may not be any sca rules, so avoid wildcards
+        chmod -R u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+        chown -R root:${GROUP} ${DIR}/ruleset/sca/
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -219,8 +219,10 @@ case "$1" in
         fi
 
         # Set correct permissions, owner and group. ruleset directory may be empty.
-        chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
-        chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
+        if [ -z "$(ls -A ${DIR}/ruleset/sca/)" ]; then
+            chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+            chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
+        fi
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -218,9 +218,9 @@ case "$1" in
             done
         fi
 
-        # Set correct permissions, owner and group
-        chmod 640 ${DIR}/ruleset/sca/*
-        chown root:${GROUP} ${DIR}/ruleset/sca/*
+        # Set correct permissions, owner and group. ruleset directory may be empty.
+        chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
+        chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
         # Delete the temporary directory
         rm -rf ${SCA_BASE_DIR}
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2196|

This PR is a port of #2197 by @lod. This replaces `chmod` on all the SCA policies available (`*`) with a recursive option (`--recursive`). This way, we avoid a "_No such file or directory_" error if the _sca_ folder contains no policy files.