### PR TITLE
Fix SCA files permission error

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -95,7 +95,7 @@ case "$1" in
         fi
 
         # Set correct permissions, owner and group. ruleset directory may be empty.
-        if [ -z "$(ls -A ${DIR}/ruleset/sca/)" ]; then
+        if [ -n "$(ls -A ${DIR}/ruleset/sca/)" ]; then
             chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
             chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
         fi

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -219,7 +219,7 @@ case "$1" in
         fi
 
         # Set correct permissions, owner and group. ruleset directory may be empty.
-        if [ -z "$(ls -A ${DIR}/ruleset/sca/)" ]; then
+        if [ -n "$(ls -A ${DIR}/ruleset/sca/)" ]; then
             chmod --recursive u=rwX,g=rX,o= ${DIR}/ruleset/sca/
             chown --recursive root:${GROUP} ${DIR}/ruleset/sca/
         fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/17840|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR fixes an error with the permissions of some SCA files.

## Logs example
<details><summary>Manager</summary>

```
root@debian12:/home/vagrant# apt install ./wazuh-manager_4.4.5-1_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.4.5-1_amd64.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 3 not upgraded.
Need to get 0 B/171 MB of archives.
After this operation, 631 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-manager_4.4.5-1_amd64.deb wazuh-manager amd64 4.4.5-1 [171 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 70590 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.4.5-1_amd64.deb ...
Unpacking wazuh-manager (4.4.5-1) ...
Setting up wazuh-manager (4.4.5-1) ...
root@debian12:/home/vagrant# ls -lah /var/ossec/ruleset/sca/
total 9.0M
drwxr-x--- 2 root wazuh 4.0K Jul 10 10:34 .
drwxr-x--- 5 root wazuh 4.0K Jul 10 10:34 ..
-rw-r----- 1 root wazuh 203K Jul 10 10:29 cis_amazon_linux_1.yml.disabled
-rw-r----- 1 root wazuh 231K Jul 10 10:29 cis_amazon_linux_2.yml.disabled
-rw-r----- 1 root wazuh  47K Jul 10 10:29 cis_apache_24.yml.disabled
-rw-r----- 1 root wazuh  33K Jul 10 10:29 cis_apple_macOS_10.11.yml.disabled
-rw-r----- 1 root wazuh  30K Jul 10 10:29 cis_apple_macOS_10.12.yml.disabled
-rw-r----- 1 root wazuh  30K Jul 10 10:29 cis_apple_macOS_10.13.yml.disabled
-rw-r----- 1 root wazuh  60K Jul 10 10:29 cis_apple_macOS_10.14.yml.disabled
-rw-r----- 1 root wazuh  64K Jul 10 10:29 cis_apple_macOS_10.15.yml.disabled
-rw-r----- 1 root wazuh  76K Jul 10 10:29 cis_apple_macOS_11.1.yml.disabled
-rw-r----- 1 root wazuh  89K Jul 10 10:29 cis_apple_macOS_12.0.yml.disabled
-rw-r----- 1 root wazuh 205K Jul 10 10:29 cis_centos6_linux.yml.disabled
-rw-r----- 1 root wazuh 257K Jul 10 10:29 cis_centos7_linux.yml.disabled
-rw-r----- 1 root wazuh 227K Jul 10 10:29 cis_centos8_linux.yml.disabled
-rw-r----- 1 root wazuh 235K Jul 10 10:29 cis_debian10.yml.disabled
-rw-r----- 1 root wazuh 175K Jul 10 10:29 cis_debian7.yml.disabled
-rw-r----- 1 root wazuh 203K Jul 10 10:29 cis_debian8.yml.disabled
-rw-r----- 1 root wazuh 202K Jul 10 10:29 cis_debian9.yml.disabled
-rw-r----- 1 root wazuh  63K Jul 10 10:29 cis_iis_10.yml.disabled
-rw-r----- 1 root wazuh  20K Jul 10 10:29 cis_mongodb_36.yml.disabled
-rw-r----- 1 root wazuh  22K Jul 10 10:29 cis_mysql5-6_community.yml.disabled
-rw-r----- 1 root wazuh  28K Jul 10 10:29 cis_mysql5-6_enterprise.yml.disabled
-rw-r----- 1 root wazuh  68K Jul 10 10:29 cis_nginx_1.yml.disabled
-rw-r----- 1 root wazuh 203K Jul 10 10:29 cis_oracle_database_19c.yml.disabled
-rw-r----- 1 root wazuh  50K Jul 10 10:29 cis_postgre-sql-13.yml.disabled
-rw-r----- 1 root wazuh  56K Jul 10 10:29 cis_rhel5_linux.yml.disabled
-rw-r----- 1 root wazuh 206K Jul 10 10:29 cis_rhel6_linux.yml.disabled
-rw-r----- 1 root wazuh 251K Jul 10 10:29 cis_rhel7_linux.yml.disabled
-rw-r----- 1 root wazuh 228K Jul 10 10:29 cis_rhel8_linux.yml.disabled
-rw-r----- 1 root wazuh 271K Jul 10 10:29 cis_rhel9_linux.yml.disabled
-rw-r----- 1 root wazuh  60K Jul 10 10:29 cis_sles11_linux.yml.disabled
-rw-r----- 1 root wazuh  62K Jul 10 10:29 cis_sles12_linux.yml.disabled
-rw-r----- 1 root wazuh 177K Jul 10 10:29 cis_sles15_linux.yml.disabled
-rw-r----- 1 root wazuh  79K Jul 10 10:29 cis_solaris11.4.yml.disabled
-rw-r----- 1 root wazuh  63K Jul 10 10:29 cis_solaris11.yml.disabled
-rw-r----- 1 root wazuh  35K Jul 10 10:29 cis_sqlserver_2012.yml.disabled
-rw-r----- 1 root wazuh  35K Jul 10 10:29 cis_sqlserver_2014.yml.disabled
-rw-r----- 1 root wazuh  35K Jul 10 10:29 cis_sqlserver_2016.yml.disabled
-rw-r----- 1 root wazuh  35K Jul 10 10:29 cis_sqlserver_2017.yml.disabled
-rw-r----- 1 root wazuh  34K Jul 10 10:29 cis_sqlserver_2019.yml.disabled
-rw-r----- 1 root wazuh 202K Jul 10 10:29 cis_ubuntu14-04.yml.disabled
-rw-r----- 1 root wazuh 202K Jul 10 10:29 cis_ubuntu16-04.yml.disabled
-rw-r----- 1 root wazuh 241K Jul 10 10:29 cis_ubuntu18-04.yml.disabled
-rw-r----- 1 root wazuh 377K Jul 10 10:29 cis_ubuntu20-04.yml.disabled
-rw-r----- 1 root wazuh 321K Jul 10 10:29 cis_ubuntu22-04.yml.disabled
-rw-r----- 1 root wazuh 666K Jul 10 10:29 cis_win10_enterprise.yml.disabled
-rw-r----- 1 root wazuh 666K Jul 10 10:29 cis_win11_enterprise.yml.disabled
-rw-r----- 1 root wazuh 388K Jul 10 10:29 cis_win2012r2.yml.disabled
-rw-r----- 1 root wazuh 444K Jul 10 10:29 cis_win2016.yml.disabled
-rw-r----- 1 root wazuh 444K Jul 10 10:29 cis_win2019.yml.disabled
-rw-r----- 1 root wazuh 613K Jul 10 10:29 cis_win2022.yml.disabled
-rw-r----- 1 root wazuh  19K Jul 10 10:29 sca_unix_audit.yml.disabled
-rw-r----- 1 root wazuh 6.7K Jul 10 10:29 web_vulnerabilities.yml.disabled
root@debian12:/home/vagrant# 

```
</details>

<details><summary>Agent</summary>

```
root@debian12:/home/vagrant# apt install ./wazuh-agent_4.4.5-1_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.4.5-1_amd64.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 3 not upgraded.
Need to get 0 B/8916 kB of archives.
After this operation, 30.2 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_4.4.5-1_amd64.deb wazuh-agent amd64 4.4.5-1 [8916 kB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 70590 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.4.5-1_amd64.deb ...
Unpacking wazuh-agent (4.4.5-1) ...
Setting up wazuh-agent (4.4.5-1) ...
root@debian12:/home/vagrant# ls -lah /var/ossec/ruleset/sca/
total 8.0K
drwxr-x--- 2 root wazuh 4.0K Jul 10 10:42 .
drwxr-x--- 3 root wazuh 4.0K Jul 10 10:42 ..
```

</details>

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
