### PR TITLE
Create fixedup_smf_manifest

### DIFF
--- a/solaris/solaris11/fixedup_smf_manifest
+++ b/solaris/solaris11/fixedup_smf_manifest
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<!DOCTYPE service_bundle
+  SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type="manifest" name="site/wazuh-install">
+    <service version="1" type="service" name="site/wazuh-install">
+        <dependency restart_on="none" type="service"
+            name="multi_user_dependency" grouping="require_all">
+            <service_fmri value="svc:/milestone/multi-user"/>
+        </dependency>
+        <dependent restart_on="none"
+            name="wazuh-install_multi-user-server" grouping="optional_all">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
+        <exec_method timeout_seconds="60" type="method" name="refresh"
+                     exec="var/ossec/bin/wazuh-control restart"/>
+        <exec_method timeout_seconds="60" type="method" name="start"
+                     exec="var/ossec/bin/wazuh-control start"/>
+        <exec_method timeout_seconds="60" type="method" name="stop"
+                     exec="var/ossec/bin/wazuh-control stop"/>
+         <property_group type="framework" name="startd">
+                     <propval type="astring" name="duration" value="transient"/>
+        </property_group>
+        <instance enabled="true" name="default"> </instance>
+    </service>
+</service_bundle>


### PR DESCRIPTION
For whatever reasons the installer removes this directory


/var/ossec/installation_scripts

The smf manifest starts  wazuh with a script in the directory listed above

<exec_method timeout_seconds="60" type="method" name="start"
                     exec="var/ossec/installation_scripts/postinstall.sh"/>


I have written the  smc manifest file to use the "var/ossec/bin/wazuh-control script to start /stop wazuh agent on Solaris

|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
