### PR TITLE
Provided port number option to `wazuh-install.sh` script

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -18,6 +18,15 @@ function checks_arch() {
 
 function checks_arguments() {
 
+    # -------------- Port option validation ---------------------
+
+    if [ -n "${port}" ]; then
+        if [ -z "${AIO}" ] && [ -z "${dashboard}" ]; then
+            common_logger -e "The argument -p|--port can only be used with -a|--all-in-one or -wd|--wazuh-dashboard."
+            exit 1
+        fi
+    fi
+
     # -------------- Configurations ---------------------------------
 
     if [ -f "${tar_file}" ]; then

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -20,7 +20,7 @@ function checks_arguments() {
 
     # -------------- Port option validation ---------------------
 
-    if [ -n "${port}" ]; then
+    if [ -n "${port_specified}" ]; then
         if [ -z "${AIO}" ] && [ -z "${dashboard}" ]; then
             common_logger -e "The argument -p|--port can only be used with -a|--all-in-one or -wd|--wazuh-dashboard."
             exit 1

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -340,3 +340,18 @@ function checks_ports() {
     fi
 
 }
+
+function checks_available_port() {
+    chosen_port="$1"
+    shift
+    ports_list=("$@")
+
+    if [ "$chosen_port" -ne "${http_port}" ]; then
+        for port in "${ports_list[@]}"; do
+            if [ "$chosen_port" -eq "$port" ]; then
+                common_logger -e "Port ${chosen_port} is reserved by Wazuh. Please, choose another port."
+                exit 1
+            fi
+        done
+    fi
+}

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -52,6 +52,10 @@ function dashboard_configure() {
         fi
     fi
 
+    if [ -n "${port_specified}" ]; then
+        sed -i 's/server\.port: [0-9]\+$/server.port: '"${chosen_port}"'/' /etc/wazuh-dashboard/opensearch_dashboards.yml
+    fi
+
     common_logger "Wazuh dashboard post-install configuration finished."
 
 }

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -129,7 +129,7 @@ function dashboard_initialize() {
 
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"
-        common_logger -nl "You can access the web interface https://${print_ip}\n    User: admin\n    Password: ${u_pass}"
+        common_logger -nl "You can access the web interface https://${print_ip}:${http_port}\n    User: admin\n    Password: ${u_pass}"
 
     elif [ ${j} -eq 12 ]; then
         flag="-w"
@@ -187,7 +187,7 @@ function dashboard_initializeAIO() {
     if [ "${http_code}" -eq "200" ]; then
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"
-        common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>\n    User: admin\n    Password: ${u_pass}"
+        common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>:${http_port}\n    User: admin\n    Password: ${u_pass}"
     else
         common_logger -e "Wazuh dashboard installation failed."
         installCommon_rollBack

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -9,11 +9,10 @@
 function dashboard_changePort() {
 
     chosen_port="$1"
+    http_port="${chosen_port}" 
 
-    sed -i "s/^readonly http_port=.*/readonly http_port=${chosen_port}/" "$0"
     sed -i 's/server\.port: [0-9]\+$/server.port: '"${chosen_port}"'/' "$0"
-
-    common_logger "Port changed to ${chosen_port}."
+    common_logger "Wazuh web interface port will be ${chosen_port}."
 }
 
 function dashboard_configure() {
@@ -52,9 +51,7 @@ function dashboard_configure() {
         fi
     fi
 
-    if [ -n "${port_specified}" ]; then
-        sed -i 's/server\.port: [0-9]\+$/server.port: '"${chosen_port}"'/' /etc/wazuh-dashboard/opensearch_dashboards.yml
-    fi
+    sed -i 's/server\.port: [0-9]\+$/server.port: '"${chosen_port}"'/' /etc/wazuh-dashboard/opensearch_dashboards.yml
 
     common_logger "Wazuh dashboard post-install configuration finished."
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -41,7 +41,7 @@ function getHelp() {
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
     echo -e ""
     echo -e "        -p,  --port"
-    echo -e "                Specifies the Wazuh web user interface port. By default is the 443 TCP port."
+    echo -e "                Specifies the Wazuh web user interface port. By default is the 443 TCP port. Recommended ports are: 8443, 8444, 8080, 8888, 9000."
     echo -e ""
     echo -e "        -s,  --start-cluster"
     echo -e "                Initialize Wazuh indexer cluster security settings."
@@ -247,6 +247,8 @@ function main() {
     if [ -n "${port_specified}" ]; then
         checks_available_port "${port_number}" "${wazuh_aio_ports[@]}"
         dashboard_changePort "${port_number}"
+    else
+        dashboard_changePort "${http_port}"
     fi
     
     if [ -n "${AIO}" ]; then

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -120,7 +120,7 @@ function main() {
                     getHelp
                     exit 1
                 fi
-                port=1
+                port_specified=1
                 port_number="${2}"
                 shift 2
                 ;;
@@ -243,7 +243,13 @@ function main() {
     else
         checks_health
     fi
-    if [ -n "${AIO}" ] ; then
+
+    if [ -n "${port_specified}" ]; then
+        checks_available_port "${port_number}" "${wazuh_aio_ports[@]}"
+        dashboard_changePort "${port_number}"
+    fi
+    
+    if [ -n "${AIO}" ]; then
         rm -f "${tar_file}"
         checks_ports "${wazuh_aio_ports[@]}"
     fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -40,6 +40,9 @@ function getHelp() {
     echo -e "        -o,  --overwrite"
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
     echo -e ""
+    echo -e "        -p,  --port"
+    echo -e "                Specifies the Wazuh web user interface port. By default is the 443 TCP port."
+    echo -e ""
     echo -e "        -s,  --start-cluster"
     echo -e "                Initialize Wazuh indexer cluster security settings."
     echo -e ""
@@ -110,6 +113,16 @@ function main() {
             "-o"|"--overwrite")
                 overwrite=1
                 shift 1
+                ;;
+            "-p"|"--port")
+                if [ -z "${2}" ]; then
+                    common_logger -e "Error on arguments. Probably missing <port> after -p|--port"
+                    getHelp
+                    exit 1
+                fi
+                port=1
+                port_number="${2}"
+                shift 2
                 ;;
             "-s"|"--start-cluster")
                 start_indexer_cluster=1

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -247,7 +247,7 @@ function main() {
     if [ -n "${port_specified}" ]; then
         checks_available_port "${port_number}" "${wazuh_aio_ports[@]}"
         dashboard_changePort "${port_number}"
-    else
+    elif [ -n "${AIO}" ] || [ -n "${dashboard}" ]; then
         dashboard_changePort "${http_port}"
     fi
     

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -48,7 +48,8 @@ readonly filebeat_config_file="${resources}/tpl/wazuh/filebeat/filebeat.yml"
 adminUser="wazuh"
 adminPassword="wazuh"
 
-readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 443)
+readonly http_port=443
+readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 "${http_port}")
 readonly wazuh_indexer_ports=( 9200 9300 )
 readonly wazuh_manager_ports=( 1514 1515 1516 55000 )
-readonly wazuh_dashboard_ports=( 443 )
+readonly wazuh_dashboard_ports=( "${http_port}" )

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -48,7 +48,7 @@ readonly filebeat_config_file="${resources}/tpl/wazuh/filebeat/filebeat.yml"
 adminUser="wazuh"
 adminPassword="wazuh"
 
-readonly http_port=443
+http_port=443
 readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 "${http_port}")
 readonly wazuh_indexer_ports=( 9200 9300 )
 readonly wazuh_manager_ports=( 1514 1515 1516 55000 )


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18164|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to add a new optional parameter, `-p|--port` to allow choosing the Wazuh web interface port. This new option can only be used while performing an AIO installation or installing the Wazuh dashboard.

```
> bash wazuh-install.sh -a -p 8443
> bash wazuh-install.sh -wd dashboard --port 8443
```

Some tests have been done in the "Final tests" of the related issue: https://github.com/wazuh/wazuh/issues/18164#issuecomment-1667789913


Is compulsory to make the necessary changes in the documentation. https://github.com/wazuh/wazuh-documentation/pull/6322