### PR TITLE
Fix MacOS spec version for INTEL - 4.5.2

### DIFF
--- a/macos/specs/wazuh-agent-intel64.pkgproj
+++ b/macos/specs/wazuh-agent-intel64.pkgproj
@@ -1203,7 +1203,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>wazuh-agent-4.5.1-1.intel64</string>
+			<string>wazuh-agent-4.5.2-1.intel64</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 			<key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2339|

## Description

Spec version for MacOS INTEL is fixed to 4.5.2.