### PR TITLE
Add a version control mechanism in cve.db for Vulnerability Detector

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -86,9 +86,6 @@ case "$1" in
         fi
     fi
 
-    # Remove Vuln-detector database
-    rm -f ${DIR}/queue/vulnerabilities/cve.db || true
-
     # Remove groups backup files
     rm -rf ${DIR}/backup/groups
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -235,9 +235,6 @@ if [ -f %{_localstatedir}/queue/db/global.db ]; then
   chown wazuh:wazuh %{_localstatedir}/queue/db/global.db*
 fi
 
-# Remove Vuln-detector database
-rm -f %{_localstatedir}/queue/vulnerabilities/cve.db || true
-
 # Remove plain-text agent information if exists
 if [ -d %{_localstatedir}/queue/agent-info ]; then
   rm -rf %{_localstatedir}/queue/agent-info/* > /dev/null 2>&1


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/16699|

## Description
Due the requirements of related issue, are needed a update post-instalation events avoiding the remove  of `cve.db` thus is now these events is implemented and controlled by the own module `wazuh-analisisd`.

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [X] Package upgrade
- [X] Package downgrade
- [ ] Package remove
- [X] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package