### PR TITLE
Improved `curl` error messages in downloads

### DIFF
--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -8,7 +8,7 @@
 
 function filebeat_configure(){
 
-    eval "common_curl -so /etc/filebeat/wazuh-template.json ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 --fail ${debug}"
+    eval "common_curl -sSo /etc/filebeat/wazuh-template.json ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 --fail ${debug}"
     if [ ! -f "/etc/filebeat/wazuh-template.json" ]; then
         common_logger -e "Error downloading wazuh-template.json file."
         installCommon_rollBack
@@ -16,7 +16,7 @@ function filebeat_configure(){
     fi
 
     eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
-    eval "common_curl -s ${filebeat_wazuh_module} --max-time 300 --retry 5 --retry-delay 5 --fail | tar -xvz -C /usr/share/filebeat/module ${debug}"
+    eval "common_curl -sS ${filebeat_wazuh_module} --max-time 300 --retry 5 --retry-delay 5 --fail | tar -xvz -C /usr/share/filebeat/module ${debug}"
     if [ ! -d "/usr/share/filebeat/module" ]; then
         common_logger -e "Error downloading wazuh filebeat module."
         installCommon_rollBack
@@ -55,7 +55,7 @@ function filebeat_copyCertificates() {
             if ! tar -tvf "${tar_file}" | grep -q "${server_node_names[0]}" ; then
                 common_logger -e "Tar file does not contain certificate for the node ${server_node_names[0]}."
                 installCommon_rollBack
-                exit 1;
+                exit 1
             fi
             eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /etc/filebeat/filebeat.yml ${debug}"
             eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /etc/filebeat/filebeat.yml ${debug}"

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -67,7 +67,7 @@ function filebeat_copyCertificates() {
             if ! tar -tvf "${tar_file}" | grep -q "${winame}" ; then
                 common_logger -e "Tar file does not contain certificate for the node ${winame}."
                 installCommon_rollBack
-                exit 1;
+                exit 1
             fi
             eval "sed -i s/filebeat.pem/${winame}.pem/ /etc/filebeat/filebeat.yml ${debug}"
             eval "sed -i s/filebeat-key.pem/${winame}-key.pem/ /etc/filebeat/filebeat.yml ${debug}"
@@ -81,7 +81,7 @@ function filebeat_copyCertificates() {
         eval "chown root:root ${filebeat_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
-        exit 1;
+        exit 1
     fi
 
 }

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -355,7 +355,7 @@ function installCommon_installChrome() {
 
     if [ "${sys_type}" == "yum" ]; then
         chrome_package="/tmp/wazuh-install-files/chrome.rpm"
-        common_curl -so "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm --max-time 100 --retry 5 --retry-delay 5 --fail
+        common_curl -sSo "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm --max-time 100 --retry 5 --retry-delay 5 --fail "${debug}"
         eval "yum install ${chrome_package} -y ${debug}"
 
         if [ "${PIPESTATUS[0]}" != 0 ]; then
@@ -364,7 +364,7 @@ function installCommon_installChrome() {
 
     elif [ "${sys_type}" == "apt-get" ]; then
         chrome_package="/tmp/wazuh-install-files/chrome.deb"
-        common_curl -so "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb --max-time 100 --retry 5 --retry-delay 5 --fail
+        common_curl -sSo "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb --max-time 100 --retry 5 --retry-delay 5 --fail "${debug}"
         installCommon_aptInstall "${chrome_package}"
 
         if [ "${install_result}" != 0 ]; then

--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -111,7 +111,7 @@ function offline_download() {
 
   for package in "${packages_to_download[@]}"
   do
-    
+
     package_name="${package}_${package_type}_package"
     eval "package_base_url=${package}_${package_type}_base_url"
 

--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -123,7 +123,6 @@ function offline_download() {
       exit 1
     fi
 
-
   done
 
   common_logger "The packages are in ${dest_path}"

--- a/unattended_installer/install_functions/wazuh-offline-download.sh
+++ b/unattended_installer/install_functions/wazuh-offline-download.sh
@@ -111,17 +111,18 @@ function offline_download() {
 
   for package in "${packages_to_download[@]}"
   do
-
+    
     package_name="${package}_${package_type}_package"
     eval "package_base_url=${package}_${package_type}_base_url"
 
-    eval "common_curl -so ${dest_path}/${!package_name} ${!package_base_url}/${!package_name} --max-time 300 --retry 5 --retry-delay 5 --fail"
-    if [  "${PIPESTATUS[0]}" != 0  ]; then
-        common_logger -e "The ${package} package could not be downloaded. Exiting."
-        exit 1
+    if output=$(common_curl -sSo "${dest_path}/${!package_name}" "${!package_base_url}/${!package_name}" --max-time 300 --retry 5 --retry-delay 5 --fail 2>&1); then
+      common_logger "The ${package} package was downloaded."
     else
-        common_logger "The ${package} package was downloaded."
+      common_logger -e "The ${package} package could not be downloaded. Exiting."
+      eval "echo \${output} ${debug}"
+      exit 1
     fi
+
 
   done
 
@@ -145,12 +146,12 @@ function offline_download() {
   for file in "${files_to_download[@]}"
   do
 
-    eval "common_curl -sO ${file} --max-time 300 --retry 5 --retry-delay 5 --fail"
-    if [  "${PIPESTATUS[0]}" != 0  ]; then
-        common_logger -e "The resource ${file} could not be downloaded. Exiting."
-        exit 1
-    else
+    if output=$(common_curl -sSO ${file} --max-time 300 --retry 5 --retry-delay 5 --fail 2>&1); then
         common_logger "The resource ${file} was downloaded."
+    else
+        common_logger -e "The resource ${file} could not be downloaded. Exiting."
+        eval "echo \${output} ${debug}"
+        exit 1
     fi
 
   done


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1896|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to improve the `curl` error message generation commands while downloading resources. Before, if this type of `curl` command failed, the error was not inserted into the log file or into the console (if the `verbose` option was enabled).

The testing of the affected curls is attached in the related issue.

