### PR TITLE
Added umask to wazuh-indexer.service

### DIFF
--- a/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer.service
+++ b/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer.service
@@ -18,6 +18,7 @@ WorkingDirectory=/usr/share/wazuh-indexer
 
 User=wazuh-indexer
 Group=wazuh-indexer
+UMask=0027
 
 ExecStart=/usr/share/wazuh-indexer/bin/systemd-entrypoint -p ${PID_DIR}/wazuh-indexer.pid --quiet
 

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -8,7 +8,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 
 current_path="$( cd $(dirname $0) ; pwd -P )"
 architecture="x86_64"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2139|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The umask is added for the creation of files with the necessary permissions

## Logs example

<!--
Paste here related logs
-->

### Ubuntu 22.04 test
<details>
<summary>/usr/lib/systemd/system/wazuh-indexer.service</summary>

```console
root@ubuntu22:~# cat /usr/lib/systemd/system/wazuh-indexer.service
[Unit]
Description=Wazuh-indexer
Documentation=https://documentation.wazuh.com
Wants=network-online.target
After=network-online.target

[Service]
Type=notify
RuntimeDirectory=wazuh-indexer
PrivateTmp=yes
Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
Environment=OPENSEARCH_PATH_CONF=/etc/wazuh-indexer
Environment=PID_DIR=/run/wazuh-indexer
Environment=OPENSEARCH_SD_NOTIFY=true
EnvironmentFile=-/etc/sysconfig/wazuh-indexer

WorkingDirectory=/usr/share/wazuh-indexer

User=wazuh-indexer
Group=wazuh-indexer
UMask=0027

ExecStart=/usr/share/wazuh-indexer/bin/systemd-entrypoint -p ${PID_DIR}/wazuh-indexer.pid --quiet

# StandardOutput is configured to redirect to journalctl since
# some error messages may be logged in standard output before
# wazuh-indexer logging system is initialized. Elasticsearch
# stores its logs in /var/log/wazuh-indexer and does not use
# journalctl by default. If you also want to enable journalctl
# logging, you can simply remove the "quiet" option from ExecStart.
StandardOutput=journal
StandardError=inherit

# Specifies the maximum file descriptor number that can be opened by this process
LimitNOFILE=65535

# Specifies the maximum number of processes
LimitNPROC=4096

# Specifies the maximum size of virtual memory
LimitAS=infinity

# Specifies the maximum file size
LimitFSIZE=infinity

# Disable timeout logic and wait until process is stopped
TimeoutStopSec=0

# SIGTERM signal is used to stop the Java process
KillSignal=SIGTERM

# Send the signal only to the JVM rather than its control group
KillMode=process

# Java process is never killed
SendSIGKILL=no

# When a JVM receives a SIGTERM signal it exits with code 143
SuccessExitStatus=143

# Allow a slow startup before the systemd notifier module kicks in to extend the timeout
TimeoutStartSec=180

[Install]
WantedBy=multi-user.target
```

</details>

<details>
<summary>System info</summary>

```console
root@ubuntu22:~# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.5.2"
WAZUH_REVISION="40502"
WAZUH_TYPE="server"
root@ubuntu22:~# cat /etc/*release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04 LTS"
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```
</details>


<details>
<summary>After install</summary>

```console
root@ubuntu22:~# ls -la /var/log/wazuh-indexer/
total 212
drwxr-x---  2 wazuh-indexer wazuh-indexer  4096 Aug 22 15:43 .
drwxrwxr-x 10 root          syslog         4096 Aug 22 15:45 ..
-rw-r-----  1 wazuh-indexer wazuh-indexer 56782 Aug 22 15:49 gc.log
-rw-r-----  1 wazuh-indexer wazuh-indexer  2007 Aug 22 15:43 gc.log.00
-rw-r-----  1 wazuh-indexer wazuh-indexer 42275 Aug 22 15:48 wazuh-cluster.log
-rw-r-----  1 wazuh-indexer wazuh-indexer  2358 Aug 22 15:47 wazuh-cluster_deprecation.json
-rw-r-----  1 wazuh-indexer wazuh-indexer  1374 Aug 22 15:47 wazuh-cluster_deprecation.log
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer 87370 Aug 22 15:48 wazuh-cluster_server.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_task_detailslog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_task_detailslog.log
root@ubuntu22:~# date 
Tue Aug 22 15:49:44 UTC 2023
root@ubuntu22:~# poweroff
```
</details>

<details>
<summary>After reboot</summary>

```console
root@ubuntu22:~# ls -la /var/log/wazuh-indexer/
total 336
drwxr-x---  2 wazuh-indexer wazuh-indexer   4096 Aug 22 15:50 .
drwxrwxr-x 10 root          syslog          4096 Aug 22 15:50 ..
-rw-r-----  1 wazuh-indexer wazuh-indexer  30773 Aug 22 15:50 gc.log
-rw-r-----  1 wazuh-indexer wazuh-indexer   2007 Aug 22 15:43 gc.log.00
-rw-r-----  1 wazuh-indexer wazuh-indexer  57854 Aug 22 15:49 gc.log.01
-rw-r-----  1 wazuh-indexer wazuh-indexer   1983 Aug 22 15:50 gc.log.02
-rw-r-----  1 wazuh-indexer wazuh-indexer  72501 Aug 22 15:50 wazuh-cluster.log
-rw-r-----  1 wazuh-indexer wazuh-indexer   3803 Aug 22 15:50 wazuh-cluster_deprecation.json
-rw-r-----  1 wazuh-indexer wazuh-indexer   2249 Aug 22 15:50 wazuh-cluster_deprecation.log
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer 145128 Aug 22 15:50 wazuh-cluster_server.json
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_task_detailslog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer      0 Aug 22 15:43 wazuh-cluster_task_detailslog.log
root@ubuntu22:~# date 
Tue Aug 22 15:50:43 UTC 2023
root@ubuntu22:~# poweroff

```
</details>

<details>
<summary>After changing the date on the host</summary>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/local-test/vagrant-tests/ubuntu/jummy-22.04$ date
mié 23 ago 2023 12:51:45 -03
cbordon@cbordon-MS-7C88:~/Documents/wazuh/local-test/vagrant-tests/ubuntu/jummy-22.04$ vagrant ssh
Welcome to Ubuntu 22.04 LTS (GNU/Linux 5.15.0-39-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Wed Aug 23 15:51:33 UTC 2023

  System load:  0.560546875        Processes:               161
  Usage of /:   15.6% of 39.86GB   Users logged in:         0
  Memory usage: 32%                IPv4 address for enp0s3: 10.0.2.15
  Swap usage:   0%                 IPv4 address for enp0s8: 192.168.56.254


213 updates can be applied immediately.
136 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable


Last login: Wed Aug 23 15:51:41 2023 from 10.0.2.2
vagrant@ubuntu22:~$ sudo su -
root@ubuntu22:~# ls -la /var/log/wazuh-indexer/
total 308
drwxr-x---  2 wazuh-indexer wazuh-indexer  4096 Aug 23 15:51 .
drwxrwxr-x 10 root          syslog         4096 Aug 23 15:51 ..
-rw-r-----  1 wazuh-indexer wazuh-indexer 38254 Aug 23 15:52 gc.log
-rw-r-----  1 wazuh-indexer wazuh-indexer  2007 Aug 22 15:43 gc.log.00
-rw-r-----  1 wazuh-indexer wazuh-indexer 57854 Aug 22 15:49 gc.log.01
-rw-r-----  1 wazuh-indexer wazuh-indexer  1983 Aug 22 15:50 gc.log.02
-rw-r-----  1 wazuh-indexer wazuh-indexer 34079 Aug 22 15:50 gc.log.03
-rw-r-----  1 wazuh-indexer wazuh-indexer  1983 Aug 23 15:51 gc.log.04
-rw-r-----  1 wazuh-indexer wazuh-indexer 14976 Aug 23 15:51 wazuh-cluster-2023-08-22-1.json.gz
-rw-r-----  1 wazuh-indexer wazuh-indexer 13598 Aug 23 15:51 wazuh-cluster-2023-08-22-1.log.gz
-rw-r-----  1 wazuh-indexer wazuh-indexer 33774 Aug 23 15:51 wazuh-cluster.log
-rw-r-----  1 wazuh-indexer wazuh-indexer  5248 Aug 23 15:51 wazuh-cluster_deprecation.json
-rw-r-----  1 wazuh-indexer wazuh-indexer  3124 Aug 23 15:51 wazuh-cluster_deprecation.log
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_indexing_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_index_search_slowlog.log
-rw-r-----  1 wazuh-indexer wazuh-indexer 66521 Aug 23 15:51 wazuh-cluster_server.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_task_detailslog.json
-rw-r-----  1 wazuh-indexer wazuh-indexer     0 Aug 22 15:43 wazuh-cluster_task_detailslog.log
root@ubuntu22:~# date
Tue Aug 22 15:52:12 UTC 2023

```
</details>

## Tests

### Build:
   - DEB: https://ci.wazuh.info/job/Packages_builder/162016/
   - RPM: https://ci.wazuh.info/job/Packages_builder/162020/

### Test install:
   - DEB: https://ci.wazuh.info/view/Tests/job/Test_stack/801/console
   - RPM: https://ci.wazuh.info/view/Tests/job/Test_stack/800/console


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
