### PR TITLE
Fixed `source_branch` variable in `master` branch

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-readonly source_branch="4.8"
+readonly source_branch="master"
 
 function getHelp() {
 

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-readonly source_branch="master"
+readonly source_branch="4.8.0"
 
 function getHelp() {
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2367|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR is a fix of https://github.com/wazuh/wazuh-packages/pull/2370. The `source_branch` has been replaced for the `4.8.0` value. Now, the `curl` command of the builder looks like:
https://raw.githubusercontent.com/wazuh/wazuh/4.8.0/src/init/dist-detect.sh
