### PR TITLE
Fix builder

### DIFF
--- a/wazuhapp/opensearch-dashboards/Docker/build.sh
+++ b/wazuhapp/opensearch-dashboards/Docker/build.sh
@@ -21,6 +21,7 @@ wazuh_app_raw_repo_url="https://raw.githubusercontent.com/wazuh/wazuh-kibana-app
 plugin_platform_app_repo_url="https://github.com/opensearch-project/OpenSearch-Dashboards.git"
 plugin_platform_app_raw_repo_url="https://raw.githubusercontent.com/opensearch-project/OpenSearch-Dashboards"
 wazuh_app_package_json_url="${wazuh_app_raw_repo_url}/${wazuh_branch}/plugins/main/package.json"
+wazuh_app_nvmrc_url="${wazuh_app_raw_repo_url}/${wazuh_branch}/.nvmrc"
 
 # Script vars
 wazuh_version=""
@@ -46,12 +47,16 @@ change_node_version () {
 
 
 prepare_env() {
-    echo "Downloading package.json from wazuh-kibana-app repository"
+    echo "Downloading package.json and .nvmrc from wazuh-kibana-app repository"
     if ! curl $wazuh_app_package_json_url -o "/tmp/package.json" ; then
         echo "Error downloading package.json from GitHub."
         exit 1
     fi
 
+    if ! curl $wazuh_app_nvmrc_url -o "/tmp/.nvmrc" ; then
+        echo "Error downloading package.json from GitHub."
+        exit 1
+    fi
     wazuh_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
                     print(pkg["version"])')
     plugin_platform_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
@@ -66,11 +71,11 @@ prepare_env() {
         exit 1
     fi
 
-    plugin_platform_node_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
-                          print(pkg["engines"]["node"])')
+    plugin_platform_node_version=$(python -c 'import json, os; f=open("/tmp/.nvmrc"); pkg=f.readline(); f.close();\
+                          print(pkg)')
 
     plugin_platform_yarn_version=$(python -c 'import json, os; f=open("/tmp/package.json"); pkg=json.load(f); f.close();\
-                          print(pkg["engines"]["yarn"])')
+                          print(str(pkg["engines"]["yarn"]).replace("^",""))')
 }
 
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2393|

## Description

This issue aims to fix an error detected when a Dashboard package is generated based in versions of OpenSeach higher than 2.6.0. 
It was caused due to a change in the format of Opensearch Dashboard's `package.json`, from which the node version was previously taken. 
The solution is to take that value from a file that is already in the `wazuh-kibana-app` repository, on which we have control of the format.

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
