### PR TITLE
Bump Wazuh dashboard to 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The following table shows the references for the versions of each component.
 |-----------------|-----------------------|
 | 4.3.x           | 1.2.0                 |
 | 4.4.0           | 2.4.1                 |
-| 4.4.1 - 4.5.1   | 2.6.0                 |
+| 4.4.1 - 4.5.2   | 2.6.0                 |
+| 4.6.0           | 2.8.0                 |
 
 ### Wazuh indexer
 

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -16,7 +16,7 @@ revision="$2"
 future="$3"
 repository="$4"
 reference="$5"
-opensearch_version="2.6.0"
+opensearch_version="2.8.0"
 base_dir=/opt/wazuh-dashboard-base
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/base/docker/Dockerfile
+++ b/stack/dashboard/base/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN yum install -y \
     jq \
     unzip
 
-RUN git clone https://github.com/google/brotli.git
+RUN git clone https://github.com/google/brotli.git -b v1.0.9
 
 RUN cd brotli && chmod +x ./bootstrap && ./bootstrap && ./configure --prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib64/brotli --libdir=/usr/lib64/brotli --datarootdir=/usr/share --mandir=/usr/share/man/man1 --docdir=/usr/share/doc \
     && make && make install

--- a/stack/dashboard/base/files/etc/services/wazuh-dashboard.service
+++ b/stack/dashboard/base/files/etc/services/wazuh-dashboard.service
@@ -7,7 +7,7 @@ User=wazuh-dashboard
 Group=wazuh-dashboard
 EnvironmentFile=-/etc/default/wazuh-dashboard
 EnvironmentFile=-/etc/sysconfig/wazuh-dashboard
-ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards "-c /etc/wazuh-dashboard/opensearch_dashboards.yml"
+ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards
 WorkingDirectory=/usr/share/wazuh-dashboard
 
 [Install]

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -58,6 +58,7 @@ override_dh_install:
 	useradd -g $(GROUP) $(USER)
 
 	tar -xf $(DASHBOARD_FILE)
+	sed -i "s/cross_platform_1.REPO_ROOT\, 'config\//'\/etc\/wazuh-dashboard\/', '/g" "wazuh-dashboard-base/node_modules/@osd/utils/target/path/index.js"
 
 	mkdir -p $(TARGET_DIR)$(CONFIG_DIR)
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)

--- a/stack/dashboard/rpm/docker/x86_64/Dockerfile
+++ b/stack/dashboard/rpm/docker/x86_64/Dockerfile
@@ -1,13 +1,16 @@
-FROM rockylinux:8.5
+FROM amd64/centos:7
+
+# Enable EPEL
+RUN yum install -y http://packages.wazuh.com/utils/pkg/epel-release-latest-7.noarch.rpm
 
 # Install all the necessary tools to build the packages
 RUN yum clean all && yum update -y
 RUN yum install -y openssh-clients sudo gnupg \
-    yum-utils epel-release redhat-rpm-config rpm-devel \
+    yum-utils redhat-rpm-config rpm-devel \
     zlib zlib-devel rpm-build autoconf automake \
     glibc-devel libtool perl
 
-RUN yum install -y https://repo.ius.io/ius-release-el$(rpm -E '%{rhel}').rpm  
+RUN yum install -y https://repo.ius.io/ius-release-el$(rpm -E '%{rhel}').rpm
 
 RUN yum update -y && yum install -y python3
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -54,6 +54,7 @@ useradd -g %{GROUP} %{USER}
 %build
 
 tar -xf %{DASHBOARD_FILE}
+sed -i "s/cross_platform_1.REPO_ROOT\, 'config\//'\/etc\/wazuh-dashboard\/', '/g" "wazuh-dashboard-base/node_modules/@osd/utils/target/path/index.js"
 
 # -----------------------------------------------------------------------------
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -391,6 +391,7 @@ rm -fr %{buildroot}
 %attr(640, %{USER}, %{GROUP}) "%{INSTALL_DIR}/LICENSE.txt"
 %attr(640, %{USER}, %{GROUP}) "%{INSTALL_DIR}/NOTICE.txt"
 %attr(640, %{USER}, %{GROUP}) "%{INSTALL_DIR}/README.txt"
+%attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/use_node"
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/opensearch-dashboards"
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/opensearch-dashboards-plugin"
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/opensearch-dashboards-keystore"


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2392|

## Description

This pull request bumps the Wazuh dashboard to OpenSearch 2.8.0

## Tests


- [x] Test_stack: https://ci.wazuh.info/job/Test_stack_tier/82/
- [x] Builder
  - [x] https://ci.wazuh.info/view/Packages/job/Packages_builder/163908/
  - [x] https://ci.wazuh.info/view/Packages/job/Packages_builder/163903/
  - [x] https://ci.wazuh.info/view/Packages/job/Packages_builder/163902/
  - [x] https://ci.wazuh.info/view/Packages/job/Packages_builder/163901/
  
<details><summary>Upgrade - Debian 11</summary>

```
root@debian11:/home/vagrant# curl -sO https://packages.wazuh.com/4.5/wazuh-install.sh && sudo bash ./wazuh-install.sh -a -i
04/09/2023 15:36:51 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.1
04/09/2023 15:36:51 INFO: Verbose logging redirected to /var/log/wazuh-install.log
04/09/2023 15:36:59 WARNING: Hardware and system checks ignored.
04/09/2023 15:37:00 INFO: --- Dependencies ----
04/09/2023 15:37:00 INFO: Installing apt-transport-https.
04/09/2023 15:37:01 INFO: Installing software-properties-common.
04/09/2023 15:37:10 INFO: Wazuh repository added.
04/09/2023 15:37:10 INFO: --- Configuration files ---
04/09/2023 15:37:10 INFO: Generating configuration files.
04/09/2023 15:37:10 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
04/09/2023 15:37:11 INFO: --- Wazuh indexer ---
04/09/2023 15:37:11 INFO: Starting Wazuh indexer installation.
04/09/2023 15:38:04 INFO: Wazuh indexer installation finished.
04/09/2023 15:38:04 INFO: Wazuh indexer post-install configuration finished.
04/09/2023 15:38:04 INFO: Starting service wazuh-indexer.
04/09/2023 15:38:31 INFO: wazuh-indexer service started.
04/09/2023 15:38:31 INFO: Initializing Wazuh indexer cluster security settings.
04/09/2023 15:38:41 INFO: Wazuh indexer cluster initialized.
04/09/2023 15:38:41 INFO: --- Wazuh server ---
04/09/2023 15:38:41 INFO: Starting the Wazuh manager installation.
04/09/2023 15:39:14 INFO: Wazuh manager installation finished.
04/09/2023 15:39:14 INFO: Starting service wazuh-manager.
04/09/2023 15:39:30 INFO: wazuh-manager service started.
04/09/2023 15:39:30 INFO: Starting Filebeat installation.
04/09/2023 15:39:33 INFO: Filebeat installation finished.
04/09/2023 15:39:34 INFO: Filebeat post-install configuration finished.
04/09/2023 15:39:34 INFO: Starting service filebeat.
04/09/2023 15:39:35 INFO: filebeat service started.
04/09/2023 15:39:35 INFO: --- Wazuh dashboard ---
04/09/2023 15:39:35 INFO: Starting Wazuh dashboard installation.
04/09/2023 15:40:16 INFO: Wazuh dashboard installation finished.
04/09/2023 15:40:16 INFO: Wazuh dashboard post-install configuration finished.
04/09/2023 15:40:16 INFO: Starting service wazuh-dashboard.
04/09/2023 15:40:17 INFO: wazuh-dashboard service started.
04/09/2023 15:40:37 INFO: Initializing Wazuh dashboard web application.
04/09/2023 15:40:38 INFO: Wazuh dashboard web application initialized.
04/09/2023 15:40:38 INFO: --- Summary ---
04/09/2023 15:40:38 INFO: You can access the web interface https://<wazuh-dashboard-ip>
    User: admin
    Password: v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI
04/09/2023 15:40:38 INFO: Installation finished.
You have mail in /var/mail/root
root@debian11:/home/vagrant# systemctl stop filebeat
systemctl stop wazuh-dashboard
root@debian11:/home/vagrant# curl -X PUT "https://localhost:9200/_cluster/settings"  -u admin:v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI -k -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": "primaries"
  }
}
'
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"primaries"}}}},"transient":{}}root@debian11:/home/vagrant# 
root@debian11:/home/vagrant# curl -X POST "https://localhost:9200/_flush/synced" -u admin:v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI -k
{"_shards":{"total":7,"successful":7,"failed":0}}root@debian11:/home/vagrant# systemctl stop wazuh-indexer
root@debian11:/home/vagrant# yum install https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.6.0-wp.2392_amd64.deb
bash: yum: command not found
root@debian11:/home/vagrant# yum install https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.6.0-wp.2392_amd64.deb^C
root@debian11:/home/vagrant# apt install https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.6.0-wp.2392_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer
root@debian11:/home/vagrant# wget https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.6.0-wp.2392_amd64.deb
--2023-09-04 15:44:03--  https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-indexer/wazuh-indexer_4.6.0-wp.2392_amd64.deb
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 143.204.231.40, 143.204.231.78, 143.204.231.67, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|143.204.231.40|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 685485530 (654M) [binary/octet-stream]
Saving to: ‘wazuh-indexer_4.6.0-wp.2392_amd64.deb’

wazuh-indexer_4.6.0-wp.2392_amd64.deb                               100%[==================================================================================================================================================================>] 653.73M  26.3MB/s    in 26s     

2023-09-04 15:44:35 (25.3 MB/s) - ‘wazuh-indexer_4.6.0-wp.2392_amd64.deb’ saved [685485530/685485530]

root@debian11:/home/vagrant# apt install ./wazuh-indexer_4.6.0-wp.2392_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.6.0-wp.2392_amd64.deb'
The following packages will be upgraded:
  wazuh-indexer
1 upgraded, 0 newly installed, 0 to remove and 53 not upgraded.
Need to get 0 B/685 MB of archives.
After this operation, 1,739 kB disk space will be freed.
Get:1 /home/vagrant/wazuh-indexer_4.6.0-wp.2392_amd64.deb wazuh-indexer amd64 4.6.0-wp.2392 [685 MB]
Reading changelogs... Done
(Reading database ... 186868 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.6.0-wp.2392_amd64.deb ...
Unpacking wazuh-indexer (4.6.0-wp.2392) over (4.5.1-1) ...
Setting up wazuh-indexer (4.6.0-wp.2392) ...
Installing new version of config file /etc/wazuh-indexer/opensearch-notifications-core/notifications-core.yml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/log4j2.xml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_idle_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-security/config.yml ...
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable wazuh-indexer
systemctl start wazuh-indexer
root@debian11:/home/vagrant# curl -k -u admin:v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           12          97   8    0.83    0.56     0.35 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
root@debian11:/home/vagrant# curl -X PUT "https://localhost:9200/_cluster/settings" -u admin:v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI -k -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": "all"
  }
}
'
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"all"}}}},"transient":{}}root@debian11:/home/vagrant#
root@debian11:/home/vagrant# curl -k -u admin:v6w5wLoRWRykbXt4LNTf+EeVzcASt?CI https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           16          97   1    0.28    0.45     0.33 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
root@debian11:/home/vagrant# wget https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-manager/wazuh-manager_4.6.0-wp.2392_amd64.deb
--2023-09-04 15:49:46--  https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-manager/wazuh-manager_4.6.0-wp.2392_amd64.deb
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 143.204.231.40, 143.204.231.67, 143.204.231.78, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|143.204.231.40|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 171353850 (163M) [binary/octet-stream]
Saving to: ‘wazuh-manager_4.6.0-wp.2392_amd64.deb’

wazuh-manager_4.6.0-wp.2392_amd64.deb                               100%[==================================================================================================================================================================>] 163.42M  25.8MB/s    in 7.1s    

2023-09-04 15:49:54 (22.9 MB/s) - ‘wazuh-manager_4.6.0-wp.2392_amd64.deb’ saved [171353850/171353850]

root@debian11:/home/vagrant# apt install ./wazuh-manager_4.6.0-wp.2392_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.6.0-wp.2392_amd64.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 53 not upgraded.
Need to get 0 B/171 MB of archives.
After this operation, 1,731 kB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-manager_4.6.0-wp.2392_amd64.deb wazuh-manager amd64 4.6.0-wp.2392 [171 MB]
Reading changelogs... Done        
(Reading database ... 186872 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.6.0-wp.2392_amd64.deb ...
Unpacking wazuh-manager (4.6.0-wp.2392) over (4.5.1-1) ...
Setting up wazuh-manager (4.6.0-wp.2392) ...
root@debian11:/home/vagrant# curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz | sudo tar -xvz -C /usr/share/filebeat/module
sudo: unable to resolve host debian11: Name or service not known
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
root@debian11:/home/vagrant# curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.6.0/extensions/elasticsearch/7.x/wazuh-template.json
root@debian11:/home/vagrant# chmod go+r /etc/filebeat/wazuh-template.json
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable filebeat
systemctl start filebeat
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
root@debian11:/home/vagrant# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2023-09-04 15:47:51 UTC; 4min 7s ago
       Docs: https://documentation.wazuh.com
   Main PID: 56982 (java)
      Tasks: 65 (limit: 4675)
     Memory: 2.2G
        CPU: 20.194s
     CGroup: /system.slice/wazuh-indexer.service
             └─56982 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTr>

Sep 04 15:47:37 debian11 systemd[1]: Starting Wazuh-indexer...
Sep 04 15:47:39 debian11 systemd-entrypoint[56982]: WARNING: A terminally deprecated method in java.lang.System has been called
Sep 04 15:47:39 debian11 systemd-entrypoint[56982]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.8.0.jar)
Sep 04 15:47:39 debian11 systemd-entrypoint[56982]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
Sep 04 15:47:39 debian11 systemd-entrypoint[56982]: WARNING: System::setSecurityManager will be removed in a future release
Sep 04 15:47:44 debian11 systemd-entrypoint[56982]: WARNING: A terminally deprecated method in java.lang.System has been called
Sep 04 15:47:44 debian11 systemd-entrypoint[56982]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.8.0.jar)
Sep 04 15:47:44 debian11 systemd-entrypoint[56982]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
Sep 04 15:47:44 debian11 systemd-entrypoint[56982]: WARNING: System::setSecurityManager will be removed in a future release
Sep 04 15:47:51 debian11 systemd[1]: Started Wazuh-indexer.
You have new mail in /var/mail/root
root@debian11:/home/vagrant# filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.2
    dial up... OK
  talk to server... OK
  version: 7.10.2
root@debian11:/home/vagrant# wget https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-dashboard/wazuh-dashboard_4.6.0-wp.2392_amd64.deb
--2023-09-04 15:52:31--  https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-dashboard/wazuh-dashboard_4.6.0-wp.2392_amd64.deb
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 143.204.231.78, 143.204.231.122, 143.204.231.40, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|143.204.231.78|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 178660768 (170M) [binary/octet-stream]
Saving to: ‘wazuh-dashboard_4.6.0-wp.2392_amd64.deb’

wazuh-dashboard_4.6.0-wp.2392_amd64.deb                             100%[==================================================================================================================================================================>] 170.38M  26.2MB/s    in 7.3s    

2023-09-04 15:52:44 (23.3 MB/s) - ‘wazuh-dashboard_4.6.0-wp.2392_amd64.deb’ saved [178660768/178660768]

root@debian11:/home/vagrant# apt install ./wazuh-dashboard_4.6.0-wp.2392_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-dashboard' instead of './wazuh-dashboard_4.6.0-wp.2392_amd64.deb'
The following packages will be upgraded:
  wazuh-dashboard
1 upgraded, 0 newly installed, 0 to remove and 53 not upgraded.
Need to get 0 B/179 MB of archives.
After this operation, 152 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-dashboard_4.6.0-wp.2392_amd64.deb wazuh-dashboard amd64 4.6.0-wp.2392 [179 MB]
Reading changelogs... Done
(Reading database ... 186885 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.6.0-wp.2392_amd64.deb ...
Unpacking wazuh-dashboard (4.6.0-wp.2392) over (4.5.1-1) ...
Setting up wazuh-dashboard (4.6.0-wp.2392) ...
Installing new version of config file /etc/systemd/system/wazuh-dashboard.service ...

Configuration file '/etc/wazuh-dashboard/opensearch_dashboards.yml'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** opensearch_dashboards.yml (Y/I/N/O/D/Z) [default=N] ? Y
Installing new version of config file /etc/wazuh-dashboard/opensearch_dashboards.yml ...
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable wazuh-dashboard
systemctl start wazuh-dashboard
```



</details>