### PR TITLE
Fixed filebeat module URL

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-readonly source_branch="4.6.0"
+source_branch="v4.6.0"
 
 function getHelp() {
 
@@ -48,9 +48,6 @@ function getHelp() {
 
 function buildInstaller() {
 
-    checkDistDetectURL
-    checkFilebeatURL
-
     output_script_path="${base_path_builder}/wazuh-install.sh"
 
     ## Create installer script
@@ -77,6 +74,8 @@ function buildInstaller() {
         echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
+        sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
+        source_branch="4.6.0"
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -132,6 +131,9 @@ function buildInstaller() {
     ## Main function and call to it
     echo >> "${output_script_path}"
     echo "main \"\$@\"" >> "${output_script_path}"
+
+    checkDistDetectURL
+    checkFilebeatURL
 
 }
 
@@ -263,7 +265,10 @@ function builder_main() {
         buildInstaller
         chmod 500 ${output_script_path}
         if [ -n "${change_filebeat_url}" ]; then
-            sed -i -E "s|(https.+)master(.+wazuh-template.json)|\1\\$\\{wazuh_major\\}\2|"  "${resources_installer}/installVariables.sh"
+            sed -i -E "s|(https.+)master(.+wazuh-template.json)|\1\\$\\{source_branch\\}\2|"  "${resources_installer}/installVariables.sh"
+        fi
+        if [ -n "${development}" ]; then
+            sed -i 's|${wazuh_version}|v${wazuh_version}|g' "${resources_installer}/installVariables.sh"
         fi
     fi
 

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -11,6 +11,7 @@ readonly wazuh_major="4.6"
 readonly wazuh_version="4.6.0"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
+readonly source_branch="v${wazuh_version}"
 
 ## Links and paths to resources
 readonly resources="https://${bucket}/${wazuh_major}"
@@ -21,7 +22,7 @@ config_file="${base_path}/config.yml"
 readonly tar_file_name="wazuh-install-files.tar"
 tar_file="${base_path}/${tar_file_name}"
 
-readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_major}/extensions/elasticsearch/7.x/wazuh-template.json"
+readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
 
 readonly dashboard_cert_path="/etc/wazuh-dashboard/certs"
 readonly filebeat_cert_path="/etc/filebeat/certs"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2404|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
2 problems were found in the formation of the URL to download the Filebeat module, the first was the one indicated in the issue, it was trying to obtain from the major-minor branch, which was not correct, we need to obtain the module from major -minor-patch or from tag in the case of production.

And another problem that was found is in the URL validation method, in all cases it gave an error because the variable used in the URL was not in the same script, this generated that the master branch was always used


## Logs example

<!--
Paste here related logs
-->

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-packages/unattended_installer$ ./builder.sh -i
Error: Could not get the dist-detect file.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-packages/unattended_installer$ ./builder.sh -i -d
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-packages/unattended_installer$ grep "source_branch" wazuh-install.sh 
readonly source_branch="${wazuh_version}"
readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
```
In the case of production, it is correct that it gives the error because the script dist-detect.sh is looking for a tag that does not exist yet (v4.6.0)

## Tests

```console
[root@centos72 ~]# git clone https://github.com/wazuh/wazuh-packages.git
Cloning into 'wazuh-packages'...
remote: Enumerating objects: 55097, done.
remote: Counting objects: 100% (4709/4709), done.
remote: Compressing objects: 100% (1829/1829), done.
remote: Total 55097 (delta 2891), reused 4381 (delta 2611), pack-reused 50388
Receiving objects: 100% (55097/55097), 16.41 MiB | 7.86 MiB/s, done.
Resolving deltas: 100% (34533/34533), done.
[root@centos72 ~]# cd wazuh-packages/
[root@centos72 wazuh-packages]# git checkout 2404-unattended-installer-accurate-url-for-filebeat-template-to4.6.0
Branch 2404-unattended-installer-accurate-url-for-filebeat-template-to4.6.0 set up to track remote branch 2404-unattended-installer-accurate-url-for-filebeat-template-to4.6.0 from origin.
Switched to a new branch '2404-unattended-installer-accurate-url-for-filebeat-template-to4.6.0'
[root@centos72 wazuh-packages]# cd unattended_installer/
[root@centos72 unattended_installer]# ./builder.sh -i -d staging
[root@centos72 unattended_installer]# cp config/certificate/config_aio.yml .
[root@centos72 unattended_installer]# cat config_aio.yml 
nodes:
  indexer:
    - name: wazuh-indexer
      ip: 127.0.0.1
  server:
    - name: wazuh-server
      ip: 127.0.0.1
  dashboard:
    - name: wazuh-dashboard
      ip: 127.0.0.1
[root@centos72 unattended_installer]# mv config_aio.yml config.yml
[root@centos72 unattended_installer]# bash wazuh-install.sh --generate-config-files
01/09/2023 19:59:07 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
01/09/2023 19:59:07 INFO: Verbose logging redirected to /var/log/wazuh-install.log
01/09/2023 19:59:10 INFO: --- Dependencies ---
01/09/2023 19:59:10 INFO: Installing lsof.
01/09/2023 19:59:16 INFO: --- Configuration files ---
01/09/2023 19:59:16 INFO: Generating configuration files.
01/09/2023 19:59:17 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
[root@centos72 unattended_installer]# bash wazuh-install.sh --wazuh-indexer wazuh-indexer
01/09/2023 20:02:17 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
01/09/2023 20:02:17 INFO: Verbose logging redirected to /var/log/wazuh-install.log
01/09/2023 20:02:27 INFO: Wazuh development repository added.
01/09/2023 20:02:27 INFO: --- Wazuh indexer ---
01/09/2023 20:02:27 INFO: Starting Wazuh indexer installation.
01/09/2023 20:04:29 INFO: Wazuh indexer installation finished.
01/09/2023 20:04:29 INFO: Wazuh indexer post-install configuration finished.
01/09/2023 20:04:29 INFO: Starting service wazuh-indexer.
01/09/2023 20:04:39 INFO: wazuh-indexer service started.
01/09/2023 20:04:39 INFO: Initializing Wazuh indexer cluster security settings.
01/09/2023 20:04:41 INFO: Wazuh indexer cluster initialized.
01/09/2023 20:04:41 INFO: Installation finished.
[root@centos72 unattended_installer]# bash wazuh-install.sh --start-cluster
01/09/2023 20:04:52 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
01/09/2023 20:04:52 INFO: Verbose logging redirected to /var/log/wazuh-install.log
01/09/2023 20:05:03 INFO: Wazuh indexer cluster security configuration initialized.
01/09/2023 20:05:37 INFO: Wazuh indexer cluster started.
[root@centos72 unattended_installer]# bash wazuh-install.sh --wazuh-server wazuh-server
01/09/2023 20:06:10 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
01/09/2023 20:06:10 INFO: Verbose logging redirected to /var/log/wazuh-install.log
01/09/2023 20:06:21 INFO: Wazuh development repository added.
01/09/2023 20:06:21 INFO: --- Wazuh server ---
01/09/2023 20:06:21 INFO: Starting the Wazuh manager installation.
01/09/2023 20:07:05 INFO: Wazuh manager installation finished.
01/09/2023 20:07:05 INFO: Starting service wazuh-manager.
01/09/2023 20:07:16 INFO: wazuh-manager service started.
01/09/2023 20:07:16 INFO: Starting Filebeat installation.
01/09/2023 20:07:26 INFO: Filebeat installation finished.
01/09/2023 20:07:27 INFO: Filebeat post-install configuration finished.
01/09/2023 20:07:31 INFO: Starting service filebeat.
01/09/2023 20:07:32 INFO: filebeat service started.
01/09/2023 20:07:32 INFO: Installation finished.
[root@centos72 unattended_installer]# bash wazuh-install.sh --wazuh-dashboard wazuh-dashboard
01/09/2023 20:08:05 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
01/09/2023 20:08:05 INFO: Verbose logging redirected to /var/log/wazuh-install.log
01/09/2023 20:08:13 INFO: Wazuh web interface port will be 443.
lsof: unacceptable port specification in: -i :
lsof 4.87
 latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
 latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
 latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
 usage: [-?abhKlnNoOPRtUvVX] [+|-c c] [+|-d s] [+D D] [+|-f[gG]] [+|-e s]
 [-F [f]] [-g [s]] [-i [i]] [+|-L [l]] [+m [m]] [+|-M] [-o [o]] [-p s]
[+|-r [t]] [-s [p:s]] [-S [t]] [-T [t]] [-u s] [+|-w] [-x [fl]] [-Z [Z]] [--] [names]
Use the ``-h'' option to get more help information.
01/09/2023 20:08:15 INFO: Wazuh development repository added.
wazuh-dashboard
01/09/2023 20:08:15 INFO: --- Wazuh dashboard ----
01/09/2023 20:08:19 INFO: --- Dependencies ---
01/09/2023 20:08:19 INFO: Installing chromium.
01/09/2023 20:08:20 WARNING: Cannot install optional dependency: chromium.
01/09/2023 20:08:20 INFO: Installing xorg-x11-fonts-100dpi.
01/09/2023 20:08:24 INFO: Installing xorg-x11-fonts-75dpi.
01/09/2023 20:08:26 INFO: Installing xorg-x11-utils.
01/09/2023 20:08:29 INFO: Installing xorg-x11-fonts-cyrillic.
01/09/2023 20:08:30 INFO: Installing xorg-x11-fonts-Type1.
01/09/2023 20:08:33 INFO: Installing xorg-x11-fonts-misc.
01/09/2023 20:08:38 INFO: Installing fontconfig.
01/09/2023 20:08:38 WARNING: Wazuh dashboard dependencies skipped. PDF report generation may not work.
01/09/2023 20:08:38 INFO: Starting Wazuh dashboard installation.
01/09/2023 20:10:11 INFO: Wazuh dashboard installation finished.
01/09/2023 20:10:11 INFO: Wazuh dashboard post-install configuration finished.
01/09/2023 20:10:11 INFO: Starting service wazuh-dashboard.
01/09/2023 20:10:11 INFO: wazuh-dashboard service started.
01/09/2023 20:10:25 INFO: Initializing Wazuh dashboard web application.
01/09/2023 20:10:26 INFO: Wazuh dashboard web application initialized.
01/09/2023 20:10:26 INFO: --- Summary ---
01/09/2023 20:10:26 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: 0OQH2*hLP+tiAm6CnyFol+EhTaXD9*x?
01/09/2023 20:10:26 INFO: Installation finished.
```

![Screenshot_20230901_171741](https://github.com/wazuh/wazuh-packages/assets/64099752/ef83e722-4c57-4639-a7ac-e9f32e8c9a92)


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
