### PR TITLE
Add new AWS files to Solaris SPECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 ## [4.8.0]
 
 - https://github.com/wazuh/wazuh-packages/releases/tag/v4.8.0
+
 ## [4.7.1]
 
 - https://github.com/wazuh/wazuh-packages/releases/tag/v4.7.1

--- a/solaris/solaris11/SPECS/template_agent.json
+++ b/solaris/solaris11/SPECS/template_agent.json
@@ -1839,6 +1839,198 @@
         "type": "file",
         "user": "root"
     },
+    "/var/ossec/wodles/aws/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/aws_tools.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/wazuh_integration.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/aws_bucket.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/cloudtrail.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/config.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/guardduty.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/load_balancers.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/server_access.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/umbrella.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/vpcflow.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/buckets_s3/waf.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/services": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/services/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/services/was_service.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/services/cloudwatchlogs.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/services/inspector.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/subscribers": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/subscribers/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/subscribers/s3_log_handler.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/subscribers/sqs_message_processor.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/aws/subscribers/sqs_queue.pyv": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
     "/var/ossec/wodles/azure": {
         "class": "static",
         "group": "wazuh",

--- a/solaris/solaris11/SPECS/template_agent.json
+++ b/solaris/solaris11/SPECS/template_agent.json
@@ -1967,7 +1967,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/wodles/aws/services/was_service.py": {
+    "/var/ossec/wodles/aws/services/aws_service.py": {
         "class": "static",
         "group": "wazuh",
         "mode": "0750",
@@ -2023,7 +2023,7 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/wodles/aws/subscribers/sqs_queue.pyv": {
+    "/var/ossec/wodles/aws/subscribers/sqs_queue.py": {
         "class": "static",
         "group": "wazuh",
         "mode": "0750",


### PR DESCRIPTION
|Related issue|
|---|
| #1997 |


## Description

Closes #1997. It modifies the Solaris11 SPEC file to include in the agents the latest modification of the AWS integration which separated the module in several files carried out in https://github.com/wazuh/wazuh/issues/13388, which is expected to be released in 4.8.0.

## Tests

Tested the modified package by creating a Solaris11 package and installing it in a Solaris11 machine respectively. Everything worked as expected, as can be seen in the following output:
<details><summary>Package installation and file permissions</summary>

    vagrant@solaris:/tmp$ sudo pkg install -g wazuh-agent_v4.8.0-sol11-i386.p5p wazuh-agent
               Packages to install:  1
                Services to change:  1
           Create boot environment: No
    Create backup boot environment: No
    
    DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
    Completed                                1/1       119/119      5.9/5.9 87.0M/s
    
    PHASE                                          ITEMS
    Installing new actions                       175/175
    Updating package state database                 Done 
    Updating package cache                           0/0 
    Updating image state                            Done 
    Creating fast lookup database                   Done 
    Updating package cache                           2/2
    root@solaris:/var/ossec# ls
    active-response  backup           etc              logs             ruleset          var
    agentless        bin              lib              queue            tmp              wodles
    root@solaris:/var/ossec/wodles/aws# ls -l
    total 110
    -rwxr-x---   1 root     wazuh          0 Sep  1 16:47 __init__.py
    -rwxr-x---   1 root     wazuh      16489 Sep  1 16:47 aws_tools.py
    -rwxr-x---   1 root     wazuh       9407 Sep  1 16:47 aws-s3
    drwxr-x---   2 root     wazuh         12 Sep  1 16:47 buckets_s3
    drwxr-x---   2 root     wazuh          6 Sep  1 16:47 services
    drwxr-x---   2 root     wazuh          6 Sep  1 16:47 subscribers
    -rwxr-x---   1 root     wazuh      22836 Sep  1 16:47 wazuh_integration.py
    root@solaris:/var/ossec/wodles/aws# ls -l buckets_s3/
    total 187
    -rwxr-x---   1 root     wazuh        462 Sep  1 16:47 __init__.py
    -rwxr-x---   1 root     wazuh      41203 Sep  1 16:47 aws_bucket.py
    -rwxr-x---   1 root     wazuh       1889 Sep  1 16:47 cloudtrail.py
    -rwxr-x---   1 root     wazuh       8844 Sep  1 16:47 config.py
    -rwxr-x---   1 root     wazuh       4353 Sep  1 16:47 guardduty.py
    -rwxr-x---   1 root     wazuh       5729 Sep  1 16:47 load_balancers.py
    -rwxr-x---   1 root     wazuh       9151 Sep  1 16:47 server_access.py
    -rwxr-x---   1 root     wazuh       2718 Sep  1 16:47 umbrella.py
    -rwxr-x---   1 root     wazuh      10934 Sep  1 16:47 vpcflow.py
    -rwxr-x---   1 root     wazuh       2897 Sep  1 16:47 waf.py
    root@solaris:/var/ossec/wodles/aws# ls -l services/
    total 78
    -rwxr-x---   1 root     wazuh        166 Sep  1 16:47 __init__.py
    -rwxr-x---   1 root     wazuh       5955 Sep  1 16:47 aws_service.py
    -rwxr-x---   1 root     wazuh      24429 Sep  1 16:47 cloudwatchlogs.py
    -rwxr-x---   1 root     wazuh       6373 Sep  1 16:47 inspector.py
    root@solaris:/var/ossec/wodles/aws# ls -l subscribers/
    total 43
    -rwxr-x---   1 root     wazuh        201 Sep  1 16:47 __init__.py
    -rwxr-x---   1 root     wazuh      10400 Sep  1 16:47 s3_log_handler.py
    -rwxr-x---   1 root     wazuh       1795 Sep  1 16:47 sqs_message_processor.py
    -rwxr-x---   1 root     wazuh       6214 Sep  1 16:47 sqs_queue.py
    
</details>

Also, the packages were built and uploaded using the Packages builder for Solaris 10 and 11. These can be found in https://packages-dev.wazuh.com/warehouse/test/4.8/solaris/i386/10/wazuh-agent_v4.8.0-solaris.aws.todelete-sol10-i386.pkg (https://ci.wazuh.info/job/Packages_builder_solaris/29099/) and https://packages-dev.wazuh.com/warehouse/test/4.8/solaris/i386/11/wazuh-agent_v4.8.0-solaris.aws.todelete-sol11-i386.p5p (https://ci.wazuh.info/job/Packages_builder_solaris/29104/) respectively:

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [x] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
