### PR TITLE
Fixed dashboard check port error

### DIFF
--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -53,4 +53,4 @@ http_port=443
 readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 "${http_port}")
 readonly wazuh_indexer_ports=( 9200 9300 )
 readonly wazuh_manager_ports=( 1514 1515 1516 55000 )
-readonly wazuh_dashboard_ports=( "${http_port}" )
+readonly wazuh_dashboard_port="${http_port}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2406|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to change the definition of the `wazuh_dashboard_port` variable, as it was not set correctly. This change solves an error that the `lsof` command was generating because it was receiving no port to check, as the variable did not exist.

