### PR TITLE
Fixed `mkdir` error in passwords backup

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -179,7 +179,9 @@ function passwords_createBackUp() {
     fi
 
     common_logger -d "Creating password backup."
-    eval "mkdir /etc/wazuh-indexer/backup ${debug}"
+    if [ ! -d "/etc/wazuh-indexer/backup" ]; then
+        eval "mkdir /etc/wazuh-indexer/backup ${debug}"
+    fi
     eval "JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -backup /etc/wazuh-indexer/backup -icl -p 9200 -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -h ${IP} ${debug}"
     if [ "${PIPESTATUS[0]}" != 0 ]; then
         common_logger -e "The backup could not be created"


### PR DESCRIPTION
## Description 

|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2414|

The aim of this PR is to modify the `wazuh-password-too.sh` script that had a bug managing the backup directory. This directory was created twice, and the second command generated an error. 
By checking the existence of the repository, the issue is fixed, and the errors are managed as expected.

Some testing has been done in the "Tests" part of the following comment: https://github.com/wazuh/wazuh-packages/issues/2414#issuecomment-1706347301