### PR TITLE
Improvements in Wazuh dahboard 4.6.0-2.8.0 package

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -92,6 +92,9 @@ sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensear
 # Replace config path
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-keystore
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-plugin
+# Add fix to Node variablas as Node is not using the NODE_OPTIONS environment variable
+sed -i 's/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"\n/g' ./bin/use_node
+sed -i 's/exec "${NODE}"/NODE_ENV=production exec "${NODE}" ${NODE_OPTIONS} /g' ./bin/use_node
 # Replace the redirection to `home` in the header logo
 sed -i "s'/app/home'/app/wazuh'g" ./src/core/target/public/core.entry.js
 # Replace others redirections to `home`

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -92,7 +92,7 @@ sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensear
 # Replace config path
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-keystore
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-plugin
-# Add fix to Node variablas as Node is not using the NODE_OPTIONS environment variable
+# Add fix to Node variables as Node is not using the NODE_OPTIONS environment variables
 sed -i 's/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"\n/g' ./bin/use_node
 sed -i 's/exec "${NODE}"/NODE_ENV=production exec "${NODE}" ${NODE_OPTIONS} /g' ./bin/use_node
 # Replace the redirection to `home` in the header logo

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -90,11 +90,8 @@ cp ./etc/styles.js ./src/core/server/rendering/views/styles.js
 sed -i "s|defaultValue: ''|defaultValue: \'Wazuh\'|g" ./src/core/server/opensearch_dashboards_config.js
 sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensearch_dashboards_config.js
 # Replace config path
-sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-keystore
 sed -i "s'\$DIR/config'/etc/wazuh-dashboard'g" ./bin/opensearch-dashboards-plugin
-sed -i "s'NODE_OPTIONS=\"--no-warnings --max-http-header-size=65536 \$OSD_NODE_OPTS \$NODE_OPTIONS\" NODE_ENV=production exec \"\${NODE}\" \"\${DIR}/src/cli/dist\" \${@}'NODE_OPTIONS=\"--no-warnings --max-http-header-size=65536 \$OSD_NODE_OPTS \$NODE_OPTIONS\"'g" ./bin/opensearch-dashboards
-echo "NODE_ENV=production exec \"\${NODE}\" \${NODE_OPTIONS} \"\${DIR}/src/cli/dist\" \${@}" >> ./bin/opensearch-dashboards
 # Replace the redirection to `home` in the header logo
 sed -i "s'/app/home'/app/wazuh'g" ./src/core/target/public/core.entry.js
 # Replace others redirections to `home`

--- a/stack/dashboard/base/files/etc/services/wazuh-dashboard.service
+++ b/stack/dashboard/base/files/etc/services/wazuh-dashboard.service
@@ -7,7 +7,7 @@ User=wazuh-dashboard
 Group=wazuh-dashboard
 EnvironmentFile=-/etc/default/wazuh-dashboard
 EnvironmentFile=-/etc/sysconfig/wazuh-dashboard
-ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards
+ExecStart=/usr/share/wazuh-dashboard/bin/opensearch-dashboards -c /etc/wazuh-dashboard/opensearch_dashboards.yml
 WorkingDirectory=/usr/share/wazuh-dashboard
 
 [Install]

--- a/stack/dashboard/deb/debian/postinst
+++ b/stack/dashboard/deb/debian/postinst
@@ -36,7 +36,7 @@ case "$1" in
                 service wazuh-dashboard restart > /dev/null 2>&1
             fi
         fi
-        if [ ! -f "${INSTALLATION_DIR}"/config/opensearch_dashboards.keystore ]; then
+        if [ ! -f "${CONFIG_DIR}"/opensearch_dashboards.keystore ]; then
             runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
             runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
             runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1

--- a/stack/dashboard/deb/debian/postinst
+++ b/stack/dashboard/deb/debian/postinst
@@ -36,10 +36,14 @@ case "$1" in
                 service wazuh-dashboard restart > /dev/null 2>&1
             fi
         fi
-        if [ ! -f "${CONFIG_DIR}"/opensearch_dashboards.keystore ]; then
+        # Move keystore file if upgrade (file exists in install dir in <= 4.6.0)
+        if [ -f "${INSTALLATION_DIR}"/opensearch_dashboards.keystore ]; then
+            mv "${INSTALLATION_DIR}"/opensearch_dashboards.keystore "${CONFIG_DIR}"/opensearch_dashboards.keystore
+        elif [ ! -f "${CONFIG_DIR}"/opensearch_dashboards.keystore ]; then
             runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
             runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
             runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+            chmod 640 "${CONFIG_DIR}"/opensearch_dashboards.keystore
         fi
     ;;
 

--- a/stack/dashboard/deb/debian/postinst
+++ b/stack/dashboard/deb/debian/postinst
@@ -37,8 +37,8 @@ case "$1" in
             fi
         fi
         # Move keystore file if upgrade (file exists in install dir in <= 4.6.0)
-        if [ -f "${INSTALLATION_DIR}"/opensearch_dashboards.keystore ]; then
-            mv "${INSTALLATION_DIR}"/opensearch_dashboards.keystore "${CONFIG_DIR}"/opensearch_dashboards.keystore
+        if [ -f "${INSTALLATION_DIR}"/config/opensearch_dashboards.keystore ]; then
+            mv "${INSTALLATION_DIR}"/config/opensearch_dashboards.keystore "${CONFIG_DIR}"/opensearch_dashboards.keystore
         elif [ ! -f "${CONFIG_DIR}"/opensearch_dashboards.keystore ]; then
             runuser "${NAME}" --shell="/bin/bash" --command="${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
             runuser "${NAME}" --shell="/bin/bash" --command="echo kibanaserver | ${INSTALLATION_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1

--- a/stack/dashboard/deb/debian/rules
+++ b/stack/dashboard/deb/debian/rules
@@ -58,7 +58,8 @@ override_dh_install:
 	useradd -g $(GROUP) $(USER)
 
 	tar -xf $(DASHBOARD_FILE)
-	sed -i "s/cross_platform_1.REPO_ROOT\, 'config\//'\/etc\/wazuh-dashboard\/', '/g" "wazuh-dashboard-base/node_modules/@osd/utils/target/path/index.js"
+	sed -i 's/OSD_NODE_OPTS_PREFIX/OSD_PATH_CONF="\/etc\/wazuh-dashboard" OSD_NODE_OPTS_PREFIX/g' "wazuh-dashboard-base/bin/opensearch-dashboards"
+	sed -i 's/OSD_USE_NODE_JS_FILE_PATH/OSD_PATH_CONF="\/etc\/wazuh-dashboard" OSD_USE_NODE_JS_FILE_PATH/g' "wazuh-dashboard-base/bin/opensearch-dashboards-keystore"
 
 	mkdir -p $(TARGET_DIR)$(CONFIG_DIR)
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)
@@ -105,7 +106,7 @@ override_dh_fixperms:
 	chmod 750 $(TARGET_DIR)/etc/default/wazuh-dashboard
 	chmod 640 "$(TARGET_DIR)$(CONFIG_DIR)"/opensearch_dashboards.yml
 	chmod 640 "$(TARGET_DIR)$(CONFIG_DIR)"/node.options
-	chmod 640 $(TARGET_DIR)/etc/systemd/system/wazuh-dashboard.service
+	chmod 640 "$(TARGET_DIR)"/etc/systemd/system/wazuh-dashboard.service
 	find "$(TARGET_DIR)$(INSTALLATION_DIR)" -type d -exec chmod 750 {} \;
 	find "$(TARGET_DIR)$(INSTALLATION_DIR)" -type f -perm 644 -exec chmod 640 {} \;
 	find "$(TARGET_DIR)$(INSTALLATION_DIR)" -type f -perm 755 -exec chmod 750 {} \;

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -136,16 +136,6 @@ fi
 %post
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
 
-# Move keystore file if upgrade (file exists in install dir in <= 4.6.0)
-if [ -f "${INSTALLATION_DIR}"/opensearch_dashboards.keystore ]; then
-  mv "${INSTALLATION_DIR}"/opensearch_dashboards.keystore "${CONFIG_DIR}"/opensearch_dashboards.keystore
-elif [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
-  runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
-  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
-  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
-  chmod 640 "%{CONFIG_DIR}"/opensearch_dashboards.keystore
-fi
-
 # -----------------------------------------------------------------------------
 
 %preun
@@ -189,6 +179,16 @@ fi
 if [ ! -d %{PID_DIR} ]; then
     mkdir -p %{PID_DIR}
     chown %{USER}:%{GROUP} %{PID_DIR}
+fi
+
+# Move keystore file if upgrade (file exists in install dir in <= 4.6.0)
+if [ -f "%{INSTALL_DIR}"/config/opensearch_dashboards.keystore ]; then
+  mv "%{INSTALL_DIR}"/config/opensearch_dashboards.keystore "%{CONFIG_DIR}"/opensearch_dashboards.keystore
+elif [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
+  runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
+  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
+  runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+  chmod 640 "%{CONFIG_DIR}"/opensearch_dashboards.keystore
 fi
 
 if [ -f %{INSTALL_DIR}/wazuh-dashboard.restart ]; then

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -54,7 +54,10 @@ useradd -g %{GROUP} %{USER}
 %build
 
 tar -xf %{DASHBOARD_FILE}
-sed -i "s/cross_platform_1.REPO_ROOT\, 'config\//'\/etc\/wazuh-dashboard\/', '/g" "wazuh-dashboard-base/node_modules/@osd/utils/target/path/index.js"
+
+# Set custom config dir
+sed -i 's/OSD_NODE_OPTS_PREFIX/OSD_PATH_CONF="\/etc\/wazuh-dashboard" OSD_NODE_OPTS_PREFIX/g' "wazuh-dashboard-base/bin/opensearch-dashboards"
+sed -i 's/OSD_USE_NODE_JS_FILE_PATH/OSD_PATH_CONF="\/etc\/wazuh-dashboard" OSD_USE_NODE_JS_FILE_PATH/g' "wazuh-dashboard-base/bin/opensearch-dashboards-keystore"
 
 # -----------------------------------------------------------------------------
 
@@ -133,7 +136,7 @@ fi
 %post
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
 
-if [ ! -f %{INSTALLATION_DIR}/config/opensearch_dashboards.keystore ]; then
+if [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
   runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
@@ -398,6 +401,7 @@ rm -fr %{buildroot}
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/opensearch-dashboards-keystore"
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/config"
 %attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/node.options"
+%attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch-dashboards.keystore"
 %attr(640, root, root) "/etc/systemd/system/wazuh-dashboard.service"
 
 %changelog

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -136,10 +136,14 @@ fi
 %post
 setcap 'cap_net_bind_service=+ep' %{INSTALL_DIR}/node/bin/node
 
-if [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
+# Move keystore file if upgrade (file exists in install dir in <= 4.6.0)
+if [ -f "${INSTALLATION_DIR}"/opensearch_dashboards.keystore ]; then
+  mv "${INSTALLATION_DIR}"/opensearch_dashboards.keystore "${CONFIG_DIR}"/opensearch_dashboards.keystore
+elif [ ! -f %{CONFIG_DIR}/opensearch_dashboards.keystore ]; then
   runuser %{USER} --shell="/bin/bash" --command="%{INSTALL_DIR}/bin/opensearch-dashboards-keystore create" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.username --stdin" > /dev/null 2>&1
   runuser %{USER} --shell="/bin/bash" --command="echo kibanaserver | %{INSTALL_DIR}/bin/opensearch-dashboards-keystore add opensearch.password --stdin" > /dev/null 2>&1
+  chmod 640 "%{CONFIG_DIR}"/opensearch_dashboards.keystore
 fi
 
 # -----------------------------------------------------------------------------

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -405,7 +405,6 @@ rm -fr %{buildroot}
 %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/bin/opensearch-dashboards-keystore"
 %dir %attr(750, %{USER}, %{GROUP}) "%{INSTALL_DIR}/config"
 %attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/node.options"
-%attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch-dashboards.keystore"
 %attr(640, root, root) "/etc/systemd/system/wazuh-dashboard.service"
 
 %changelog


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-packages/issues/2420#top|


## Description

This PR adds the necessary changes so that the Wazuh dashboard 4.6.0-2.8.0 package can use IPs in the `opensearch.hosts` configuration, and also moves the OpenSearch keystore to the Wazuh dashboard configuration directory

## Logs example

- https://ci.wazuh.info/view/Packages/job/Packages_builder_tier/3142/
- https://ci.wazuh.info/job/Packages_builder/164381/
- https://ci.wazuh.info/job/Packages_builder/164412/
- https://ci.wazuh.info/job/Packages_builder/164413/
- https://ci.wazuh.info/job/Test_stack_tier/83/

<details><summary>Upgrade in Debian 11 from 4.5.2 to 4.6.0</summary>

```
root@debian11:/home/vagrant# curl -sO https://packages.wazuh.com/4.5/wazuh-install.sh && sudo bash ./wazuh-install.sh -a -i
06/09/2023 17:44:19 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
06/09/2023 17:44:19 INFO: Verbose logging redirected to /var/log/wazuh-install.log
06/09/2023 17:44:24 WARNING: Hardware and system checks ignored.
06/09/2023 17:44:24 INFO: Wazuh web interface port will be 443.
06/09/2023 17:44:25 INFO: --- Dependencies ----
06/09/2023 17:44:25 INFO: Installing apt-transport-https.
06/09/2023 17:44:26 INFO: Installing software-properties-common.
06/09/2023 17:44:31 INFO: Wazuh repository added.
06/09/2023 17:44:31 INFO: --- Configuration files ---
06/09/2023 17:44:31 INFO: Generating configuration files.
06/09/2023 17:44:31 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
06/09/2023 17:44:31 INFO: --- Wazuh indexer ---
06/09/2023 17:44:31 INFO: Starting Wazuh indexer installation.
06/09/2023 17:45:11 INFO: Wazuh indexer installation finished.
06/09/2023 17:45:11 INFO: Wazuh indexer post-install configuration finished.
06/09/2023 17:45:11 INFO: Starting service wazuh-indexer.
06/09/2023 17:45:24 INFO: wazuh-indexer service started.
06/09/2023 17:45:24 INFO: Initializing Wazuh indexer cluster security settings.
06/09/2023 17:45:34 INFO: Wazuh indexer cluster initialized.
06/09/2023 17:45:34 INFO: --- Wazuh server ---
06/09/2023 17:45:34 INFO: Starting the Wazuh manager installation.
06/09/2023 17:46:00 INFO: Wazuh manager installation finished.
06/09/2023 17:46:00 INFO: Starting service wazuh-manager.
06/09/2023 17:46:14 INFO: wazuh-manager service started.
06/09/2023 17:46:14 INFO: Starting Filebeat installation.
06/09/2023 17:46:17 INFO: Filebeat installation finished.
06/09/2023 17:46:18 INFO: Filebeat post-install configuration finished.
06/09/2023 17:46:18 INFO: Starting service filebeat.
06/09/2023 17:46:18 INFO: filebeat service started.
06/09/2023 17:46:18 INFO: --- Wazuh dashboard ---
06/09/2023 17:46:18 INFO: Starting Wazuh dashboard installation.
06/09/2023 17:46:43 INFO: Wazuh dashboard installation finished.
06/09/2023 17:46:43 INFO: Wazuh dashboard post-install configuration finished.
06/09/2023 17:46:43 INFO: Starting service wazuh-dashboard.
06/09/2023 17:46:43 INFO: wazuh-dashboard service started.
06/09/2023 17:47:00 INFO: Initializing Wazuh dashboard web application.
06/09/2023 17:47:01 INFO: Wazuh dashboard web application initialized.
06/09/2023 17:47:01 INFO: --- Summary ---
06/09/2023 17:47:01 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q
06/09/2023 17:47:01 INFO: Installation finished.
root@debian11:/home/vagrant# systemctl stop filebeat
systemctl stop wazuh-dashboard
root@debian11:/home/vagrant# curl -X PUT "https://localhost:9200/_cluster/settings"  -u admin:H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q -k -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": "primaries"
  }
}
'
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"primaries"}}}},"transient":{}}root@debian11:/home/vagrant# 
root@debian11:/home/vagrant# curl -X POST "https://localhost:9200/_flush/synced" -u admin:H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q -k
{"_shards":{"total":7,"successful":7,"failed":0}}root@debian11:/home/vagrant# 
root@debian11:/home/vagrant# systemctl stop wazuh-indexer
root@debian11:/home/vagrant# apt install ./wazuh-indexer_4.6.0-wp.2420_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.6.0-wp.2420_amd64.deb'
The following packages will be upgraded:
  wazuh-indexer
1 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
Need to get 0 B/684 MB of archives.
After this operation, 1,739 kB disk space will be freed.
Get:1 /home/vagrant/wazuh-indexer_4.6.0-wp.2420_amd64.deb wazuh-indexer amd64 4.6.0-1 [684 MB]
Reading changelogs... Done
(Reading database ... 186868 files and directories currently installed.)
Progress: [ 20%] [###########################################............................................................................................................................................................................] 
Setting up wazuh-indexer (4.6.0-1) ...#######################............................................................................................................................................................................] 
Installing new version of config file /etc/wazuh-indexer/opensearch-notifications-core/notifications-core.yml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/log4j2.xml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_idle_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-security/config.yml ...
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable wazuh-indexer
systemctl start wazuh-indexer
root@debian11:/home/vagrant# curl -k -u admin:H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           12          97  10    0.57    0.46     0.25 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
root@debian11:/home/vagrant# curl -X PUT "https://localhost:9200/_cluster/settings" -u admin:H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q -k -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": "all"
  }
}
'
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"all"}}}},"transient":{}}root@debian11:/home/vagrant# 
root@debian11:/home/vagrant# curl -k -u admin:H.69t?XfoK.W2QS9y4pxU1t1P+DS7v7Q https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           15          97   1    0.27    0.39     0.23 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
root@debian11:/home/vagrant# 
root@debian11:/home/vagrant# apt install ./wazuh-manager_4.6.0-wp.2420_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.6.0-wp.2420_amd64.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
Need to get 0 B/171 MB of archives.
After this operation, 1,704 kB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-manager_4.6.0-wp.2420_amd64.deb wazuh-manager amd64 4.6.0-1 [171 MB]
Reading changelogs... Done        
(Reading database ... 186872 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.6.0-wp.2420_amd64.deb ...
Unpacking wazuh-manager (4.6.0-1) over (4.5.2-1) ...
Setting up wazuh-manager (4.6.0-1) ...
root@debian11:/home/vagrant# curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz | sudo tar -xvz -C /usr/share/filebeat/module
sudo: unable to resolve host debian11: Name or service not known
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
root@debian11:/home/vagrant# curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.6.0/extensions/elasticsearch/7.x/wazuh-template.json
root@debian11:/home/vagrant# chmod go+r /etc/filebeat/wazuh-template.json
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable filebeat
systemctl start filebeat
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
root@debian11:/home/vagrant# apt install ./wazuh-dashboard_4.6.0-1_amd64.deb ^C
root@debian11:/home/vagrant# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
-rw-r--r-- 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 17:46 /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
You have mail in /var/mail/root
root@debian11:/home/vagrant# sha1sum /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
91fb111839fb819f29e77dcdffee07eef1582f59  /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
root@debian11:/home/vagrant# apt install ./wazuh-dashboard_4.6.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-dashboard' instead of './wazuh-dashboard_4.6.0-1_amd64.deb'
The following packages will be upgraded:
  wazuh-dashboard
1 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
Need to get 0 B/179 MB of archives.
After this operation, 152 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-dashboard_4.6.0-1_amd64.deb wazuh-dashboard amd64 4.6.0-1 [179 MB]
Reading changelogs... Done
(Reading database ... 186885 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.6.0-1_amd64.deb ...
Unpacking wazuh-dashboard (4.6.0-1) over (4.5.2-1) ...
Setting up wazuh-dashboard (4.6.0-1) ...
Installing new version of config file /etc/systemd/system/wazuh-dashboard.service ...

Configuration file '/etc/wazuh-dashboard/opensearch_dashboards.yml'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** opensearch_dashboards.yml (Y/I/N/O/D/Z) [default=N] ? N
root@debian11:/home/vagrant# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
ls: cannot access '/usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore': No such file or directory
root@debian11:/home/vagrant# ls -l /etc/wazuh-dashboard/opensearch_dashboards.keystore 
-rw-r--r-- 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 17:46 /etc/wazuh-dashboard/opensearch_dashboards.keystore
root@debian11:/home/vagrant# sha1sum /etc/wazuh-dashboard/opensearch_dashboards.keystore 
91fb111839fb819f29e77dcdffee07eef1582f59  /etc/wazuh-dashboard/opensearch_dashboards.keystore
oot@debian11:/home/vagrant# cat /etc/wazuh-dashboard/opensearch_dashboards.yml
server.host: 0.0.0.0
opensearch.hosts: https://127.0.0.1:9200
server.port: 443
opensearch.ssl.verificationMode: certificate
# opensearch.username: kibanaserver
# opensearch.password: kibanaserver
opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
opensearch_security.multitenancy.enabled: false
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
server.ssl.enabled: true
server.ssl.key: "/etc/wazuh-dashboard/certs/wazuh-dashboard-key.pem"
server.ssl.certificate: "/etc/wazuh-dashboard/certs/wazuh-dashboard.pem"
opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
uiSettings.overrides.defaultRoute: /app/wazuh
opensearch_security.cookie.secure: true
root@debian11:/home/vagrant# ls -l /etc/wazuh-dashboard/certs/
total 12
-r-------- 1 wazuh-dashboard wazuh-dashboard 1204 Sep  6 17:44 root-ca.pem
-r-------- 1 wazuh-dashboard wazuh-dashboard 1704 Sep  6 17:44 wazuh-dashboard-key.pem
-r-------- 1 wazuh-dashboard wazuh-dashboard 1245 Sep  6 17:44 wazuh-dashboard.pem
root@debian11:/home/vagrant# systemctl daemon-reload
systemctl enable wazuh-dashboard
systemctl start wazuh-dashboard
root@debian11:/home/vagrant# systemctl status wazuh-dashboard
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2023-09-06 17:56:17 UTC; 1min 47s ago
   Main PID: 100566 (node)
      Tasks: 11 (limit: 4675)
     Memory: 205.4M
        CPU: 3.895s
     CGroup: /system.slice/wazuh-dashboard.service
             └─100566 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-dashboard/src/cli/dist -c /etc/wazuh-dashboard/opensearch_dashboards.yml

Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Waiting until all OpenSearch nodes are compatible with OpenSearch D>
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Starting saved objects migrations"}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Detected mapping change in \"properties.visualization-visbuilder\""}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Creating index .kibana_2."}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Migrating .kibana_1 saved objects to .kibana_2"}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Pointing alias .kibana to .kibana_2."}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","savedobjects-service"],"pid":100566,"message":"Finished in 224ms."}
Sep 06 17:56:21 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:21Z","tags":["info","plugins-system"],"pid":100566,"message":"Starting [44] plugins: [alertingDashboards,usageCollection,opensearchDash>
Sep 06 17:56:22 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:22Z","tags":["listening","info"],"pid":100566,"message":"Server running at https://0.0.0.0:443"}
Sep 06 17:56:22 debian11 opensearch-dashboards[100566]: {"type":"log","@timestamp":"2023-09-06T17:56:22Z","tags":["info","http","server","OpenSearchDashboards"],"pid":100566,"message":"http server running at https://0.0.0.0:443"}
```

</details>

<details><summary>Upgrade in CentOS 7 from 4.5.2 to 4.6.0</summary>

```
[root@centos7 vagrant]# curl -sO https://packages.wazuh.com/4.5/wazuh-install.sh && sudo bash ./wazuh-install.sh -a
06/09/2023 16:04:05 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
06/09/2023 16:04:05 INFO: Verbose logging redirected to /var/log/wazuh-install.log
06/09/2023 16:04:09 INFO: --- Dependencies ---
06/09/2023 16:04:09 INFO: Installing lsof.
06/09/2023 16:04:09 INFO: Wazuh web interface port will be 443.
06/09/2023 16:04:10 INFO: Wazuh repository added.
06/09/2023 16:04:10 INFO: --- Configuration files ---
06/09/2023 16:04:10 INFO: Generating configuration files.
06/09/2023 16:04:10 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
06/09/2023 16:04:10 INFO: --- Wazuh indexer ---
06/09/2023 16:04:10 INFO: Starting Wazuh indexer installation.
06/09/2023 16:05:28 INFO: Wazuh indexer installation finished.
06/09/2023 16:05:28 INFO: Wazuh indexer post-install configuration finished.
06/09/2023 16:05:28 INFO: Starting service wazuh-indexer.
06/09/2023 16:05:35 INFO: wazuh-indexer service started.
06/09/2023 16:05:35 INFO: Initializing Wazuh indexer cluster security settings.
06/09/2023 16:05:45 INFO: Wazuh indexer cluster initialized.
06/09/2023 16:05:45 INFO: --- Wazuh server ---
06/09/2023 16:05:45 INFO: Starting the Wazuh manager installation.
06/09/2023 16:06:15 INFO: Wazuh manager installation finished.
06/09/2023 16:06:15 INFO: Starting service wazuh-manager.
06/09/2023 16:06:28 INFO: wazuh-manager service started.
06/09/2023 16:06:28 INFO: Starting Filebeat installation.
06/09/2023 16:06:33 INFO: Filebeat installation finished.
06/09/2023 16:06:34 INFO: Filebeat post-install configuration finished.
06/09/2023 16:06:34 INFO: Starting service filebeat.
06/09/2023 16:06:34 INFO: filebeat service started.
06/09/2023 16:06:34 INFO: --- Wazuh dashboard ---
06/09/2023 16:06:34 INFO: Starting Wazuh dashboard installation.
06/09/2023 16:07:25 INFO: Wazuh dashboard installation finished.
06/09/2023 16:07:25 INFO: Wazuh dashboard post-install configuration finished.
06/09/2023 16:07:25 INFO: Starting service wazuh-dashboard.
06/09/2023 16:07:25 INFO: wazuh-dashboard service started.
06/09/2023 16:07:39 INFO: Initializing Wazuh dashboard web application.
06/09/2023 16:07:41 INFO: Wazuh dashboard web application initialized.
06/09/2023 16:07:41 INFO: --- Summary ---
06/09/2023 16:07:41 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E
06/09/2023 16:07:41 INFO: Installation finished.
[root@centos7 vagrant]# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
-rw-r--r--. 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 16:07 /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
[root@centos7 vagrant]# wget https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-indexer-4.6.0-wp.2420.x86_64.rpm
--2023-09-06 16:22:23--  https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-indexer-4.6.0-wp.2420.x86_64.rpm
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 52.84.66.65, 52.84.66.16, 52.84.66.124, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|52.84.66.65|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 705928884 (673M) [binary/octet-stream]
Saving to: ‘wazuh-indexer-4.6.0-wp.2420.x86_64.rpm’

100%[====================================================================>] 705,928,884 24.8MB/s   in 29s    

2023-09-06 16:22:53 (22.9 MB/s) - ‘wazuh-indexer-4.6.0-wp.2420.x86_64.rpm’ saved [705928884/705928884]

[root@centos7 vagrant]# wget https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-manager-4.6.0-wp.2420.x86_64.rpm
--2023-09-06 16:22:57--  https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-manager-4.6.0-wp.2420.x86_64.rpm
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 52.84.66.124, 52.84.66.16, 52.84.66.65, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|52.84.66.124|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 172780707 (165M) [binary/octet-stream]
Saving to: ‘wazuh-manager-4.6.0-wp.2420.x86_64.rpm’

100%[====================================================================>] 172,780,707 25.0MB/s   in 7.8s   

2023-09-06 16:23:05 (21.2 MB/s) - ‘wazuh-manager-4.6.0-wp.2420.x86_64.rpm’ saved [172780707/172780707]

[root@centos7 vagrant]# wget https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm
--2023-09-06 16:23:10--  https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm
Resolving packages-dev.wazuh.com (packages-dev.wazuh.com)... 52.84.66.65, 52.84.66.124, 52.84.66.16, ...
Connecting to packages-dev.wazuh.com (packages-dev.wazuh.com)|52.84.66.65|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 275128406 (262M) [binary/octet-stream]
Saving to: ‘wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm’

100%[====================================================================>] 275,128,406 24.2MB/s   in 12s    

2023-09-06 16:23:23 (21.8 MB/s) - ‘wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm’ saved [275128406/275128406]

[root@centos7 vagrant]# systemctl stop filebeat
[root@centos7 vagrant]# systemctl stop wazuh-dashboard
[root@centos7 vagrant]# curl -X PUT "https://localhost:9200/_cluster/settings"  -u admin:SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E -k -H 'Content-Type: application/json' -d'
> {
>   "persistent": {
>     "cluster.routing.allocation.enable": "primaries"
>   }
> }
> '
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"primaries"}}}},"transient":{}}
[root@centos7 vagrant]# curl -X POST "https://localhost:9200/_flush/synced" -u admin:SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E -k
{"_shards":{"total":7,"successful":7,"failed":0}}
[root@centos7 vagrant]# systemctl stop wazuh-indexer
[root@centos7 vagrant]# yum localinstall wazuh-indexer-4.6.0-wp.2420.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-indexer-4.6.0-wp.2420.x86_64.rpm: wazuh-indexer-4.6.0-1.x86_64
Marking wazuh-indexer-4.6.0-wp.2420.x86_64.rpm as an update to wazuh-indexer-4.5.2-1.x86_64
Resolving Dependencies
--> Running transaction check
---> Package wazuh-indexer.x86_64 0:4.5.2-1 will be updated
---> Package wazuh-indexer.x86_64 0:4.6.0-1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

==============================================================================================================
 Package                Arch            Version            Repository                                    Size
==============================================================================================================
Updating:
 wazuh-indexer          x86_64          4.6.0-1            /wazuh-indexer-4.6.0-wp.2420.x86_64          930 M

Transaction Summary
==============================================================================================================
Upgrade  1 Package

Total size: 930 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : wazuh-indexer-4.6.0-1.x86_64                                                               1/2 
  Cleanup    : wazuh-indexer-4.5.2-1.x86_64                                                               2/2 
  Verifying  : wazuh-indexer-4.6.0-1.x86_64                                                               1/2 
  Verifying  : wazuh-indexer-4.5.2-1.x86_64                                                               2/2 

Updated:
  wazuh-indexer.x86_64 0:4.6.0-1                                                                              

Complete!
[root@centos7 vagrant]# systemctl daemon-reload
[root@centos7 vagrant]# systemctl enable wazuh-indexer
[root@centos7 vagrant]# systemctl start wazuh-indexer
[root@centos7 vagrant]# curl -k -u admin:SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           17          97   4    0.45    0.22     0.16 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
[root@centos7 vagrant]# curl -X PUT "https://localhost:9200/_cluster/settings" -u  admin:SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E -k -H 'Content-Type: application/json' -d'
> {
>   "persistent": {
>     "cluster.routing.allocation.enable": "all"
>   }
> }
> '
{"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"all"}}}},"transient":{}}[root@centos7 vagrant]# 
[root@centos7 vagrant]# curl -k -u admin:SWHH*sEk5qZB0weCwNTp0oFhvAT?ew2E https://localhost:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
127.0.0.1           17          97   0    0.21    0.19     0.15 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
[root@centos7 vagrant]# yum localinstall wazuh-manager-4.6.0-wp.2420.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-manager-4.6.0-wp.2420.x86_64.rpm: wazuh-manager-4.6.0-1.x86_64
Marking wazuh-manager-4.6.0-wp.2420.x86_64.rpm as an update to wazuh-manager-4.5.2-1.x86_64
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.5.2-1 will be updated
---> Package wazuh-manager.x86_64 0:4.6.0-1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

==============================================================================================================
 Package                Arch            Version            Repository                                    Size
==============================================================================================================
Updating:
 wazuh-manager          x86_64          4.6.0-1            /wazuh-manager-4.6.0-wp.2420.x86_64          599 M

Transaction Summary
==============================================================================================================
Upgrade  1 Package

Total size: 599 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : wazuh-manager-4.6.0-1.x86_64                                                               1/2 
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
  Cleanup    : wazuh-manager-4.5.2-1.x86_64                                                               2/2 
  Verifying  : wazuh-manager-4.6.0-1.x86_64                                                               1/2 
  Verifying  : wazuh-manager-4.5.2-1.x86_64                                                               2/2 

Updated:
  wazuh-manager.x86_64 0:4.6.0-1                                                                              

Complete!
[root@centos7 vagrant]# curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz | sudo tar -xvz -C /usr/share/filebeat/module
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
[root@centos7 vagrant]# curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.6.0/extensions/elasticsearch/7.x/wazuh-template.json
[root@centos7 vagrant]# chmod go+r /etc/filebeat/wazuh-template.json
[root@centos7 vagrant]# systemctl daemon-reload
[root@centos7 vagrant]# systemctl enable filebeat
[root@centos7 vagrant]# systemctl start filebeat
[root@centos7 vagrant]# filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.2
    dial up... OK
  talk to server... OK
  version: 7.10.2
[root@centos7 vagrant]# yum localinstall wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm: wazuh-dashboard-4.6.0-1.x86_64
Marking wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm as an update to wazuh-dashboard-4.5.2-1.x86_64
Resolving Dependencies
--> Running transaction check
---> Package wazuh-dashboard.x86_64 0:4.5.2-1 will be updated
---> Package wazuh-dashboard.x86_64 0:4.6.0-1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

==============================================================================================================
 Package                 Arch           Version           Repository                                     Size
==============================================================================================================
Updating:
 wazuh-dashboard         x86_64         4.6.0-1           /wazuh-dashboard-4.6.0-wp.2420.x86_64         883 M

Transaction Summary
==============================================================================================================
Upgrade  1 Package

Total size: 883 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : wazuh-dashboard-4.6.0-1.x86_64                                                             1/2 
warning: /etc/wazuh-dashboard/opensearch_dashboards.yml created as /etc/wazuh-dashboard/opensearch_dashboards.yml.rpmnew
  Cleanup    : wazuh-dashboard-4.5.2-1.x86_64                                                             2/2 
  Verifying  : wazuh-dashboard-4.6.0-1.x86_64                                                             1/2 
  Verifying  : wazuh-dashboard-4.5.2-1.x86_64                                                             2/2 

Updated:
  wazuh-dashboard.x86_64 0:4.6.0-1                                                                            

Complete!
[root@centos7 vagrant]# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
-rw-r--r--. 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 16:07 /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
[root@centos7 vagrant]# ls -l /etc/wazuh-dashboard/opensearch_dashboards.keystore 
-rw-r-----. 1 wazuh-dashboard wazuh-dashboard 226 Sep  6 16:34 /etc/wazuh-dashboard/opensearch_dashboards.keystore
[root@centos7 vagrant]# rm -rf /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
[root@centos7 vagrant]# systemctl daemon-reload
[root@centos7 vagrant]# systemctl enable wazuh-dashboard
[root@centos7 vagrant]# systemctl start wazuh-dashboard

**Error related to Wazuh dashboard keystore**

[root@centos7 vagrant]# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
-rw-r--r--. 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 17:28 /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
[root@centos7 vagrant]# sha1sum /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
7b51e96efe13b6fc99272db80de5fc5734f0b2df  /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore
[root@centos7 vagrant]# yum localinstall wazuh-dashboard-4.6.0-1.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-dashboard-4.6.0-1.x86_64.rpm: wazuh-dashboard-4.6.0-1.x86_64
Marking wazuh-dashboard-4.6.0-1.x86_64.rpm as an update to wazuh-dashboard-4.5.2-1.x86_64
Resolving Dependencies
--> Running transaction check
---> Package wazuh-dashboard.x86_64 0:4.5.2-1 will be updated
---> Package wazuh-dashboard.x86_64 0:4.6.0-1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

====================================================================================================================================
 Package                        Arch                  Version                  Repository                                      Size
====================================================================================================================================
Updating:
 wazuh-dashboard                x86_64                4.6.0-1                  /wazuh-dashboard-4.6.0-1.x86_64                883 M

Transaction Summary
====================================================================================================================================
Upgrade  1 Package

Total size: 883 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : wazuh-dashboard-4.6.0-1.x86_64                                                                                   1/2 
warning: /etc/wazuh-dashboard/opensearch_dashboards.yml created as /etc/wazuh-dashboard/opensearch_dashboards.yml.rpmnew
  Cleanup    : wazuh-dashboard-4.5.2-1.x86_64                                                                                   2/2 
  Verifying  : wazuh-dashboard-4.6.0-1.x86_64                                                                                   1/2 
  Verifying  : wazuh-dashboard-4.5.2-1.x86_64                                                                                   2/2 

Updated:
  wazuh-dashboard.x86_64 0:4.6.0-1                                                                                                  

Complete!
[root@centos7 vagrant]# ls -l /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore 
ls: cannot access /usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore: No such file or directory
[root@centos7 vagrant]# ls -l /etc/wazuh-dashboard/opensearch_dashboards.keystore 
-rw-r--r--. 1 wazuh-dashboard wazuh-dashboard 254 Sep  6 17:28 /etc/wazuh-dashboard/opensearch_dashboards.keystore
[root@centos7 vagrant]# sha1sum /etc/wazuh-dashboard/opensearch_dashboards.keystore 
7b51e96efe13b6fc99272db80de5fc5734f0b2df  /etc/wazuh-dashboard/opensearch_dashboards.keystore

[root@centos7 vagrant]# chmod 500 /etc/wazuh-dashboard/certs
[root@centos7 vagrant]# chmod 400 /etc/wazuh-dashboard/certs/*
[root@centos7 vagrant]# chown -R wazuh-dashboard:wazuh-dashboard /etc/wazuh-dashboard/certs
[root@centos7 vagrant]# systemctl restart wazuh-dashboard.service 
[root@centos7 vagrant]# systemctl status wazuh-dashboard.service 
● wazuh-dashboard.service - wazuh-dashboard
   Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2023-09-06 17:36:17 UTC; 2s ago
 Main PID: 31286 (node)
   CGroup: /system.slice/wazuh-dashboard.service
           └─31286 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=war...

Sep 06 17:36:17 centos7 systemd[1]: Started wazuh-dashboard.
Sep 06 17:36:17 centos7 opensearch-dashboards[31286]: v16.20.0
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...ce]"}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...ed."}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...ed."}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...ed."}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...t,exp
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","save......"}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","save...ons"}
Sep 06 17:36:19 centos7 opensearch-dashboards[31286]: {"type":"log","@timestamp":"2023-09-06T17:36:19Z","tags":["info","plug...expre
Hint: Some lines were ellipsized, use -l to show in full.
[root@centos7 vagrant]# 
```

</details>

<details><summary>AIO install</summary>

```
[root@centos71 unattended_installer]# bash wazuh-install.sh -a -i
06/09/2023 15:26:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
06/09/2023 15:26:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
06/09/2023 15:26:59 INFO: --- Dependencies ---
06/09/2023 15:26:59 INFO: Installing lsof.
06/09/2023 15:27:03 WARNING: Hardware and system checks ignored.
06/09/2023 15:27:03 INFO: Wazuh web interface port will be 443.
06/09/2023 15:27:05 INFO: Wazuh development repository added.
06/09/2023 15:27:05 INFO: --- Configuration files ---
06/09/2023 15:27:05 INFO: Generating configuration files.
06/09/2023 15:27:05 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
06/09/2023 15:27:05 INFO: --- Wazuh indexer ---
06/09/2023 15:27:05 INFO: Starting Wazuh indexer installation.
06/09/2023 15:28:11 INFO: Wazuh indexer installation finished.
06/09/2023 15:28:11 INFO: Wazuh indexer post-install configuration finished.
06/09/2023 15:28:11 INFO: Starting service wazuh-indexer.
06/09/2023 15:28:18 INFO: wazuh-indexer service started.
06/09/2023 15:28:18 INFO: Initializing Wazuh indexer cluster security settings.
06/09/2023 15:28:29 INFO: Wazuh indexer cluster initialized.
06/09/2023 15:28:29 INFO: --- Wazuh server ---
06/09/2023 15:28:29 INFO: Starting the Wazuh manager installation.
06/09/2023 15:28:58 INFO: Wazuh manager installation finished.
06/09/2023 15:28:58 INFO: Starting service wazuh-manager.
06/09/2023 15:29:09 INFO: wazuh-manager service started.
06/09/2023 15:29:09 INFO: Starting Filebeat installation.
06/09/2023 15:29:16 INFO: Filebeat installation finished.
06/09/2023 15:29:17 INFO: Filebeat post-install configuration finished.
06/09/2023 15:29:17 INFO: Starting service filebeat.
06/09/2023 15:29:17 INFO: filebeat service started.
06/09/2023 15:29:17 INFO: --- Wazuh dashboard ---
06/09/2023 15:29:20 INFO: --- Dependencies ---
06/09/2023 15:29:20 INFO: Installing chromium.
06/09/2023 15:29:21 WARNING: Cannot install optional dependency: chromium.
06/09/2023 15:29:21 INFO: Installing xorg-x11-fonts-100dpi.
06/09/2023 15:29:22 INFO: Installing xorg-x11-fonts-75dpi.
06/09/2023 15:29:23 INFO: Installing xorg-x11-utils.
06/09/2023 15:29:24 INFO: Installing xorg-x11-fonts-cyrillic.
06/09/2023 15:29:25 INFO: Installing xorg-x11-fonts-Type1.
06/09/2023 15:29:27 INFO: Installing xorg-x11-fonts-misc.
06/09/2023 15:29:29 INFO: Installing fontconfig.
06/09/2023 15:29:29 WARNING: Wazuh dashboard dependencies skipped. PDF report generation may not work.
06/09/2023 15:29:29 INFO: Starting Wazuh dashboard installation.
06/09/2023 15:30:20 INFO: Wazuh dashboard installation finished.
06/09/2023 15:30:20 INFO: Wazuh dashboard post-install configuration finished.
06/09/2023 15:30:20 INFO: Starting service wazuh-dashboard.
06/09/2023 15:30:20 INFO: wazuh-dashboard service started.
06/09/2023 15:30:35 INFO: Initializing Wazuh dashboard web application.
06/09/2023 15:30:36 INFO: Wazuh dashboard web application initialized.
06/09/2023 15:30:36 INFO: --- Summary ---
06/09/2023 15:30:36 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: bWAlsRGBJ88QKU+CBXO5+L7vi9kC7XO1
06/09/2023 15:30:36 INFO: Installation finished.
[root@centos71 unattended_installer]# grep -R "warehouse" wazuh-install.sh 
        eval "yum install https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-dashboard-4.6.0-wp.2420.x86_64.rpm -y ${debug}"
        eval "yum install https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-indexer-4.6.0-wp.2420.x86_64.rpm -y ${debug}"
        eval "${sys_type} install https://packages-dev.wazuh.com/warehouse/test/4.6/rpm/wazuh-manager-4.6.0-wp.2420.x86_64.rpm -y ${debug}"
[root@centos71 unattended_installer]# grep NODE_OPTIONS /usr/share/wazuh-dashboard/bin/use_node 
# NODE_OPTIONS is built using config/node.options and overridden by any previously set NODE_OPTIONS.
  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"
 NODE_ENV=production exec "${NODE}" ${NODE_OPTIONS}  "${OSD_HOME}${OSD_USE_NODE_JS_FILE_PATH}" "${@}"
  NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"
 NODE_ENV=production exec "${NODE}" ${NODE_OPTIONS}  "${@}"
[root@centos71 unattended_installer]# grep "127" /etc/wazuh-dashboard/opensearch_dashboards.yml 
opensearch.hosts: https://127.0.0.1:9200
[root@centos71 unattended_installer]# systemctl status wazuh-dashboard.service 
● wazuh-dashboard.service - wazuh-dashboard
   Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2023-09-06 16:05:44 UTC; 7s ago
 Main PID: 30166 (node)
   CGroup: /system.slice/wazuh-dashboard.service
           └─30166 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-dashboard/src/cli/dist -c /etc/wazuh-dashboard/opensearch_da...

Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","plugins-service"],"pid":30166,"message":"Plugin \"dataSource\" is disabled."}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","plugins-service"],"pid":30166,"message":"Plugin \"visTypeXy\" is disabled."}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","plugins-service"],"pid":30166,"message":"Plugin \"mlCommonsDashboards\" is disabled."}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["warning","config","deprecation"],"pid":30166,"message":"\"opensearch.requestHeade...Allowlist\""}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","plugins-system"],"pid":30166,"message":"Setting up [44] plugins: [alerting...mbeddable,exp
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","savedobjects-service"],"pid":30166,"message":"Waiting until all OpenSearch...grations..."}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","savedobjects-service"],"pid":30166,"message":"Starting saved objects migrations"}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","plugins-system"],"pid":30166,"message":"Starting [44] plugins: [alertingDa...eddable,expre
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["listening","info"],"pid":30166,"message":"Server running at https://0.0.0.0:443"}
Sep 06 16:05:46 centos71 opensearch-dashboards[30166]: {"type":"log","@timestamp":"2023-09-06T16:05:46Z","tags":["info","http","server","OpenSearchDashboards"],"pid":30166,"message":"http server ...0.0.0.0:443"}
Hint: Some lines were ellipsized, use -l to show in full.
```

</details>

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package remove
- [x] Package install/remove/install

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [x] Package install/remove/install
  - [x] Package install/purge/install
  - [x] Check file permissions after installing the package
