### PR TITLE
Reverted --all options for cert-tools

### DIFF
--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -20,7 +20,7 @@ function getHelp() {
     echo -e "                Creates the admin certificates, add root-ca.pem and root-ca.key."
     echo -e ""
     echo -e "        -A, --all </path/to/root-ca.pem> </path/to/root-ca.key>"
-    echo -e "                Creates Wazuh server, Wazuh indexer, Wazuh dashboard, and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created."
+    echo -e "                Creates certificates specified in config.yml and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created."
     echo -e ""
     echo -e "        -ca, --root-ca-certificates"
     echo -e "                Creates the root-ca certificates."
@@ -186,26 +186,21 @@ function main() {
         fi
 
         if [[ -n "${all}" ]]; then
-            if [[ ${#indexer_node_names[@]} -gt 0 ]] && [[ ${#server_node_names[@]} -gt 0 ]] && [[ ${#dashboard_node_names[@]} -gt 0 ]]; then
-                cert_checkRootCA
-                cert_generateAdmincertificate
-                common_logger "Admin certificates created."
-                if cert_generateIndexercertificates; then
-                    common_logger "Wazuh indexer certificates created."
-                fi
-                if cert_generateFilebeatcertificates; then
-                    common_logger "Wazuh server certificates created."
-                fi
-                if cert_generateDashboardcertificates; then
-                    common_logger "Wazuh dashboard certificates created."
-                fi
-                cert_cleanFiles
-                cert_setpermisions
-                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
-            else
-                common_logger -e "You must specify at least one indexer, one server and one dashboard node."
-                exit 1
+            cert_checkRootCA
+            cert_generateAdmincertificate
+            common_logger "Admin certificates created."
+            if cert_generateIndexercertificates; then
+                common_logger "Wazuh indexer certificates created."
             fi
+            if cert_generateFilebeatcertificates; then
+                common_logger "Wazuh server certificates created."
+            fi
+            if cert_generateDashboardcertificates; then
+                common_logger "Wazuh dashboard certificates created."
+            fi
+            cert_cleanFiles
+            cert_setpermisions
+            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
         fi
 
         if [[ -n "${ca}" ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2441|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The changes applied to the cert-tools are rolled back, in the same way as was done in this [PR](https://github.com/wazuh/wazuh-packages/pull/1991)

## Logs example

<!--
Paste here related logs
-->

## Tests

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/testing-cert-tool$ cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: demo.indexer
      ip: demo.indexer
```

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/testing-cert-tool$ bash wazuh-certs-tool.sh -h

NAME
        wazuh-cert-tool.sh - Manages the creation of certificates of the Wazuh components.

SYNOPSIS
        wazuh-cert-tool.sh [OPTIONS]

DESCRIPTION
        -a,  --admin-certificates </path/to/root-ca.pem> </path/to/root-ca.key>
                Creates the admin certificates, add root-ca.pem and root-ca.key.

        -A, --all </path/to/root-ca.pem> </path/to/root-ca.key>
                Creates certificates specified in config.yml and admin certificates. Add a root-ca.pem and root-ca.key or leave it empty so a new one will be created.

        -ca, --root-ca-certificates
                Creates the root-ca certificates.

        -v,  --verbose
                Enables verbose mode.

        -wd,  --wazuh-dashboard-certificates </path/to/root-ca.pem> </path/to/root-ca.key>
                Creates the Wazuh dashboard certificates, add root-ca.pem and root-ca.key.

        -wi,  --wazuh-indexer-certificates </path/to/root-ca.pem> </path/to/root-ca.key>
                Creates the Wazuh indexer certificates, add root-ca.pem and root-ca.key.

        -ws,  --wazuh-server-certificates </path/to/root-ca.pem> </path/to/root-ca.key>
                Creates the Wazuh server certificates, add root-ca.pem and root-ca.key.

        -tmp,  --cert_tmp_path </path/to/tmp_dir>
                Modifies the default tmp directory (/tmp/wazuh-ceritificates) to the specified one.
                Must be used along with one of these options: -a, -A, -ca, -wi, -wd, -ws

```


```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/testing-cert-tool$ bash wazuh-certs-tool.sh -A
11/09/2023 13:52:40 INFO: Admin certificates created.
11/09/2023 13:52:41 INFO: Wazuh indexer certificates created.
```


```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/testing-cert-tool$ ls -la wazuh-certificates/
total 32
drwxr--r-- 2 cbordon cbordon 4096 sep 11 13:52 .
drwxrwxr-x 4 cbordon cbordon 4096 sep 11 13:52 ..
-rwxr--r-- 1 cbordon cbordon 1708 sep 11 13:52 admin-key.pem
-rwxr--r-- 1 cbordon cbordon 1119 sep 11 13:52 admin.pem
-rwxr--r-- 1 cbordon cbordon 1704 sep 11 13:52 demo.indexer-key.pem
-rwxr--r-- 1 cbordon cbordon 1294 sep 11 13:52 demo.indexer.pem
-rwxr--r-- 1 cbordon cbordon 1704 sep 11 13:52 root-ca.key
-rwxr--r-- 1 cbordon cbordon 1204 sep 11 13:52 root-ca.pem
```

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
