### PR TITLE
Avoids deleting the entire syscheckd folder when creating WPK

### DIFF
--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -222,7 +222,11 @@ clean() {
     rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*}
     rm -rf src/{headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd}
     rm -rf src/{os_dbd,os_execd,os_integrator,os_maild,os_net,os_regex,os_xml,os_zlib}
-    rm -rf src/{remoted,reportd,shared,syscheckd,unit_tests,wazuh_db}
+    rm -rf src/{remoted,reportd,shared,unit_tests,wazuh_db}
+
+    # Clean syscheckd folder
+    find src/syscheckd -type f -not -name "wazuh-syscheckd" -not -name "libfimdb.dylib" -not -name "libfimdb.so" -delete
+
 
     if [[ "${BUILD_TARGET}" != "winagent" ]]; then
         rm -rf src/win32


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/18965|


## Description

This change avoids deleting the entire syscheckd folder when creating WPKs, it keeps the wazuh-syscheckd, libfimdb.dylib and libfimdb.so files.


## Tests
After the changes, we can see how the necessary syscheckd files are preserved:
![image](https://github.com/wazuh/wazuh-packages/assets/13004400/c957273c-6c30-4ef4-b2ae-fae6a91618d5)

And the agent can be updated correctly:
```
2023/09/13 23:06:05 - Generating Backup.
tar: ./var/ossec/queue/sockets/upgrade: socket ignored
tar: ./var/ossec/queue/sockets/logcollector: socket ignored
tar: ./var/ossec/queue/sockets/syscheck: socket ignored
tar: ./var/ossec/queue/sockets/queue: socket ignored
tar: ./var/ossec/queue/sockets/com: socket ignored
tar: ./var/ossec/queue/sockets/control: socket ignored
tar: ./var/ossec/queue/sockets/wmodules: socket ignored
tar: ./var/ossec/queue/alerts/execq: socket ignored
tar: ./var/ossec/queue/alerts/cfgaq: socket ignored
2023/09/13 23:06:07 - Upgrade started.

 Wazuh v4.6.0 (Rev. 40600) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux vagrant 5.15.0-83-generic (ubuntu 22.04)
  - User: root
  - Host: vagrant


  -- Press ENTER to continue or Ctrl-C to abort. --

 - You already have Wazuh installed. Do you want to update it? (y/n): 
    - Installation will be made at  /var/ossec .

4- Installing the system

DIR="/var/ossec"
 - Running the Makefile

Stopping Wazuh...
agent
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Wait for success...
success
Starting Wazuh...

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - Update completed.

2023/09/13 23:06:19 - Installation result = 0
2023/09/13 23:06:20 - Waiting connection... Status = connected. Remaining attempts: 29.
2023/09/13 23:06:20 - Connected to manager.
2023/09/13 23:06:20 - Upgrade finished successfully.
```

