### PR TITLE
Fixed dashboard port check

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -10,6 +10,8 @@ function dashboard_changePort() {
 
     chosen_port="$1"
     http_port="${chosen_port}" 
+    wazuh_dashboard_ports=( "${http_port}" )
+    wazuh_aio_ports=(9200 9300 1514 1515 1516 55000 "${http_port}")
 
     sed -i 's/server\.port: [0-9]\+$/server.port: '"${chosen_port}"'/' "$0"
     common_logger "Wazuh web interface port will be ${chosen_port}."

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -49,7 +49,7 @@ adminUser="wazuh"
 adminPassword="wazuh"
 
 http_port=443
-readonly wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 "${http_port}")
+wazuh_aio_ports=( 9200 9300 1514 1515 1516 55000 "${http_port}")
 readonly wazuh_indexer_ports=( 9200 9300 )
 readonly wazuh_manager_ports=( 1514 1515 1516 55000 )
-readonly wazuh_dashboard_ports=( "${http_port}" )
+wazuh_dashboard_ports=( "${http_port}" )


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2451|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to fix the Wazuh dashboard port check when the `-p|--port` option was specified in the Installation Assistant. This bug stopped the execution of the script if the default dashboard port was used, but a different port was specified.



## Tests



The Installer has been modified by adding a debug line: `INFO: Checking port <port>` to know what port the Installer is checking

<details><summary>:green_circle: Installing Wazuh dashboard specifying the port</summary>

```console
root@ubuntu22:/home/vagrant# lsof -sTCP:LISTEN  -i:443
root@ubuntu22:/home/vagrant# 

root@ubuntu22:/home/vagrant# bash wazuh-install.sh -wd dashboard -i -p 8080
14/09/2023 10:08:07 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.3
14/09/2023 10:08:07 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 10:08:18 WARNING: Hardware and system checks ignored.
14/09/2023 10:08:18 INFO: Wazuh web interface port will be 8080.
14/09/2023 10:08:18 INFO: Checking port 8080
14/09/2023 10:08:26 INFO: Wazuh development repository added.
dashboard
14/09/2023 10:08:26 INFO: --- Wazuh dashboard ----
```
</details>


<details><summary>:green_circle: Installing Wazuh dashboard specifying the port when the default port is used</summary>

```console
root@ubuntu22:/home/vagrant# lsof -sTCP:LISTEN  -i:443
COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
python3 55396 root    3u  IPv4 360575      0t0  TCP *:https (LISTEN)

root@ubuntu22:/home/vagrant# bash wazuh-install.sh -wd dashboard -i -p 8081
14/09/2023 10:12:38 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.3
14/09/2023 10:12:38 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 10:12:46 WARNING: Hardware and system checks ignored.
14/09/2023 10:12:46 INFO: Wazuh web interface port will be 8081.
14/09/2023 10:12:46 INFO: Checking port 8081
14/09/2023 10:12:54 INFO: Wazuh development repository added.
dashboard
14/09/2023 10:12:54 INFO: --- Wazuh dashboard ----
```
</details>

<details><summary>:green_circle: AIO specifying the port</summary>

```console
root@ubuntu22:/home/vagrant# lsof -sTCP:LISTEN  -i:443
root@ubuntu22:/home/vagrant# 

root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -p 8080 -o
14/09/2023 10:18:49 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
14/09/2023 10:18:49 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 10:18:50 INFO: --- Removing existing Wazuh installation ---
14/09/2023 10:18:50 INFO: Removing Wazuh indexer.
14/09/2023 10:18:50 INFO: Wazuh indexer removed.
14/09/2023 10:18:50 INFO: Wazuh GPG key was not found in the system
14/09/2023 10:18:51 INFO: Installation cleaned.
14/09/2023 10:18:57 WARNING: Hardware and system checks ignored.
14/09/2023 10:18:57 INFO: Wazuh web interface port will be 8080.
14/09/2023 10:18:57 INFO: Checking port 9200
14/09/2023 10:18:57 INFO: Checking port 9300
14/09/2023 10:18:57 INFO: Checking port 1514
14/09/2023 10:18:57 INFO: Checking port 1515
14/09/2023 10:18:57 INFO: Checking port 1516
14/09/2023 10:18:57 INFO: Checking port 55000
14/09/2023 10:18:57 INFO: Checking port 8080
14/09/2023 10:19:05 INFO: Wazuh development repository added.

```

</details>

<details><summary>:green_circle: AIO specifying the port when the default port is used</summary>

```console
root@ubuntu22:/home/vagrant# lsof -sTCP:LISTEN  -i:443
COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
python3 55396 root    3u  IPv4 360575      0t0  TCP *:https (LISTEN)

root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -p 8080 -o
14/09/2023 10:18:49 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
14/09/2023 10:18:49 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 10:18:50 INFO: --- Removing existing Wazuh installation ---
14/09/2023 10:18:50 INFO: Removing Wazuh indexer.
14/09/2023 10:18:50 INFO: Wazuh indexer removed.
14/09/2023 10:18:50 INFO: Wazuh GPG key was not found in the system
14/09/2023 10:18:51 INFO: Installation cleaned.
14/09/2023 10:18:57 WARNING: Hardware and system checks ignored.
14/09/2023 10:18:57 INFO: Wazuh web interface port will be 8080.
14/09/2023 10:18:57 INFO: Checking port 9200
14/09/2023 10:18:57 INFO: Checking port 9300
14/09/2023 10:18:57 INFO: Checking port 1514
14/09/2023 10:18:57 INFO: Checking port 1515
14/09/2023 10:18:57 INFO: Checking port 1516
14/09/2023 10:18:57 INFO: Checking port 55000
14/09/2023 10:18:57 INFO: Checking port 8080
14/09/2023 10:19:05 INFO: Wazuh development repository added.

```

</details>

In every test, the Wazuh stack is working as expected:
![image](https://github.com/wazuh/wazuh-packages/assets/72193239/aeb1a20e-9959-4d8e-a734-be1d6fef2696)
