### PR TITLE
Adding Centos 7 to chromium installation exception

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -280,6 +280,8 @@ function installCommon_checkChromium() {
         if (! yum list installed 2>/dev/null | grep -q -E ^"google-chrome-stable"\\.) && (! yum list installed 2>/dev/null | grep -q -E ^"chromium"\\.); then
             if [ "${DIST_NAME}" == "amzn" ]; then
                 installCommon_installChrome
+            elif [[ "${DIST_NAME}" == "centos" ]] && [[ "${DIST_VER}" == "7" ]]; then
+                installCommon_installChrome
             else
                 dashboard_dependencies=(chromium)
             fi


### PR DESCRIPTION
|Related issue|
|---|
|close https://github.com/wazuh/wazuh-packages/issues/2446|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
I was able to verify that installing chromium in the previous way no longer works for Centos 7, so the way of installing is changed and the same exception that we used for Amazon Linux is used



## Logs example

<!--
Paste here related logs
-->

<details>
<summary>Centos 7</summary>

```console
[root@centos7-1 ~]# git clone https://github.com/wazuh/wazuh-packages.git
Cloning into 'wazuh-packages'...
remote: Enumerating objects: 55492, done.
remote: Counting objects: 100% (5104/5104), done.
remote: Compressing objects: 100% (1925/1925), done.
remote: Total 55492 (delta 3128), reused 4812 (delta 2893), pack-reused 50388
Receiving objects: 100% (55492/55492), 16.52 MiB | 8.11 MiB/s, done.
Resolving deltas: 100% (34770/34770), done.
[root@centos7-1 ~]# cd wazuh-packages/
[root@centos7-1 wazuh-packages]# git checkout 2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0
Branch 2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0 set up to track remote branch 2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0 from origin.
Switched to a new branch '2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0'
[root@centos7-1 wazuh-packages]# cd unattended_installer/
[root@centos7-1 unattended_installer]# bash builder.sh -i -d pre-release
[root@centos7-1 unattended_installer]# bash wazuh-install.sh -a
14/09/2023 19:52:41 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
14/09/2023 19:52:41 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 19:52:44 INFO: --- Dependencies ---
14/09/2023 19:52:44 INFO: Installing lsof.
14/09/2023 19:52:50 INFO: Wazuh web interface port will be 443.
14/09/2023 19:52:52 INFO: Wazuh development repository added.
14/09/2023 19:52:52 INFO: --- Configuration files ---
14/09/2023 19:52:52 INFO: Generating configuration files.
14/09/2023 19:52:53 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
14/09/2023 19:52:53 INFO: --- Wazuh indexer ---
14/09/2023 19:52:53 INFO: Starting Wazuh indexer installation.
14/09/2023 19:55:01 INFO: Wazuh indexer installation finished.
14/09/2023 19:55:01 INFO: Wazuh indexer post-install configuration finished.
14/09/2023 19:55:01 INFO: Starting service wazuh-indexer.
14/09/2023 19:55:12 INFO: wazuh-indexer service started.
14/09/2023 19:55:12 INFO: Initializing Wazuh indexer cluster security settings.
14/09/2023 19:55:23 INFO: Wazuh indexer cluster initialized.
14/09/2023 19:55:23 INFO: --- Wazuh server ---
14/09/2023 19:55:23 INFO: Starting the Wazuh manager installation.
14/09/2023 19:56:14 INFO: Wazuh manager installation finished.
14/09/2023 19:56:14 INFO: Starting service wazuh-manager.
14/09/2023 19:56:24 INFO: wazuh-manager service started.
14/09/2023 19:56:24 INFO: Starting Filebeat installation.
14/09/2023 19:56:30 INFO: Filebeat installation finished.
14/09/2023 19:56:32 INFO: Filebeat post-install configuration finished.
14/09/2023 19:56:32 INFO: Starting service filebeat.
14/09/2023 19:56:32 INFO: filebeat service started.
14/09/2023 19:56:32 INFO: --- Wazuh dashboard ---
14/09/2023 19:56:33 INFO: Installing chrome.
14/09/2023 19:57:20 INFO: --- Dependencies ---
14/09/2023 19:57:20 INFO: Installing xorg-x11-fonts-100dpi.
14/09/2023 19:57:23 INFO: Installing xorg-x11-fonts-75dpi.
14/09/2023 19:57:25 INFO: Installing xorg-x11-utils.
14/09/2023 19:57:27 INFO: Installing xorg-x11-fonts-cyrillic.
14/09/2023 19:57:28 INFO: Installing xorg-x11-fonts-Type1.
14/09/2023 19:57:30 INFO: Installing xorg-x11-fonts-misc.
14/09/2023 19:57:34 INFO: Starting Wazuh dashboard installation.
14/09/2023 19:59:09 INFO: Wazuh dashboard installation finished.
14/09/2023 19:59:09 INFO: Wazuh dashboard post-install configuration finished.
14/09/2023 19:59:09 INFO: Starting service wazuh-dashboard.
14/09/2023 19:59:09 INFO: wazuh-dashboard service started.
14/09/2023 19:59:26 INFO: Initializing Wazuh dashboard web application.
14/09/2023 19:59:27 INFO: Wazuh dashboard web application initialized.
14/09/2023 19:59:27 INFO: --- Summary ---
14/09/2023 19:59:27 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: N3MjUFmTuS6.f6oD8XFOY.TEDSjJYxof
14/09/2023 19:59:27 INFO: Installation finished.
[root@centos7-1 unattended_installer]# cat /etc/*release
CentOS Linux release 7.8.2003 (Core)
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

CentOS Linux release 7.8.2003 (Core)
CentOS Linux release 7.8.2003 (Core)
```
</details>

<details>
<summary>Centos 8</summary>

```console
[root@centos8 ~]# git clone https://github.com/wazuh/wazuh-packages.git
Cloning into 'wazuh-packages'...
remote: Enumerating objects: 55492, done.
remote: Counting objects: 100% (5103/5103), done.
remote: Compressing objects: 100% (1924/1924), done.
remote: Total 55492 (delta 3127), reused 4811 (delta 2893), pack-reused 50389
Receiving objects: 100% (55492/55492), 16.88 MiB | 7.19 MiB/s, done.
Resolving deltas: 100% (34753/34753), done.
[root@centos8 ~]# cd wazuh-packages/
[root@centos8 wazuh-packages]# git checkout 2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0
Branch '2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0' set up to track remote branch '2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0' from 'origin'.
Switched to a new branch '2446-warning-in-the-quickstart-installation-on-centos-7-unable-to-install-chromium-to4.6.0'
[root@centos8 wazuh-packages]# cd unattended_installer/
[root@centos8 unattended_installer]# bash builder.sh -i -d pre-release
[root@centos8 unattended_installer]# bash wazuh-install.sh -a
14/09/2023 20:15:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
14/09/2023 20:15:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 20:16:05 ERROR: Your system does not meet the recommended minimum hardware requirements of 4Gb of RAM and 2 CPU cores. If you want to proceed with the installation use the -i option to ignore these requirements.
[root@centos8 unattended_installer]# bash wazuh-install.sh -a -i
14/09/2023 20:16:16 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
14/09/2023 20:16:16 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/09/2023 20:16:24 WARNING: Hardware and system checks ignored.
14/09/2023 20:16:24 INFO: Wazuh web interface port will be 443.
14/09/2023 20:16:26 INFO: Wazuh development repository added.
14/09/2023 20:16:26 INFO: --- Configuration files ---
14/09/2023 20:16:26 INFO: Generating configuration files.
14/09/2023 20:16:27 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
14/09/2023 20:16:27 INFO: --- Wazuh indexer ---
14/09/2023 20:16:27 INFO: Starting Wazuh indexer installation.
14/09/2023 20:18:49 INFO: Wazuh indexer installation finished.
14/09/2023 20:18:49 INFO: Wazuh indexer post-install configuration finished.
14/09/2023 20:18:49 INFO: Starting service wazuh-indexer.
14/09/2023 20:19:00 INFO: wazuh-indexer service started.
14/09/2023 20:19:00 INFO: Initializing Wazuh indexer cluster security settings.
14/09/2023 20:19:11 INFO: Wazuh indexer cluster initialized.
14/09/2023 20:19:11 INFO: --- Wazuh server ---
14/09/2023 20:19:11 INFO: Starting the Wazuh manager installation.
14/09/2023 20:20:25 INFO: Wazuh manager installation finished.
14/09/2023 20:20:25 INFO: Starting service wazuh-manager.
14/09/2023 20:20:41 INFO: wazuh-manager service started.
14/09/2023 20:20:41 INFO: Starting Filebeat installation.
14/09/2023 20:20:50 INFO: Filebeat installation finished.
14/09/2023 20:20:52 INFO: Filebeat post-install configuration finished.
14/09/2023 20:20:52 INFO: Starting service filebeat.
14/09/2023 20:20:52 INFO: filebeat service started.
14/09/2023 20:20:52 INFO: --- Wazuh dashboard ---
14/09/2023 20:20:58 INFO: --- Dependencies ---
14/09/2023 20:20:58 INFO: Installing chromium.
14/09/2023 20:22:01 INFO: Installing nss.
14/09/2023 20:22:05 INFO: Installing xorg-x11-fonts-100dpi.
14/09/2023 20:22:08 INFO: Installing xorg-x11-fonts-75dpi.
14/09/2023 20:22:10 INFO: Installing xorg-x11-utils.
14/09/2023 20:22:12 INFO: Installing xorg-x11-fonts-cyrillic.
14/09/2023 20:22:13 INFO: Installing xorg-x11-fonts-Type1.
14/09/2023 20:22:15 INFO: Installing xorg-x11-fonts-misc.
14/09/2023 20:22:19 INFO: Installing fontconfig.
14/09/2023 20:22:20 INFO: Starting Wazuh dashboard installation.
14/09/2023 20:23:49 INFO: Wazuh dashboard installation finished.
14/09/2023 20:23:49 INFO: Wazuh dashboard post-install configuration finished.
14/09/2023 20:23:50 INFO: Starting service wazuh-dashboard.
14/09/2023 20:23:50 INFO: wazuh-dashboard service started.
14/09/2023 20:24:16 INFO: Initializing Wazuh dashboard web application.
14/09/2023 20:24:16 INFO: Wazuh dashboard web application initialized.
14/09/2023 20:24:16 INFO: --- Summary ---
14/09/2023 20:24:16 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: Pgc0+y+Pqeff76mrGffTWeGaeC5XQUD0
14/09/2023 20:24:16 INFO: Installation finished.
[root@centos8 unattended_installer]# cat /etc/*release
CentOS Linux release 8.5.2111
NAME="CentOS Linux"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"
CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
CentOS Linux release 8.5.2111
CentOS Linux release 8.5.2111
```
</details>


## Tests
![Screenshot_20230914_170803](https://github.com/wazuh/wazuh-packages/assets/64099752/bdcdc3e0-9a2b-4f0f-8169-71e340530641)
![Screenshot_20230914_170926](https://github.com/wazuh/wazuh-packages/assets/64099752/6148705f-e859-4438-8b94-5fb0825b84b9)


## Jenkins tests
Centos 7: https://ci.wazuh.info/view/Tests/job/Test_unattended/4431/console
Centos 8: https://ci.wazuh.info/view/Tests/job/Test_unattended/4442/console

