### PR TITLE
Implement code signing for `libfimdb.dll` for packages

### DIFF
--- a/windows/generate_wazuh_msi.ps1
+++ b/windows/generate_wazuh_msi.ps1
@@ -83,6 +83,7 @@ function BuildWazuhMsi(){
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"
         & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
+        & $SIGNTOOL_EXE sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\syscheckd\build\bin\libfimdb.dll"
     }
 
     Write-Host "Building MSI installer..."


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#18952|

## Objective

The objective of this PR is to enhance the security and trustworthiness of the `libfimdb.dll` library by implementing code signing, like the previous dll and executable in Wazuh.


## Description
- Add the library in the `wazuh-installer-sign-exes.bat` tool.
- Verify that the signed DLL functions correctly in the application. 

> [!NOTE]  
> The validation process was conducted using a generic certificate due to security concerns, which solely verifies the presence of a digital signature.

## Quality Assurance
No test was added in this pull-request. Using a self-signed certificate, we attach `PoC` of the sign library

![Screenshot from 2023-09-15 12-24-46](https://github.com/wazuh/wazuh/assets/27935340/6654215b-60de-43e9-adb2-a057cf6ba12c)

![Screenshot from 2023-09-15 12-25-25](https://github.com/wazuh/wazuh/assets/27935340/4fb7dd7b-e00b-4b38-8932-5b0d66df6e44)


## Exploratory tests
Not apply


### Check summary
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [X] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [X] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
