### PR TITLE
Added exception list for config.yml checksums in GHA tests

### DIFF
--- a/.github/actions/upgrade-indexer/common.sh
+++ b/.github/actions/upgrade-indexer/common.sh
@@ -73,7 +73,7 @@ function compare_arrays() {
 # Steps before installing the RPM release package.
 function add_production_repository() {
 
-    rpm --import https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
+    rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
     echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH\nenabled=1\nname=EL-$releasever - Wazuh\nbaseurl=https://packages.wazuh.com/4.x/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo
 
 }

--- a/.github/actions/upgrade-indexer/upgrade-indexer.sh
+++ b/.github/actions/upgrade-indexer/upgrade-indexer.sh
@@ -35,7 +35,7 @@ print_files "files_new"
 
 compare_arrays
 if [ "$?" -eq 0 ]; then
-    echo "Same or accepted checksums - Test passed correctly."
+    echo "Valid checksums - Test passed correctly."
     exit 0
 fi
 echo "Error: different checksums detected."

--- a/.github/actions/upgrade-indexer/upgrade-indexer.sh
+++ b/.github/actions/upgrade-indexer/upgrade-indexer.sh
@@ -35,7 +35,7 @@ print_files "files_new"
 
 compare_arrays
 if [ "$?" -eq 0 ]; then
-    echo "Same checksums - Test passed correctly."
+    echo "Same or accepted checksums - Test passed correctly."
     exit 0
 fi
 echo "Error: different checksums detected."


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2429|

## Description

This PR modifies the scripts used to test the upgrade of the Wazuh indexer in GHA because the config.yml file has changed compared to the version prior to 4.6.0, the modification consists of maintaining a list with the SHA values of a given file, in this way if it detects a SHA change, it is reflected as expected

## Tests

<details><summary>Upgrade 4.5.2 -> 4.6.0</summary>

```
root@ubuntu22:/home/vagrant# bash upgrade-indexer.sh "./wazuh-indexer_4.6.0-1_amd64.deb" "45"
New path detected (/etc).
Installing old version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/683 MB of archives.
After this operation, 971 MB of additional disk space will be used.
Selecting previously unselected package wazuh-indexer.
(Reading database ... 75812 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.5.2-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.5.2-1) ...
Setting up wazuh-indexer (4.5.2-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Old files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: b9eb7a16aa1969ee394370d3369a9d6b
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Installing new version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.6.0-1_amd64.deb'
The following packages will be upgraded:
  wazuh-indexer
1 upgraded, 0 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/685 MB of archives.
After this operation, 1,739 kB disk space will be freed.
Get:1 /home/vagrant/wazuh-indexer_4.6.0-1_amd64.deb wazuh-indexer amd64 4.6.0-1 [685 MB]
(Reading database ... 76935 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.6.0-1_amd64.deb ...
Unpacking wazuh-indexer (4.6.0-1) over (4.5.2-1) ...
Setting up wazuh-indexer (4.6.0-1) ...
Installing new version of config file /etc/wazuh-indexer/opensearch-notifications-core/notifications-core.yml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/log4j2.xml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_idle_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-security/config.yml ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-indexer_4.6.0-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
New files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: 25c499973687a8fd3eb8b9ceb3da7a68
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Comparing opensearch.yml.example file checksum...
Old: ab1ad1f166434f3abac7a751c1e57fba
New: ab1ad1f166434f3abac7a751c1e57fba
opensearch.yml.example - Same checksum.
Comparing action_groups.yml file checksum...
Old: 49915bd12633877031bbbb8755475c57
New: 49915bd12633877031bbbb8755475c57
action_groups.yml - Same checksum.
Comparing audit.yml file checksum...
Old: 708fac768f8535fec7cc8f861ea2f51e
New: 708fac768f8535fec7cc8f861ea2f51e
audit.yml - Same checksum.
Comparing config.yml file checksum...
Old: b9eb7a16aa1969ee394370d3369a9d6b
New: 25c499973687a8fd3eb8b9ceb3da7a68
config.yml - Expected change.
Comparing whitelist.yml file checksum...
Old: e2edf5dc1ea24205d4a2110867090b86
New: e2edf5dc1ea24205d4a2110867090b86
whitelist.yml - Same checksum.
Comparing nodes_dn.yml file checksum...
Old: 586267623e1846bffa3eb8f516309579
New: 586267623e1846bffa3eb8f516309579
nodes_dn.yml - Same checksum.
Comparing internal_users.yml file checksum...
Old: c0b5e164a86cf3ed5dd41ffb063f81b5
New: c0b5e164a86cf3ed5dd41ffb063f81b5
internal_users.yml - Same checksum.
Comparing roles_mapping.yml file checksum...
Old: 5183f75b0697f931c2b4bcc28cd39cca
New: 5183f75b0697f931c2b4bcc28cd39cca
roles_mapping.yml - Same checksum.
Comparing allowlist.yml file checksum...
Old: 5025498ed9e6413047936860fda91c84
New: 5025498ed9e6413047936860fda91c84
allowlist.yml - Same checksum.
Comparing tenants.yml file checksum...
Old: 7f5efc3999ffbd51cc1c72a7d7c0b02c
New: 7f5efc3999ffbd51cc1c72a7d7c0b02c
tenants.yml - Same checksum.
Comparing roles.yml file checksum...
Old: 14916520220fe82010e7ce3295c06f6b
New: 14916520220fe82010e7ce3295c06f6b
roles.yml - Same checksum.
Same checksums - Test passed correctly.
root@ubuntu22:/home/vagrant# cat /usr/share/wazuh-indexer/VERSION 
4.6.0
```

</details>

<details><summary>Upgrade 4.5.2 -> 4.7.0</summary>

```
root@ubuntu22:/home/vagrant# bash upgrade-indexer.sh "./wazuh-indexer_4.7.0-1_amd64.deb" "45"
New path detected (/etc).
Installing old version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/683 MB of archives.
After this operation, 971 MB of additional disk space will be used.
Selecting previously unselected package wazuh-indexer.
(Reading database ... 75812 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.5.2-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.5.2-1) ...
Setting up wazuh-indexer (4.5.2-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
/home/vagrant/common.sh: line 98: ${f}: ambiguous redirect
Changed file.
Old files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: b9eb7a16aa1969ee394370d3369a9d6b
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Installing new version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.7.0-1_amd64.deb'
The following packages will be upgraded:
  wazuh-indexer
1 upgraded, 0 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/684 MB of archives.
After this operation, 1,739 kB disk space will be freed.
Get:1 /home/vagrant/wazuh-indexer_4.7.0-1_amd64.deb wazuh-indexer amd64 4.7.0-1 [684 MB]
(Reading database ... 76935 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.7.0-1_amd64.deb ...
Unpacking wazuh-indexer (4.7.0-1) over (4.5.2-1) ...
Setting up wazuh-indexer (4.7.0-1) ...
Installing new version of config file /etc/wazuh-indexer/opensearch-notifications-core/notifications-core.yml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/log4j2.xml ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-performance-analyzer/rca_idle_cluster_manager.conf ...
Installing new version of config file /etc/wazuh-indexer/opensearch-security/config.yml ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-indexer_4.7.0-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
New files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: 25c499973687a8fd3eb8b9ceb3da7a68
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Comparing opensearch.yml.example file checksum...
Old: ab1ad1f166434f3abac7a751c1e57fba
New: ab1ad1f166434f3abac7a751c1e57fba
opensearch.yml.example - Same checksum.
Comparing action_groups.yml file checksum...
Old: 49915bd12633877031bbbb8755475c57
New: 49915bd12633877031bbbb8755475c57
action_groups.yml - Same checksum.
Comparing audit.yml file checksum...
Old: 708fac768f8535fec7cc8f861ea2f51e
New: 708fac768f8535fec7cc8f861ea2f51e
audit.yml - Same checksum.
Comparing config.yml file checksum...
Old: b9eb7a16aa1969ee394370d3369a9d6b
New: 25c499973687a8fd3eb8b9ceb3da7a68
config.yml - Expected change.
Comparing whitelist.yml file checksum...
Old: e2edf5dc1ea24205d4a2110867090b86
New: e2edf5dc1ea24205d4a2110867090b86
whitelist.yml - Same checksum.
Comparing nodes_dn.yml file checksum...
Old: 586267623e1846bffa3eb8f516309579
New: 586267623e1846bffa3eb8f516309579
nodes_dn.yml - Same checksum.
Comparing internal_users.yml file checksum...
Old: c0b5e164a86cf3ed5dd41ffb063f81b5
New: c0b5e164a86cf3ed5dd41ffb063f81b5
internal_users.yml - Same checksum.
Comparing roles_mapping.yml file checksum...
Old: 5183f75b0697f931c2b4bcc28cd39cca
New: 5183f75b0697f931c2b4bcc28cd39cca
roles_mapping.yml - Same checksum.
Comparing allowlist.yml file checksum...
Old: 5025498ed9e6413047936860fda91c84
New: 5025498ed9e6413047936860fda91c84
allowlist.yml - Same checksum.
Comparing tenants.yml file checksum...
Old: 7f5efc3999ffbd51cc1c72a7d7c0b02c
New: 7f5efc3999ffbd51cc1c72a7d7c0b02c
tenants.yml - Same checksum.
Comparing roles.yml file checksum...
Old: 14916520220fe82010e7ce3295c06f6b
New: 14916520220fe82010e7ce3295c06f6b
roles.yml - Same checksum.
Same checksums - Test passed correctly.
root@ubuntu22:/home/vagrant# cat /usr/share/wazuh-indexer/VERSION 
4.7.0

```

</details>

<details><summary>Upgrade 4.6.0 -> 4.7.0</summary>

- Script modified to accept custom package as base

```
root@ubuntu22:/home/vagrant# bash upgrade-indexer.sh "./wazuh-indexer_4.7.0-1_amd64.deb" "45" "./wazuh-indexer_4.6.0-1_amd64.deb" 
New path detected (/etc).
Installing old version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.6.0-1_amd64.deb'
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/685 MB of archives.
After this operation, 969 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-indexer_4.6.0-1_amd64.deb wazuh-indexer amd64 4.6.0-1 [685 MB]
Selecting previously unselected package wazuh-indexer.
(Reading database ... 75812 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.6.0-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.6.0-1) ...
Setting up wazuh-indexer (4.6.0-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-indexer_4.6.0-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
/home/vagrant/common.sh: line 99: ${f}: ambiguous redirect
Changed file.
Old files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: 25c499973687a8fd3eb8b9ceb3da7a68
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Installing new version of Wazuh indexer...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of './wazuh-indexer_4.7.0-1_amd64.deb'
The following packages will be upgraded:
  wazuh-indexer
1 upgraded, 0 newly installed, 0 to remove and 142 not upgraded.
Need to get 0 B/684 MB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 /home/vagrant/wazuh-indexer_4.7.0-1_amd64.deb wazuh-indexer amd64 4.7.0-1 [684 MB]
(Reading database ... 76939 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.7.0-1_amd64.deb ...
Unpacking wazuh-indexer (4.7.0-1) over (4.6.0-1) ...
Setting up wazuh-indexer (4.7.0-1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-indexer_4.7.0-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
Processing /etc/wazuh-indexer/opensearch-security/action_groups.yml file...
Processing /etc/wazuh-indexer/opensearch-security/allowlist.yml file...
Processing /etc/wazuh-indexer/opensearch-security/audit.yml file...
Processing /etc/wazuh-indexer/opensearch-security/config.yml file...
Processing /etc/wazuh-indexer/opensearch-security/internal_users.yml file...
Processing /etc/wazuh-indexer/opensearch-security/nodes_dn.yml file...
Processing /etc/wazuh-indexer/opensearch-security/opensearch.yml.example file...
Processing /etc/wazuh-indexer/opensearch-security/roles_mapping.yml file...
Processing /etc/wazuh-indexer/opensearch-security/roles.yml file...
Processing /etc/wazuh-indexer/opensearch-security/tenants.yml file...
Processing /etc/wazuh-indexer/opensearch-security/whitelist.yml file...
New files...
Key: opensearch.yml.example
Value: ab1ad1f166434f3abac7a751c1e57fba
Key: action_groups.yml
Value: 49915bd12633877031bbbb8755475c57
Key: audit.yml
Value: 708fac768f8535fec7cc8f861ea2f51e
Key: config.yml
Value: 25c499973687a8fd3eb8b9ceb3da7a68
Key: whitelist.yml
Value: e2edf5dc1ea24205d4a2110867090b86
Key: nodes_dn.yml
Value: 586267623e1846bffa3eb8f516309579
Key: internal_users.yml
Value: c0b5e164a86cf3ed5dd41ffb063f81b5
Key: roles_mapping.yml
Value: 5183f75b0697f931c2b4bcc28cd39cca
Key: allowlist.yml
Value: 5025498ed9e6413047936860fda91c84
Key: tenants.yml
Value: 7f5efc3999ffbd51cc1c72a7d7c0b02c
Key: roles.yml
Value: 14916520220fe82010e7ce3295c06f6b
Comparing opensearch.yml.example file checksum...
Old: ab1ad1f166434f3abac7a751c1e57fba
New: ab1ad1f166434f3abac7a751c1e57fba
opensearch.yml.example - Same checksum.
Comparing action_groups.yml file checksum...
Old: 49915bd12633877031bbbb8755475c57
New: 49915bd12633877031bbbb8755475c57
action_groups.yml - Same checksum.
Comparing audit.yml file checksum...
Old: 708fac768f8535fec7cc8f861ea2f51e
New: 708fac768f8535fec7cc8f861ea2f51e
audit.yml - Same checksum.
Comparing config.yml file checksum...
Old: 25c499973687a8fd3eb8b9ceb3da7a68
New: 25c499973687a8fd3eb8b9ceb3da7a68
config.yml - Same checksum.
Comparing whitelist.yml file checksum...
Old: e2edf5dc1ea24205d4a2110867090b86
New: e2edf5dc1ea24205d4a2110867090b86
whitelist.yml - Same checksum.
Comparing nodes_dn.yml file checksum...
Old: 586267623e1846bffa3eb8f516309579
New: 586267623e1846bffa3eb8f516309579
nodes_dn.yml - Same checksum.
Comparing internal_users.yml file checksum...
Old: c0b5e164a86cf3ed5dd41ffb063f81b5
New: c0b5e164a86cf3ed5dd41ffb063f81b5
internal_users.yml - Same checksum.
Comparing roles_mapping.yml file checksum...
Old: 5183f75b0697f931c2b4bcc28cd39cca
New: 5183f75b0697f931c2b4bcc28cd39cca
roles_mapping.yml - Same checksum.
Comparing allowlist.yml file checksum...
Old: 5025498ed9e6413047936860fda91c84
New: 5025498ed9e6413047936860fda91c84
allowlist.yml - Same checksum.
Comparing tenants.yml file checksum...
Old: 7f5efc3999ffbd51cc1c72a7d7c0b02c
New: 7f5efc3999ffbd51cc1c72a7d7c0b02c
tenants.yml - Same checksum.
Comparing roles.yml file checksum...
Old: 14916520220fe82010e7ce3295c06f6b
New: 14916520220fe82010e7ce3295c06f6b
roles.yml - Same checksum.
Same or accepted checksums - Test passed correctly.
```

</details>


