### PR TITLE
Update the `internal_users.yml` file when passwords change

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -18,8 +18,6 @@ function passwords_changePassword() {
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
                 awk -v new=${hashes[i]} 'prev=="'${users[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
-                cp -f /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
-                chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/opensearch-security/internal_users.yml
             fi
 
             if [ "${users[i]}" == "admin" ]; then
@@ -37,8 +35,6 @@ function passwords_changePassword() {
         fi
         if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
             awk -v new="${hash}" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
-            cp -f /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
-            chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/opensearch-security/internal_users.yml
         fi
 
         if [ "${nuser}" == "admin" ]; then
@@ -607,6 +603,7 @@ function passwords_runSecurityAdmin() {
         common_logger -e "Could not load the changes."
         exit 1;
     fi
+    eval "cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml"
     eval "rm -rf /etc/wazuh-indexer/backup/ ${debug}"
 
     if [[ -n "${nuser}" ]] && [[ -n ${autopass} ]]; then

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -18,6 +18,8 @@ function passwords_changePassword() {
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
                 awk -v new=${hashes[i]} 'prev=="'${users[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+                cp -f /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+                chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/opensearch-security/internal_users.yml
             fi
 
             if [ "${users[i]}" == "admin" ]; then
@@ -35,6 +37,8 @@ function passwords_changePassword() {
         fi
         if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
             awk -v new="${hash}" 'prev=="'${nuser}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+            cp -f /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+            chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/opensearch-security/internal_users.yml
         fi
 
         if [ "${nuser}" == "admin" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2454|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to update the `internal_users.yml` file when the passwords are changed, whether in the Installation Assistant or in the Password tool.
The change consist in copy the `internal_users.yml` file into the `opensearch-security` folder before removing the backup done in the passwords change.

 

## Logs example

<details><summary>:green_circle: Step-by-step installation using the Installation Assistant</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -wi node-1 -o -i -t wazuh-install-files.tar && bash wazuh-install.sh -s
18/09/2023 13:18:52 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
18/09/2023 13:18:52 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/09/2023 13:18:54 INFO: --- Removing existing Wazuh installation ---
18/09/2023 13:18:54 INFO: Removing Wazuh indexer.
18/09/2023 13:18:55 INFO: Wazuh indexer removed.
18/09/2023 13:18:55 INFO: Wazuh GPG key was not found in the system
18/09/2023 13:18:55 INFO: Installation cleaned.
18/09/2023 13:19:04 WARNING: Hardware and system checks ignored.
18/09/2023 13:19:12 INFO: Wazuh repository added.
18/09/2023 13:19:12 INFO: --- Wazuh indexer ---
18/09/2023 13:19:12 INFO: Starting Wazuh indexer installation.
18/09/2023 13:20:10 INFO: Wazuh indexer installation finished.
18/09/2023 13:20:10 INFO: Wazuh indexer post-install configuration finished.
18/09/2023 13:20:10 INFO: Starting service wazuh-indexer.
18/09/2023 13:20:40 INFO: wazuh-indexer service started.
18/09/2023 13:20:40 INFO: Initializing Wazuh indexer cluster security settings.
+ passwords_changePassword
+ '[' -n 1 ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -z 1 ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ '[' '' == admin ']'
+ '[' '' == kibanaserver ']'
+ '[' '' == admin ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ '[' '' == kibanaserver ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ set +x
18/09/2023 13:20:42 INFO: Wazuh indexer cluster initialized.
18/09/2023 13:20:42 INFO: Installation finished.
18/09/2023 13:20:42 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
18/09/2023 13:20:42 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/09/2023 13:21:03 INFO: Wazuh indexer cluster security configuration initialized.
+ passwords_changePassword
+ '[' -n 1 ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -z ']'
+ eval 'mkdir /etc/wazuh-indexer/backup/ 2>/dev/null'
++ mkdir /etc/wazuh-indexer/backup/
+ eval 'cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null'
++ cp /etc/wazuh-indexer/opensearch-security/action_groups.yml /etc/wazuh-indexer/opensearch-security/allowlist.yml /etc/wazuh-indexer/opensearch-security/audit.yml /etc/wazuh-indexer/opensearch-security/config.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml /etc/wazuh-indexer/opensearch-security/nodes_dn.yml /etc/wazuh-indexer/opensearch-security/opensearch.yml.example /etc/wazuh-indexer/opensearch-security/roles_mapping.yml /etc/wazuh-indexer/opensearch-security/roles.yml /etc/wazuh-indexer/opensearch-security/tenants.yml /etc/wazuh-indexer/opensearch-security/whitelist.yml /etc/wazuh-indexer/backup/
+ passwords_createBackUp
+ '[' -z 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
++ grep 'plugins.security.ssl.transport.pemtrustedcas_filepath: ' /etc/wazuh-indexer/opensearch.yml
+ capem='plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem'
+ rcapem='plugins.security.ssl.transport.pemtrustedcas_filepath: '
+ capem=/etc/wazuh-indexer/certs/root-ca.pem
+ [[ -z '' ]]
+ passwords_readAdmincerts
+ [[ -f /etc/wazuh-indexer/certs/admin.pem ]]
+ adminpem=/etc/wazuh-indexer/certs/admin.pem
+ [[ -f /etc/wazuh-indexer/certs/admin-key.pem ]]
+ adminkey=/etc/wazuh-indexer/certs/admin-key.pem
+ common_logger -d 'Creating password backup.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:21:14'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'Creating password backup.' ']'
+ case ${1} in
+ message='Creating password backup.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ eval 'mkdir /etc/wazuh-indexer/backup >> /var/log/wazuh-install.log 2>&1'
++ mkdir /etc/wazuh-indexer/backup
+ eval 'JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -backup /etc/wazuh-indexer/backup -icl -p 9200 -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h 127.0.0.1 >> /var/log/wazuh-install.log 2>&1'
++ JAVA_HOME=/usr/share/wazuh-indexer/jdk/
++ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer
++ /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -backup /etc/wazuh-indexer/backup -icl -p 9200 -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h 127.0.0.1
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'Password backup created in /etc/wazuh-indexer/backup.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:21:19'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'Password backup created in /etc/wazuh-indexer/backup.' ']'
+ case ${1} in
+ message='Password backup created in /etc/wazuh-indexer/backup.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$F0f2BDpKEVvNEdFLe7f8T.LtbIs8nmfr1F5V0Ej1TRVEQcxzPCTTS' 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' admin == admin ']'
+ adminpass='ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$zTMlTFNxXNDefFJcPkuQHeDPguUXn3l88MD3u4mUkfYsdlAXGRppm' 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' kibanaserver == admin ']'
+ '[' kibanaserver == kibanaserver ']'
+ dashpass='Z2WnenZhDmnSASyu0xUHHQ+G*IGbBB+k'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$zIR7HIRTAVJuw6nHtClKJOBl8AwNG7lSAJLvz6JhwA5AL2/JKJGxy' 'prev=="kibanaro:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' kibanaro == admin ']'
+ '[' kibanaro == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$ktPWDBu2fYlcPeZbXySXpu2mafmioDJ.AAmcMXoLjsbzowdC6luy.' 'prev=="logstash:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' logstash == admin ']'
+ '[' logstash == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$XrUDaQiYNgMtozTuw78pIeff9VuDfD0V.LWX.tTuu11Iv/.BDaPvC' 'prev=="readall:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' readall == admin ']'
+ '[' readall == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$YbUCsEnPEZFfQXbOrcWKIuNM8O7WHWCeTiTLgGnaMMhceU2h3aZTe' 'prev=="snapshotrestore:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' snapshotrestore == admin ']'
+ '[' snapshotrestore == kibanaserver ']'
+ '[' '' == admin ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ '[' '' == kibanaserver ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ set +x
Wait
+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ set +x
18/09/2023 13:24:47 INFO: Wazuh indexer cluster started.
root@ubuntu22:/home/vagrant# ls -la /etc/wazuh-indexer/opensearch-security/internal_users.yml 
-rw-r----- 1 wazuh-indexer wazuh-indexer 1133 Sep 18 13:24 /etc/wazuh-indexer/opensearch-security/internal_users.yml
root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$F0f2BDpKEVvNEdFLe7f8T.LtbIs8nmfr1F5V0Ej1TRVEQcxzPCTTS
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$zTMlTFNxXNDefFJcPkuQHeDPguUXn3l88MD3u4mUkfYsdlAXGRppm
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: $2y$12$zIR7HIRTAVJuw6nHtClKJOBl8AwNG7lSAJLvz6JhwA5AL2/JKJGxy
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: $2y$12$ktPWDBu2fYlcPeZbXySXpu2mafmioDJ.AAmcMXoLjsbzowdC6luy.
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: $2y$12$XrUDaQiYNgMtozTuw78pIeff9VuDfD0V.LWX.tTuu11Iv/.BDaPvC
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: $2y$12$YbUCsEnPEZFfQXbOrcWKIuNM8O7WHWCeTiTLgGnaMMhceU2h3aZTe
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -ws wazuh-1 -i
18/09/2023 13:25:17 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
18/09/2023 13:25:17 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/09/2023 13:25:28 WARNING: Hardware and system checks ignored.
18/09/2023 13:25:34 INFO: Wazuh repository added.
18/09/2023 13:25:34 INFO: --- Wazuh server ---
18/09/2023 13:25:34 INFO: Starting the Wazuh manager installation.
18/09/2023 13:26:40 INFO: Wazuh manager installation finished.
18/09/2023 13:26:40 INFO: Starting service wazuh-manager.
18/09/2023 13:27:10 INFO: wazuh-manager service started.
18/09/2023 13:27:10 INFO: Starting Filebeat installation.
18/09/2023 13:27:19 INFO: Filebeat installation finished.
18/09/2023 13:27:20 INFO: Filebeat post-install configuration finished.
18/09/2023 13:27:22 ERROR: The Wazuh API user wazuh does not exist
18/09/2023 13:27:22 ERROR: The Wazuh API user wazuh-wui does not exist
+ passwords_changePassword
+ '[' -n 1 ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -z 1 ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ '[' admin == admin ']'
+ adminpass='ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi'
+ '[' '' == admin ']'
+ '[' -n 1 ']'
+ '[' -n 'filebeat/stable,now 7.10.2 amd64 [installed]' ']'
+ grep -q password
+ filebeat keystore list
+ eval 'echo ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi | filebeat keystore add password --force --stdin >> /var/log/wazuh-install.log 2>&1'
++ filebeat keystore add password --force --stdin
++ echo 'ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi'
+ passwords_restartService filebeat
+ '[' 1 -ne 1 ']'
+ grep -E -q '^\ *1\ .*systemd$'
+ ps -e
+ eval 'systemctl daemon-reload >> /var/log/wazuh-install.log 2>&1'
++ systemctl daemon-reload
+ eval 'systemctl restart filebeat.service >> /var/log/wazuh-install.log 2>&1'
++ systemctl restart filebeat.service
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'filebeat started.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:27:23'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'filebeat started.' ']'
+ case ${1} in
+ message='filebeat started.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ '[' '' == kibanaserver ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ set +x
18/09/2023 13:27:23 INFO: Starting service filebeat.
18/09/2023 13:27:25 INFO: filebeat service started.
18/09/2023 13:27:25 INFO: Installation finished.
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -wd dashboard -i
18/09/2023 13:31:56 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
18/09/2023 13:31:56 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/09/2023 13:32:05 WARNING: Hardware and system checks ignored.
18/09/2023 13:32:05 INFO: Wazuh web interface port will be 443.
18/09/2023 13:32:10 INFO: Wazuh repository added.
dashboard
18/09/2023 13:32:10 INFO: --- Wazuh dashboard ----
18/09/2023 13:32:10 INFO: Starting Wazuh dashboard installation.
18/09/2023 13:33:08 INFO: Wazuh dashboard installation finished.
18/09/2023 13:33:08 INFO: Wazuh dashboard post-install configuration finished.
18/09/2023 13:33:08 INFO: Starting service wazuh-dashboard.
18/09/2023 13:33:10 INFO: wazuh-dashboard service started.
+ passwords_changePassword
+ '[' -n 1 ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -z 1 ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ '[' admin == admin ']'
+ adminpass='ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ '[' kibanaserver == admin ']'
+ '[' kibanaserver == kibanaserver ']'
+ dashpass='Z2WnenZhDmnSASyu0xUHHQ+G*IGbBB+k'
+ '[' '' == admin ']'
+ '[' -n 1 ']'
+ '[' -n 'filebeat/stable,now 7.10.2 amd64 [installed]' ']'
+ grep -q password
+ filebeat keystore list
+ eval 'echo ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi | filebeat keystore add password --force --stdin >> /var/log/wazuh-install.log 2>&1'
++ filebeat keystore add password --force --stdin
++ echo 'ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi'
+ passwords_restartService filebeat
+ '[' 1 -ne 1 ']'
+ grep -E -q '^\ *1\ .*systemd$'
+ ps -e
+ eval 'systemctl daemon-reload >> /var/log/wazuh-install.log 2>&1'
++ systemctl daemon-reload
+ eval 'systemctl restart filebeat.service >> /var/log/wazuh-install.log 2>&1'
++ systemctl restart filebeat.service
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'filebeat started.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:33:13'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'filebeat started.' ']'
+ case ${1} in
+ message='filebeat started.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ '[' '' == kibanaserver ']'
+ '[' -n 1 ']'
+ '[' -n 'wazuh-dashboard/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -n 'Z2WnenZhDmnSASyu0xUHHQ+G*IGbBB+k' ']'
+ /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root list
+ grep -q opensearch.password
+ eval 'echo Z2WnenZhDmnSASyu0xUHHQ+G*IGbBB+k | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password '
++ /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
++ echo 'Z2WnenZhDmnSASyu0xUHHQ+G*IGbBB+k'
+ passwords_restartService wazuh-dashboard
+ '[' 1 -ne 1 ']'
+ grep -E -q '^\ *1\ .*systemd$'
+ ps -e
+ eval 'systemctl daemon-reload >> /var/log/wazuh-install.log 2>&1'
++ systemctl daemon-reload
+ eval 'systemctl restart wazuh-dashboard.service >> /var/log/wazuh-install.log 2>&1'
++ systemctl restart wazuh-dashboard.service
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'wazuh-dashboard started.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:33:21'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'wazuh-dashboard started.' ']'
+ case ${1} in
+ message='wazuh-dashboard started.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ set +x
18/09/2023 13:33:41 INFO: Initializing Wazuh dashboard web application.
18/09/2023 13:33:42 INFO: Wazuh dashboard web application initialized.
18/09/2023 13:33:42 INFO: --- Summary ---
18/09/2023 13:33:42 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: ng5nMONDzvXWWapDE2CVJ*CUux*o.Kzi
18/09/2023 13:33:42 INFO: Installation finished.
root@ubuntu22:/home/vagrant# 


root@ubuntu22:/home/vagrant# wget https://localhost --no-check-certificate
--2023-09-18 13:35:21--  https://localhost/
Resolving localhost (localhost)... 127.0.0.1
Connecting to localhost (localhost)|127.0.0.1|:443... connected.
WARNING: cannot verify localhost's certificate, issued by ‘L=California,O=Wazuh,OU=Wazuh’:
  Unable to locally verify the issuer's authority.
    WARNING: certificate common name ‘dashboard’ doesn't match requested host name ‘localhost’.
HTTP request sent, awaiting response... 302 Found
Location: /app/login? [following]
--2023-09-18 13:35:21--  https://localhost/app/login?
Reusing existing connection to localhost:443.
HTTP request sent, awaiting response... 200 OK
Length: 92716 (91K) [text/html]
Saving to: ‘index.html’

index.html                100%[=====================================>]  90.54K  --.-KB/s    in 0.001s  

2023-09-18 13:35:21 (130 MB/s) - ‘index.html’ saved [92716/92716]

```
</details>



<details><summary>:green_circle: AIO installation</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -o
18/09/2023 13:37:00 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
18/09/2023 13:37:00 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/09/2023 13:37:02 INFO: --- Removing existing Wazuh installation ---
18/09/2023 13:37:02 INFO: Removing Wazuh indexer.
18/09/2023 13:37:02 INFO: Wazuh indexer removed.
18/09/2023 13:37:02 INFO: Wazuh GPG key was not found in the system
18/09/2023 13:37:03 INFO: Installation cleaned.
18/09/2023 13:37:10 WARNING: Hardware and system checks ignored.
18/09/2023 13:37:10 INFO: Wazuh web interface port will be 443.
18/09/2023 13:37:19 INFO: Wazuh repository added.
18/09/2023 13:37:19 INFO: --- Configuration files ---
18/09/2023 13:37:19 INFO: Generating configuration files.
18/09/2023 13:37:21 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
18/09/2023 13:37:21 INFO: --- Wazuh indexer ---
18/09/2023 13:37:21 INFO: Starting Wazuh indexer installation.
18/09/2023 13:38:13 INFO: Wazuh indexer installation finished.
18/09/2023 13:38:13 INFO: Wazuh indexer post-install configuration finished.
18/09/2023 13:38:13 INFO: Starting service wazuh-indexer.
18/09/2023 13:38:34 INFO: wazuh-indexer service started.
18/09/2023 13:38:34 INFO: Initializing Wazuh indexer cluster security settings.
18/09/2023 13:38:45 INFO: Wazuh indexer cluster initialized.
18/09/2023 13:38:45 INFO: --- Wazuh server ---
18/09/2023 13:38:45 INFO: Starting the Wazuh manager installation.
18/09/2023 13:39:36 INFO: Wazuh manager installation finished.
18/09/2023 13:39:36 INFO: Starting service wazuh-manager.
18/09/2023 13:40:02 INFO: wazuh-manager service started.
18/09/2023 13:40:02 INFO: Starting Filebeat installation.
18/09/2023 13:40:10 INFO: Filebeat installation finished.
18/09/2023 13:40:11 INFO: Filebeat post-install configuration finished.
18/09/2023 13:40:11 INFO: Starting service filebeat.
18/09/2023 13:40:13 INFO: filebeat service started.
18/09/2023 13:40:13 INFO: --- Wazuh dashboard ---
18/09/2023 13:40:13 INFO: Starting Wazuh dashboard installation.
18/09/2023 13:41:07 INFO: Wazuh dashboard installation finished.
18/09/2023 13:41:07 INFO: Wazuh dashboard post-install configuration finished.
18/09/2023 13:41:07 INFO: Starting service wazuh-dashboard.
18/09/2023 13:41:08 INFO: wazuh-dashboard service started.
+ passwords_changePassword
+ '[' -n 1 ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -z ']'
+ eval 'mkdir /etc/wazuh-indexer/backup/ 2>/dev/null'
++ mkdir /etc/wazuh-indexer/backup/
+ eval 'cp /etc/wazuh-indexer/opensearch-security/* /etc/wazuh-indexer/backup/ 2>/dev/null'
++ cp /etc/wazuh-indexer/opensearch-security/action_groups.yml /etc/wazuh-indexer/opensearch-security/allowlist.yml /etc/wazuh-indexer/opensearch-security/audit.yml /etc/wazuh-indexer/opensearch-security/config.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml /etc/wazuh-indexer/opensearch-security/nodes_dn.yml /etc/wazuh-indexer/opensearch-security/opensearch.yml.example /etc/wazuh-indexer/opensearch-security/roles_mapping.yml /etc/wazuh-indexer/opensearch-security/roles.yml /etc/wazuh-indexer/opensearch-security/tenants.yml /etc/wazuh-indexer/opensearch-security/whitelist.yml /etc/wazuh-indexer/backup/
+ passwords_createBackUp
+ '[' -z 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
++ grep 'plugins.security.ssl.transport.pemtrustedcas_filepath: ' /etc/wazuh-indexer/opensearch.yml
+ capem='plugins.security.ssl.transport.pemtrustedcas_filepath: /etc/wazuh-indexer/certs/root-ca.pem'
+ rcapem='plugins.security.ssl.transport.pemtrustedcas_filepath: '
+ capem=/etc/wazuh-indexer/certs/root-ca.pem
+ [[ -z '' ]]
+ passwords_readAdmincerts
+ [[ -f /etc/wazuh-indexer/certs/admin.pem ]]
+ adminpem=/etc/wazuh-indexer/certs/admin.pem
+ [[ -f /etc/wazuh-indexer/certs/admin-key.pem ]]
+ adminkey=/etc/wazuh-indexer/certs/admin-key.pem
+ common_logger -d 'Creating password backup.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:41:23'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'Creating password backup.' ']'
+ case ${1} in
+ message='Creating password backup.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ eval 'mkdir /etc/wazuh-indexer/backup >> /var/log/wazuh-install.log 2>&1'
++ mkdir /etc/wazuh-indexer/backup
+ eval 'JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -backup /etc/wazuh-indexer/backup -icl -p 9200 -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h "127.0.0.1" >> /var/log/wazuh-install.log 2>&1'
++ JAVA_HOME=/usr/share/wazuh-indexer/jdk/
++ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer
++ /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -backup /etc/wazuh-indexer/backup -icl -p 9200 -nhnv -cacert /etc/wazuh-indexer/certs/root-ca.pem -cert /etc/wazuh-indexer/certs/admin.pem -key /etc/wazuh-indexer/certs/admin-key.pem -h 127.0.0.1
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'Password backup created in /etc/wazuh-indexer/backup.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:41:28'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'Password backup created in /etc/wazuh-indexer/backup.' ']'
+ case ${1} in
+ message='Password backup created in /etc/wazuh-indexer/backup.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$p2eT5y9U3F68dyBCEWWF1uDaFpB44Y5naFjsUF7okw3rH1KmRzCzO' 'prev=="admin:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' admin == admin ']'
+ adminpass='Yk0Le2b.LrICxgLQd3h?+g0TP7SH*aMU'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$9yYdaSM.15zZQ9RmXKaadOpMKiyYHx.KMDMOf/r9iq5vb4IZ5dJiy' 'prev=="kibanaserver:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' kibanaserver == admin ']'
+ '[' kibanaserver == kibanaserver ']'
+ dashpass='URgRQ8fOUh4VbtvNj4?X4i?Re22?+eM4'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$f1r9OkOvDuR3cCQtiZdqR.DDzSHaBF5fsPFq57seqtgCjNfJ.GyR6' 'prev=="kibanaro:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' kibanaro == admin ']'
+ '[' kibanaro == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$xtN88lgjw950ldOb7T/iZuzSLIsy2CbHYTx/ZIHPsdZXN.4qHOJeW' 'prev=="logstash:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' logstash == admin ']'
+ '[' logstash == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$xUisUUxzUB2ABALUkxchielvmw.sEMF/QAXvnCYbVagsa9wcr0PRK' 'prev=="readall:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' readall == admin ']'
+ '[' readall == kibanaserver ']'
+ for i in "${!passwords[@]}"
+ '[' -n 'wazuh-indexer/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -f /etc/wazuh-indexer/backup/internal_users.yml ']'
+ awk -v 'new=$2y$12$L0I3eMiiN.zq0VhSQEfK5.eIZyacFe4RFGIEMw098aF7Qk2L87DUS' 'prev=="snapshotrestore:"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml
+ mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+ '[' snapshotrestore == admin ']'
+ '[' snapshotrestore == kibanaserver ']'
+ '[' '' == admin ']'
+ '[' -n 1 ']'
+ '[' -n 'filebeat/stable,now 7.10.2 amd64 [installed]' ']'
+ filebeat keystore list
+ grep -q password
+ eval 'echo Yk0Le2b.LrICxgLQd3h?+g0TP7SH*aMU | filebeat keystore add password --force --stdin >> /var/log/wazuh-install.log 2>&1'
++ echo 'Yk0Le2b.LrICxgLQd3h?+g0TP7SH*aMU'
++ filebeat keystore add password --force --stdin
+ passwords_restartService filebeat
+ '[' 1 -ne 1 ']'
+ ps -e
+ grep -E -q '^\ *1\ .*systemd$'
+ eval 'systemctl daemon-reload >> /var/log/wazuh-install.log 2>&1'
++ systemctl daemon-reload
+ eval 'systemctl restart filebeat.service >> /var/log/wazuh-install.log 2>&1'
++ systemctl restart filebeat.service
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'filebeat started.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:41:29'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'filebeat started.' ']'
+ case ${1} in
+ message='filebeat started.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ '[' '' == kibanaserver ']'
+ '[' -n 1 ']'
+ '[' -n 'wazuh-dashboard/stable,now 4.5.2-1 amd64 [installed]' ']'
+ '[' -n 'URgRQ8fOUh4VbtvNj4?X4i?Re22?+eM4' ']'
+ grep -q opensearch.password
+ /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root list
+ eval 'echo URgRQ8fOUh4VbtvNj4?X4i?Re22?+eM4 | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password '
++ echo 'URgRQ8fOUh4VbtvNj4?X4i?Re22?+eM4'
++ /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+ passwords_restartService wazuh-dashboard
+ '[' 1 -ne 1 ']'
+ grep -E -q '^\ *1\ .*systemd$'
+ ps -e
+ eval 'systemctl daemon-reload >> /var/log/wazuh-install.log 2>&1'
++ systemctl daemon-reload
+ eval 'systemctl restart wazuh-dashboard.service >> /var/log/wazuh-install.log 2>&1'
++ systemctl restart wazuh-dashboard.service
+ '[' 0 '!=' 0 ']'
+ common_logger -d 'wazuh-dashboard started.'
++ date '+%d/%m/%Y %H:%M:%S'
+ now='18/09/2023 13:41:30'
+ mtype=INFO:
+ debugLogger=
+ nolog=
+ '[' -n -d ']'
+ '[' -n -d ']'
+ case ${1} in
+ debugLogger=1
+ mtype=DEBUG:
+ shift 1
+ '[' -n 'wazuh-dashboard started.' ']'
+ case ${1} in
+ message='wazuh-dashboard started.'
+ shift 1
+ '[' -n '' ']'
+ '[' -z 1 ']'
+ '[' -n 1 ']'
+ '[' -n '' ']'
+ set +x
Wait

+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ set +x
18/09/2023 13:42:44 INFO: Initializing Wazuh dashboard web application.
18/09/2023 13:42:44 INFO: Wazuh dashboard web application initialized.
18/09/2023 13:42:44 INFO: --- Summary ---
18/09/2023 13:42:44 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: Yk0Le2b.LrICxgLQd3h?+g0TP7SH*aMU
18/09/2023 13:42:44 INFO: Installation finished.
root@ubuntu22:/home/vagrant# 
root@ubuntu22:/home/vagrant# wget https://localhost --no-check-certificate
--2023-09-18 13:42:50--  https://localhost/
Resolving localhost (localhost)... 127.0.0.1
Connecting to localhost (localhost)|127.0.0.1|:443... connected.
WARNING: cannot verify localhost's certificate, issued by ‘L=California,O=Wazuh,OU=Wazuh’:
  Unable to locally verify the issuer's authority.
    WARNING: certificate common name ‘wazuh-dashboard’ doesn't match requested host name ‘localhost’.
HTTP request sent, awaiting response... 302 Found
Location: /app/login? [following]
--2023-09-18 13:42:50--  https://localhost/app/login?
Reusing existing connection to localhost:443.
HTTP request sent, awaiting response... 200 OK
Length: 92716 (91K) [text/html]
Saving to: ‘index.html.1’

index.html.1              100%[=====================================>]  90.54K  --.-KB/s    in 0s      

2023-09-18 13:42:50 (200 MB/s) - ‘index.html.1’ saved [92716/92716]

root@ubuntu22:/home/vagrant# 

root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$p2eT5y9U3F68dyBCEWWF1uDaFpB44Y5naFjsUF7okw3rH1KmRzCzO
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$9yYdaSM.15zZQ9RmXKaadOpMKiyYHx.KMDMOf/r9iq5vb4IZ5dJiy
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: $2y$12$f1r9OkOvDuR3cCQtiZdqR.DDzSHaBF5fsPFq57seqtgCjNfJ.GyR6
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: $2y$12$xtN88lgjw950ldOb7T/iZuzSLIsy2CbHYTx/ZIHPsdZXN.4qHOJeW
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: $2y$12$xUisUUxzUB2ABALUkxchielvmw.sEMF/QAXvnCYbVagsa9wcr0PRK
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: $2y$12$L0I3eMiiN.zq0VhSQEfK5.eIZyacFe4RFGIEMw098aF7Qk2L87DUS
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
root@ubuntu22:/home/vagrant# 
```
</details>

<details><summary>:green_circle: Changing the password for the admin user</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -u admin
18/09/2023 14:04:04 INFO: Generating password hash
+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ eval 'rm -rf /etc/wazuh-indexer/backup/ >> /var/log/wazuh-passwords-tool.log 2>&1'
++ rm -rf /etc/wazuh-indexer/backup/
+ set +x
18/09/2023 14:04:12 INFO: The password for user admin is nOru8CqPB+1ZYxuT?G.4iHdb*tUD8U4R
18/09/2023 14:04:12 WARNING: Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
root@ubuntu22:/home/vagrant# ls -la /etc/wazuh-indexer/opensearch-security/internal_users.yml 
-rw-r----- 1 wazuh-indexer wazuh-indexer 1143 Sep 18 14:04 /etc/wazuh-indexer/opensearch-security/internal_users.yml
root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$YVASt/7Kyg6B3bGB6gdq/.B/T.cfC9P4rgt/kdvlKT0OlwciPQU2m
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: "$2y$12$Pk2Rgqsb.fngbTZybU3gLeNHQ.MuzP6ixLwXz0IYUVlEPW/JTbMLm"
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: "$2y$12$wgimLIM2WO9XL04V315vTekp9lYvmmjedUfOQYuqxo7p4/mMp.Fei"
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: "$2y$12$YqHP0XIaEIf9.sCzCN.fLe4b2aU975jBhvX01Gc0dV/tvxCd9SAni"
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: "$2y$12$yraUlVXQHHcwp/gCYBboD.zSPnfIcxUEyZL.yUoJcag5Sn812LYMK"
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: "$2y$12$1ZjRbwEqMH//zI4jZ2RwwOFlLM6G7RYYz/B3GEme2geeXQ7sAmqY6"
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"

```
</details>

<details><summary>:green_circle: Changing the password for the kibanaserver user</summary>

```console
root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$1xiV1O.5/LjdIr0ILwLu/u0NGSzJM8E1zDvU9bo/e1eUv9z5BnMUy
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$P..RuD6sI4ZZGygrVFkLE.VAhouE5s2wo0fyfo1zzCPo5o6pp.PzK
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: $2y$12$pJLengAdzGdo.bf3lvkkUeZTCZe8ziTT4iSiOqkjN72AHQuEHbzqG
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: $2y$12$3/Im2oLweoM1NO1E6RFeUusK8faKcDvR/N5Whk5HsRabS0bMKauHK
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: $2y$12$ZL11SSHIR5O.8RQ3ugjG/uEdvMGgjrZ8zeFuUrxvKjEEw8UdVWuMi
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: $2y$12$BKgpMtdwuRhMbl4y33Al1eN55vCQW8uO1hZREHy5L.r3O5LOYCC42
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
  
root@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -u kibanaserver
18/09/2023 14:16:03 INFO: Generating password hash
+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ eval 'rm -rf /etc/wazuh-indexer/backup/ >> /var/log/wazuh-passwords-tool.log 2>&1'
++ rm -rf /etc/wazuh-indexer/backup/
+ set +x
18/09/2023 14:16:16 INFO: The password for user kibanaserver is onQNEMnpc3JC.t0BeO8pob?m6T9*Vqh?
18/09/2023 14:16:16 WARNING: Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.

root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: "$2y$12$1xiV1O.5/LjdIr0ILwLu/u0NGSzJM8E1zDvU9bo/e1eUv9z5BnMUy"
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$E6BKaLAMi.Wy.jjcho.E8egB7UhqOrnhkRvX9LWphkPR79K5CMCqq
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: "$2y$12$pJLengAdzGdo.bf3lvkkUeZTCZe8ziTT4iSiOqkjN72AHQuEHbzqG"
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: "$2y$12$3/Im2oLweoM1NO1E6RFeUusK8faKcDvR/N5Whk5HsRabS0bMKauHK"
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: "$2y$12$ZL11SSHIR5O.8RQ3ugjG/uEdvMGgjrZ8zeFuUrxvKjEEw8UdVWuMi"
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: "$2y$12$BKgpMtdwuRhMbl4y33Al1eN55vCQW8uO1hZREHy5L.r3O5LOYCC42"
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
root@ubuntu22:/home/vagrant# 

```
</details>

<details><summary>:green_circle: Changing the password all users</summary>

```console
oot@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -a
18/09/2023 13:59:57 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ eval 'rm -rf /etc/wazuh-indexer/backup/ >> /var/log/wazuh-passwords-tool.log 2>&1'
++ rm -rf /etc/wazuh-indexer/backup/
+ set +x
18/09/2023 14:00:13 INFO: The password for user admin is D*dbVCjsnCU.DuTYeesT.suSpQ+0LC3b
18/09/2023 14:00:13 INFO: The password for user kibanaserver is tTLYIIHuIb5KYbN?adUJ*dKUwUS9Zocy
18/09/2023 14:00:13 INFO: The password for user kibanaro is J8+jyU8kXsL?eHLCF80vKp0*2Ux?ebAJ
18/09/2023 14:00:13 INFO: The password for user logstash is R?vkinR8M38Jp19YLQ1j?6RsCBa2HHE3
18/09/2023 14:00:13 INFO: The password for user readall is ASUmz76yJ6UzK0tJ+.N4CUla746l7fka
18/09/2023 14:00:13 INFO: The password for user snapshotrestore is wEgy0jE3mPkN2?aja0*J7wZ39HdV3a1*
18/09/2023 14:00:13 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.

root@ubuntu22:/home/vagrant# ls -la /etc/wazuh-indexer/opensearch-security/internal_users.yml 
-rw-r----- 1 wazuh-indexer wazuh-indexer 1133 Sep 18 14:00 /etc/wazuh-indexer/opensearch-security/internal_users.yml

root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$YTAZHywSCGGeSlkBHFHwUeqAPcBkusUxqxGBdTfn82xefjbLTC8A2
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$Pk2Rgqsb.fngbTZybU3gLeNHQ.MuzP6ixLwXz0IYUVlEPW/JTbMLm
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: $2y$12$wgimLIM2WO9XL04V315vTekp9lYvmmjedUfOQYuqxo7p4/mMp.Fei
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: $2y$12$YqHP0XIaEIf9.sCzCN.fLe4b2aU975jBhvX01Gc0dV/tvxCd9SAni
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: $2y$12$yraUlVXQHHcwp/gCYBboD.zSPnfIcxUEyZL.yUoJcag5Sn812LYMK
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: $2y$12$1ZjRbwEqMH//zI4jZ2RwwOFlLM6G7RYYz/B3GEme2geeXQ7sAmqY6
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
root@ubuntu22:/home/vagrant# 

```
</details>

<details><summary>:green_circle: Changing the password all users with the wazuh password</summary>

```console
root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: "$2y$12$1xiV1O.5/LjdIr0ILwLu/u0NGSzJM8E1zDvU9bo/e1eUv9z5BnMUy"
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$E6BKaLAMi.Wy.jjcho.E8egB7UhqOrnhkRvX9LWphkPR79K5CMCqq
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: "$2y$12$pJLengAdzGdo.bf3lvkkUeZTCZe8ziTT4iSiOqkjN72AHQuEHbzqG"
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: "$2y$12$3/Im2oLweoM1NO1E6RFeUusK8faKcDvR/N5Whk5HsRabS0bMKauHK"
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: "$2y$12$ZL11SSHIR5O.8RQ3ugjG/uEdvMGgjrZ8zeFuUrxvKjEEw8UdVWuMi"
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: "$2y$12$BKgpMtdwuRhMbl4y33Al1eN55vCQW8uO1hZREHy5L.r3O5LOYCC42"
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"
  
root@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -a -au wazuh -ap gJTLD2xC*XsmpRpB7C1o.hhHaZb9pIQ.
+ eval 'cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml'
++ cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml
+ eval 'rm -rf /etc/wazuh-indexer/backup/ >> /var/log/wazuh-passwords-tool.log 2>&1'
++ rm -rf /etc/wazuh-indexer/backup/
+ set +x
18/09/2023 14:18:49 INFO: The password for user admin is TXzqtCIS9Q0mI7v+OW+GJVJKzdWBudpp
18/09/2023 14:18:49 INFO: The password for user kibanaserver is jt2?tI5*06Dt*r*3LIUPlbFmLwlr8xeq
18/09/2023 14:18:49 INFO: The password for user kibanaro is HXzxKkfeu8KIEKyQSg5*KmSInNLE5cyY
18/09/2023 14:18:49 INFO: The password for user logstash is NJwcugLe?Eura4hLc4scfaEzhV5o9jK.
18/09/2023 14:18:49 INFO: The password for user readall is nBMVrRo+PXf5f0TlgBRb?p1xHnD2NQyH
18/09/2023 14:18:49 INFO: The password for user snapshotrestore is Eo7T.URrkgJDC*B6NwMcEDgwnQ?*j?Os
18/09/2023 14:18:49 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
18/09/2023 14:18:53 INFO: The password for Wazuh API user wazuh is mpQiTPODiGMqazRV+gNFhu7ngb4qIjL1
18/09/2023 14:18:54 INFO: The password for Wazuh API user wazuh-wui is DCUlU*e?Xu4YtzE+p1TrVkNCnYyZoEGo
18/09/2023 14:18:54 INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.

root@ubuntu22:/home/vagrant# cat /etc/wazuh-indexer/opensearch-security/internal_users.yml 
---
_meta:
  type: "internalusers"
  config_version: 2
admin:
  hash: $2y$12$jITxm.nL59B8A7dDOIjpEOcddRe27KIx8bxmYtWcpVWqiTQKMCT6S
  reserved: true
  backend_roles:
  - "admin"
  description: "Demo admin user"
kibanaserver:
  hash: $2y$12$/llCWUsBq.G34qqxCK9HJu/HNXbEQ7AolXQ6z6BKyKws7FkAK.Ysu
  reserved: true
  description: "Demo kibanaserver user"
kibanaro:
  hash: $2y$12$npMD8J9xpr7f29/2bW1d1uay7O6rRKUEzi/2iUauPQ1lhryHgQwHe
  reserved: false
  backend_roles:
  - "kibanauser"
  - "readall"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
  description: "Demo kibanaro user"
logstash:
  hash: $2y$12$tvrty7eVxPODDTCW/De1b.mjkGyJo5oH6WpfyPhijPVulhIcPBsSa
  reserved: false
  backend_roles:
  - "logstash"
  description: "Demo logstash user"
readall:
  hash: $2y$12$Gb96OQgOXK./nslcFRsg1usS6sS9vGHN7bJP0adeDz21jtbpU7g1q
  reserved: false
  backend_roles:
  - "readall"
  description: "Demo readall user"
snapshotrestore:
  hash: $2y$12$ezWs/LOAER31l7hH9Mr0UuvuRxoeWjipMP1t/mgueOH6XEFdqlNN6
  reserved: false
  backend_roles:
  - "snapshotrestore"
  description: "Demo snapshotrestore user"

```
</details>
