### PR TITLE
Handle stack  base file not present during build

### DIFF
--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -65,9 +65,7 @@ build_deb() {
             version=$(cat ${current_path}/../../../VERSION)
         fi
         basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
-        if test -f "${basefile}"; then
-            echo "Building using base file: ${basefile}"
-        else
+        if ! test -f "${basefile}"; then
             echo "Did not find expected Wazuh dashboard base file: ${basefile} in output path. Exiting..."
             exit 1
         fi

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -58,6 +58,15 @@ build_deb() {
             base_cmd+="--app-url ${url}"
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
+    else
+        version=$(cat ${current_path}/../../../VERSION)
+        basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
+        if test -f "${basefile}"; then
+            echo "Building using base file: ${basefile}"
+        else
+            echo "Did not find expected Wazuh Dashboard base file: ${basefile} in output path. Exiting..."
+            exit 0
+        fi
     fi
 
     # Build the Docker image

--- a/stack/dashboard/deb/build_package.sh
+++ b/stack/dashboard/deb/build_package.sh
@@ -59,13 +59,17 @@ build_deb() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        version=$(cat ${current_path}/../../../VERSION)
+        if [ "${reference}" ];then
+            version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
+        else
+            version=$(cat ${current_path}/../../../VERSION)
+        fi
         basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
         if test -f "${basefile}"; then
             echo "Building using base file: ${basefile}"
         else
-            echo "Did not find expected Wazuh Dashboard base file: ${basefile} in output path. Exiting..."
-            exit 0
+            echo "Did not find expected Wazuh dashboard base file: ${basefile} in output path. Exiting..."
+            exit 1
         fi
     fi
 

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -58,6 +58,16 @@ build_rpm() {
             base_cmd+="--app-url ${url}"
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
+    else
+        version=$(cat ${current_path}/../../../VERSION)
+        basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
+        if test -f "${basefile}"; then
+            echo "Building using base file: ${basefile}"
+        else
+            echo "Did not find expected Wazuh Dashboard base file: ${basefile} in output path. Exiting..."
+            exit 0
+        fi
+
     fi
 
     # Build the Docker image

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -65,10 +65,8 @@ build_rpm() {
             version=$(cat ${current_path}/../../../VERSION)
         fi
         basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
-        if test -f "${basefile}"; then
-            echo "Building using base file: ${basefile}"
-        else
-            echo "Did not find expected Wazuh dashboard base file: ${basefile} in output path. Exiting..."
+        if ! test -f "${basefile}"; then
+            echo "Did not find expected Wazuh dndexer base file: ${basefile} in output path. Exiting..."
             exit 1
         fi
     fi

--- a/stack/dashboard/rpm/build_package.sh
+++ b/stack/dashboard/rpm/build_package.sh
@@ -59,15 +59,18 @@ build_rpm() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        version=$(cat ${current_path}/../../../VERSION)
+        if [ "${reference}" ];then
+            version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
+        else
+            version=$(cat ${current_path}/../../../VERSION)
+        fi
         basefile="${outdir}/wazuh-dashboard-base-${version}-${revision}-linux-x64.tar.xz"
         if test -f "${basefile}"; then
             echo "Building using base file: ${basefile}"
         else
-            echo "Did not find expected Wazuh Dashboard base file: ${basefile} in output path. Exiting..."
-            exit 0
+            echo "Did not find expected Wazuh dashboard base file: ${basefile} in output path. Exiting..."
+            exit 1
         fi
-
     fi
 
     # Build the Docker image

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -51,13 +51,17 @@ build_deb() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        version=$(cat ${current_path}/../../../VERSION)
+        if [ "${reference}" ];then
+            version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
+        else
+            version=$(cat ${current_path}/../../../VERSION)
+        fi
         basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
         if test -f "${basefile}"; then
             echo "Building using base file: ${basefile}"
         else
-            echo "Did not find expected Wazuh Indexer base file: ${basefile} in output path. Exiting..."
-            exit 0
+            echo "Did not find expected Wazuh indexer base file: ${basefile} in output path. Exiting..."
+            exit 1
         fi
     fi
 

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -40,7 +40,7 @@ build_deb() {
 
     # Copy the necessary files
     cp ${current_path}/builder.sh ${dockerfile_path}
-
+    
     if [ "${build_base}" == "yes" ];then
         # Base generation
         if [ "${future}" == "yes" ];then
@@ -50,6 +50,15 @@ build_deb() {
             base_cmd+="--reference ${reference}"
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
+    else
+        version=$(cat ${current_path}/../../../VERSION)
+        basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
+        if test -f "${basefile}"; then
+            echo "Building using base file: ${basefile}"
+        else
+            echo "Did not find expected Wazuh Indexer base file: ${basefile} in output path. Exiting..."
+            exit 0
+        fi
     fi
 
     # Build the Docker image

--- a/stack/indexer/deb/build_package.sh
+++ b/stack/indexer/deb/build_package.sh
@@ -57,9 +57,7 @@ build_deb() {
             version=$(cat ${current_path}/../../../VERSION)
         fi
         basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
-        if test -f "${basefile}"; then
-            echo "Building using base file: ${basefile}"
-        else
+        if ! test -f "${basefile}"; then
             echo "Did not find expected Wazuh indexer base file: ${basefile} in output path. Exiting..."
             exit 1
         fi

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -51,15 +51,13 @@ build_rpm() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        if [ "${reference}" ];then
+        if ! [ "${reference}" ];then
             version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
         else
             version=$(cat ${current_path}/../../../VERSION)
         fi
         basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
-        if test -f "${basefile}"; then
-            echo "Building using base file: ${basefile}"
-        else
+        if ! test -f "${basefile}"; then
             echo "Did not find expected Wazuh indexer base file: ${basefile} in output path. Exiting..."
             exit 1
         fi

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -51,13 +51,17 @@ build_rpm() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        version=$(cat ${current_path}/../../../VERSION)
+        if [ "${reference}" ];then
+            version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
+        else
+            version=$(cat ${current_path}/../../../VERSION)
+        fi
         basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
         if test -f "${basefile}"; then
             echo "Building using base file: ${basefile}"
         else
-            echo "Did not find expected Wazuh Indexer base file: ${basefile} in output path. Exiting..."
-            exit 0
+            echo "Did not find expected Wazuh indexer base file: ${basefile} in output path. Exiting..."
+            exit 1
         fi
     fi
 

--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -50,6 +50,15 @@ build_rpm() {
             base_cmd+="--reference ${reference}"
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
+    else
+        version=$(cat ${current_path}/../../../VERSION)
+        basefile="${outdir}/wazuh-indexer-base-${version}-${revision}-linux-x64.tar.xz"
+        if test -f "${basefile}"; then
+            echo "Building using base file: ${basefile}"
+        else
+            echo "Did not find expected Wazuh Indexer base file: ${basefile} in output path. Exiting..."
+            exit 0
+        fi
     fi
 
     # Build the Docker image


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2145 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR Aims to handle the building the stack packages when the option to not build the base file is used. 

- When  the `-b no` option is passed, if no base is present it will stop the `build_package.sh` script with the expected file name and location.

```console
root@ubuntu-focal:/vagrant/wazuh-packages/stack/indexer/deb# ./build_package.sh -b no
Did not find expected Wazuh Indexer base file: /vagrant/wazuh-packages/stack/indexer/deb/output/wazuh-indexer-base-4.6.0-1-linux-x64.tar.xz found in output path. Exiting...
```
- If the expected file is present the build will continue normally:
```console
root@ubuntu-focal:/vagrant/wazuh-packages/stack/indexer/deb# ls /vagrant/wazuh-packages/stack/indexer/deb/output
wazuh-indexer-base-4.6.0-1-linux-x64.tar.xz

root@ubuntu-focal:/vagrant/wazuh-packages/stack/indexer/deb# ./build_package.sh -b no
Building using base file: /vagrant/wazuh-packages/stack/indexer/deb/output/wazuh-indexer-base-4.6.0-1-linux-x64.tar.xz
[+] Building 1.6s (10/10) FINISHED                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 756B                            
.
.
.
dpkg-deb --build debian/wazuh-indexer ..
dpkg-deb: building package `wazuh-indexer' in `../wazuh-indexer_4.6.0-1_amd64.deb'.
 dpkg-genchanges -b >../wazuh-indexer_4.6.0-1_amd64.changes
dpkg-genchanges: binary-only upload (no source code included)
 dpkg-source --after-build wazuh-indexer-4.6.0
dpkg-buildpackage: binary-only upload (no source included)

WARNING generated by debuild:
Making debian/rules executable!

root@ubuntu-focal:/vagrant/wazuh-packages/stack/indexer/deb# ls /vagrant/wazuh-packages/stack/indexer/deb/output
wazuh-indexer-base-4.6.0-1-linux-x64.tar.xz  wazuh-indexer_4.6.0-1_amd64.deb  wazuh-indexer_4.6.0-1_amd64.deb.sha512 
```
- If the `--reference` option is used, it will check the version from the referenced branch instead of the version from the branch used to launch the script.
```console
root@ubuntu-focal:/vagrant/wazuh-packages/stack/indexer/deb# ./build_package.sh -b no --reference master
Did not find expected Wazuh Indexer base file: /vagrant/wazuh-packages/stack/indexer/deb/output/wazuh-indexer-base-4.8.0-1-linux-x64.tar.xz in output path. Exiting...
```