### PR TITLE
Improved error message to warning in not recommended systems

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -208,8 +208,7 @@ function check_dist() {
         fi
     fi
     if [ -n "${notsupported}" ] && [ -z "${ignore}" ]; then
-        common_logger -e "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check."
-        exit 1
+        common_logger -w "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check. The installation may not finish successfully."
     fi
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2464|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to change the error message of the not recommended system to a warning message. 
Besides, the installation is not stopped anymore, but there is no guarantee that the installation will finish successfully, so the warning message has been changed.

## Logs

<details><summary>:green_circle: Installation in a not-recommended system (RockyLinux)</summary>

```console
[root@rockylinux8 vagrant]# bash wazuh-install.sh -a
19/09/2023 10:09:16 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
19/09/2023 10:09:16 INFO: Verbose logging redirected to /var/log/wazuh-install.log
19/09/2023 10:09:22 WARNING: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check. The installation may not finish successfully.
19/09/2023 10:09:32 INFO: Wazuh web interface port will be 443.
19/09/2023 10:09:34 INFO: Wazuh development repository added.
19/09/2023 10:09:34 INFO: --- Configuration files ---
19/09/2023 10:09:34 INFO: Generating configuration files.
19/09/2023 10:09:35 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
19/09/2023 10:09:35 INFO: --- Wazuh indexer ---
19/09/2023 10:09:35 INFO: Starting Wazuh indexer installation.
```

</details>

<details><summary>:green_circle: Installation in a recommended system</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a
19/09/2023 10:20:21 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
19/09/2023 10:20:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
19/09/2023 10:20:34 INFO: Wazuh web interface port will be 443.
19/09/2023 10:20:43 INFO: Wazuh development repository added.
19/09/2023 10:20:43 INFO: --- Configuration files ---
19/09/2023 10:20:43 INFO: Generating configuration files.
19/09/2023 10:20:44 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
19/09/2023 10:20:44 INFO: --- Wazuh indexer ---
19/09/2023 10:20:44 INFO: Starting Wazuh indexer installation.
```
</details>




