### PR TITLE
Fixed Wazuh indexer remaining files

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -489,13 +489,9 @@ function installCommon_rollBack() {
     fi
 
     if [[ ( -n "${indexer_remaining_files}" || -n "${indexer_installed}" ) && ( -n "${indexer}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
-        common_logger "Removing Wazuh indexer."
-        if [ "${sys_type}" == "yum" ]; then
-            eval "yum remove wazuh-indexer -y ${debug}"
-        elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt-get remove --purge wazuh-indexer -y ${debug}"
-        fi
-        common_logger "Wazuh indexer removed."
+        eval "rm -rf /var/lib/wazuh-indexer/ ${debug}"
+        eval "rm -rf /usr/share/wazuh-indexer/ ${debug}"
+        eval "rm -rf /etc/wazuh-indexer/ ${debug}"
     fi
 
     if [[ -n "${filebeat_installed}" && ( -n "${wazuh}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2487|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to modify the `installCommon_rollBack` function to remove some Wazuh indexer remaining files. These files stopped the execution of the script after an uninstallation of the Wazuh stack.

## Logs

The following logs show how the Installation Assistant is going to install the Wazuh indexer after an uninstallation.

<details><summary>:green_circle: Uninstallation after AIO</summary>

```console

[root@ip-172-31-79-73 ec2-user]# bash wazuh-install.sh -u -i
02/10/2023 13:58:47 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
02/10/2023 13:58:47 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2023 13:58:50 INFO: Removing Wazuh manager.
02/10/2023 13:59:17 INFO: Wazuh manager removed.
02/10/2023 13:59:17 INFO: Removing Wazuh indexer.
02/10/2023 13:59:20 INFO: Wazuh indexer removed.
02/10/2023 13:59:20 INFO: Removing Filebeat.
02/10/2023 13:59:21 INFO: Filebeat removed.
02/10/2023 13:59:21 INFO: Removing Wazuh dashboard.
02/10/2023 13:59:35 INFO: Wazuh dashboard removed.


[root@ip-172-31-79-73 ec2-user]# bash wazuh-install.sh -a -i
02/10/2023 14:02:38 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
02/10/2023 14:02:38 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2023 14:02:53 WARNING: Hardware and system checks ignored.
02/10/2023 14:02:53 INFO: Wazuh web interface port will be 443.
02/10/2023 14:02:55 INFO: Wazuh repository added.
02/10/2023 14:02:55 INFO: --- Configuration files ---
02/10/2023 14:02:55 INFO: Generating configuration files.
02/10/2023 14:02:58 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
02/10/2023 14:02:58 INFO: --- Wazuh indexer ---
02/10/2023 14:02:58 INFO: Starting Wazuh indexer installation.
```

</details>

<details><summary>:green_circle: Uninstallation after Wazuh indexer installation</summary>

```console
[root@ip-172-31-79-73 ec2-user]# bash wazuh-install.sh -wi wazuh-indexer -i
02/10/2023 15:11:26 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
02/10/2023 15:11:26 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2023 15:11:35 WARNING: Hardware and system checks ignored.
02/10/2023 15:11:36 INFO: Wazuh repository added.
02/10/2023 15:11:37 INFO: --- Wazuh indexer ---
02/10/2023 15:11:37 INFO: Starting Wazuh indexer installation.
02/10/2023 15:12:57 INFO: Wazuh indexer installation finished.
02/10/2023 15:12:57 INFO: Wazuh indexer post-install configuration finished.
02/10/2023 15:12:57 INFO: Starting service wazuh-indexer.
grep: warning: stray \ before white space
grep: warning: stray \ before white space
02/10/2023 15:13:20 INFO: wazuh-indexer service started.
02/10/2023 15:13:20 INFO: Initializing Wazuh indexer cluster security settings.
02/10/2023 15:13:24 INFO: Wazuh indexer cluster initialized.
02/10/2023 15:13:24 INFO: Installation finished.

[root@ip-172-31-79-73 ec2-user]# bash wazuh-install.sh -u -i
02/10/2023 15:13:38 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
02/10/2023 15:13:38 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2023 15:13:41 INFO: Wazuh manager was not found in the system so it was not uninstalled.
02/10/2023 15:13:41 INFO: Filebeat was not found in the system so it was not uninstalled.
02/10/2023 15:13:41 INFO: Wazuh dashboard was not found in the system so it was not uninstalled.
02/10/2023 15:13:41 INFO: Removing Wazuh indexer.
02/10/2023 15:13:43 INFO: Wazuh indexer removed.

[root@ip-172-31-79-73 ec2-user]# bash wazuh-install.sh -wi wazuh-indexer -i
02/10/2023 15:13:48 INFO: Starting Wazuh installation assistant. Wazuh version: 4.5.2
02/10/2023 15:13:48 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/10/2023 15:13:56 WARNING: Hardware and system checks ignored.
02/10/2023 15:13:58 INFO: Wazuh repository added.
02/10/2023 15:13:58 INFO: --- Wazuh indexer ---
02/10/2023 15:13:58 INFO: Starting Wazuh indexer installation.

```

The `grep` warning is known and reported: https://github.com/wazuh/wazuh-packages/issues/2473

</details>