### PR TITLE
Intel64 macos packages will fail to install on arm machines

### DIFF
--- a/macos/specs/wazuh-agent-intel64.pkgproj
+++ b/macos/specs/wazuh-agent-intel64.pkgproj
@@ -996,6 +996,42 @@
 			<array>
 				<dict>
 					<key>BEHAVIOR</key>
+					<integer>2</integer>
+					<key>DICTIONARY</key>
+					<dict>
+						<key>IC_REQUIREMENT_CPU_ARCHITECTURE_FAMILY</key>
+						<integer>2</integer>
+						<key>IC_REQUIREMENT_CPU_INTEL_ARCHITECTURE_TYPE</key>
+						<integer>2</integer>
+						<key>IC_REQUIREMENT_CPU_MINIMUM_CPU_CORES_COUNT</key>
+						<integer>1</integer>
+						<key>IC_REQUIREMENT_CPU_MINIMUM_FREQUENCY</key>
+						<integer>866666</integer>
+						<key>IC_REQUIREMENT_CPU_POWERPC_ARCHITECTURE_TYPE</key>
+						<integer>0</integer>
+					</dict>
+					<key>IC_REQUIREMENT_CHECK_TYPE</key>
+					<integer>0</integer>
+					<key>IDENTIFIER</key>
+					<string>fr.whitebox.Packages.requirement.cpu</string>
+					<key>MESSAGE</key>
+					<array>
+						<dict>
+							<key>LANGUAGE</key>
+							<string>English</string>
+							<key>SECONDARY_VALUE</key>
+							<string></string>
+							<key>VALUE</key>
+							<string>This installer has been built for 64-bit Intel architecture.</string>
+						</dict>
+					</array>
+					<key>NAME</key>
+					<string>Processor</string>
+					<key>STATE</key>
+					<true/>
+				</dict>
+				<dict>
+					<key>BEHAVIOR</key>
 					<integer>3</integer>
 					<key>DICTIONARY</key>
 					<dict>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2344|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This fix addresses an issue where Intel64 macOS packages were encountering installation failures on ARM-based machines. The update ensures seamless installation and compatibility across both Intel64 and ARM architectures

## Logs example
### Installing on Intel:
![Screenshot from 2023-10-03 12-52-53](https://github.com/wazuh/wazuh-packages/assets/21695385/3509d2cd-0dd0-4e33-a195-9401d3885786)

### Installing on ARM:
![Screenshot from 2023-10-02 19-52-10](https://github.com/wazuh/wazuh-packages/assets/21695385/760cf67a-5fdf-4f92-be1f-d4b897e2bf73)
Installing using the graphics interface:
![Screenshot from 2023-10-03 13-27-43](https://github.com/wazuh/wazuh-packages/assets/21695385/414d46ca-ba2f-42bd-8892-552ec7d1a31c)



<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [x] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
