### PR TITLE
Replace requestHeadersWhitelist with requestHeadersAllowlist due too …

### DIFF
--- a/stack/dashboard/base/files/etc/opensearch_dashboards.yml
+++ b/stack/dashboard/base/files/etc/opensearch_dashboards.yml
@@ -4,7 +4,7 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 #opensearch.username:
 #opensearch.password:
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard.yml
+++ b/unattended_installer/config/dashboard/dashboard.yml
@@ -4,7 +4,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -4,7 +4,7 @@ opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -4,7 +4,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true

--- a/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
@@ -2,7 +2,7 @@ server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver
 # opensearch.password: kibanaserver
-opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true


### PR DESCRIPTION
…deprecation

|Related issue|
|---|
|#2489|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR aims to resolve the deprecation of the requestHeadersWhitelist configuration by the new opensearch requestHeadersAllowlist configuration for the OVA.

This was fixed in https://github.com/wazuh/wazuh-packages/issues/1969 but in this commit the changes were removed https://github.com/wazuh/wazuh-packages/commit/4e52191c9cb50c50642085da1c2e6cc02580e8e4#diff-788eaabba00f1868a8487ba2 b80eba89c902873cdfa0719f3bf2af5b428186eb

## Logs example

<!--
Paste here related logs
-->

## Tests

<details><summary>System used to generate OVA</summary>

```console
[root@stack-amazonlin2 ova]# uname -a
Linux wazuh-server 4.14.314-237.533.amzn2.x86_64 #1 SMP Thu May 4 09:55:30 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
[root@stack-amazonlin2 ova]# 
```

</details>


<details><summary>Prerequisites to generate the OVA</summary>

[ova_generation.log](https://github.com/wazuh/wazuh-packages/files/12796652/ova_generation.log)
 
</details>

<details><summary>The services are raised because the provisioner turns them off to export the VM:
</summary>

```console
drwxrwxr-x 2 vagrant vagrant     73 oct  3 13:30 cert_tool wazuh-dashboard
● wazuh-dashboard.service - wazuh-dashboard
   Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; vendor preset: disabled)
   Active: active (running) since mar 2023-10-03 19:55:53 UTC; 48s ago
 Main PID: 7417 (node)
   CGroup: /system.slice/wazuh-dashboard.service
           └─7417 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-...

oct 03 19:56:24 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:24Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:27 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:27Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:29 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:29Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:32 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:32Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:34 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:34Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:37 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:37Z","tags":["error","opensearch","da...:9200"}
oct 03 19:56:40 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:40Z","tags":["info","savedobjects-ser...tions"}
oct 03 19:56:40 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:40Z","tags":["info","plugins-system"]...,expres
oct 03 19:56:40 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:40Z","tags":["listening","info"],"pid...0:443"}
oct 03 19:56:41 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:41Z","tags":["info","http","server","...0:443"}
Hint: Some lines were ellipsized, use -l to show in full.
[root@stack-amazonlin2 ova]# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
   Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: disabled)
   Active: active (running) since mar 2023-10-03 19:56:37 UTC; 9s ago
     Docs: https://documentation.wazuh.com
 Main PID: 7435 (java)
   CGroup: /system.slice/wazuh-indexer.service
           └─7435 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.neg...

oct 03 19:55:53 wazuh-server systemd[1]: Starting Wazuh-indexer...
oct 03 19:56:05 wazuh-server systemd-entrypoint[7435]: WARNING: A terminally deprecated method in java.lang.System has been called
oct 03 19:56:05 wazuh-server systemd-entrypoint[7435]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenS....0.jar)
oct 03 19:56:05 wazuh-server systemd-entrypoint[7435]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstra...nSearch
oct 03 19:56:05 wazuh-server systemd-entrypoint[7435]: WARNING: System::setSecurityManager will be removed in a future release
oct 03 19:56:16 wazuh-server systemd-entrypoint[7435]: WARNING: A terminally deprecated method in java.lang.System has been called
oct 03 19:56:16 wazuh-server systemd-entrypoint[7435]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Secur....0.jar)
oct 03 19:56:16 wazuh-server systemd-entrypoint[7435]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
oct 03 19:56:16 wazuh-server systemd-entrypoint[7435]: WARNING: System::setSecurityManager will be removed in a future release
oct 03 19:56:37 wazuh-server systemd[1]: Started Wazuh-indexer.
Hint: Some lines were ellipsized, use -l to show in full.
[root@stack-amazonlin2 ova]# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
   Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: disabled)
   Active: active (running) since mar 2023-10-03 19:56:06 UTC; 45s ago
  Process: 7436 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/wazuh-manager.service
           ├─7630 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─7631 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─7634 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─7637 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
           ├─7679 /var/ossec/bin/wazuh-authd
           ├─7693 /var/ossec/bin/wazuh-db
           ├─7718 /var/ossec/bin/wazuh-execd
           ├─7733 /var/ossec/bin/wazuh-analysisd
           ├─7795 /var/ossec/bin/wazuh-syscheckd
           ├─7811 /var/ossec/bin/wazuh-remoted
           ├─7847 /var/ossec/bin/wazuh-logcollector
           ├─7867 /var/ossec/bin/wazuh-monitord
           └─7877 /var/ossec/bin/wazuh-modulesd

oct 03 19:55:59 wazuh-server env[7436]: Started wazuh-db...
oct 03 19:56:00 wazuh-server env[7436]: Started wazuh-execd...
oct 03 19:56:01 wazuh-server env[7436]: Started wazuh-analysisd...
oct 03 19:56:01 wazuh-server env[7436]: Started wazuh-syscheckd...
oct 03 19:56:02 wazuh-server env[7436]: Started wazuh-remoted...
oct 03 19:56:03 wazuh-server env[7436]: Started wazuh-logcollector...
oct 03 19:56:03 wazuh-server env[7436]: Started wazuh-monitord...
oct 03 19:56:04 wazuh-server env[7436]: Started wazuh-modulesd...
oct 03 19:56:06 wazuh-server env[7436]: Completed.
oct 03 19:56:06 wazuh-server systemd[1]: Started Wazuh manager.
[root@stack-amazonlin2 ova]# systemctl status filebeat
● filebeat.service - Filebeat sends log files to Logstash or directly to Elasticsearch.
   Loaded: loaded (/usr/lib/systemd/system/filebeat.service; enabled; vendor preset: disabled)
   Active: active (running) since mar 2023-10-03 19:55:53 UTC; 1min 7s ago
     Docs: https://www.elastic.co/products/beats/filebeat
 Main PID: 7418 (filebeat)
   CGroup: /system.slice/filebeat.service
           └─7418 /usr/share/filebeat/bin/filebeat --environment systemd -c /etc/filebeat/filebeat.yml --path.home /usr/share/filebeat --path.confi...

oct 03 19:55:53 wazuh-server systemd[1]: Started Filebeat sends log files to Logstash or directly to Elasticsearch..
[root@stack-amazonlin2 ova]# 
```

</details>


<details><summary>New configuration applied correctly:</summary>

```console
[root@stack-amazonlin2 ova]# ls -la /etc/wazuh-dashboard/
certs/                          node.options                    opensearch_dashboards.keystore  opensearch_dashboards.yml
[root@stack-amazonlin2 ova]# ls -la /etc/wazuh-dashboard/opensearch_dashboards.yml 
-rw-r----- 1 wazuh-dashboard wazuh-dashboard 712 oct  3 19:38 /etc/wazuh-dashboard/opensearch_dashboards.yml
[root@stack-amazonlin2 ova]# cat /etc/wazuh-dashboard/opensearch_dashboards.yml 
server.host: 0.0.0.0
opensearch.hosts: https://127.0.0.1:9200
server.port: 443
opensearch.ssl.verificationMode: certificate
# opensearch.username: kibanaserver
# opensearch.password: kibanaserver
opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
opensearch_security.multitenancy.enabled: false
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
server.ssl.enabled: true
server.ssl.key: "/etc/wazuh-dashboard/certs/wazuh-dashboard-key.pem"
server.ssl.certificate: "/etc/wazuh-dashboard/certs/wazuh-dashboard.pem"
opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
uiSettings.overrides.defaultRoute: /app/wazuh
opensearch_security.cookie.secure: true
[root@stack-amazonlin2 ova]# 
```

</details>

<details><summary>The errors are looked for in the logs and as you can see they do not appear</summary>

```console
[root@stack-amazonlin2 ova]# journalctl -r -u wazuh-dashboard | grep -i -E "error|critical|fatal|warning"
oct 03 19:56:37 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:37Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:34 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:34Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:32 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:32Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:29 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:29Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:27 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:27Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:24 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:24Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:22 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:22Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:19 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:19Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:17 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:17Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:14 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:14Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:12 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:12Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:09 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:09Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:07 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:07Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:04 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:04Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:56:02 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:56:02Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:55:59 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:55:59Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
oct 03 19:55:57 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:55:57Z","tags":["error","savedobjects-service"],"pid":7417,"message":"Unable to retrieve version information from OpenSearch nodes."}
oct 03 19:55:57 wazuh-server opensearch-dashboards[7417]: {"type":"log","@timestamp":"2023-10-03T19:55:57Z","tags":["error","opensearch","data"],"pid":7417,"message":"[ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200"}
[root@stack-amazonlin2 ova]# 

[root@stack-amazonlin2 ova]# journalctl -r -u wazuh-dashboard | grep -i -E "error|critical|fatal|warning" | grep requestHeadersWhitelist
[root@stack-amazonlin2 ova]# uname -a
Linux wazuh-server 4.14.314-237.533.amzn2.x86_64 #1 SMP Thu May 4 09:55:30 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
[root@stack-amazonlin2 ova]# 
```

</details>
