### PR TITLE
Adding flatccrt library to rpm SPECS

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -663,6 +663,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/lib/libcontent_manager.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libindexer_connector.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/librocksdb.so.8
+%attr(750, root, wazuh) %{_localstatedir}/lib/libflatccrt.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/librouter.so
 %attr(750, root, wazuh) %{_localstatedir}/lib/libvulnerability_scanner.so
 %{_localstatedir}/lib/libpython3.9.so.1.0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19045|

## Description

Adding a missing library to rpm specs.

![image](https://github.com/wazuh/wazuh-packages/assets/13010397/594d10c2-4cd4-4565-b0db-da4018ea677a)

