### PR TITLE
Removed negation from the reference condition

### DIFF
--- a/stack/indexer/rpm/build_package.sh
+++ b/stack/indexer/rpm/build_package.sh
@@ -51,7 +51,7 @@ build_rpm() {
         fi
         ../base/generate_base.sh -s ${outdir} -r ${revision} ${base_cmd}
     else
-        if ! [ "${reference}" ];then
+        if [ "${reference}" ];then
             version=$(curl -sL https://raw.githubusercontent.com/wazuh/wazuh-packages/${reference}/VERSION | cat)
         else
             version=$(cat ${current_path}/../../../VERSION)


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2522|

## Description

This pull request fixes a bug condition that prevents searching the base file correctly if the `-b no` parameter is used.

## Logs example

```
╰─➤  bash build_package.sh -b no          
+ build
+ build_name=
+ file_path=
+ '[' x86_64 = x86_64 ']'
+ architecture=x86_64
+ build_name=rpm_indexer_builder_x86
+ file_path=/wazuh-packages/tags/stack/indexer/rpm/docker/x86_64
+ build_rpm rpm_indexer_builder_x86 /wazuh-packages/tags/stack/indexer/rpm/docker/x86_64
+ container_name=rpm_indexer_builder_x86
+ dockerfile_path=/wazuh-packages/tags/stack/indexer/rpm/docker/x86_64
+ cp /wazuh-packages/tags/stack/indexer/rpm/builder.sh /wazuh-packages/tags/stack/indexer/rpm/docker/x86_64
+ '[' no == yes ']'
+ '[' '' ']'
++ cat /wazuh-packages/tags/stack/indexer/rpm/../../../VERSION
+ version=4.7.0
+ basefile=/wazuh-packages/tags/stack/indexer/rpm/output/wazuh-indexer-base-4.7.0-1-linux-x64.tar.xz
+ test -f /wazuh-packages/tags/stack/indexer/rpm/output/wazuh-indexer-base-4.7.0-1-linux-x64.tar.xz
+ echo 'Did not find expected Wazuh indexer base file: /wazuh-packages/tags/stack/indexer/rpm/output/wazuh-indexer-base-4.7.0-1-linux-x64.tar.xz in output path. Exiting...'
Did not find expected Wazuh indexer base file: /wazuh-packages/tags/stack/indexer/rpm/output/wazuh-indexer-base-4.7.0-1-linux-x64.tar.xz in output path. Exiting...
+ exit 1
```
