### PR TITLE
Add new role to grant ISM API permissions

### DIFF
--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -100,6 +100,7 @@ override_dh_install:
 	cp /root/documentation-templates/wazuh/config.yml $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/config.yml
 
 	# Copy Wazuh's config files for the security plugin
+	cp -pr $(REPO_DIR)/config/indexer/roles/action_groups.yml $(TARGET_DIR)$(CONFIG_DIR)/opensearch-security/
 	cp -pr $(REPO_DIR)/config/indexer/roles/roles_mapping.yml $(TARGET_DIR)$(CONFIG_DIR)/opensearch-security/
 	cp -pr $(REPO_DIR)/config/indexer/roles/roles.yml $(TARGET_DIR)$(CONFIG_DIR)/opensearch-security/
 	cp -pr $(REPO_DIR)/config/indexer/roles/internal_users.yml $(TARGET_DIR)$(CONFIG_DIR)/opensearch-security/

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -93,6 +93,7 @@ cp %{REPO_DIR}/wazuh-passwords-tool.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/o
 cp /root/documentation-templates/wazuh/config.yml ${RPM_BUILD_ROOT}%{INSTALL_DIR}/plugins/opensearch-security/tools/config.yml
 
 # Copy Wazuh's config files for the security plugin
+cp %{REPO_DIR}/config/indexer/roles/action_groups.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/opensearch-security
 cp %{REPO_DIR}/config/indexer/roles/internal_users.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/opensearch-security
 cp %{REPO_DIR}/config/indexer/roles/roles.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/opensearch-security
 cp %{REPO_DIR}/config/indexer/roles/roles_mapping.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/opensearch-security

--- a/unattended_installer/config/indexer/roles/action_groups.yml
+++ b/unattended_installer/config/indexer/roles/action_groups.yml
@@ -1,0 +1,12 @@
+---
+_meta:
+  type: "actiongroups"
+  config_version: 2
+
+# ISM API permissions group
+manage_ism:
+  reserved: true
+  hidden: false
+  allowed_actions:
+  - "cluster:admin/opendistro/ism/*"
+  static: false

--- a/unattended_installer/config/indexer/roles/roles.yml
+++ b/unattended_installer/config/indexer/roles/roles.yml
@@ -147,3 +147,11 @@ manage_wazuh_index:
     - "index"
   tenant_permissions: []
   static: false
+
+# ISM API permissions role
+manage_ism:
+  reserved: true
+  hidden: false
+  cluster_permissions:
+  - "manage_ism"
+  static: false

--- a/unattended_installer/config/indexer/roles/roles_mapping.yml
+++ b/unattended_installer/config/indexer/roles/roles_mapping.yml
@@ -76,7 +76,7 @@ kibana_user:
   and_backend_roles: []
   description: "Maps kibanauser to kibana_user"
 
-  # Wazuh monitoring and statistics index permissions
+# Wazuh monitoring and statistics index permissions
 manage_wazuh_index:
   reserved: true
   hidden: false
@@ -85,3 +85,10 @@ manage_wazuh_index:
   users:
   - "kibanaserver"
   and_backend_roles: []
+
+# ISM API permissions role mapping
+manage_ism:
+  reserved: true
+  hidden: false
+  users:
+  - "kibanaserver"


### PR DESCRIPTION
|Related issue|
|---|
| #2552  |

## Description

A new role has been added to grant ISM API permissions, required by the app to upload the ISM policy for auto-rollover. It's mapped to the `kibanaserver` internal user by default.

A new file has been created: `action_groups.yml`, used to group all permissions required by the ISM API.


## Tests

Check the following:

- [x] The `manage_ism` action group is created in a fresh installation or upgrade.
- [x] The `manage_ism` action group can be used in other roles.
- [x] The `manage_ism` role is created in a fresh installation or upgrade.
- [x] The `manage_ism` role uses the `manage_ism` action group as cluster permissions.
- [x] The `manage_ism` role is mapped to the `kibanaserver` internal user.
- [x] The `manage_ism` role can be mapped to other users.
- [x] Any request to the ISM API is authorized for the `kibanaserver` user (or any other with the `manage_ism` role)

```bash
curl -X GET https://<indexer_url>:9200/_plugins/_ism/explain/wazuh-alerts-* -k -u "kibanaserver:<password>"
```
