### PR TITLE
Updated Wazuh dashboard references in Installation Assistant

### DIFF
--- a/unattended_installer/config/dashboard/dashboard.yml
+++ b/unattended_installer/config/dashboard/dashboard.yml
@@ -11,5 +11,5 @@ server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/kibana-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/kibana.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-server.defaultRoute: /app/wazuh
+server.defaultRoute: /app/wz-home
 opensearch_security.cookie.secure: true

--- a/unattended_installer/config/dashboard/dashboard_all_in_one.yml
+++ b/unattended_installer/config/dashboard/dashboard_all_in_one.yml
@@ -11,5 +11,5 @@ server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/kibana-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/kibana.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-uiSettings.overrides.defaultRoute: /app/wazuh
+uiSettings.overrides.defaultRoute: /app/wz-home
 opensearch_security.cookie.secure: true

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -11,5 +11,5 @@ server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-uiSettings.overrides.defaultRoute: /app/wazuh
+uiSettings.overrides.defaultRoute: /app/wz-home
 opensearch_security.cookie.secure: true

--- a/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended_distributed.yml
@@ -9,5 +9,5 @@ server.ssl.enabled: true
 server.ssl.key: "/etc/wazuh-dashboard/certs/dashboard-key.pem"
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
-uiSettings.overrides.defaultRoute: /app/wazuh
+uiSettings.overrides.defaultRoute: /app/wz-home
 opensearch_security.cookie.secure: true


### PR DESCRIPTION
## Description

This PR is related to https://github.com/wazuh/internal-devel-requests/issues/394.
The aim of this PR is to update the `/app/wazuh` value references in the Installation Assistant to the `/app/wz-home`. 

The change in `unattended_installer/config/dashboard/dashboard.yml` modifies the `server.defaultRoute` parameter instead of the `uiSettings.overrides.defaultRoute` parameter. However, this change is necessary to correctly manage the URL `https://<WAZUH_DASHBOARD_ADDRESS>/app/wz-home`.
This has been validated by @Desvelao.