### PR TITLE
Firewall validation in the installation assistant

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -389,7 +389,7 @@ function checks_firewall(){
 
     # Record of the ports that must be exposed according to the installation
     if [ -n "${AIO}" ]; then
-        f_message+="these ports: 1515 1514 ${http_port}"
+        f_message+="these ports: 1515, 1514, ${http_port}"
     elif [ -n "${dashboard}" ]; then
         f_message+="this port: ${http_port}"
     else

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -393,10 +393,13 @@ function checks_firewall(){
     elif [ -n "${dashboard}" ]; then
         f_message+="this port: ${http_port}"
     else
+        f_message+="these ports:"
         for port in "${ports_list[@]}"; do
-            f_ports="${f_ports} ${port}"
+            f_message+=" ${port},"
         done
-        f_message+="these ports:${f_ports}"  
+
+        # Deletes last comma
+        f_message="${f_message%,}"
     fi
 
     # Check if the firewall is installed

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -330,7 +330,7 @@ function checks_ports() {
     used_port=0
     ports=("$@")
 
-    checks_firewalld
+    checks_firewalld "${ports}"
 
     if command -v lsof > /dev/null; then
         port_command="lsof -sTCP:LISTEN  -i:"
@@ -380,15 +380,15 @@ function checks_available_port() {
 }
 
 function checks_firewalld(){
+    ports=("$@")
+
     if [ "${sys_type}" == "yum" ]; then
         if yum list installed 2>/dev/null | grep -q -E ^"firewalld"\\.;then
-            common_logger -e "The system has a firewall installed, remember to open the necessary ports for component communication."
-            exit 1
+            common_logger -w "The system has a firewalld installed. Consider that traffic should be allowed in these ports: ${ports}."
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
         if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
-            common_logger -e "The system has a firewall installed, remember to open the necessary ports for component communication."
-            exit 1
+            common_logger -w "The system has a firewalld installed. Consider that traffic should be allowed in these ports: ${ports}."
         fi
     fi
 }

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -330,6 +330,8 @@ function checks_ports() {
     used_port=0
     ports=("$@")
 
+    checks_firewalld
+
     if command -v lsof > /dev/null; then
         port_command="lsof -sTCP:LISTEN  -i:"
     else
@@ -374,5 +376,19 @@ function checks_available_port() {
                 exit 1
             fi
         done
+    fi
+}
+
+function checks_firewalld(){
+    if [ "${sys_type}" == "yum" ]; then
+        if yum list installed 2>/dev/null | grep -q -E ^"firewalld"\\.;then
+            common_logger -e "The system has a firewall installed, remember to open the necessary ports for component communication."
+            exit 1
+        fi
+    elif [ "${sys_type}" == "apt-get" ]; then
+        if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
+            common_logger -e "The system has a firewall installed, remember to open the necessary ports for component communication."
+            exit 1
+        fi
     fi
 }

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -330,7 +330,7 @@ function checks_ports() {
     used_port=0
     ports=("$@")
 
-    checks_firewalld "${ports}"
+    checks_firewalld "${ports[@]}"
 
     if command -v lsof > /dev/null; then
         port_command="lsof -sTCP:LISTEN  -i:"
@@ -380,15 +380,29 @@ function checks_available_port() {
 }
 
 function checks_firewalld(){
-    ports=("$@")
+    ports_list=("$@")
+    f_ports=""
+    f_message=""
+
+    if [ -n "${AIO}" ]; then
+        f_message="Please ensure that traffic is allowed on these ports: 1515 1514 ${http_port}"
+    elif [ -n "${dashboard}" ]; then
+        f_message="Please ensure that traffic is allowed on this port: ${http_port}"
+    else
+        for port in "${ports_list[@]}"; do
+            f_ports="${f_ports} ${port}"
+        done
+        f_message="Please ensure that traffic is allowed on these ports: ${f_ports}"  
+    fi
+
 
     if [ "${sys_type}" == "yum" ]; then
         if yum list installed 2>/dev/null | grep -q -E ^"firewalld"\\.;then
-            common_logger -w "The system has a firewalld installed. Consider that traffic should be allowed in these ports: ${ports}."
+            common_logger -w "The system has Firewalld installed. ${f_message}."
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
         if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
-            common_logger -w "The system has a firewalld installed. Consider that traffic should be allowed in these ports: ${ports}."
+            common_logger -w "The system has Firewalld installed. ${f_message}."
         fi
     fi
 }

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -382,7 +382,7 @@ function checks_available_port() {
 function checks_firewall(){
     ports_list=("$@")
     f_ports=""
-    f_message="The system has firewall installed. Please ensure that traffic is allowed on "
+    f_message="The system has firewall enabled. Please ensure that traffic is allowed on "
     firewalld_installed=0
     ufw_installed=0
 

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -396,7 +396,7 @@ function checks_firewall(){
         for port in "${ports_list[@]}"; do
             f_ports="${f_ports} ${port}"
         done
-        f_message+="these ports: ${f_ports}"  
+        f_message+="these ports:${f_ports}"  
     fi
 
     # Check if the firewall is installed

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -330,7 +330,7 @@ function checks_ports() {
     used_port=0
     ports=("$@")
 
-    checks_firewalld "${ports[@]}"
+    checks_firewall "${ports[@]}"
 
     if command -v lsof > /dev/null; then
         port_command="lsof -sTCP:LISTEN  -i:"
@@ -379,30 +379,53 @@ function checks_available_port() {
     fi
 }
 
-function checks_firewalld(){
+function checks_firewall(){
     ports_list=("$@")
     f_ports=""
-    f_message=""
+    f_message="The system has firewall installed. Please ensure that traffic is allowed on "
+    firewalld_installed=0
+    ufw_installed=0
 
+
+    # Record of the ports that must be exposed according to the installation
     if [ -n "${AIO}" ]; then
-        f_message="Please ensure that traffic is allowed on these ports: 1515 1514 ${http_port}"
+        f_message+="these ports: 1515 1514 ${http_port}"
     elif [ -n "${dashboard}" ]; then
-        f_message="Please ensure that traffic is allowed on this port: ${http_port}"
+        f_message+="this port: ${http_port}"
     else
         for port in "${ports_list[@]}"; do
             f_ports="${f_ports} ${port}"
         done
-        f_message="Please ensure that traffic is allowed on these ports: ${f_ports}"  
+        f_message+="these ports: ${f_ports}"  
     fi
 
-
+    # Check if the firewall is installed
     if [ "${sys_type}" == "yum" ]; then
         if yum list installed 2>/dev/null | grep -q -E ^"firewalld"\\.;then
-            common_logger -w "The system has Firewalld installed. ${f_message}."
+            firewalld_installed=1
+        fi
+        if yum list installed 2>/dev/null | grep -q -E ^"ufw"\\.;then
+            ufw_installed=1
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
         if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
-            common_logger -w "The system has Firewalld installed. ${f_message}."
+            firewalld_installed=1
+        fi
+        if apt list --installed 2>/dev/null | grep -q -E ^"ufw"\/; then
+            ufw_installed=1
         fi
     fi
+
+    # Check if the firewall is running
+    if [ "${firewalld_installed}" == "1" ]; then
+        if firewall-cmd --state 2>/dev/null | grep -q -w "running"; then
+            common_logger -w "${f_message/firewall/Firewalld}."
+        fi
+    fi
+    if [ "${ufw_installed}" == "1" ]; then
+        if ufw status 2>/dev/null | grep -q -w "active"; then
+            common_logger -w "${f_message/firewall/UFW}."
+        fi
+    fi
+
 }


### PR DESCRIPTION
|Related issue|
|---|
|close https://github.com/wazuh/wazuh-packages/issues/2539|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Validations are created to detect if the system has Firewalld or UFW installed and enabled, to indicate by a Warning message which ports should be opened in the firewall

## Logs example

<!--
Paste here related logs
-->
### Ubuntu Jammy: 
Firewalld: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1777142732
Without Firewalld: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1777131414
Firewalld and UFW: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1777448920

### Rocky Linux 8:
Firewalld: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1776009345
Without Firewalld: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1777122116
Firewalld and UFW: https://github.com/wazuh/wazuh-packages/issues/2539#issuecomment-1777449521


## Tests

Centos 7: https://ci.wazuh.info/view/Tests/job/Test_unattended/4553/console
Ubuntu Bionic: https://ci.wazuh.info/view/Tests/job/Test_unattended/4554/console
Distributed: https://ci.wazuh.info/view/Tests/job/Test_unattended_distributed/548/console
