### PR TITLE
Fix home button navigation on click

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -92,10 +92,12 @@ sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensear
 # Add fix to Node variables as Node is not using the NODE_OPTIONS environment variables
 sed -i 's/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"/NODE_OPTIONS="$OSD_NODE_OPTS_PREFIX $OSD_NODE_OPTS $NODE_OPTIONS"\n/g' ./bin/use_node
 sed -i 's/exec "${NODE}"/NODE_ENV=production exec "${NODE}" ${NODE_OPTIONS} /g' ./bin/use_node
+# Replace the redirections to home app
+app_home='wz-home'
 # Replace the redirection to `home` in the header logo
-sed -i "s'/app/home'/app/wz-home'g" ./src/core/target/public/core.entry.js
+sed -i "s'/app/home'/app/${app_home}'g" ./src/core/target/public/core.entry.js
 # Replace others redirections to `home`
-sed -i 's/navigateToApp("home")/navigateToApp("wazuh")/g' ./src/core/target/public/core.entry.js
+sed -i "s/navigateToApp(\"home\")/navigateToApp(\"${app_home}\")/g" ./src/core/target/public/core.entry.js
 # Changed from Opensearch Documentation links to Wazuh Documentation
 # Help menu
 ## Help header - Version


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-dashboard-plugins/issues/5893|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This pull request fixes the navigation of home button to the home application (`wz-home`).

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
