### PR TITLE
Wazuh password tool now recognize UI created users

### DIFF
--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -33,7 +33,7 @@ jobs:
           name: scripts
       - name: Install wazuh
         run: |
-          sudo bash wazuh-install.sh -a
+          sudo bash wazuh-install.sh -a -v
       - name: Uncompress wazuh install files 
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script
@@ -49,7 +49,7 @@ jobs:
           name: scripts
       - name: Install wazuh
         run: |
-          sudo bash wazuh-install.sh -a
+          sudo bash wazuh-install.sh -a -v
       - name: Uncompress wazuh install files 
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh-packages/issues/2503

The aim of this PR is to allow the Wazuh password tool to work for users created through the UI. Until now, these users were not in the `internal_users.yml` file so the Wazuh password tool did not recognize them. Using the `securityadmin` tool and updating the internal users before reading them fixes the problem.

Two more changes have been added:
- The new generated hash is fixed and now it is contained with double quotes in the `internal_users.yml` file.
- A backup of the internal users is made and saved in the `/etc/wazuh-indexer/internal_users_backup` with the following name: `internal_users_<datetime>.yml.bkp` before changing the passwords.

## Testing

The testing has been done in: https://github.com/wazuh/wazuh-packages/issues/2503#issuecomment-1779005948