### PR TITLE
Fixed `internalusers-backup` directory owner and permissions

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -611,14 +611,18 @@ function passwords_updateInternalUsers() {
     
     common_logger "Updating the internal users."
     backup_datetime=$(date +"%Y%m%d_%H%M%S")
+    internal_users_backup_path="/etc/wazuh-indexer/internalusers-backup"
     passwords_getNetworkHost
     passwords_createBackUp
 
-    eval "mkdir -p /etc/wazuh-indexer/internalusers-backup"
-    eval "cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/internalusers-backup/internal_users_${backup_datetime}.yml.bkp"
+    eval "mkdir -p ${internal_users_backup_path} ${debug}"
+    eval "cp /etc/wazuh-indexer/backup/internal_users.yml ${internal_users_backup_path}/internal_users_${backup_datetime}.yml.bkp ${debug}"
+    eval "chmod 750 ${internal_users_backup_path} ${debug}"
+    eval "chmod 640 ${internal_users_backup_path}/internal_users_${backup_datetime}.yml.bkp"
+    eval "chown -R wazuh-indexer:wazuh-indexer ${internal_users_backup_path} ${debug}"
     common_logger "A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder."
 
-    eval "cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml"
+    eval "cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml ${debug}"
     eval "rm -rf /etc/wazuh-indexer/backup/ ${debug}"
     common_logger -d "The internal users have been updated before changing the passwords."
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh-packages/issues/2503

The aim of this PR is to modify the changes done in https://github.com/wazuh/wazuh-packages/pull/2558. This PR changes the owner and the permissions of the new created folder `/etc/wazuh-indexer/internalusers-backup`. Without this changes, if the Wazuh indexer is restarted, it generated the following error because it does not have the correct owner and permissions:

```console
Exception in thread "main" org.opensearch.bootstrap.BootstrapException: java.nio.file.AccessDeniedException: /etc/wazuh-indexer/internal_users_backup
```

## Testing

The following testing has been performed to ensure that the change is correct.
This test consist in generating an internal users backup, check the permissions and owners, and try to restart the `wazuh-indexer` service in search of errors.

<details><summary>Show log</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -u test
26/10/2023 10:03:58 INFO: Updating the internal users.
26/10/2023 10:04:02 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
26/10/2023 10:04:02 ERROR: The given user does not exist

root@ubuntu22:/home/vagrant# ls -l /etc/wazuh-indexer/
total 64
dr-x------ 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 certs
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 10:04 internalusers-backup
-rw-rw---- 1 wazuh-indexer wazuh-indexer  2941 Oct 26 09:52 jvm.options
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 19 11:38 jvm.options.d
-rw-rw---- 1 wazuh-indexer wazuh-indexer 14808 Oct 19 11:38 log4j2.properties
-rw-rw---- 1 wazuh-indexer wazuh-indexer   196 Oct 26 09:52 opensearch.keystore
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-notifications
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-notifications-core
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-observability
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-performance-analyzer
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-reports-scheduler
drwxr-x--- 2 wazuh-indexer wazuh-indexer  4096 Oct 26 09:52 opensearch-security
-rw-rw---- 1 wazuh-indexer wazuh-indexer  2152 Oct 26 09:52 opensearch.yml
root@ubuntu22:/home/vagrant# ls -l /etc/wazuh-indexer/internalusers-backup/
total 4
-rw-r----- 1 wazuh-indexer wazuh-indexer 1145 Oct 26 10:04 internal_users_20231026_100358.yml.bkp

root@ubuntu22:/home/vagrant# systemctl restart wazuh-indexer
root@ubuntu22:/home/vagrant# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2023-10-26 10:04:47 UTC; 6s ago
       Docs: https://documentation.wazuh.com
   Main PID: 54151 (java)
      Tasks: 65 (limit: 2234)
     Memory: 1.3G
        CPU: 39.910s
     CGroup: /system.slice/wazuh-indexer.service
             └─54151 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=>

Oct 26 10:04:26 ubuntu22 systemd[1]: Starting Wazuh-indexer...
Oct 26 10:04:29 ubuntu22 systemd-entrypoint[54151]: WARNING: A terminally deprecated method in java.lang.System has been called
Oct 26 10:04:29 ubuntu22 systemd-entrypoint[54151]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.6.0.jar)
Oct 26 10:04:29 ubuntu22 systemd-entrypoint[54151]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
Oct 26 10:04:29 ubuntu22 systemd-entrypoint[54151]: WARNING: System::setSecurityManager will be removed in a future release
Oct 26 10:04:31 ubuntu22 systemd-entrypoint[54151]: WARNING: A terminally deprecated method in java.lang.System has been called
Oct 26 10:04:31 ubuntu22 systemd-entrypoint[54151]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.6.0.jar)
Oct 26 10:04:31 ubuntu22 systemd-entrypoint[54151]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
Oct 26 10:04:31 ubuntu22 systemd-entrypoint[54151]: WARNING: System::setSecurityManager will be removed in a future release
Oct 26 10:04:47 ubuntu22 systemd[1]: Started Wazuh-indexer.

```
</details>

Before this changes, the owner and permissions were the following:
<details><summary>Show log</summary>

```console
root@ubuntu22:/home/vagrant# ls -la /etc/wazuh-indexer/internal_users_backup/
total 20
drw-------  2 root          root          4096 Oct 25 10:14 .
drwxr-x--- 11 wazuh-indexer wazuh-indexer 4096 Oct 26 09:35 ..
-rw-------  1 root          root          2094 Oct 25 10:04 internal_users_20231025_100407.yml.bkp
-rw-------  1 root          root          1859 Oct 25 10:10 internal_users_20231025_100958.yml.bkp
-rw-------  1 root          root          2132 Oct 25 10:14 internal_users_20231025_101446.yml.bkp
root@ubuntu22:/home/vagrant# ls -la /etc/wazuh-indexer/
total 76
drwxr-x---  11 wazuh-indexer wazuh-indexer  4096 Oct 26 09:35 .
drwxr-xr-x 105 root          root           4096 Oct 26 08:33 ..
dr-x------   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 certs
drw-------   2 root          root           4096 Oct 25 10:14 internal_users_backup
-rw-rw----   1 wazuh-indexer wazuh-indexer  2941 Oct 24 16:05 jvm.options
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 19 11:38 jvm.options.d
-rw-rw----   1 wazuh-indexer wazuh-indexer 14808 Oct 19 11:38 log4j2.properties
-rw-rw----   1 wazuh-indexer wazuh-indexer   196 Oct 24 16:05 opensearch.keystore
-rw-------   1 wazuh-indexer wazuh-indexer    73 Oct 24 16:05 .opensearch.keystore.initial_md5sum
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-notifications
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-notifications-core
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-observability
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-performance-analyzer
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-reports-scheduler
drwxr-x---   2 wazuh-indexer wazuh-indexer  4096 Oct 24 16:05 opensearch-security
-rw-rw----   1 wazuh-indexer wazuh-indexer  2074 Oct 26 09:35 opensearch.yml
```
</details>