### PR TITLE
Fixed fetching network host in Password tool

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -362,7 +362,7 @@ function passwords_getApiUserId() {
 
 function passwords_getNetworkHost() {
 
-    IP=$(grep -hr "network.host:" /etc/wazuh-indexer/opensearch.yml)
+    IP=$(grep -hr "^network.host:" /etc/wazuh-indexer/opensearch.yml)
     NH="network.host: "
     IP="${IP//$NH}"
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1958|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to improve the fetching of the network host value of the `opensearch.yml` file of the `passwords_getNetworkHost` function. If a commented line like `#network.host: "XXX.XXX.XXX.XXX"` was included in the file, and the function fetched it.

With this change, these kinds of lines are ignored.

The testing is in: https://github.com/wazuh/wazuh-packages/issues/1958#issuecomment-1780875983