### PR TITLE
Add ISM script in installation assistant

### DIFF
--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -177,6 +177,8 @@ function indexer_startCluster() {
         exit 1
     else
         common_logger "Wazuh indexer cluster security configuration initialized."
+        eval "bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh ${debug}"
+        common_logger "Wazuh indexer cluster ISM initialized."
     fi
     eval "common_curl --silent ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent --max-time 300 --retry 5 --retry-delay 5 ${debug}"
     if [  "${PIPESTATUS[0]}" != 0  ]; then

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -179,7 +179,7 @@ function indexer_startCluster() {
         exit 1
     else
         common_logger "Wazuh indexer cluster security configuration initialized."
-        eval "bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh ${debug}"
+        eval "bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh -i ${wazuh_indexer_ip} ${debug}"
         common_logger "Wazuh indexer cluster ISM initialized."
     fi
     eval "common_curl --silent ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent --max-time 300 --retry 5 --retry-delay 5 ${debug}"

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -123,6 +123,8 @@ function indexer_initialize() {
 
     if [ -n "${AIO}" ]; then
         eval "sudo -u wazuh-indexer JAVA_HOME=/usr/share/wazuh-indexer/jdk/ OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /etc/wazuh-indexer/opensearch-security -icl -p 9200 -nhnv -cacert ${indexer_cert_path}/root-ca.pem -cert ${indexer_cert_path}/admin.pem -key ${indexer_cert_path}/admin-key.pem -h 127.0.0.1 ${debug}"
+        eval "bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh ${debug}"
+        common_logger "Wazuh indexer cluster ISM initialized."
     fi
 
     if [ "${#indexer_node_names[@]}" -eq 1 ] && [ -z "${AIO}" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/internal-devel-requests/issues/425|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The execution of the indexer-ism-init.sh script is added to AIO installations and distributed to the installation assistant.



## Logs example

<!--
Paste here related logs
-->
AIO: https://github.com/wazuh/internal-devel-requests/issues/425#issuecomment-1799521457
Distributed: https://github.com/wazuh/internal-devel-requests/issues/425#issuecomment-1801788574


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
