### PR TITLE
Moved ISM scripts from package to base

### DIFF
--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -67,6 +67,8 @@ cp -r /root/stack/indexer/base/files/etc/wazuh-indexer/* ./etc/wazuh-indexer/
 cp -r /root/stack/indexer/base/files/etc/sysconfig ./etc/
 cp -r /root/stack/indexer/base/files/etc/init.d ./etc/
 cp -r /root/stack/indexer/base/files/usr ./
+cp -r /root/stack/indexer/indexer-ism-init.sh bin/
+cp -r /root/stack/indexer/indexer-init.sh bin/
 rm -rf ./plugins/opensearch-security/tools/install_demo_configuration.sh
 cp /root/VERSION .
 

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -106,8 +106,6 @@ override_dh_install:
 	cp -pr $(REPO_DIR)/config/indexer/roles/internal_users.yml $(TARGET_DIR)$(CONFIG_DIR)/opensearch-security/
 
 	cp /root/stack/indexer/indexer-security-init.sh $(TARGET_DIR)$(INSTALLATION_DIR)/bin/
-	cp /root/stack/indexer/indexer-ism-init.sh $(TARGET_DIR)$(INSTALLATION_DIR)/bin/
-	cp /root/stack/indexer/indexer-init.sh $(TARGET_DIR)$(INSTALLATION_DIR)/bin/
 
 	# Create group and user in chroot environment
 	groupadd -r $(GROUP)

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -99,8 +99,6 @@ cp %{REPO_DIR}/config/indexer/roles/roles.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/ope
 cp %{REPO_DIR}/config/indexer/roles/roles_mapping.yml ${RPM_BUILD_ROOT}%{CONFIG_DIR}/opensearch-security
 
 cp /root/stack/indexer/indexer-security-init.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/bin/
-cp /root/stack/indexer/indexer-ism-init.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/bin/
-cp /root/stack/indexer/indexer-init.sh ${RPM_BUILD_ROOT}%{INSTALL_DIR}/bin/
 
 chmod 750 ${RPM_BUILD_ROOT}/etc/init.d/wazuh-indexer
 


### PR DESCRIPTION
|Related issue|
|---|
|related https://github.com/wazuh/internal-devel-requests/issues/425|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
It was necessary to move the place where the new scripts are copied so that they are in the base, this is necessary for the implementation in wazuh-docker


## Logs example

<!--
Paste here related logs
-->

<details>
<summary>Centos 7</summary>

```console
[root@centos-7 ~]# yum localinstall -y /home/vagrant/wazuh-indexer-4.8.0-40800.x86_64.rpm 
Loaded plugins: fastestmirror
Examining /home/vagrant/wazuh-indexer-4.8.0-40800.x86_64.rpm: wazuh-indexer-4.8.0-40800.x86_64
Marking /home/vagrant/wazuh-indexer-4.8.0-40800.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-indexer.x86_64 0:4.8.0-40800 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

============================================================================================================================================================================================================================================
 Package                                               Arch                                           Version                                               Repository                                                                 Size
============================================================================================================================================================================================================================================
Installing:
 wazuh-indexer                                         x86_64                                         4.8.0-40800                                           /wazuh-indexer-4.8.0-40800.x86_64                                         1.0 G

Transaction Summary
============================================================================================================================================================================================================================================
Install  1 Package

Total size: 1.0 G
Installed size: 1.0 G
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-indexer-4.8.0-40800.x86_64                                                                                                                                                                                         1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
  Verifying  : wazuh-indexer-4.8.0-40800.x86_64                                                                                                                                                                                         1/1 

Installed:
  wazuh-indexer.x86_64 0:4.8.0-40800                                                                                                                                                                                                        

Complete!
[root@centos-7 ~]#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0  10268      0 --:--:-- --:--:-- --:--:-- 10272
[root@centos-7 ~]#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
[root@centos-7 ~]#             mkdir -p /etc/wazuh-indexer/certs/
[root@centos-7 ~]#             mv ./certs/demo-indexer-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
[root@centos-7 ~]#             mv ./certs/demo-indexer.pem /etc/wazuh-indexer/certs/indexer.pem
[root@centos-7 ~]#             mv ./certs/admin-key.pem /etc/wazuh-indexer/certs/admin-key.pem
[root@centos-7 ~]#             mv ./certs/admin.pem /etc/wazuh-indexer/certs/admin.pem
[root@centos-7 ~]#             mv ./certs/root-ca.pem /etc/wazuh-indexer/certs/root-ca.pem
[root@centos-7 ~]#             rm -rf ./certs/
[root@centos-7 ~]#             systemctl daemon-reload
[root@centos-7 ~]#             systemctl enable wazuh-indexer
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service to /usr/lib/systemd/system/wazuh-indexer.service.
[root@centos-7 ~]#             systemctl start wazuh-indexer
[root@centos-7 ~]# /usr/share/wazuh-indexer/bin/indexer-init.sh 
Executing Wazuh indexer security init script...
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
Executing Wazuh indexer ISM init script...
TEMPLATES AND POLICIES - Uploading wazuh-alerts template
TEMPLATES AND POLICIES - Uploading wazuh-archives template
TEMPLATES AND POLICIES - Uploading rollover_policy ISM policy
TEMPLATES AND POLICIES - Creating write indices
[root@centos-7 ~]# curl -O https://packages-dev.wazuh.com/staging/yum/wazuh-manager-4.8.0-40800.x86_64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  165M  100  165M    0     0   9.9M      0  0:00:16  0:00:16 --:--:-- 11.1M
[root@centos-7 ~]# yum localinstall -y wazuh-manager-4.8.0-40800.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-manager-4.8.0-40800.x86_64.rpm: wazuh-manager-4.8.0-40800.x86_64
Marking wazuh-manager-4.8.0-40800.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.8.0-40800 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

============================================================================================================================================================================================================================================
 Package                                               Arch                                           Version                                               Repository                                                                 Size
============================================================================================================================================================================================================================================
Installing:
 wazuh-manager                                         x86_64                                         4.8.0-40800                                           /wazuh-manager-4.8.0-40800.x86_64                                         602 M

Transaction Summary
============================================================================================================================================================================================================================================
Install  1 Package

Total size: 602 M
Installed size: 602 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.8.0-40800.x86_64                                                                                                                                                                                         1/1 
  Verifying  : wazuh-manager-4.8.0-40800.x86_64                                                                                                                                                                                         1/1 

Installed:
  wazuh-manager.x86_64 0:4.8.0-40800                                                                                                                                                                                                        

Complete!
[root@centos-7 ~]#             systemctl daemon-reload
[root@centos-7 ~]#             systemctl enable wazuh-manager
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
[root@centos-7 ~]#             systemctl start wazuh-manager
[root@centos-7 ~]#             rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
[root@centos-7 ~]#             echo "[wazuh]" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "gpgcheck=1" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "enabled=1" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "name=EL-\$releasever - Wazuh" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "baseurl=https://packages-dev.wazuh.com/pre-release/yum/" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             echo "protect=1" >> /etc/yum.repos.d/wazuh.repo
[root@centos-7 ~]#             yum install filebeat -y
Loaded plugins: fastestmirror
Determining fastest mirrors
 * base: espejito.fder.edu.uy
 * extras: espejito.fder.edu.uy
 * updates: espejito.fder.edu.uy
base                                                                                                                                                                                                                 | 3.6 kB  00:00:00     
extras                                                                                                                                                                                                               | 2.9 kB  00:00:00     
updates                                                                                                                                                                                                              | 2.9 kB  00:00:00     
wazuh                                                                                                                                                                                                                | 3.4 kB  00:00:00     
(1/5): base/7/x86_64/group_gz                                                                                                                                                                                        | 153 kB  00:00:00     
(2/5): extras/7/x86_64/primary_db                                                                                                                                                                                    | 250 kB  00:00:00     
(3/5): wazuh/primary_db                                                                                                                                                                                              | 404 kB  00:00:01     
(4/5): updates/7/x86_64/primary_db                                                                                                                                                                                   |  24 MB  00:00:03     
(5/5): base/7/x86_64/primary_db                                                                                                                                                                                      | 6.1 MB  00:01:03     
Resolving Dependencies
--> Running transaction check
---> Package filebeat.x86_64 0:7.10.2-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

============================================================================================================================================================================================================================================
 Package                                                   Arch                                                    Version                                                     Repository                                              Size
============================================================================================================================================================================================================================================
Installing:
 filebeat                                                  x86_64                                                  7.10.2-1                                                    wazuh                                                   21 M

Transaction Summary
============================================================================================================================================================================================================================================
Install  1 Package

Total download size: 21 M
Installed size: 70 M
Downloading packages:
filebeat-oss-7.10.2-x86_64.rpm                                                                                                                                                                                       |  21 MB  00:00:03     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : filebeat-7.10.2-1.x86_64                                                                                                                                                                                                 1/1 
  Verifying  : filebeat-7.10.2-1.x86_64                                                                                                                                                                                                 1/1 

Installed:
  filebeat.x86_64 0:7.10.2-1                                                                                                                                                                                                                

Complete!
[root@centos-7 ~]#             curl -so /etc/filebeat/filebeat.yml https://packages.wazuh.com/resources/4.2/open-distro/filebeat/7.x/filebeat.yml
[root@centos-7 ~]#             curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.2/extensions/elasticsearch/7.x/wazuh-template.json
[root@centos-7 ~]#             chmod go+r /etc/filebeat/wazuh-template.json
[root@centos-7 ~]#             curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.2.tar.gz | tar -xvz -C /usr/share/filebeat/module
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/module.yml
[root@centos-7 ~]#             sed -i 's/<elasticsearch_ip>/127.0.0.1/g' /etc/filebeat/filebeat.yml
[root@centos-7 ~]#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0  11764      0 --:--:-- --:--:-- --:--:-- 11756
[root@centos-7 ~]#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
[root@centos-7 ~]#             mkdir -p /etc/filebeat/certs/
[root@centos-7 ~]#             mv ./certs/demo-filebeat-key.pem /etc/filebeat/certs/filebeat-key.pem
[root@centos-7 ~]#             mv ./certs/demo-filebeat.pem /etc/filebeat/certs/filebeat.pem
[root@centos-7 ~]#             mv ./certs/root-ca.pem /etc/filebeat/certs/root-ca.pem
[root@centos-7 ~]#             rm -rf ./certs/
[root@centos-7 ~]#             systemctl daemon-reload
[root@centos-7 ~]#             systemctl enable filebeat
Created symlink from /etc/systemd/system/multi-user.target.wants/filebeat.service to /usr/lib/systemd/system/filebeat.service.
[root@centos-7 ~]#             systemctl start filebeat
[root@centos-7 ~]#             filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
[root@centos-7 ~]# curl -O https://packages-dev.wazuh.com/staging/yum/wazuh-dashboard-4.8.0-40800.x86_64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  268M  100  268M    0     0   9.7M      0  0:00:27  0:00:27 --:--:-- 11.0M
[root@centos-7 ~]# yum localinstall -y wazuh-dashboard-4.8.0-40800.x86_64.rpm 
Loaded plugins: fastestmirror
Examining wazuh-dashboard-4.8.0-40800.x86_64.rpm: wazuh-dashboard-4.8.0-40800.x86_64
Marking wazuh-dashboard-4.8.0-40800.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-dashboard.x86_64 0:4.8.0-40800 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

============================================================================================================================================================================================================================================
 Package                                                Arch                                          Version                                              Repository                                                                  Size
============================================================================================================================================================================================================================================
Installing:
 wazuh-dashboard                                        x86_64                                        4.8.0-40800                                          /wazuh-dashboard-4.8.0-40800.x86_64                                        890 M

Transaction Summary
============================================================================================================================================================================================================================================
Install  1 Package

Total size: 890 M
Installed size: 890 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-dashboard-4.8.0-40800.x86_64                                                                                                                                                                                       1/1 
  Verifying  : wazuh-dashboard-4.8.0-40800.x86_64                                                                                                                                                                                       1/1 

Installed:
  wazuh-dashboard.x86_64 0:4.8.0-40800                                                                                                                                                                                                      

Complete!
[root@centos-7 ~]#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0  10518      0 --:--:-- --:--:-- --:--:-- 10520
[root@centos-7 ~]#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
[root@centos-7 ~]#             mkdir -p /etc/wazuh-dashboard/certs/
[root@centos-7 ~]#             mv ./certs/demo-dashboard-key.pem /etc/wazuh-dashboard/certs/dashboard-key.pem
[root@centos-7 ~]#             mv ./certs/demo-dashboard.pem /etc/wazuh-dashboard/certs/dashboard.pem
[root@centos-7 ~]#             mv ./certs/root-ca.pem /etc/wazuh-dashboard/certs/root-ca.pem
[root@centos-7 ~]#             rm -rf ./certs/
[root@centos-7 ~]#             systemctl daemon-reload
[root@centos-7 ~]#             systemctl enable wazuh-dashboard
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service to /etc/systemd/system/wazuh-dashboard.service.
[root@centos-7 ~]#             systemctl start wazuh-dashboard
[root@centos-7 ~]# ip add
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 52:54:00:4d:77:d3 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global noprefixroute dynamic eth0
       valid_lft 85802sec preferred_lft 85802sec
    inet6 fe80::5054:ff:fe4d:77d3/64 scope link 
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 08:00:27:f9:09:03 brd ff:ff:ff:ff:ff:ff
    inet 192.168.56.249/24 brd 192.168.56.255 scope global noprefixroute eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fef9:903/64 scope link 
       valid_lft forever preferred_lft forever
```
![Screenshot_20231108_121016](https://github.com/wazuh/wazuh-packages/assets/64099752/ce2b0008-b3ac-4a59-8d6e-c527e5e9a058)


</details>

<details>
<summary>Ubuntu Focal</summary>

```console

root@ubuntu20:~# apt install -y /home/vagrant/wazuh-indexer_4.8.0-40800_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-indexer' instead of '/home/vagrant/wazuh-indexer_4.8.0-40800_amd64.deb'
The following NEW packages will be installed:
  wazuh-indexer
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/752 MB of archives.
After this operation, 1050 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-indexer_4.8.0-40800_amd64.deb wazuh-indexer amd64 4.8.0-40800 [752 MB]
Selecting previously unselected package wazuh-indexer.
(Reading database ... 63239 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.8.0-40800_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.8.0-40800) ...
Setting up wazuh-indexer (4.8.0-40800) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Processing triggers for systemd (245.4-4ubuntu3.15) ...
Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
root@ubuntu20:~#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0  12926      0 --:--:-- --:--:-- --:--:-- 12909
root@ubuntu20:~#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
root@ubuntu20:~#             mkdir -p /etc/wazuh-indexer/certs/
root@ubuntu20:~#             mv ./certs/demo-indexer-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
root@ubuntu20:~#             mv ./certs/demo-indexer.pem /etc/wazuh-indexer/certs/indexer.pem
root@ubuntu20:~#             mv ./certs/admin-key.pem /etc/wazuh-indexer/certs/admin-key.pem
root@ubuntu20:~#             mv ./certs/admin.pem /etc/wazuh-indexer/certs/admin.pem
root@ubuntu20:~#             mv ./certs/root-ca.pem /etc/wazuh-indexer/certs/root-ca.pem
root@ubuntu20:~#             rm -rf ./certs/
root@ubuntu20:~#             systemctl daemon-reload
root@ubuntu20:~#             systemctl enable wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.

root@ubuntu20:~#             systemctl start wazuh-indexer
root@ubuntu20:~# /usr/share/wazuh-indexer/bin/indexer-init.sh 
Executing Wazuh indexer security init script...
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
Executing Wazuh indexer ISM init script...
TEMPLATES AND POLICIES - Uploading wazuh-alerts template
TEMPLATES AND POLICIES - Uploading wazuh-archives template
TEMPLATES AND POLICIES - Uploading rollover_policy ISM policy
TEMPLATES AND POLICIES - Creating write indices
root@ubuntu20:~# curl -O https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-manager/wazuh-manager_4.8.0-40800_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  164M  100  164M    0     0  9452k      0  0:00:17  0:00:17 --:--:-- 10.9M
root@ubuntu20:~#             systemctl daemon-reload
root@ubuntu20:~#             systemctl enable wazuh-manager
Failed to enable unit: Unit file wazuh-manager.service does not exist.
root@ubuntu20:~#             systemctl start wazuh-manager
Failed to start wazuh-manager.service: Unit wazuh-manager.service not found.
root@ubuntu20:~# apt install -y ./wazuh-manager_4.8.0-40800_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.8.0-40800_amd64.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/172 MB of archives.
After this operation, 635 MB of additional disk space will be used.
Get:1 /root/wazuh-manager_4.8.0-40800_amd64.deb wazuh-manager amd64 4.8.0-40800 [172 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 64414 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.8.0-40800_amd64.deb ...
Unpacking wazuh-manager (4.8.0-40800) ...
Setting up wazuh-manager (4.8.0-40800) ...
Processing triggers for systemd (245.4-4ubuntu3.15) ...
N: Download is performed unsandboxed as root as file '/root/wazuh-manager_4.8.0-40800_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
root@ubuntu20:~#             systemctl daemon-reload
root@ubuntu20:~#             systemctl enable wazuh-manager
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
root@ubuntu20:~#             systemctl start wazuh-manager
root@ubuntu20:~#             curl -s https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
OK
root@ubuntu20:~#             echo "deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main" | tee -a /etc/apt/sources.list.d/wazuh.list
deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main
root@ubuntu20:~#             apt-get update
Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]                            
Get:3 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]                          
Get:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]               
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]       
Get:6 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [8628 kB]                 
Get:7 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [2569 kB]    
Get:8 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [34.7 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal/universe Translation-en [5124 kB]                  
Get:10 http://archive.ubuntu.com/ubuntu focal/universe amd64 c-n-f Metadata [265 kB]              
Get:11 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]             
Get:12 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]       
Get:13 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 c-n-f Metadata [9136 B]       
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2957 kB]          
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [481 kB]      
Get:16 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [398 kB]        
Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [17.2 kB]                  
Get:18 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [2479 kB]                 
Get:19 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [13.2 kB]        
Get:20 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [2367 kB]             
Get:21 http://archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [346 kB]         
Get:22 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [552 B]      
Get:23 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1128 kB]               
Get:24 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [270 kB]             
Get:25 http://security.ubuntu.com/ubuntu focal-security/restricted Translation-en [329 kB]         
Get:26 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 c-n-f Metadata [552 B]         
Get:27 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [896 kB]              
Get:28 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [188 kB]         
Get:29 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [19.2 kB]    
Get:30 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [23.6 kB]             
Get:31 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [25.7 kB]         
Get:32 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [25.8 kB]                              
Get:33 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [7484 B]                         
Get:34 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [620 B]                          
Get:35 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.7 kB]                                
Get:36 http://archive.ubuntu.com/ubuntu focal-backports/main Translation-en [16.3 kB]                             
Get:37 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [1420 B]                             
Get:38 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]       
Get:39 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [25.0 kB]                            
Get:40 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [16.3 kB]                          
Get:41 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [880 B]                          
Get:42 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]                      
Get:43 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [5504 B]                           
Get:44 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [548 B]
Fetched 29.3 MB in 7s (4493 kB/s)                                                                                                                                                                                                          
Reading package lists... Done
root@ubuntu20:~#             apt-get install filebeat -y
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  filebeat
0 upgraded, 1 newly installed, 0 to remove and 236 not upgraded.
Need to get 22.1 MB of archives.
After this operation, 73.6 MB of additional disk space will be used.
Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 filebeat amd64 7.10.2 [22.1 MB]
Fetched 22.1 MB in 5s (4765 kB/s)   
Selecting previously unselected package filebeat.
(Reading database ... 85733 files and directories currently installed.)
Preparing to unpack .../filebeat_7.10.2_amd64.deb ...
Unpacking filebeat (7.10.2) ...
Setting up filebeat (7.10.2) ...
Processing triggers for systemd (245.4-4ubuntu3.15) ...
root@ubuntu20:~#             curl -so /etc/filebeat/filebeat.yml https://packages.wazuh.com/resources/4.2/open-distro/filebeat/7.x/filebeat.yml
root@ubuntu20:~#             curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.2/extensions/elasticsearch/7.x/wazuh-template.json
root@ubuntu20:~#             chmod go+r /etc/filebeat/wazuh-template.json
root@ubuntu20:~#             curl -s https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.1.tar.gz | tar -xvz -C /usr/share/filebeat/module
wazuh/
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/fields.yml
wazuh/_meta/docs.asciidoc
root@ubuntu20:~#             sed -i 's/<elasticsearch_ip>/127.0.0.1/g' /etc/filebeat/filebeat.yml
root@ubuntu20:~#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10005  100 10005    0     0  12696      0 --:--:-- --:--:-- --:--:-- 12680
root@ubuntu20:~#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
root@ubuntu20:~#             mkdir -p /etc/filebeat/certs/
root@ubuntu20:~#             mv ./certs/demo-filebeat-key.pem /etc/filebeat/certs/filebeat-key.pem
root@ubuntu20:~#             mv ./certs/demo-filebeat.pem /etc/filebeat/certs/filebeat.pem
root@ubuntu20:~#             mv ./certs/root-ca.pem /etc/filebeat/certs/root-ca.pem
root@ubuntu20:~#             rm -rf ./certs/systemctl daemon-reload
root@ubuntu20:~#             systemctl enable filebeat
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
root@ubuntu20:~#             systemctl start filebeat
root@ubuntu20:~#             filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
root@ubuntu20:~# curl -O https://packages-dev.wazuh.com/staging/apt/pool/main/w/wazuh-dashboard/wazuh-dashboard_4.8.0-40800_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  174M  100  174M    0     0  9474k      0  0:00:18  0:00:18 --:--:-- 11.1M
root@ubuntu20:~# apt install -y ./wazuh-dashboard_4.8.0-40800_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'wazuh-dashboard' instead of './wazuh-dashboard_4.8.0-40800_amd64.deb'
The following NEW packages will be installed:
  wazuh-dashboard
0 upgraded, 1 newly installed, 0 to remove and 236 not upgraded.
Need to get 0 B/183 MB of archives.
After this operation, 974 MB of additional disk space will be used.
Get:1 /root/wazuh-dashboard_4.8.0-40800_amd64.deb wazuh-dashboard amd64 4.8.0-40800 [183 MB]
Selecting previously unselected package wazuh-dashboard.
(Reading database ... 86052 files and directories currently installed.)
Preparing to unpack .../wazuh-dashboard_4.8.0-40800_amd64.deb ...
Creating wazuh-dashboard group... OK
Creating wazuh-dashboard user... OK
Unpacking wazuh-dashboard (4.8.0-40800) ...
Setting up wazuh-dashboard (4.8.0-40800) ...
N: Download is performed unsandboxed as root as file '/root/wazuh-dashboard_4.8.0-40800_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
root@ubuntu20:~#             curl -O https://s3.amazonaws.com/warehouse.wazuh.com/stack/demo-certs.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 10005  100 10005    0     0  10587      0 --:--:-- --:--:-- --:--:-- 10576
root@ubuntu20:~#             tar -xf demo-certs.tar.gz && rm -f demo-certs.tar.gz
root@ubuntu20:~#             mkdir -p /etc/wazuh-dashboard/certs/
root@ubuntu20:~#             mv ./certs/demo-dashboard-key.pem /etc/wazuh-dashboard/certs/dashboard-key.pem
root@ubuntu20:~#             mv ./certs/demo-dashboard.pem /etc/wazuh-dashboard/certs/dashboard.pem
root@ubuntu20:~#             mv ./certs/root-ca.pem /etc/wazuh-dashboard/certs/root-ca.pem
root@ubuntu20:~#             rm -rf ./certs/
root@ubuntu20:~#             systemctl daemon-reload
root@ubuntu20:~#             systemctl enable wazuh-dashboard
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
root@ubuntu20:~#             systemctl start wazuh-dashboard
root@ubuntu20:~# ip add
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 02:2e:89:e3:fa:23 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global dynamic enp0s3
       valid_lft 85696sec preferred_lft 85696sec
    inet6 fe80::2e:89ff:fee3:fa23/64 scope link 
       valid_lft forever preferred_lft forever
3: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:83:e3:ab brd ff:ff:ff:ff:ff:ff
    inet 192.168.56.253/24 brd 192.168.56.255 scope global enp0s8
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fe83:e3ab/64 scope link 
       valid_lft forever preferred_lft forever
```
![Screenshot_20231108_122430](https://github.com/wazuh/wazuh-packages/assets/64099752/b8df2d53-a625-48e9-b8a3-5de21626345f)



</details>

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
