### PR TITLE
Extend `indexer-init.sh` to accept arguments

### DIFF
--- a/stack/indexer/indexer-init.sh
+++ b/stack/indexer/indexer-init.sh
@@ -5,11 +5,134 @@
 INSTALL_PATH="/usr/share/wazuh-indexer"
 BIN_PATH="${INSTALL_PATH}/bin"
 
-main() {
-    echo "Executing Wazuh indexer security init script..."
-    /bin/bash "${BIN_PATH}/indexer-security-init.sh"
-    echo "Executing Wazuh indexer ISM init script..."
-    /bin/bash "${BIN_PATH}/indexer-ism-init.sh"
+
+#########################################################################
+# Parse arguments for security init script.
+#########################################################################
+function parse_security_args() {
+    security_args=()
+
+    while [ -n "$1" ]; do
+        case "$1" in
+        "-h" | "--help")
+            security_args+=("${1}")
+            shift
+            ;;
+        "-ho" | "--host")
+            if [ -n "$2" ]; then
+                security_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "--port")
+            if [ -n "$2" ]; then
+                security_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "--options")
+            if [ -n "$2" ]; then
+                security_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        *)
+            shift
+            ;;
+        esac
+    done
 }
+
+
+#########################################################################
+# Run the security init script.
+#########################################################################
+function run_security_init() {
+    echo "Executing Wazuh indexer security init script..."
+    parse_security_args "$@"
+    /bin/bash "${BIN_PATH}/indexer-security-init.sh" "${security_args[@]}"
+}
+
+
+#########################################################################
+# Parse arguments for ISM init script.
+#########################################################################
+function parse_ism_args() {
+    ism_args=()
+
+    while [ -n "${1}" ]; do
+        case "${1}" in
+        "-a" | "--min-index-age")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-d" | "--min-doc-count")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-h" | "--help")
+            ism_args+=("${1}")
+            shift
+            ;;
+        "-i" | "--indexer-hostname")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-p" | "--indexer-password")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-s" | "--min-shard-size")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-P" | "--priority")
+            if [ -n "${2}" ]; then
+                ism_args+=("${1}" "${2}")
+                shift 2
+            fi
+            ;;
+        "-v" | "--verbose")
+            ism_args+=("${1}")
+            shift
+            ;;
+        *)
+            shift
+            ;;
+        esac
+    done
+}
+
+
+#########################################################################
+# Run the ISM init script.
+#########################################################################
+function run_ism_init() {
+    echo "Executing Wazuh indexer ISM init script..."
+    parse_ism_args "$@"
+    /bin/bash "${BIN_PATH}/indexer-ism-init.sh" "${ism_args[@]}";
+}
+
+
+#########################################################################
+# Main function.
+#########################################################################
+function main() {
+    # If run_security_init returns 0, then run_ism_init
+    if run_security_init "$@" -gt 0; then
+        run_ism_init "$@"
+    fi
+}
+
 
 main "$@"

--- a/stack/indexer/indexer-security-init.sh
+++ b/stack/indexer/indexer-security-init.sh
@@ -122,7 +122,7 @@ help() {
     echo "Usage: $0 [OPTIONS]"
     echo
     echo "    -ho, --host <host>    [Optional] Target IP or DNS to configure security."
-    echo "    -p, --port <port>     [Optional] wazuh-indexer security port."
+    echo "    --port <port>         [Optional] wazuh-indexer security port."
     echo "    --options <options>   [Optional] Custom securityadmin options."
     echo "    -h, --help            Show this help."
     echo
@@ -156,7 +156,7 @@ main() {
                 help 1
             fi
             ;;
-        "-p"|"--port")
+        "--port")
             if [ -n "$2" ]; then
                 PORT="$2"
                 PORT=$(echo "${PORT}" | tr -d "[\"\']")


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/internal-devel-requests/issues/425 |


## Description

This PR extends the `indexer-init.sh` script to accept arguments. The children scripts (`indexer-security-init.sh` and `indexer-ism-init.sh`) receive only the arguments that they accept / need.

This fixes the problem described in https://github.com/wazuh/internal-devel-requests/issues/425#issuecomment-1804171066.

Moreover, now the `indexer-ism-init.sh` script is only executed if the `indexer-security-init.sh` exits correctly (code 0). This is a requirement which was not handled before.

## Logs example

Test cases

1. Invalid arguments in `indexer-security-init.sh`

    <details><summary>Details</summary>
    <p>
    
    ```
    bash /usr/share/wazuh-indexer/bin/indexer-init.sh -ho null
    Executing Wazuh indexer security init script...
    The given information does not match with an IP address or a DNS.
    ```
    
    </p>
    </details> 

2. Invalid arguments in `indexer-ism-init.sh`

    In this case, the `indexer-security-init.sh` succeeds and the `indexer-ism-init.sh` fails, as expected.


3. Show help option

    <details><summary>Details</summary>
    <p>
    
    ```
    bash /usr/share/wazuh-indexer/bin/indexer-init.sh -h
    Executing Wazuh indexer security init script...
    
    Usage: /usr/share/wazuh-indexer/bin/indexer-security-init.sh [OPTIONS]
    
        -ho, --host <host>    [Optional] Target IP or DNS to configure security.
        --port <port>         [Optional] wazuh-indexer security port.
        --options <options>   [Optional] Custom securityadmin options.
        -h, --help            Show this help.
    
    Executing Wazuh indexer ISM init script...
    
    NAME
            indexer-ism-init.sh - Manages the Index State Management plugin for Wazuh indexer index rollovers policies.
    
    SYNOPSIS
            indexer-ism-init.sh [OPTIONS]
    
    DESCRIPTION
            -a,  --min-index-age <index-age>
                    Set the minimum index age. By default 7d.
    
            -d, --min-doc-count <doc-count>
                    Set the minimum document count. By default 200000000.
    
            -h,  --help
                    Shows help.
    
            -i, --indexer-hostname <hostname>
                    Specifies the Wazuh indexer hostname or IP.
    
            -p, --indexer-password <password>
                    Specifies the Wazuh indexer admin user password.
    
            -P, --priority <priority>
                    Specifies the policy's priority.
    
            -s, --min-shard-size <shard-size>
                    Set the minimum shard size in GB. By default 25.
    
            -v, --verbose
                    Set verbose mode. Prints more information.
    ```

4. Valid arguments and successful execution

    <details><summary>Details</summary>
    <p>
    
    ```
    bash /usr/share/wazuh-indexer/bin/indexer-init.sh -ho 192.168.56.10 -a 30d -d 1000 -i 192.168.56.10 -s 5 -p admin -P 1
    Executing Wazuh indexer security init script...
    **************************************************************************
    ** This tool will be deprecated in the next major release of OpenSearch **
    ** https://github.com/opensearch-project/security/issues/1755           **
    **************************************************************************
    Security Admin v7
    Will connect to 192.168.56.10:9200 ... done
    Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
    OpenSearch Version: 2.10.0
    Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
    Clustername: wazuh-indexer-cluster
    Clusterstate: GREEN
    Number of nodes: 2
    Number of data nodes: 2
    .opendistro_security index already exists, so we do not need to create one.
    Populate config from /etc/wazuh-indexer/opensearch-security/
    Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
       SUCC: Configuration for 'config' created or updated
    Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
       SUCC: Configuration for 'roles' created or updated
    Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
       SUCC: Configuration for 'rolesmapping' created or updated
    Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
       SUCC: Configuration for 'internalusers' created or updated
    Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
       SUCC: Configuration for 'actiongroups' created or updated
    Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
       SUCC: Configuration for 'tenants' created or updated
    Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
       SUCC: Configuration for 'nodesdn' created or updated
    Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
       SUCC: Configuration for 'whitelist' created or updated
    Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
       SUCC: Configuration for 'audit' created or updated
    Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
       SUCC: Configuration for 'allowlist' created or updated
    SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
    SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
    Done with success
    Executing Wazuh indexer ISM init script...
    wazuh-alerts template uploaded
    wazuh-archives template uploaded
    rollover_policy policy already exists
    Indexer ISM initialization finished successfully
    ```
    
    </p>
    </details> 

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
