### PR TITLE
Update the initialize cluster script in the offline installation workflow

### DIFF
--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -77,10 +77,10 @@ function dashboard_installation() {
         enable_start_service "wazuh-dashboard"
     elif [ "${sys_type}" == "rpm" ]; then
         /usr/share/wazuh-dashboard/bin/opensearch-dashboards "-c /etc/wazuh-dashboard/opensearch_dashboards.yml" --allow-root > /dev/null 2>&1 &
-    fi  
+    fi
 
     sleep 10
-    # In this context, 302 HTTP code refers to SSL certificates warning: success. 
+    # In this context, 302 HTTP code refers to SSL certificates warning: success.
     if [ "$(curl -k -s -I -w "%{http_code}" https://localhost -o /dev/null --fail)" -ne "302" ]; then
         echo "ERROR: The Wazuh dashboard installation has failed."
         exit 1
@@ -91,7 +91,7 @@ function dashboard_installation() {
 
 function download_resources() {
 
-    check_file "${ABSOLUTE_PATH}"/wazuh-install.sh 
+    check_file "${ABSOLUTE_PATH}"/wazuh-install.sh
     bash "${ABSOLUTE_PATH}"/wazuh-install.sh -dw "${sys_type}"
     echo "INFO: Downloading the resources..."
 
@@ -118,7 +118,7 @@ function download_resources() {
 }
 
 function enable_start_service() {
-    
+
     systemctl daemon-reload
     systemctl enable "${1}"
     systemctl start "${1}"
@@ -166,7 +166,7 @@ function filebeat_installation() {
         enable_start_service "filebeat"
     elif [ "${sys_type}" == "rpm" ]; then
         /usr/share/filebeat/bin/filebeat --environment systemd -c /etc/filebeat/filebeat.yml --path.home /usr/share/filebeat --path.config /etc/filebeat --path.data /var/lib/filebeat --path.logs /var/log/filebeat &
-    fi    
+    fi
 
     sleep 10
     check_shards
@@ -190,7 +190,7 @@ function indexer_initialize() {
         echo "ERROR: The indexer node is not started."
         exit 1
     fi
-    /usr/share/wazuh-indexer/bin/indexer-security-init.sh
+    /usr/share/wazuh-indexer/bin/indexer-init.sh
 
 }
 
@@ -199,10 +199,10 @@ function indexer_installation() {
     if [ "${sys_type}" == "rpm" ]; then
         rpm --import ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH
     fi
-    
-    install_package "wazuh-indexer" 
+
+    install_package "wazuh-indexer"
     check_package "wazuh-indexer"
-    
+
     echo "INFO: Generating certificates of the Wazuh indexer..."
     NODE_NAME=node-1
     mkdir /etc/wazuh-indexer/certs
@@ -293,7 +293,7 @@ function install_package() {
         dpkg -i ./wazuh-offline/wazuh-packages/"${1}"*.deb
     elif [ "${sys_type}" == "rpm" ]; then
         rpm -ivh ./wazuh-offline/wazuh-packages/"${1}"*.rpm
-    fi    
+    fi
 
 }
 
@@ -306,6 +306,6 @@ function manager_installation() {
         enable_start_service "wazuh-manager"
     elif [ "${sys_type}" == "rpm" ]; then
         /var/ossec/bin/wazuh-control start
-    fi 
+    fi
 
 }

--- a/.github/workflows/offline-installation.yml
+++ b/.github/workflows/offline-installation.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     paths:
       - 'unattended_installer/install_functions/wazuh-offline-download.sh'
-      
+  workflow_dispatch:
+
 jobs:
   Build-wazuh-install-script:
     runs-on: ubuntu-latest
@@ -28,7 +29,7 @@ jobs:
           path: |
             unattended_installer/wazuh-install.sh
           if-no-files-found: error
-          
+
   Test-offline-installation-debian:
     runs-on: ubuntu-latest
     needs: Build-wazuh-install-script
@@ -41,7 +42,7 @@ jobs:
 
       - name: Move unattended script
         run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
-      
+
       - name: Run script
         run: sudo bash $GITHUB_WORKSPACE/.github/actions/offline-installation/offline-installation.sh
 
@@ -54,9 +55,9 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: script
-      
+
       - name: Move unattended script
         run: cp $GITHUB_WORKSPACE/wazuh-install.sh $GITHUB_WORKSPACE/.github/actions/offline-installation/wazuh-install.sh
-      
+
       - name: Launch docker and run script
         run: sudo docker run -v $GITHUB_WORKSPACE/.github/actions/offline-installation/:/tests centos:centos7 bash /tests/offline-installation.sh


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/internal-devel-requests/issues/440|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This pull request updates the script used to initialize the Wazuh indexer cluster using the new script and adds the `workflow_dispatch` to the offline installation workflow

## Logs example

- https://github.com/wazuh/wazuh-packages/pull/2591/checks
