### PR TITLE
Updated Filebeat module version to 0.3

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -71,7 +71,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages-dev.wazuh.com/'${devrepo}'"' >> "${output_script_path}"
         echo 'readonly reporelease="unstable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
         sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
@@ -79,7 +79,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
         echo 'readonly reporelease="stable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="4.x"' >> "${output_script_path}"
     fi


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2604|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Updated Filebeat module version to 0.3

## Logs example

<!--
Paste here related logs
-->

<details>
<summary>Installation</summary>

```console
root@ubuntu20:~# git clone https://github.com/wazuh/wazuh-packages.git
Cloning into 'wazuh-packages'...
remote: Enumerating objects: 57380, done.
remote: Counting objects: 100% (453/453), done.
remote: Compressing objects: 100% (258/258), done.
remote: Total 57380 (delta 225), reused 357 (delta 178), pack-reused 56927
Receiving objects: 100% (57380/57380), 16.86 MiB | 8.47 MiB/s, done.
Resolving deltas: 100% (36008/36008), done.
root@ubuntu20:~# cd wazuh-packages/
root@ubuntu20:~/wazuh-packages# git checkout change/2604-update-filebeat-module-to-03-version-in-unattended 
Branch 'change/2604-update-filebeat-module-to-03-version-in-unattended' set up to track remote branch 'change/2604-update-filebeat-module-to-03-version-in-unattended' from 'origin'.
Switched to a new branch 'change/2604-update-filebeat-module-to-03-version-in-unattended'
root@ubuntu20:~/wazuh-packages# cd unattended_installer/
root@ubuntu20:~/wazuh-packages/unattended_installer# bash builder -i -d
bash: builder: No such file or directory
root@ubuntu20:~/wazuh-packages/unattended_installer# bash builder.sh -i -d
root@ubuntu20:~/wazuh-packages/unattended_installer# bash wazuh-install.sh -a -v
14/11/2023 15:20:23 INFO: Starting Wazuh installation assistant. Wazuh version: 4.7.0
14/11/2023 15:20:23 INFO: Verbose logging redirected to /var/log/wazuh-install.log
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:4 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [2569 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [8628 kB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [398 kB]
Get:8 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [13.2 kB]
Get:9 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [2367 kB]
Get:10 http://security.ubuntu.com/ubuntu focal-security/restricted Translation-en [329 kB]
Get:11 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 c-n-f Metadata [552 B]
Get:12 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [897 kB]
Get:13 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [188 kB]
Get:14 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [19.2 kB]
Get:15 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [23.6 kB]
Get:16 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [5504 B]
Get:17 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [548 B]
Get:18 http://archive.ubuntu.com/ubuntu focal/universe Translation-en [5124 kB]
Get:19 http://archive.ubuntu.com/ubuntu focal/universe amd64 c-n-f Metadata [265 kB]
Get:20 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [144 kB]
Get:21 http://archive.ubuntu.com/ubuntu focal/multiverse Translation-en [104 kB]
Get:22 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 c-n-f Metadata [9136 B]
Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2959 kB]
Get:24 http://archive.ubuntu.com/ubuntu focal-updates/main Translation-en [481 kB]
Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [17.2 kB]
Get:26 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [2479 kB]
Get:27 http://archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [346 kB]
Get:28 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [552 B]
Get:29 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1130 kB]
Get:30 http://archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [270 kB]
Get:31 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [25.7 kB]
Get:32 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [25.8 kB]
Get:33 http://archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [7484 B]
Get:34 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [620 B]
Get:35 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.7 kB]
Get:36 http://archive.ubuntu.com/ubuntu focal-backports/main Translation-en [16.3 kB]
Get:37 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [1420 B]
Get:38 http://archive.ubuntu.com/ubuntu focal-backports/restricted amd64 c-n-f Metadata [116 B]
Get:39 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [25.0 kB]
Get:40 http://archive.ubuntu.com/ubuntu focal-backports/universe Translation-en [16.3 kB]
Get:41 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [880 B]
Get:42 http://archive.ubuntu.com/ubuntu focal-backports/multiverse amd64 c-n-f Metadata [116 B]
Fetched 29.3 MB in 6s (4851 kB/s)
Reading package lists...
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Reading package lists...
14/11/2023 15:20:46 INFO: Wazuh web interface port will be 443.
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Reading package lists...
14/11/2023 15:20:49 INFO: --- Dependencies ----
14/11/2023 15:20:49 INFO: Installing apt-transport-https.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: apt-transport-https 0 upgraded, 1 newly installed, 0 to remove and 238 not upgraded. Need to get 1704 B of archives. After this operation, 162 kB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 apt-transport-https all 2.0.9 [1704 B] Fetched 1704 B in 0s (4436 B/s) Selecting previously Setting up apt-transport-https (2.0.9) ...s_2.0.9_all.deb ...stalled.)
14/11/2023 15:20:54 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: directory '/root/.gnupg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [34.7 kB]
Fetched 51.9 kB in 3s (20.5 kB/s)
Reading package lists...
14/11/2023 15:20:59 INFO: Wazuh development repository added.
14/11/2023 15:20:59 INFO: --- Configuration files ---
14/11/2023 15:20:59 INFO: Generating configuration files.
14/11/2023 15:20:59 DEBUG: Creating the root certificate.
Generating a RSA private key
..........................................................+++++
.....+++++
writing new private key to '/tmp/wazuh-certificates//root-ca.key'
-----
Generating RSA private key, 2048 bit long modulus (2 primes)
..................................................+++++
...........................................................................+++++
e is 65537 (0x010001)
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
Getting CA Private Key
14/11/2023 15:20:59 DEBUG: Creating the Wazuh indexer certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
...........+++++
.....+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-indexer-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-indexer
Getting CA Private Key
14/11/2023 15:20:59 DEBUG: Creating the Wazuh server certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
..........+++++
............................................................................................................................................................................................................+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-server-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-server
Getting CA Private Key
14/11/2023 15:20:59 DEBUG: Creating the Wazuh dashboard certificates.
Ignoring -days; not generating a certificate
Generating a RSA private key
......+++++
..........................................................................................+++++
writing new private key to '/tmp/wazuh-certificates//wazuh-dashboard-key.pem'
-----
Signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-dashboard
Getting CA Private Key
14/11/2023 15:21:00 DEBUG: Generating random passwords.
14/11/2023 15:21:00 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
14/11/2023 15:21:00 INFO: --- Wazuh indexer ---
14/11/2023 15:21:00 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 238 not upgraded. Need to get 677 MB of archives. After this operation, 969 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-indexer amd64 4.7.0-1 [677 MB] Fetched 677 MB in 1min 15s (9080 kB/s) Selecting previo Processing triggers for libc-bin (2.31-0ubuntu9.2) ....earch.keystore)
14/11/2023 15:22:56 INFO: Wazuh indexer installation finished.
14/11/2023 15:22:56 DEBUG: Configuring Wazuh indexer.
14/11/2023 15:22:56 INFO: Wazuh indexer post-install configuration finished.
14/11/2023 15:22:56 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
14/11/2023 15:23:05 INFO: wazuh-indexer service started.
14/11/2023 15:23:05 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.8.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
14/11/2023 15:23:16 INFO: Wazuh indexer cluster initialized.
14/11/2023 15:23:16 INFO: --- Wazuh server ---
14/11/2023 15:23:16 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 238 not upgraded. Need to get 171 MB of archives. After this operation, 629 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-manager amd64 4.7.0-1 [171 MB] Fetched 171 MB in 20s (8388  Processing triggers for systemd (245.4-4ubuntu3.15) ... ...installed.)
14/11/2023 15:24:18 INFO: Wazuh manager installation finished.
14/11/2023 15:24:18 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
14/11/2023 15:24:35 INFO: wazuh-manager service started.
14/11/2023 15:24:35 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 238 not upgraded. Need to get 22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 filebeat amd64 7.10.2 [22.1 MB] Fetched 22.1 MB in 5s (4286 kB/s) Selecting previously unselect Processing triggers for systemd (245.4-4ubuntu3.15) ...tly installed.)
14/11/2023 15:24:48 INFO: Filebeat installation finished.
wazuh/
wazuh/archives/
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/module.yml
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
14/11/2023 15:24:49 INFO: Filebeat post-install configuration finished.
14/11/2023 15:24:49 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
14/11/2023 15:24:50 INFO: filebeat service started.
14/11/2023 15:24:50 INFO: --- Wazuh dashboard ---
14/11/2023 15:24:51 INFO: Installing chrome.
Reading package lists... Building dependency tree... Reading state information... The following additional packages will be installed: adwaita-icon-theme at-spi2-core cpp cpp-9 fontconfig fontconfig-config fonts-liberation gcc-9-base gtk-update-icon-cache hicolor-icon-theme humanity-icon-theme libatk-bridge2.0-0 libatk1.0-0 libatk1.0-data libatspi2.0-0 libauthen-sasl-perl libavahi-client3 libavahi-common-data libavahi-common3 libcairo-gobject2 libcairo2 libcolord2 libcups2 libdata-dump-perl libdatrie1 libdrm-amdgpu1 libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libencode-locale-perl libepoxy0 libfile-basedir-perl libfile-desktopentry-perl libfile-listing-perl libfile-mimeinfo-perl libfont-afm-perl libfontconfig1 libfontenc1 libgbm1 libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-bin libgdk-pixbuf2.0-common libgl1 libgl1-mesa-dri libglapi-mesa libglvnd0 libglx-mesa0 libglx0 libgraphite2-3 libgtk-3-0 libgtk-3-bin libgtk-3-common libharfbuzz0b libhtml-form-perl libhtml-format-perl libhtml-parser-perl libhtml-tagset-perl libhtml-tree-perl libhttp-cookies-perl libhttp-daemon-perl libhttp-date-perl libhttp-message-perl libhttp-negotiate-perl libice6 libio-html-perl libio-socket-ssl-perl libio-stringy-perl libipc-system-simple-perl libisl22 libjbig0 libjpeg-turbo8 libjpeg8 liblcms2-2 libllvm12 liblwp-mediatypes-perl liblwp-protocol-https-perl libmailtools-perl libmpc3 libnet-dbus-perl libnet-http-perl libnet-smtp-ssl-perl libnet-ssleay-perl libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpciaccess0 libpixman-1-0 librest-0.7-0 librsvg2-2 librsvg2-common libsensors-config libsensors5 libsm6 libsoup-gnome2.4-1 libthai-data libthai0 libtie-ixhash-perl libtiff5 libtimedate-perl libtry-tiny-perl libu2f-udev liburi-perl libvulkan1 libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 libwebp6 libwww-perl libwww-robotrules-perl libx11-protocol-perl libx11-xcb1 libxaw7 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-randr0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxft2 libxi6 libxinerama1 libxkbcommon0 libxkbfile1 libxml-parser-perl libxml-twig-perl libxml-xpathengine-perl libxmu6 libxpm4 libxrandr2 libxrender1 libxshmfence1 libxt6 libxtst6 libxv1 libxxf86dga1 libxxf86vm1 mesa-vulkan-drivers perl-openssl-defaults ubuntu-mono x11-common x11-utils x11-xserver-utils xdg-utils Suggested packages: cpp-doc gcc-9-locales libdigest-hmac-perl libgssapi-perl colord cups-common gvfs liblcms2-utils libcrypt-ssleay-perl librsvg2-bin lm-sensors libauthen-ntlm-perl libunicode-map8-perl libunicode-string-perl xml-twig-tools mesa-utils nickle cairo-5c xorg-docs-core The following NEW packages will be installed: adwaita-icon-theme at-spi2-core cpp cpp-9 fontconfig fontconfig-config fonts-liberation gcc-9-base google-chrome-stable gtk-update-icon-cache hicolor-icon-theme humanity-icon-theme libatk-bridge2.0-0 libatk1.0-0 libatk1.0-data libatspi2.0-0 libauthen-sasl-perl libavahi-client3 libavahi-common-data libavahi-common3 libcairo-gobject2 libcairo2 libcolord2 libcups2 libdata-dump-perl libdatrie1 libdrm-amdgpu1 libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libencode-locale-perl libepoxy0 libfile-basedir-perl libfile-desktopentry-perl libfile-listing-perl libfile-mimeinfo-perl libfont-afm-perl libfontconfig1 libfontenc1 libgbm1 libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-bin libgdk-pixbuf2.0-common libgl1 libgl1-mesa-dri libglapi-mesa libglvnd0 libglx-mesa0 libglx0 libgraphite2-3 libgtk-3-0 libgtk-3-bin libgtk-3-common libharfbuzz0b libhtml-form-perl libhtml-format-perl libhtml-parser-perl libhtml-tagset-perl libhtml-tree-perl libhttp-cookies-perl libhttp-daemon-perl libhttp-date-perl libhttp-message-perl libhttp-negotiate-perl libice6 libio-html-perl libio-socket-ssl-perl libio-stringy-perl libipc-system-simple-perl libisl22 libjbig0 libjpeg-turbo8 libjpeg8 liblcms2-2 libllvm12 liblwp-mediatypes-perl liblwp-protocol-https-perl libmailtools-perl libmpc3 libnet-dbus-perl libnet-http-perl libnet-smtp-ssl-perl libnet-ssleay-perl libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpciaccess0 libpixman-1-0 librest-0.7-0 librsvg2-2 librsvg2-common libsensors-config libsensors5 libsm6 libsoup-gnome2.4-1 libthai-data libthai0 libtie-ixhash-perl libtiff5 libtimedate-perl libtry-tiny-perl libu2f-udev liburi-perl libvulkan1 libwayland-client0 libwayland-cursor0 libwayland-egl1 libwayland-server0 libwebp6 libwww-perl libwww-robotrules-perl libx11-protocol-perl libx11-xcb1 libxaw7 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-randr0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxft2 libxi6 libxinerama1 libxkbcommon0 libxkbfile1 libxml-parser-perl libxml-twig-perl libxml-xpathengine-perl libxmu6 libxpm4 libxrandr2 libxrender1 libxshmfence1 libxt6 libxtst6 libxv1 libxxf86dga1 libxxf86vm1 mesa-vulkan-drivers perl-openssl-defaults ubuntu-mono x11-common x11-utils x11-xserver-utils xdg-utils 0 upgraded, 153 newly installed, 0 to remove and 238 not upgraded. Need to get 62.9 MB/167 MB of archives. After this operation, 969 MB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 fonts-liberation all 1:1.07.4-11 [822 kB] Get:2 /tmp/wazuh-install-files/chrome.deb google-chrome-stable amd64 119.0.6045.123-1 [104 MB] Get:3 http://archive.ubuntu.com/ubuntu focal/main amd64 libatk1.0-data all 2.35.1-1ubuntu2 [2964 B] Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 libatk1.0-0 amd64 2.35.1-1ubuntu2 [45.5 kB] Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 libatspi2.0-0 amd64 2.36.0-2 [64.2 kB] Get:6 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libatk-bridge2.0-0 amd64 2.34.2-0ubuntu2~20.04.1 [58.2 kB] Get:7 http://archive.ubuntu.com/ubuntu focal/main amd64 fontconfig-config all 2.13.1-2ubuntu3 [28.8 kB] Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 libfontconfig1 amd64 2.13.1-2ubuntu3 [114 kB] Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpixman-1-0 amd64 0.38.4-0ubuntu2.1 [227 kB] Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-render0 amd64 1.14-2 [14.8 kB] Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-shm0 amd64 1.14-2 [5584 B] Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libxrender1 amd64 1:0.9.10-1 [18.7 kB] Get:13 http://archive.ubuntu.com/ubuntu focal/main amd64 libcairo2 amd64 1.16.0-4ubuntu1 [583 kB] Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libavahi-common-data amd64 0.7-4ubuntu7.2 [21.4 kB] Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libavahi-common3 amd64 0.7-4ubuntu7.2 [21.7 kB] Get:16 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libavahi-client3 amd64 0.7-4ubuntu7.2 [25.5 kB] Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcups2 amd64 2.3.1-9ubuntu1.6 [233 kB] Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwayland-server0 amd64 1.18.0-1ubuntu0.1 [31.3 kB] Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgbm1 amd64 21.2.6-0ubuntu0.1~20.04.2 [29.2 kB] Get:20 http://archive.ubuntu.com/ubuntu focal/main amd64 hicolor-icon-theme all 0.17-2 [9976 B] Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libjpeg-turbo8 amd64 2.0.3-0ubuntu1.20.04.3 [118 kB] Get:22 http://archive.ubuntu.com/ubuntu focal/main amd64 libjpeg8 amd64 8c-2ubuntu8 [2194 B] Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libjbig0 amd64 2.1-3.1ubuntu0.20.04.1 [27.3 kB] Get:24 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwebp6 amd64 0.6.1-2ubuntu0.20.04.3 [185 kB] Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libtiff5 amd64 4.1.0+git191117-2ubuntu0.20.04.10 [163 kB] Get:26 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgdk-pixbuf2.0-common all 2.40.0+dfsg-3ubuntu0.4 [4592 B] Get:27 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgdk-pixbuf2.0-0 amd64 2.40.0+dfsg-3ubuntu0.4 [168 kB] Get:28 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 gtk-update-icon-cache amd64 3.24.20-0ubuntu1.1 [28.8 kB] Get:29 http://archive.ubuntu.com/ubuntu focal/main amd64 libcairo-gobject2 amd64 1.16.0-4ubuntu1 [17.2 kB] Get:30 http://archive.ubuntu.com/ubuntu focal/main amd64 fontconfig amd64 2.13.1-2ubuntu3 [171 kB] Get:31 http://archive.ubuntu.com/ubuntu focal/main amd64 libgraphite2-3 amd64 1.3.13-11build1 [73.5 kB] Get:32 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libharfbuzz0b amd64 2.6.4-1ubuntu4.2 [391 kB] Get:33 http://archive.ubuntu.com/ubuntu focal/main amd64 libthai-data all 0.1.28-3 [134 kB] Get:34 http://archive.ubuntu.com/ubuntu focal/main amd64 libdatrie1 amd64 0.2.12-3 [18.7 kB] Get:35 http://archive.ubuntu.com/ubuntu focal/main amd64 libthai0 amd64 0.1.28-3 [18.1 kB] Get:36 http://archive.ubuntu.com/ubuntu focal/main amd64 libpango-1.0-0 amd64 1.44.7-2ubuntu4 [162 kB] Get:37 http://archive.ubuntu.com/ubuntu focal/main amd64 libpangoft2-1.0-0 amd64 1.44.7-2ubuntu4 [34.9 kB] Get:38 http://archive.ubuntu.com/ubuntu focal/main amd64 libpangocairo-1.0-0 amd64 1.44.7-2ubuntu4 [24.8 kB] Get:39 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 librsvg2-2 amd64 2.48.9-1ubuntu0.20.04.4 [2313 kB] Get:40 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 librsvg2-common amd64 2.48.9-1ubuntu0.20.04.4 [9224 B] Get:41 http://archive.ubuntu.com/ubuntu focal/main amd64 humanity-icon-theme all 0.6.15 [1250 kB] Get:42 http://archive.ubuntu.com/ubuntu focal/main amd64 ubuntu-mono all 19.04-0ubuntu3 [147 kB] Get:43 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 adwaita-icon-theme all 3.36.1-2ubuntu0.20.04.2 [3441 kB] Get:44 http://archive.ubuntu.com/ubuntu focal/main amd64 liblcms2-2 amd64 2.9-4 [140 kB] Get:45 http://archive.ubuntu.com/ubuntu focal/main amd64 libcolord2 amd64 1.4.4-2 [133 kB] Get:46 http://archive.ubuntu.com/ubuntu focal/main amd64 libepoxy0 amd64 1.5.4-1 [191 kB] Get:47 http://archive.ubuntu.com/ubuntu focal/main amd64 libsoup-gnome2.4-1 amd64 2.70.0-1 [6136 B] Get:48 http://archive.ubuntu.com/ubuntu focal/main amd64 librest-0.7-0 amd64 0.8.1-1 [32.2 kB] Get:49 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwayland-client0 amd64 1.18.0-1ubuntu0.1 [23.9 kB] Get:50 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwayland-cursor0 amd64 1.18.0-1ubuntu0.1 [10.3 kB] Get:51 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwayland-egl1 amd64 1.18.0-1ubuntu0.1 [5596 B] Get:52 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcomposite1 amd64 1:0.4.5-1 [6976 B] Get:53 http://archive.ubuntu.com/ubuntu focal/main amd64 libxfixes3 amd64 1:5.0.3-2 [10.9 kB] Get:54 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcursor1 amd64 1:1.2.0-2 [20.1 kB] Get:55 http://archive.ubuntu.com/ubuntu focal/main amd64 libxdamage1 amd64 1:1.1.5-2 [6996 B] Get:56 http://archive.ubuntu.com/ubuntu focal/main amd64 libxi6 amd64 2:1.7.10-0ubuntu1 [29.9 kB] Get:57 http://archive.ubuntu.com/ubuntu focal/main amd64 libxinerama1 amd64 2:1.1.4-2 [6904 B] Get:58 http://archive.ubuntu.com/ubuntu focal/main amd64 libxkbcommon0 amd64 0.10.0-1 [98.4 kB] Get:59 http://archive.ubuntu.com/ubuntu focal/main amd64 libxrandr2 amd64 2:1.5.2-0ubuntu1 [18.5 kB] Get:60 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgtk-3-common all 3.24.20-0ubuntu1.1 [234 kB] Get:61 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgtk-3-0 amd64 3.24.20-0ubuntu1.1 [2620 kB] Get:62 http://archive.ubuntu.com/ubuntu focal/main amd64 libu2f-udev all 1.1.10-1 [6108 B] Get:63 http://archive.ubuntu.com/ubuntu focal/main amd64 libvulkan1 amd64 1.2.131.2-1 [93.3 kB] Get:64 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 xdg-utils all 1.1.3-2ubuntu1.20.04.2 [61.4 kB] Get:65 http://archive.ubuntu.com/ubuntu focal/main amd64 x11-common all 1:7.7+19ubuntu14 [22.3 kB] Get:66 http://archive.ubuntu.com/ubuntu focal/main amd64 libxtst6 amd64 2:1.2.3-1 [12.8 kB] Get:67 http://archive.ubuntu.com/ubuntu focal/main amd64 at-spi2-core amd64 2.36.0-2 [48.7 kB] Get:68 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 gcc-9-base amd64 9.4.0-1ubuntu1~20.04.2 [18.9 kB] Get:69 http://archive.ubuntu.com/ubuntu focal/main amd64 libisl22 amd64 0.22.1-1 [592 kB] Get:70 http://archive.ubuntu.com/ubuntu focal/main amd64 libmpc3 amd64 1.1.0-1 [40.8 kB] Get:71 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 cpp-9 amd64 9.4.0-1ubuntu1~20.04.2 [7502 kB] Get:72 http://archive.ubuntu.com/ubuntu focal/main amd64 cpp amd64 4:9.3.0-1ubuntu2 [27.6 kB] Get:73 http://archive.ubuntu.com/ubuntu focal/main amd64 libdata-dump-perl all 1.23-1 [27.0 kB] Get:74 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libdrm-amdgpu1 amd64 2.4.107-8ubuntu1~20.04.2 [18.6 kB] Get:75 http://archive.ubuntu.com/ubuntu focal/main amd64 libpciaccess0 amd64 0.16-0ubuntu1 [17.9 kB] Get:76 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libdrm-intel1 amd64 2.4.107-8ubuntu1~20.04.2 [60.3 kB] Get:77 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libdrm-nouveau2 amd64 2.4.107-8ubuntu1~20.04.2 [16.6 kB] Get:78 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libdrm-radeon1 amd64 2.4.107-8ubuntu1~20.04.2 [19.7 kB] Get:79 http://archive.ubuntu.com/ubuntu focal/main amd64 libencode-locale-perl all 1.05-1 [12.3 kB] Get:80 http://archive.ubuntu.com/ubuntu focal/main amd64 libipc-system-simple-perl all 1.26-1 [22.8 kB] Get:81 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-basedir-perl all 0.08-1 [16.9 kB] Get:82 http://archive.ubuntu.com/ubuntu focal/main amd64 liburi-perl all 1.76-2 [77.5 kB] Get:83 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-desktopentry-perl all 0.22-1 [18.2 kB] Get:84 http://archive.ubuntu.com/ubuntu focal/main amd64 libtimedate-perl all 2.3200-1 [34.0 kB] Get:85 http://archive.ubuntu.com/ubuntu focal/main amd64 libhttp-date-perl all 6.05-1 [9920 B] Get:86 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-listing-perl all 6.04-1 [9774 B] Get:87 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-mimeinfo-perl all 0.29-1 [41.5 kB] Get:88 http://archive.ubuntu.com/ubuntu focal/main amd64 libfont-afm-perl all 1.20-2 [13.2 kB] Get:89 http://archive.ubuntu.com/ubuntu focal/main amd64 libfontenc1 amd64 1:1.1.4-0ubuntu1 [14.0 kB] Get:90 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgdk-pixbuf2.0-bin amd64 2.40.0+dfsg-3ubuntu0.4 [14.1 kB] Get:91 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libglapi-mesa amd64 21.2.6-0ubuntu0.1~20.04.2 [27.4 kB] Get:92 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libllvm12 amd64 1:12.0.0-3ubuntu1~20.04.5 [18.8 MB] Get:93 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsensors-config all 1:3.6.0-2ubuntu1.1 [6052 B] Get:94 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsensors5 amd64 1:3.6.0-2ubuntu1.1 [27.2 kB] Get:95 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgl1-mesa-dri amd64 21.2.6-0ubuntu0.1~20.04.2 [11.0 MB] Get:96 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libx11-xcb1 amd64 2:1.6.9-2ubuntu1.6 [9448 B] Get:97 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-dri2-0 amd64 1.14-2 [6920 B] Get:98 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-dri3-0 amd64 1.14-2 [6552 B] Get:99 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-glx0 amd64 1.14-2 [22.1 kB] Get:100 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-present0 amd64 1.14-2 [5560 B] Get:101 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-sync1 amd64 1.14-2 [8884 B] Get:102 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-xfixes0 amd64 1.14-2 [9296 B] Get:103 http://archive.ubuntu.com/ubuntu focal/main amd64 libxshmfence1 amd64 1.3-1 [5028 B] Get:104 http://archive.ubuntu.com/ubuntu focal/main amd64 libxxf86vm1 amd64 1:1.1.4-1build1 [10.2 kB] Get:105 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libglx-mesa0 amd64 21.2.6-0ubuntu0.1~20.04.2 [137 kB] Get:106 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgtk-3-bin amd64 3.24.20-0ubuntu1.1 [61.9 kB] Get:107 http://archive.ubuntu.com/ubuntu focal/main amd64 libhtml-tagset-perl all 3.20-4 [12.5 kB] Get:108 http://archive.ubuntu.com/ubuntu focal/main amd64 libhtml-parser-perl amd64 3.72-5 [86.3 kB] Get:109 http://archive.ubuntu.com/ubuntu focal/main amd64 libio-html-perl all 1.001-1 [14.9 kB] Get:110 http://archive.ubuntu.com/ubuntu focal/main amd64 liblwp-mediatypes-perl all 6.04-1 [19.5 kB] Get:111 http://archive.ubuntu.com/ubuntu focal/main amd64 libhttp-message-perl all 6.22-1 [76.1 kB] Get:112 http://archive.ubuntu.com/ubuntu focal/main amd64 libhtml-form-perl all 6.07-1 [22.2 kB] Get:113 http://archive.ubuntu.com/ubuntu focal/main amd64 libhtml-tree-perl all 5.07-2 [200 kB] Get:114 http://archive.ubuntu.com/ubuntu focal/main amd64 libhtml-format-perl all 2.12-1 [41.3 kB] Get:115 http://archive.ubuntu.com/ubuntu focal/main amd64 libhttp-cookies-perl all 6.08-1 [18.3 kB] Get:116 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libhttp-daemon-perl all 6.06-1ubuntu0.1 [22.0 kB] Get:117 http://archive.ubuntu.com/ubuntu focal/main amd64 libhttp-negotiate-perl all 6.01-1 [12.5 kB] Get:118 http://archive.ubuntu.com/ubuntu focal/main amd64 libice6 amd64 2:1.0.10-0ubuntu1 [41.0 kB] Get:119 http://archive.ubuntu.com/ubuntu focal/main amd64 perl-openssl-defaults amd64 4 [7192 B] Get:120 http://archive.ubuntu.com/ubuntu focal/main amd64 libnet-ssleay-perl amd64 1.88-2ubuntu1 [291 kB] Get:121 http://archive.ubuntu.com/ubuntu focal/main amd64 libio-socket-ssl-perl all 2.067-1 [176 kB] Get:122 http://archive.ubuntu.com/ubuntu focal/main amd64 libio-stringy-perl all 2.111-3 [55.8 kB] Get:123 http://archive.ubuntu.com/ubuntu focal/main amd64 libnet-http-perl all 6.19-1 [22.8 kB] Get:124 http://archive.ubuntu.com/ubuntu focal/main amd64 libtry-tiny-perl all 0.30-1 [20.5 kB] Get:125 http://archive.ubuntu.com/ubuntu focal/main amd64 libwww-robotrules-perl all 6.02-1 [12.6 kB] Get:126 http://archive.ubuntu.com/ubuntu focal/main amd64 libwww-perl all 6.43-1 [140 kB] Get:127 http://archive.ubuntu.com/ubuntu focal/main amd64 liblwp-protocol-https-perl all 6.07-2ubuntu2 [8560 B] Get:128 http://archive.ubuntu.com/ubuntu focal/main amd64 libnet-smtp-ssl-perl all 1.04-1 [5948 B] Get:129 http://archive.ubuntu.com/ubuntu focal/main amd64 libmailtools-perl all 2.21-1 [80.7 kB] Get:130 http://archive.ubuntu.com/ubuntu focal/main amd64 libxml-parser-perl amd64 2.46-1 [193 kB] Get:131 http://archive.ubuntu.com/ubuntu focal/main amd64 libxml-twig-perl all 1:3.50-2 [155 kB] Get:132 http://archive.ubuntu.com/ubuntu focal/main amd64 libnet-dbus-perl amd64 1.2.0-1 [177 kB] Get:133 http://archive.ubuntu.com/ubuntu focal/main amd64 libsm6 amd64 2:1.2.3-1 [16.1 kB] Get:134 http://archive.ubuntu.com/ubuntu focal/main amd64 libtie-ixhash-perl all 1.23-2 [11.2 kB] Get:135 http://archive.ubuntu.com/ubuntu focal/main amd64 libx11-protocol-perl all 0.56-7 [149 kB] Get:136 http://archive.ubuntu.com/ubuntu focal/main amd64 libxt6 amd64 1:1.1.5-1 [160 kB] Get:137 http://archive.ubuntu.com/ubuntu focal/main amd64 libxmu6 amd64 2:1.1.3-0ubuntu1 [45.8 kB] Get:138 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libxpm4 amd64 1:3.5.12-1ubuntu0.20.04.2 [34.9 kB] Get:139 http://archive.ubuntu.com/ubuntu focal/main amd64 libxaw7 amd64 2:1.0.13-1 [173 kB] Get:140 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-randr0 amd64 1.14-2 [16.3 kB] Get:141 http://archive.ubuntu.com/ubuntu focal/main amd64 libxcb-shape0 amd64 1.14-2 [5928 B] Get:142 http://archive.ubuntu.com/ubuntu focal/main amd64 libxft2 amd64 2.3.3-0ubuntu1 [39.2 kB] Get:143 http://archive.ubuntu.com/ubuntu focal/main amd64 libxkbfile1 amd64 1:1.1.0-1 [65.3 kB] Get:144 http://archive.ubuntu.com/ubuntu focal/main amd64 libxml-xpathengine-perl all 0.14-1 [31.8 kB] Get:145 http://archive.ubuntu.com/ubuntu focal/main amd64 libxv1 amd64 2:1.0.11-1 [10.7 kB] Get:146 http://archive.ubuntu.com/ubuntu focal/main amd64 libxxf86dga1 amd64 2:1.1.5-0ubuntu1 [12.0 kB] Get:147 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 mesa-vulkan-drivers amd64 21.2.6-0ubuntu0.1~20.04.2 [5788 kB] Get:148 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libglvnd0 amd64 1.3.2-1~ubuntu0.20.04.2 [48.1 kB] Get:149 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libglx0 amd64 1.3.2-1~ubuntu0.20.04.2 [32.5 kB] Get:150 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgl1 amd64 1.3.2-1~ubuntu0.20.04.2 [85.8 kB] Get:151 http://archive.ubuntu.com/ubuntu focal/main amd64 x11-utils amd64 7.7+5 [199 kB] Get:152 http://archive.ubuntu.com/ubuntu focal/main amd64 x11-xserver-utils amd64 7.7+8 [162 kB] Get:153 http://archive.ubuntu.com/ubuntu focal/main amd64 libauthen-sasl-perl all 2.1600-1 [48.7 kB] Fetched 62.9 MB in 12s (5 Processing triggers for libgdk-pixbuf2.0-0:amd64 (2.40.0+dfsg-3ubuntu0.4) ...google-chrome (google-chrome) in auto modeuto modee) in auto modeone removed.
14/11/2023 15:25:44 INFO: --- Dependencies ----
14/11/2023 15:25:44 INFO: Installing libnss3-dev.
Reading package lists... Building dependency tree... Reading state information... The following additional packages will be installed: libnspr4-dev libnss3 The following NEW packages will be installed: libnspr4-dev libnss3-dev The following packages will be upgraded: libnss3 1 upgraded, 2 newly installed, 0 to remove and 237 not upgraded. Need to get 1692 kB of archives. After this operation, 2612 kB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 libnspr4-dev amd64 2:4.25-1 [206 kB] Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libnss3 amd64 2:3.49.1-1ubuntu1.9 [1256 kB] Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64  Processing triggers for libc-bin (2.31-0ubuntu9.2) ...1.9_amd64.deb ...) ...s) Selecting previously unselected package libnspr4-dev.
14/11/2023 15:25:52 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 237 not upgraded. Need to get 179 MB of archives. After this operation, 965 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.7.0-1 [179 MB] Fetched 179 MB in 22s (8247 kB/s) Selecting previou Setting up wazuh-dashboard (4.7.0-1) ...4.7.0-1_amd64.deb ...nstalled.)
14/11/2023 15:26:44 INFO: Wazuh dashboard installation finished.
14/11/2023 15:26:44 DEBUG: Wazuh dashboard certificate setup finished.
14/11/2023 15:26:44 INFO: Wazuh dashboard post-install configuration finished.
14/11/2023 15:26:44 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
14/11/2023 15:26:45 INFO: wazuh-dashboard service started.
14/11/2023 15:26:45 DEBUG: Setting Wazuh indexer cluster passwords.
14/11/2023 15:26:47 DEBUG: Generating password hashes.
14/11/2023 15:26:51 DEBUG: Password hashes generated.
14/11/2023 15:26:51 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.8.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
14/11/2023 15:26:53 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
14/11/2023 15:26:53 DEBUG: filebeat started.
14/11/2023 15:26:55 DEBUG: wazuh-dashboard started.
14/11/2023 15:26:55 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.8.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /root/wazuh-packages/unattended_installer
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
14/11/2023 15:26:56 DEBUG: Passwords changed.
14/11/2023 15:27:03 INFO: Initializing Wazuh dashboard web application.
14/11/2023 15:27:05 INFO: Wazuh dashboard web application initialized.
14/11/2023 15:27:05 INFO: --- Summary ---
14/11/2023 15:27:05 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: +2in+nKX?*kV3EkfhaT0jl4dRYNgAbMJ
14/11/2023 15:27:05 INFO: Installation finished.
```
</details>

### Filebeat module installed
```console
root@ubuntu20:~/wazuh-packages/unattended_installer# cat /usr/share/filebeat/module/wazuh/alerts/ingest/pipeline.json 
{
  "description": "Wazuh alerts pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "date_index_name": {
        "field": "timestamp",
        "date_rounding": "d",
        "index_name_prefix": "{{fields.index_prefix}}",
        "index_name_format": "yyyy.MM.dd",
        "ignore_failure": false
      }
    },

    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
