### PR TITLE
Added permissions change for merged.mg files in upgrade

### DIFF
--- a/.github/workflows/test-install-deb.yml
+++ b/.github/workflows/test-install-deb.yml
@@ -22,7 +22,7 @@ jobs:
           skip_after_successful_duplicate: 'false'
 
       - name: Wait for the package to be built
-        uses: ArcticLampyrid/action-wait-for-workflow@v1.0.3
+        uses: ArcticLampyrid/action-wait-for-workflow@v1.0.4
         id: wait-for-build
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-install-rpm.yml
+++ b/.github/workflows/test-install-rpm.yml
@@ -21,7 +21,7 @@ jobs:
           skip_after_successful_duplicate: 'false'
 
       - name: Wait for the package to be built
-        uses: ArcticLampyrid/action-wait-for-workflow@v1.0.3
+        uses: ArcticLampyrid/action-wait-for-workflow@v1.0.4
         id: wait-for-build
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -170,6 +170,8 @@ case "$1" in
     chmod 0660 ${DIR}/logs/active-responses.log
     chmod 0640 ${DIR}/logs/integrations.log
 
+    # Set merged.mg permissions to new ones
+    find ${DIR}/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
 
     if [ -f ${DIR}/etc/shared/ar.conf ]; then
         chown root:wazuh ${DIR}/etc/shared/ar.conf

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -330,6 +330,9 @@ fi
 rm -f %{_localstatedir}/etc/shared/ar.conf  >/dev/null 2>&1
 rm -f %{_localstatedir}/etc/shared/merged.mg  >/dev/null 2>&1
 
+# Set merged.mg permissions to new ones
+find %{_localstatedir}/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
+
 # CentOS
 if [ -r "/etc/centos-release" ]; then
   DIST_NAME="centos"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-jenkins/issues/5929|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes a permissions discordance in the merged.mg files, when updating a manager using packages update. After this change, the merged.mg files will be set to `644` permissions.
<!--
Add a clear description of how the problem has been solved.
-->

## Logs example

<!--
Paste here related logs
-->

<details>
<summary>Ubuntu22</summary>

```console
root@server-slave-ubu22:/home/vagrant# curl -sO https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager/wazuh-manager_4.5.4-1_amd64.deb

root@server-slave-ubu22:/home/vagrant# dpkg -i wazuh-manager_4.5.4-1_amd64.deb 
Selecting previously unselected package wazuh-manager.
(Reading database ... 71284 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.5.4-1_amd64.deb ...
Unpacking wazuh-manager (4.5.4-1) ...
Setting up wazuh-manager (4.5.4-1) ...

root@server-slave-ubu22:/home/vagrant# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.5.4...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/11/17 10:57:11 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.

root@server-slave-ubu22:/home/vagrant# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-rw---- 1 wazuh wazuh 899315 Nov 17 10:57 /var/ossec/etc/shared/default/merged.mg

root@server-slave-ubu22:/home/vagrant# curl -sO https://packages-dev.wazuh.com/warehouse/test/4.7/deb/var/wazuh-manager_4.7.0-1_amd64.deb

root@server-slave-ubu22:/home/vagrant# dpkg -i wazuh-manager_4.7.0-1_amd64.deb 
(Reading database ... 92559 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.7.0-1_amd64.deb ...
Unpacking wazuh-manager (4.7.0-1) over (4.5.4-1) ...
Setting up wazuh-manager (4.7.0-1) ...

root@server-slave-ubu22:/home/vagrant# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-r--r-- 1 wazuh wazuh 899315 Nov 17 10:57 /var/ossec/etc/shared/default/merged.mg
```
</details>

<details>
<summary>Centos7</summary>

```console
[root@agent1-centos7 vagrant]# curl -sO https://packages.wazuh.com/4.x/yum/wazuh-manager-4.5.4-1.x86_64.rpm

[root@agent1-centos7 vagrant]# rpm -i wazuh-manager-4.5.4-1.x86_64.rpm 
advertencia:wazuh-manager-4.5.4-1.x86_64.rpm: EncabezadoV3 RSA/SHA256 Signature, ID de clave 29111145: NOKEY

[root@agent1-centos7 vagrant]# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.5.4...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2023/11/17 10:58:00 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
Started wazuh-modulesd...
Completed.

[root@agent1-centos7 vagrant]# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-rw----. 1 wazuh wazuh 899315 nov 17 10:58 /var/ossec/etc/shared/default/merged.mg

[root@agent1-centos7 vagrant]# curl -sO https://packages-dev.wazuh.com/warehouse/test/4.7/rpm/var/wazuh-manager-4.7.0-1.x86_64.rpm

[root@agent1-centos7 vagrant]# rpm -U wazuh-manager-4.7.0-1.x86_64.rpm 
advertencia:/var/ossec/etc/ossec.conf creado como /var/ossec/etc/ossec.conf.rpmnew

[root@agent1-centos7 vagrant]# ls -la /var/ossec/etc/shared/default/merged.mg 
-rw-r--r--. 1 wazuh wazuh 899315 nov 17 10:58 /var/ossec/etc/shared/default/merged.mg
```
</details>

## Tests
- Tests for Linux RPM
  - [x] Build the package for x86_64
- Tests for Linux deb
  - [x] Build the package for x86_64