### PR TITLE
Merge 4.7.0 into 4.7.1

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -71,7 +71,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages-dev.wazuh.com/'${devrepo}'"' >> "${output_script_path}"
         echo 'readonly reporelease="unstable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
         sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
@@ -79,7 +79,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
         echo 'readonly reporelease="stable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.2.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="4.x"' >> "${output_script_path}"
     fi

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -217,31 +217,3 @@ function dashboard_install() {
 
 }
 
-function dashboard_installReportDependencies() {
-
-    # Flags that indicates that is an optional installation.
-    optional_installation=1
-    report_dependencies=1
-
-    installCommon_checkChromium
-
-    if [ "${sys_type}" == "yum" ]; then
-        dashboard_dependencies+=( nss xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype )
-        installCommon_yumInstallList "${dashboard_dependencies[@]}"
-
-        # In RHEL cases, remove the CentOS repositories configuration
-        if [ "${centos_repos_configured}" == 1 ]; then
-            installCommon_removeCentOSrepositories
-        fi
-    
-    elif [ "${sys_type}" == "apt-get" ]; then
-        dashboard_dependencies+=( libnss3-dev fonts-liberation libfontconfig1 )
-        installCommon_aptInstallList "${dashboard_dependencies[@]}"
-    fi
-
-    if [ "${pdf_warning}" == 1 ]; then
-        common_logger -w "Wazuh dashboard dependencies skipped. PDF report generation may not work."
-    fi
-    optional_installation=0
-
-}

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -134,7 +134,8 @@ function installCommon_aptInstallList(){
             common_logger "Installing $dep."
             installCommon_aptInstall "${dep}"
             if [ "${install_result}" != 0 ]; then
-                installCommon_checkOptionalInstallation
+                common_logger -e "Cannot install dependency: ${dep}."
+                exit 1
             fi
         done
     fi
@@ -168,20 +169,6 @@ function installCommon_changePasswordApi() {
         fi
         if [ "${nuser}" == "wazuh-wui" ] && { [ -n "${dashboard}" ] || [ -n "${AIO}" ]; }; then
                 passwords_changeDashboardApiPassword "${password}"
-        fi
-    fi
-
-}
-
-function installCommon_checkOptionalInstallation() {
-
-    if [ "${optional_installation}" != 1 ]; then
-        common_logger -e "Cannot install dependency: ${dep}."
-        exit 1
-    else
-        common_logger -w "Cannot install optional dependency: ${dep}."
-        if [ "${report_dependencies}" == 1 ]; then 
-            pdf_warning=1
         fi
     fi
 
@@ -292,37 +279,7 @@ function installCommon_changePasswords() {
 
 }
 
-function installCommon_checkChromium() {
-
-    if [ "${sys_type}" == "yum" ]; then
-        if (! yum list installed 2>/dev/null | grep -q -E ^"google-chrome-stable"\\.) && (! yum list installed 2>/dev/null | grep -q -E ^"chromium"\\.); then
-            if [ "${DIST_NAME}" == "amzn" ]; then
-                installCommon_installChrome
-            elif [[ "${DIST_NAME}" == "centos" ]] && [[ "${DIST_VER}" == "7" ]]; then
-                installCommon_installChrome
-            elif [[ "${DIST_NAME}" == "rhel" ]] && [[ "${DIST_VER}" == "8" || "${DIST_VER}" == "9" ]]; then
-                installCommon_configureCentOSRepositories
-                dashboard_dependencies=(chromium)
-            else
-                dashboard_dependencies=(chromium)
-            fi
-        fi
-        
-    elif [ "${sys_type}" == "apt-get" ]; then
-        if (! apt list --installed 2>/dev/null | grep -q -E ^"google-chrome-stable"\/) && (! apt list --installed 2>/dev/null | grep -q -E ^"chromium-browser"\/); then
-
-            # Report generation doesn't work with Chromium in Ubuntu 22 and Ubuntu 20
-            if [[ "${DIST_NAME}" == "ubuntu" ]] && [[ "${DIST_VER}" == "22" || "${DIST_VER}" == "20" || "${DIST_VER}" == "18" ]]; then
-                installCommon_installChrome
-            else
-                dashboard_dependencies=(chromium-browser)
-            fi
-        fi
-    fi
-
-}
-
-# Adds the CentOS repository to install the dashboard dependencies. 
+# Adds the CentOS repository to install lsof.
 function installCommon_configureCentOSRepositories() {
 
     centos_repos_configured=1
@@ -390,38 +347,20 @@ function installCommon_installCheckDependencies() {
 
     if [ "${sys_type}" == "yum" ]; then
         dependencies=( systemd grep tar coreutils sed procps-ng gawk lsof curl openssl )
+        if [[ "${DIST_NAME}" == "rhel" ]] && [[ "${DIST_VER}" == "8" || "${DIST_VER}" == "9" ]]; then
+            installCommon_configureCentOSRepositories
+        fi
         installCommon_yumInstallList "${dependencies[@]}"
+
+        # In RHEL cases, remove the CentOS repositories configuration
+        if [ "${centos_repos_configured}" == 1 ]; then
+            installCommon_removeCentOSrepositories
+        fi
 
     elif [ "${sys_type}" == "apt-get" ]; then
         eval "apt-get update -q ${debug}"
         dependencies=( systemd grep tar coreutils sed procps gawk lsof curl openssl )
         installCommon_aptInstallList "${dependencies[@]}"
-    fi
-
-}
-
-function installCommon_installChrome() {
-
-    dep="chrome"
-    common_logger "Installing ${dep}."
-
-    if [ "${sys_type}" == "yum" ]; then
-        chrome_package="/tmp/wazuh-install-files/chrome.rpm"
-        common_curl -so "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm --max-time 100 --retry 5 --retry-delay 5 --fail
-        eval "yum install ${chrome_package} -y ${debug}"
-
-        if [ "${PIPESTATUS[0]}" != 0 ]; then
-            installCommon_checkOptionalInstallation
-        fi
-
-    elif [ "${sys_type}" == "apt-get" ]; then
-        chrome_package="/tmp/wazuh-install-files/chrome.deb"
-        common_curl -so "${chrome_package}" https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb --max-time 100 --retry 5 --retry-delay 5 --fail
-        installCommon_aptInstall "${chrome_package}"
-
-        if [ "${install_result}" != 0 ]; then
-            installCommon_checkOptionalInstallation
-        fi
     fi
 
 }
@@ -576,7 +515,7 @@ function installCommon_restoreWazuhrepo() {
 }
 
 function installCommon_removeCentOSrepositories() {
-    
+
     eval "rm -f ${centos_repo} ${debug}"
     eval "rm -f ${centos_key} ${debug}"
     eval "yum clean all ${debug}"
@@ -765,7 +704,8 @@ function installCommon_yumInstallList(){
 
             eval "echo \${yum_output} ${debug}"
             if [  "${yum_code}" != 0  ]; then
-                installCommon_checkOptionalInstallation
+                common_logger -e "Cannot install dependency: ${dep}."
+                exit 1
             fi
         done
     fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -217,10 +217,6 @@ function main() {
 
     common_checkSystem
 
-    if [ -z "${uninstall}" ]; then
-        installCommon_installCheckDependencies
-    fi
-    
     if [ -z "${download}" ]; then
         check_dist
     fi
@@ -321,7 +317,6 @@ function main() {
 
     if [ -n "${dashboard}" ]; then
         common_logger "--- Wazuh dashboard ----"
-        dashboard_installReportDependencies
         dashboard_install
         dashboard_configure
         installCommon_startService "wazuh-dashboard"
@@ -361,7 +356,6 @@ function main() {
         filebeat_configure
         installCommon_startService "filebeat"
         common_logger "--- Wazuh dashboard ---"
-        dashboard_installReportDependencies
         dashboard_install
         dashboard_configure
         installCommon_startService "wazuh-dashboard"


### PR DESCRIPTION
## Description

Due to https://github.com/wazuh/wazuh-packages/issues/2625, it is necessary to bump the 4.7.0 branch into the 4.7.1 branch to apply the Wazuh dashboard PDF dependencies removal.

 