### PR TITLE
Improved message of CentOS key import failure

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -287,8 +287,7 @@ function installCommon_configureCentOSRepositories() {
     eval "common_curl -sLo ${centos_key} 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official' --max-time 300 --retry 5 --retry-delay 5 --fail"
 
     if [ ! -f "${centos_key}" ]; then
-        common_logger -w "The CentOS key could not be added. Chromium package skipped."
-        pdf_warning=1
+        common_logger -w "The CentOS key could not be added. Some dependencies may not be installed."
     else
         centos_repo="/etc/yum.repos.d/centos.repo"
         eval "touch ${centos_repo} ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2625|

The aim of this PR is to remove the remaining code of the [Wazuh dashboard PDF dependencies removal](https://github.com/wazuh/internal-devel-requests/issues/492).

This PR:
- Removes the unique occurrence of the `pdf_warning` variable.
- Improves the message of the CentOS GPG key import, removing the Chromium dependency mention.

With this, no code related to the PDF dependencies is in the Wazuh installation assistant.