### PR TITLE
Changed check yum lock function

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -70,7 +70,7 @@ function common_checkInstalled() {
     dashboard_installed=""
 
     if [ "${sys_type}" == "yum" ]; then
-        installCommon_checkYumLock
+        common_checkYumLock
         wazuh_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
     elif [ "${sys_type}" == "apt-get" ]; then
         wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
@@ -82,7 +82,7 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        installCommon_checkYumLock
+        common_checkYumLock
         indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
     elif [ "${sys_type}" == "apt-get" ]; then
         indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
@@ -94,7 +94,7 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        installCommon_checkYumLock
+        common_checkYumLock
         filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
     elif [ "${sys_type}" == "apt-get" ]; then
         filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
@@ -106,7 +106,7 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        installCommon_checkYumLock
+        common_checkYumLock
         dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
     elif [ "${sys_type}" == "apt-get" ]; then
         dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
@@ -187,5 +187,19 @@ function common_remove_gpg_key() {
             return 1
         fi
     fi
+
+}
+
+function common_checkYumLock() {
+
+    attempt=0
+    seconds=30
+    max_attempts=10
+
+    while [ -f "${yum_lockfile}" ] && [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt+1))
+        common_logger "Another process is using YUM. Waiting for it to release the lock. Next retry in ${seconds} seconds (${attempt}/${max_attempts})"
+        sleep "${seconds}"
+    done
 
 }


### PR DESCRIPTION
|Related issue|
|---|
|closes https://github.com/wazuh/wazuh-packages/issues/2638|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The place where the function is located is changed, to avoid errors in the different tools

## Logs example

<!--
Paste here related logs
-->

### Install

```console
[root@centos-7 ~]# bash wazuh-install.sh -a
24/11/2023 18:00:26 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
24/11/2023 18:00:26 INFO: Verbose logging redirected to /var/log/wazuh-install.log
24/11/2023 18:00:30 INFO: --- Dependencies ---
24/11/2023 18:00:30 INFO: Installing lsof.
24/11/2023 18:00:47 INFO: Verifying that your system meets the recommended minimum hardware requirements.
24/11/2023 18:00:47 INFO: Wazuh web interface port will be 443.
24/11/2023 18:00:50 INFO: Wazuh development repository added.
24/11/2023 18:00:50 INFO: --- Configuration files ---
24/11/2023 18:00:50 INFO: Generating configuration files.
24/11/2023 18:00:51 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
24/11/2023 18:00:51 INFO: --- Wazuh indexer ---
24/11/2023 18:00:51 INFO: Starting Wazuh indexer installation.
24/11/2023 18:03:10 INFO: Wazuh indexer installation finished.
24/11/2023 18:03:10 INFO: Wazuh indexer post-install configuration finished.
24/11/2023 18:03:10 INFO: Starting service wazuh-indexer.
24/11/2023 18:03:20 INFO: wazuh-indexer service started.
24/11/2023 18:03:20 INFO: Initializing Wazuh indexer cluster security settings.
24/11/2023 18:03:31 INFO: The Wazuh indexer cluster ISM initialized.
24/11/2023 18:03:31 INFO: Wazuh indexer cluster initialized.
24/11/2023 18:03:31 INFO: --- Wazuh server ---
24/11/2023 18:03:31 INFO: Starting the Wazuh manager installation.
24/11/2023 18:04:22 INFO: Wazuh manager installation finished.
24/11/2023 18:04:22 INFO: Starting service wazuh-manager.
24/11/2023 18:04:33 INFO: wazuh-manager service started.
24/11/2023 18:04:33 INFO: Starting Filebeat installation.
24/11/2023 18:04:40 INFO: Filebeat installation finished.
24/11/2023 18:04:43 INFO: Filebeat post-install configuration finished.
24/11/2023 18:04:43 INFO: Starting service filebeat.
24/11/2023 18:04:43 INFO: filebeat service started.
24/11/2023 18:04:43 INFO: --- Wazuh dashboard ---
24/11/2023 18:04:43 INFO: Installing chrome.
24/11/2023 18:05:24 INFO: --- Dependencies ---
24/11/2023 18:05:24 INFO: Installing xorg-x11-fonts-100dpi.
24/11/2023 18:05:29 INFO: Installing xorg-x11-fonts-75dpi.
24/11/2023 18:05:31 INFO: Installing xorg-x11-utils.
24/11/2023 18:05:32 INFO: Installing xorg-x11-fonts-cyrillic.
24/11/2023 18:05:33 INFO: Installing xorg-x11-fonts-Type1.
24/11/2023 18:05:34 INFO: Installing xorg-x11-fonts-misc.
24/11/2023 18:05:39 INFO: Starting Wazuh dashboard installation.
24/11/2023 18:07:06 INFO: Wazuh dashboard installation finished.
24/11/2023 18:07:06 INFO: Wazuh dashboard post-install configuration finished.
24/11/2023 18:07:06 INFO: Starting service wazuh-dashboard.
24/11/2023 18:07:07 INFO: wazuh-dashboard service started.
24/11/2023 18:07:08 INFO: Updating the internal users.
24/11/2023 18:07:10 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
24/11/2023 18:08:21 INFO: Initializing Wazuh dashboard web application.
24/11/2023 18:08:22 INFO: Wazuh dashboard web application initialized.
24/11/2023 18:08:22 INFO: --- Summary ---
24/11/2023 18:08:22 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: +tGNndZ9zlgqjZgEhMiys*2LXSP?DfrA
24/11/2023 18:08:22 INFO: Installation finished.
```


### password tool

```console
[root@centos-7 ~]# bash wazuh-passwords-tool.sh -v -u admin -p Vdpass480.
24/11/2023 18:09:26 INFO: Updating the internal users.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
24/11/2023 18:09:27 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
24/11/2023 18:09:27 INFO: Generating password hash
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
Successfully updated the keystore
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /root
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
24/11/2023 18:09:31 WARNING: Password changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
```

### cert tool

```console
[root@centos-7 ~]# bash wazuh-certs-tool.sh -A
24/11/2023 18:10:19 INFO: Admin certificates created.
24/11/2023 18:10:19 INFO: Wazuh indexer certificates created.
24/11/2023 18:10:19 INFO: Wazuh server certificates created.
24/11/2023 18:10:19 INFO: Wazuh dashboard certificates created.
```