### PR TITLE
Fixing wazuh-indexer.spec duplicated information

### DIFF
--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -181,18 +181,6 @@ if [ ${1} = 2 ]; then
     fi
 fi
 
-# If is an upgrade, move the securityconfig files if they exist (4.3.x versions)
-if [ ${1} = 2 ]; then
-    if [ -d "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig ]; then
-
-        if [ ! -d "%{CONFIG_DIR}"/opensearch-security ]; then
-            mkdir "%{CONFIG_DIR}"/opensearch-security
-        fi
-
-        cp -r "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig/* "%{CONFIG_DIR}"/opensearch-security
-    fi
-fi
-
 # -----------------------------------------------------------------------------
 
 %preun


### PR DESCRIPTION
|Related issue|
|--|
|[2637](https://github.com/wazuh/wazuh-packages/issues/2637)|

## Description

There was duplicate code stemming from a merge with a poorly resolved conflict.
The duplicated code is removed at https://github.com/wazuh/wazuh-packages/blame/v4.7.0/stack/indexer/rpm/wazuh-indexer.spec by deleting:

```bash
if [[ -d /run/systemd/system ]] ; then
    rm -f /etc/init.d/%{name}
fi

# If is an upgrade, move the securityconfig files if they exist (4.3.x versions)
if [ ${1} = 2 ]; then
    if [ -d "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig ]; then

        if [ ! -d "%{CONFIG_DIR}"/opensearch-security ]; then
            mkdir "%{CONFIG_DIR}"/opensearch-security
        fi

        cp -r "%{INSTALL_DIR}"/plugins/opensearch-security/securityconfig/* "%{CONFIG_DIR}"/opensearch-security
    fi
fi
```


## Logs example

https://github.com/wazuh/wazuh-packages/actions/runs/6979091415/job/18991690888?pr=2633

## Tests
  - [x] https://github.com/wazuh/wazuh-packages/actions/runs/7005246565/job/19054603943
