### PR TITLE
Removed `gnupg` package as RPM dependency in WIA

### DIFF
--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -56,6 +56,6 @@ readonly wazuh_manager_ports=( 1514 1515 1516 55000 )
 wazuh_dashboard_port="${http_port}"
 readonly wia_yum_dependencies=( systemd grep tar coreutils sed procps-ng gawk lsof curl openssl )
 readonly wia_apt_dependencies=( systemd grep tar coreutils sed procps gawk lsof curl openssl )
-readonly wazuh_yum_dependencies=( libcap gnupg2 )
+readonly wazuh_yum_dependencies=( libcap )
 readonly wazuh_apt_dependencies=( apt-transport-https libcap2-bin software-properties-common gnupg )
 wia_dependencies_installed=()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2663|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to remove the `gnupg` package as a dependency of the Wazuh installation assistant in RPM-based systems. This package is not used neither in the installation nor in the Wazuh functionality.

## Testing

Some automatic testing:
:green_circle: CentOS 7. https://ci.wazuh.info/job/Test_unattended/4715/
:green_circle: CentOS 8. https://ci.wazuh.info/job/Test_unattended/4714/
:green_circle: AL2. https://ci.wazuh.info/job/Test_unattended/4713/
:green_circle: RHEL 7. https://ci.wazuh.info/job/Test_unattended/4716/
:green_circle: RHEL 8. https://ci.wazuh.info/job/Test_unattended/4712/

A manual testing has been performed in: 