### PR TITLE
Fix .deb upgrade to v4.8 by replacing old VD configuration

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for Wazuh
 # Wazuh, Inc 2015
 set -e
@@ -262,6 +262,52 @@ case "$1" in
         if getent group ossec > /dev/null 2>&1; then 
             delgroup ossec > /dev/null 2>&1
         fi
+    fi
+
+    # Function that checks if the old (< v4.8) VD configuration is present.
+    is_old_vulndet_config_present()
+    {
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
+
+        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$OSSEC_CONFIGURATION_FILE" ); then
+            return 0
+        fi
+        return 1
+    }
+
+    # Function that updates the old (< v4.8) VD configuration with the latest one.
+    update_vulndet_config()
+    {
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local OSSEC_CONFIGURATION_FILE_TMP="$1.tmp"
+
+        touch $OSSEC_CONFIGURATION_FILE_TMP
+        local OSSEC_CONFIGURATION_FILE_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $OSSEC_CONFIGURATION_FILE)"
+        local OSSEC_CONFIGURATION_FILE_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $OSSEC_CONFIGURATION_FILE)"
+
+        # Append current config preceding the old VD config.
+        echo "${OSSEC_CONFIGURATION_FILE_BEFORE_VD}" >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new VD config.
+        local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
+        cat ${VULNDET_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new Indexer config.
+        local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
+        cat ${INDEXER_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append current config succeeding the old VD config.
+        echo "$OSSEC_CONFIGURATION_FILE_AFTER_VD" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        mv $OSSEC_CONFIGURATION_FILE_TMP $OSSEC_CONFIGURATION_FILE
+    }
+
+    # Update VD configuration if necessary.
+    if is_old_vulndet_config_present "${DIR}/etc/ossec.conf"; then
+        update_vulndet_config "${DIR}/etc/ossec.conf"
     fi
 
     if [ ! -z "$2" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#2683 |

## Description

This PR improves the `postinst` script of the Debian manager package generation process in order to upgrade the new vulnerability detection configuration. 

## Results

### Package generation

The package has been generated by running
```bash
% ./generate_debian_package.sh -b dev-14153-vulndet-refactor -t manager -a amd64 -j 8 --packages-branch dev-abc-vulndet-upgrade 
```

Full output of the command above: [package_generation.log.gz](https://github.com/wazuh/wazuh-packages/files/13650738/package_generation.log.gz)

### Fresh install

- Installation
```bash
# apt install ./wazuh-manager_4.8.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.8.0-1_amd64.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/121 MB of archives.
After this operation, 719 MB of additional disk space will be used.
Get:1 /home/server-admin/wazuh-manager_4.8.0-1_amd64.deb wazuh-manager amd64 4.8.0-1 [121 MB]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package wazuh-manager.
(Reading database ... 100346 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) ...
Setting up wazuh-manager (4.8.0-1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Scanning processes...                                                                                                                                                                         
Scanning processor microcode...                                                                                                                                                               
Scanning linux images...                                                                                                                                                                      

Running kernel seems to be up-to-date.

The processor microcode seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```

- Service start
```bash
# systemctl start wazuh-manager

# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-12-12 16:35:53 UTC; 11s ago
    Process: 892002 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 126 (limit: 9249)
     Memory: 208.5M
        CPU: 26.219s
     CGroup: /system.slice/wazuh-manager.service
             ├─892058 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─892097 /var/ossec/bin/wazuh-authd
             ├─892113 /var/ossec/bin/wazuh-db
             ├─892138 /var/ossec/bin/wazuh-execd
             ├─892149 /var/ossec/bin/wazuh-analysisd
             ├─892210 /var/ossec/bin/wazuh-syscheckd
             ├─892223 /var/ossec/bin/wazuh-remoted
             ├─892226 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─892229 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─892232 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─892267 /var/ossec/bin/wazuh-logcollector
             └─892289 /var/ossec/bin/wazuh-monitord

Dec 12 16:35:47 ubuntu-server env[892002]: Started wazuh-analysisd...
Dec 12 16:35:47 ubuntu-server env[892002]: Started wazuh-syscheckd...
Dec 12 16:35:48 ubuntu-server env[892002]: Started wazuh-remoted...
Dec 12 16:35:49 ubuntu-server env[892002]: Started wazuh-logcollector...
Dec 12 16:35:50 ubuntu-server env[892002]: Started wazuh-monitord...
Dec 12 16:35:50 ubuntu-server env[892345]: 2023/12/12 16:35:50 wazuh-modulesd:router: INFO: Loaded router module.
Dec 12 16:35:50 ubuntu-server env[892345]: 2023/12/12 16:35:50 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 12 16:35:51 ubuntu-server env[892002]: Started wazuh-modulesd...
Dec 12 16:35:53 ubuntu-server env[892002]: Completed.
Dec 12 16:35:53 ubuntu-server systemd[1]: Started Wazuh manager.
```

### Upgrade from v4.7 to v4.8

- Upgrade
```bash
# apt install ./wazuh-manager_4.8.0-1_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.8.0-1_amd64.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/121 MB of archives.
After this operation, 89.3 MB of additional disk space will be used.
Get:1 /home/server-admin/wazuh-manager_4.8.0-1_amd64.deb wazuh-manager amd64 4.8.0-1 [121 MB]
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 121634 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) over (4.7.0-1) ...
Setting up wazuh-manager (4.8.0-1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Scanning processes...                                                                                                                                                                         
Scanning processor microcode...                                                                                                                                                               
Scanning linux images...                                                                                                                                                                      

Running kernel seems to be up-to-date.

The processor microcode seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```

- Status after upgrade
```bash
# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-12-12 18:28:16 UTC; 40s ago
    Process: 1519293 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 189 (limit: 9249)
     Memory: 230.6M
        CPU: 30.763s
     CGroup: /system.slice/wazuh-manager.service
             ├─1519349 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1519350 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1519353 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1519356 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1519397 /var/ossec/bin/wazuh-authd
             ├─1519410 /var/ossec/bin/wazuh-db
             ├─1519435 /var/ossec/bin/wazuh-execd
             ├─1519446 /var/ossec/bin/wazuh-analysisd
             ├─1519455 /var/ossec/bin/wazuh-syscheckd
             ├─1519472 /var/ossec/bin/wazuh-remoted
             ├─1519481 /var/ossec/bin/wazuh-logcollector
             ├─1519571 /var/ossec/bin/wazuh-monitord
             └─1519609 /var/ossec/bin/wazuh-modulesd

Dec 12 18:28:10 ubuntu-server env[1519293]: Started wazuh-analysisd...
Dec 12 18:28:11 ubuntu-server env[1519293]: Started wazuh-syscheckd...
Dec 12 18:28:11 ubuntu-server env[1519293]: Started wazuh-remoted...
Dec 12 18:28:12 ubuntu-server env[1519293]: Started wazuh-logcollector...
Dec 12 18:28:13 ubuntu-server env[1519293]: Started wazuh-monitord...
Dec 12 18:28:13 ubuntu-server env[1519604]: 2023/12/12 18:28:13 wazuh-modulesd:router: INFO: Loaded router module.
Dec 12 18:28:13 ubuntu-server env[1519604]: 2023/12/12 18:28:13 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 12 18:28:14 ubuntu-server env[1519293]: Started wazuh-modulesd...
Dec 12 18:28:16 ubuntu-server env[1519293]: Completed.
Dec 12 18:28:16 ubuntu-server systemd[1]: Started Wazuh manager.
```

### Reinstallation of v4.8

- Reinstallation
```bash
# dpkg -i ./wazuh-manager_4.8.0-1_amd64.deb 
(Reading database ... 122390 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) over (4.8.0-1) ...
Setting up wazuh-manager (4.8.0-1) ...
```

- Service status
```bash
# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-12-12 18:31:45 UTC; 4s ago
    Process: 1564764 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 189 (limit: 9249)
     Memory: 229.7M
        CPU: 23.417s
     CGroup: /system.slice/wazuh-manager.service
             ├─1564820 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1564821 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1564824 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1564827 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─1564868 /var/ossec/bin/wazuh-authd
             ├─1564881 /var/ossec/bin/wazuh-db
             ├─1564906 /var/ossec/bin/wazuh-execd
             ├─1564917 /var/ossec/bin/wazuh-analysisd
             ├─1564926 /var/ossec/bin/wazuh-syscheckd
             ├─1564943 /var/ossec/bin/wazuh-remoted
             ├─1565026 /var/ossec/bin/wazuh-logcollector
             ├─1565058 /var/ossec/bin/wazuh-monitord
             └─1565121 /var/ossec/bin/wazuh-modulesd

Dec 12 18:31:38 ubuntu-server env[1564764]: Started wazuh-analysisd...
Dec 12 18:31:39 ubuntu-server env[1564764]: Started wazuh-syscheckd...
Dec 12 18:31:40 ubuntu-server env[1564764]: Started wazuh-remoted...
Dec 12 18:31:41 ubuntu-server env[1564764]: Started wazuh-logcollector...
Dec 12 18:31:42 ubuntu-server env[1564764]: Started wazuh-monitord...
Dec 12 18:31:42 ubuntu-server env[1565119]: 2023/12/12 18:31:42 wazuh-modulesd:router: INFO: Loaded router module.
Dec 12 18:31:42 ubuntu-server env[1565119]: 2023/12/12 18:31:42 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 12 18:31:43 ubuntu-server env[1564764]: Started wazuh-modulesd...
Dec 12 18:31:45 ubuntu-server env[1564764]: Completed.
Dec 12 18:31:45 ubuntu-server systemd[1]: Started Wazuh manager.
```