### PR TITLE
 Ensure <indexer> config is present in ossec.conf after upgrade via deb package

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for Wazuh
 # Wazuh, Inc 2015
 set -e
@@ -264,6 +264,52 @@ case "$1" in
         if getent group ossec > /dev/null 2>&1; then 
             delgroup ossec > /dev/null 2>&1
         fi
+    fi
+
+    # Function that checks if the old (< v4.8) VD configuration is present.
+    is_old_vulndet_config_present()
+    {
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
+
+        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$OSSEC_CONFIGURATION_FILE" ); then
+            return 0
+        fi
+        return 1
+    }
+
+    # Function that updates the old (< v4.8) VD configuration with the latest one.
+    update_vulndet_config()
+    {
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local OSSEC_CONFIGURATION_FILE_TMP="$1.tmp"
+
+        touch $OSSEC_CONFIGURATION_FILE_TMP
+        local OSSEC_CONFIGURATION_FILE_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $OSSEC_CONFIGURATION_FILE)"
+        local OSSEC_CONFIGURATION_FILE_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $OSSEC_CONFIGURATION_FILE)"
+
+        # Append current config preceding the old VD config.
+        echo "${OSSEC_CONFIGURATION_FILE_BEFORE_VD}" >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new VD config.
+        local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
+        cat ${VULNDET_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new Indexer config.
+        local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
+        cat ${INDEXER_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append current config succeeding the old VD config.
+        echo "$OSSEC_CONFIGURATION_FILE_AFTER_VD" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        mv $OSSEC_CONFIGURATION_FILE_TMP $OSSEC_CONFIGURATION_FILE
+    }
+
+    # Update VD configuration if necessary.
+    if is_old_vulndet_config_present "${DIR}/etc/ossec.conf"; then
+        update_vulndet_config "${DIR}/etc/ossec.conf"
     fi
 
     if [ ! -z "$2" ]; then

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # postinst script for Wazuh
 # Wazuh, Inc 2015
 set -e
@@ -234,6 +234,12 @@ case "$1" in
 
     fi
 
+    # Upgrade old (< v4.8) VD configuration if present.
+    CONFIG_VD_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
+    CONFIG_INDEXER_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
+    . ./src/init/replace_vulnerability_detector.sh
+    updateVulnerabilityDetector "${DIR}/etc/ossec.conf" $CONFIG_VD_TEMPLATE $CONFIG_INDEXER_TEMPLATE
+
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true
 
@@ -264,52 +270,6 @@ case "$1" in
         if getent group ossec > /dev/null 2>&1; then 
             delgroup ossec > /dev/null 2>&1
         fi
-    fi
-
-    # Function that checks if the old (< v4.8) VD configuration is present.
-    is_old_vulndet_config_present()
-    {
-        local CONFIG_FILE="$1"
-        local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
-
-        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$CONFIG_FILE" ); then
-            return 0
-        fi
-        return 1
-    }
-
-    # Function that updates the old (< v4.8) VD configuration with the latest one.
-    update_vulndet_config()
-    {
-        local CONFIG_FILE="$1"
-        local CONFIG_FILE_TMP="$1.tmp"
-
-        touch $CONFIG_FILE_TMP
-        local CONFIG_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $CONFIG_FILE)"
-        local CONFIG_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $CONFIG_FILE)"
-
-        # Append current config preceding the old VD config.
-        echo "${CONFIG_BEFORE_VD}" >> $CONFIG_FILE_TMP
-        echo "" >> $CONFIG_FILE_TMP
-
-        # Append new VD config.
-        local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
-        cat ${VULNDET_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
-        echo "" >> $CONFIG_FILE_TMP
-
-        # Append new Indexer config.
-        local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
-        cat ${INDEXER_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
-
-        # Append current config succeeding the old VD config.
-        echo "$CONFIG_AFTER_VD" >> $CONFIG_FILE_TMP
-
-        mv $CONFIG_FILE_TMP $CONFIG_FILE
-    }
-
-    # Update VD configuration if necessary.
-    if is_old_vulndet_config_present "${DIR}/etc/ossec.conf"; then
-        update_vulndet_config "${DIR}/etc/ossec.conf"
     fi
 
     if [ ! -z "$2" ]; then

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -237,7 +237,7 @@ case "$1" in
     # Upgrade old (< v4.8) VD configuration if present.
     CONFIG_VD_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
     CONFIG_INDEXER_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
-    . ./src/init/replace_vulnerability_detector.sh
+    . ${SCRIPTS_DIR}/src/init/replace_vulnerability_detector.sh
     updateVulnerabilityDetector "${DIR}/etc/ossec.conf" $CONFIG_VD_TEMPLATE $CONFIG_INDEXER_TEMPLATE
 
     # Restoring file permissions

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -234,11 +234,10 @@ case "$1" in
 
     fi
 
-    # Upgrade old (< v4.8) VD configuration if present.
-    CONFIG_VD_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
+    # Ensure that the 'Indexer' is configured
     CONFIG_INDEXER_TEMPLATE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
-    . ${SCRIPTS_DIR}/src/init/replace_vulnerability_detector.sh
-    updateVulnerabilityDetector "${DIR}/etc/ossec.conf" $CONFIG_VD_TEMPLATE $CONFIG_INDEXER_TEMPLATE
+    . ${SCRIPTS_DIR}/src/init/update-indexer.sh
+    updateIndexerTemplate "${DIR}/etc/ossec.conf" $CONFIG_INDEXER_TEMPLATE
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -266,50 +266,80 @@ case "$1" in
         fi
     fi
 
-    # Function that checks if the old (< v4.8) VD configuration is present.
-    is_old_vulndet_config_present()
+    # Function that checks if a config if present.
+    is_config_present()
     {
-        local OSSEC_CONFIGURATION_FILE="$1"
-        local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
+        local CONFIG_FILE="${DIR}/etc/ossec.conf"
+        local CONFIG_PATTERN="$1"
 
-        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$OSSEC_CONFIGURATION_FILE" ); then
+        if ( grep -q "$CONFIG_PATTERN" "$CONFIG_FILE" ); then
             return 0
         fi
         return 1
     }
 
-    # Function that updates the old (< v4.8) VD configuration with the latest one.
-    update_vulndet_config()
+    # Function that adds a wodle config from a template file.
+    add_wodle_config()
     {
-        local OSSEC_CONFIGURATION_FILE="$1"
-        local OSSEC_CONFIGURATION_FILE_TMP="$1.tmp"
+        local CONFIG_FILE="${DIR}/etc/ossec.conf"
+        local CONFIG_FILE_TMP="${DIR}/etc/ossec.conf.tmp"
+        local WODLE_NAME="$1"
 
-        touch $OSSEC_CONFIGURATION_FILE_TMP
-        local OSSEC_CONFIGURATION_FILE_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $OSSEC_CONFIGURATION_FILE)"
-        local OSSEC_CONFIGURATION_FILE_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $OSSEC_CONFIGURATION_FILE)"
+        touch $CONFIG_FILE_TMP
+        cat ${CONFIG_FILE} >> $CONFIG_FILE_TMP
 
-        # Append current config preceding the old VD config.
-        echo "${OSSEC_CONFIGURATION_FILE_BEFORE_VD}" >> $OSSEC_CONFIGURATION_FILE_TMP
-        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+        # Remove trailing newlines and config closure ("</ossec_config>")
+        printf "%s" "$(< ${CONFIG_FILE_TMP})" > $CONFIG_FILE_TMP
+        sed -i '$ d' $CONFIG_FILE_TMP
 
-        # Append new VD config.
-        local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
-        cat ${VULNDET_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
-        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+        # Append wodle config.
+        local WODLE_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-${WODLE_NAME}.manager.template"
+        cat ${WODLE_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
+        echo "" >> $CONFIG_FILE_TMP
 
-        # Append new Indexer config.
-        local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
-        cat ${INDEXER_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+        # Close config.
+        echo "</ossec_config>" >> $CONFIG_FILE_TMP
 
-        # Append current config succeeding the old VD config.
-        echo "$OSSEC_CONFIGURATION_FILE_AFTER_VD" >> $OSSEC_CONFIGURATION_FILE_TMP
-
-        mv $OSSEC_CONFIGURATION_FILE_TMP $OSSEC_CONFIGURATION_FILE
+        mv $CONFIG_FILE_TMP $CONFIG_FILE
     }
 
-    # Update VD configuration if necessary.
-    if is_old_vulndet_config_present "${DIR}/etc/ossec.conf"; then
-        update_vulndet_config "${DIR}/etc/ossec.conf"
+    # Function that removes a piece of config given two patterns.
+    remove_config()
+    {
+        local CONFIG_FILE="${DIR}/etc/ossec.conf"
+        local CONFIG_FILE_TMP="${DIR}/etc/ossec.conf.tmp"
+        local PATTERN_BEFORE="$1"
+        local PATTERN_AFTER="$2"
+
+        touch $CONFIG_FILE_TMP
+        local CONFIG_BEFORE="$(sed -ne "$PATTERN_BEFORE" $CONFIG_FILE)"
+        local CONFIG_AFTER="$(sed -e "$PATTERN_AFTER" $CONFIG_FILE)"
+
+        # Append current config preceding the old VD config.
+        echo "${CONFIG_BEFORE}" >> $CONFIG_FILE_TMP
+
+        # Append current config succeeding the old VD config.
+        echo "$CONFIG_AFTER" >> $CONFIG_FILE_TMP
+
+        mv $CONFIG_FILE_TMP $CONFIG_FILE
+    }
+
+    # Remove old VD config if present.
+    is_config_present "<vulnerability-detector>"
+    if [[ $? -eq 0 ]]; then
+        remove_config "/<vulnerability-detector>/q;p" "1,/<\/vulnerability-detector>/d"
+    fi
+
+    # Append new VD config if not present.
+    is_config_present "<vulnerability-detection>"
+    if [[ $? -eq 1 ]]; then
+        add_wodle_config "vulnerability-detection"
+    fi
+
+    # Append new indexer config if not present.
+    is_config_present "<indexer>"
+    if [[ $? -eq 1 ]]; then
+        add_wodle_config "indexer"
     fi
 
     if [ ! -z "$2" ]; then

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -269,10 +269,10 @@ case "$1" in
     # Function that checks if the old (< v4.8) VD configuration is present.
     is_old_vulndet_config_present()
     {
-        local OSSEC_CONFIGURATION_FILE="$1"
+        local CONFIG_FILE="$1"
         local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
 
-        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$OSSEC_CONFIGURATION_FILE" ); then
+        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$CONFIG_FILE" ); then
             return 0
         fi
         return 1
@@ -281,30 +281,30 @@ case "$1" in
     # Function that updates the old (< v4.8) VD configuration with the latest one.
     update_vulndet_config()
     {
-        local OSSEC_CONFIGURATION_FILE="$1"
-        local OSSEC_CONFIGURATION_FILE_TMP="$1.tmp"
+        local CONFIG_FILE="$1"
+        local CONFIG_FILE_TMP="$1.tmp"
 
-        touch $OSSEC_CONFIGURATION_FILE_TMP
-        local OSSEC_CONFIGURATION_FILE_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $OSSEC_CONFIGURATION_FILE)"
-        local OSSEC_CONFIGURATION_FILE_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $OSSEC_CONFIGURATION_FILE)"
+        touch $CONFIG_FILE_TMP
+        local CONFIG_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $CONFIG_FILE)"
+        local CONFIG_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $CONFIG_FILE)"
 
         # Append current config preceding the old VD config.
-        echo "${OSSEC_CONFIGURATION_FILE_BEFORE_VD}" >> $OSSEC_CONFIGURATION_FILE_TMP
-        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "${CONFIG_BEFORE_VD}" >> $CONFIG_FILE_TMP
+        echo "" >> $CONFIG_FILE_TMP
 
         # Append new VD config.
         local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
-        cat ${VULNDET_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
-        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+        cat ${VULNDET_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
+        echo "" >> $CONFIG_FILE_TMP
 
         # Append new Indexer config.
         local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
-        cat ${INDEXER_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+        cat ${INDEXER_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
 
         # Append current config succeeding the old VD config.
-        echo "$OSSEC_CONFIGURATION_FILE_AFTER_VD" >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "$CONFIG_AFTER_VD" >> $CONFIG_FILE_TMP
 
-        mv $OSSEC_CONFIGURATION_FILE_TMP $OSSEC_CONFIGURATION_FILE
+        mv $CONFIG_FILE_TMP $CONFIG_FILE
     }
 
     # Update VD configuration if necessary.

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -266,80 +266,50 @@ case "$1" in
         fi
     fi
 
-    # Function that checks if a config if present.
-    is_config_present()
+    # Function that checks if the old (< v4.8) VD configuration is present.
+    is_old_vulndet_config_present()
     {
-        local CONFIG_FILE="${DIR}/etc/ossec.conf"
-        local CONFIG_PATTERN="$1"
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local VULNERABILITY_DETECTOR_PATTERN="<vulnerability-detector>"
 
-        if ( grep -q "$CONFIG_PATTERN" "$CONFIG_FILE" ); then
+        if ( grep -q "$VULNERABILITY_DETECTOR_PATTERN" "$OSSEC_CONFIGURATION_FILE" ); then
             return 0
         fi
         return 1
     }
 
-    # Function that adds a wodle config from a template file.
-    add_wodle_config()
+    # Function that updates the old (< v4.8) VD configuration with the latest one.
+    update_vulndet_config()
     {
-        local CONFIG_FILE="${DIR}/etc/ossec.conf"
-        local CONFIG_FILE_TMP="${DIR}/etc/ossec.conf.tmp"
-        local WODLE_NAME="$1"
+        local OSSEC_CONFIGURATION_FILE="$1"
+        local OSSEC_CONFIGURATION_FILE_TMP="$1.tmp"
 
-        touch $CONFIG_FILE_TMP
-        cat ${CONFIG_FILE} >> $CONFIG_FILE_TMP
-
-        # Remove trailing newlines and config closure ("</ossec_config>")
-        printf "%s" "$(< ${CONFIG_FILE_TMP})" > $CONFIG_FILE_TMP
-        sed -i '$ d' $CONFIG_FILE_TMP
-
-        # Append wodle config.
-        local WODLE_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-${WODLE_NAME}.manager.template"
-        cat ${WODLE_TEMPLATE_FILE} >> $CONFIG_FILE_TMP
-        echo "" >> $CONFIG_FILE_TMP
-
-        # Close config.
-        echo "</ossec_config>" >> $CONFIG_FILE_TMP
-
-        mv $CONFIG_FILE_TMP $CONFIG_FILE
-    }
-
-    # Function that removes a piece of config given two patterns.
-    remove_config()
-    {
-        local CONFIG_FILE="${DIR}/etc/ossec.conf"
-        local CONFIG_FILE_TMP="${DIR}/etc/ossec.conf.tmp"
-        local PATTERN_BEFORE="$1"
-        local PATTERN_AFTER="$2"
-
-        touch $CONFIG_FILE_TMP
-        local CONFIG_BEFORE="$(sed -ne "$PATTERN_BEFORE" $CONFIG_FILE)"
-        local CONFIG_AFTER="$(sed -e "$PATTERN_AFTER" $CONFIG_FILE)"
+        touch $OSSEC_CONFIGURATION_FILE_TMP
+        local OSSEC_CONFIGURATION_FILE_BEFORE_VD="$(sed -ne '/<vulnerability-detector>/q;p' $OSSEC_CONFIGURATION_FILE)"
+        local OSSEC_CONFIGURATION_FILE_AFTER_VD="$(sed -e '1,/<\/vulnerability-detector>/d' $OSSEC_CONFIGURATION_FILE)"
 
         # Append current config preceding the old VD config.
-        echo "${CONFIG_BEFORE}" >> $CONFIG_FILE_TMP
+        echo "${OSSEC_CONFIGURATION_FILE_BEFORE_VD}" >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new VD config.
+        local VULNDET_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-vulnerability-detection.manager.template"
+        cat ${VULNDET_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
+        echo "" >> $OSSEC_CONFIGURATION_FILE_TMP
+
+        # Append new Indexer config.
+        local INDEXER_TEMPLATE_FILE="${SCRIPTS_DIR}/etc/templates/config/generic/wodle-indexer.manager.template"
+        cat ${INDEXER_TEMPLATE_FILE} >> $OSSEC_CONFIGURATION_FILE_TMP
 
         # Append current config succeeding the old VD config.
-        echo "$CONFIG_AFTER" >> $CONFIG_FILE_TMP
+        echo "$OSSEC_CONFIGURATION_FILE_AFTER_VD" >> $OSSEC_CONFIGURATION_FILE_TMP
 
-        mv $CONFIG_FILE_TMP $CONFIG_FILE
+        mv $OSSEC_CONFIGURATION_FILE_TMP $OSSEC_CONFIGURATION_FILE
     }
 
-    # Remove old VD config if present.
-    is_config_present "<vulnerability-detector>"
-    if [[ $? -eq 0 ]]; then
-        remove_config "/<vulnerability-detector>/q;p" "1,/<\/vulnerability-detector>/d"
-    fi
-
-    # Append new VD config if not present.
-    is_config_present "<vulnerability-detection>"
-    if [[ $? -eq 1 ]]; then
-        add_wodle_config "vulnerability-detection"
-    fi
-
-    # Append new indexer config if not present.
-    is_config_present "<indexer>"
-    if [[ $? -eq 1 ]]; then
-        add_wodle_config "indexer"
+    # Update VD configuration if necessary.
+    if is_old_vulndet_config_present "${DIR}/etc/ossec.conf"; then
+        update_vulndet_config "${DIR}/etc/ossec.conf"
     fi
 
     if [ ! -z "$2" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#2683 |

## Description

This PR improves the `postinst` script of the Debian manager package generation process to ensure that after an upgrade the ossec.conf file contains the Indexer configuration section.

If the existing `ossec.conf` does not have an Indexer configuration section then the default Indexer configuration is appended at the end of `ossec.conf` as part of a new `<ossec_conf>` block.
If the existing `ossec.conf` does have an Indexer configuration then no changes are done to the `ossec.conf`.

## Results

### Package generation

The package has been generated by running
```bash
% ./generate_debian_package.sh -b dev-14153-vulndet-refactor -t manager -a amd64 -j 8 --packages-branch dev-2683-fix-upgrade-config-failure
ft@ft-nb:~/wazuh/repos/wazuh-packages/debs/output$ ls -lh
total 116M
-rw-r--r-- 1 root root 116M dic 21 08:07 wazuh-manager_4.8.0-1_amd64.deb
ft@ft-nb:~/wazuh/repos/wazuh-packages/debs/output$ sha256sum wazuh-manager_4.8.0-1_amd64.deb 
27ba2451f1efd381d7a9fb6d120d827d615cd597c23485dfb7d15a10ecdc474b  wazuh-manager_4.8.0-1_amd64.deb
```

### Fresh install

- Installation
```bash
root@bookworm:~# sha256sum wazuh-manager_4.8.0-1_amd64.deb 
27ba2451f1efd381d7a9fb6d120d827d615cd597c23485dfb7d15a10ecdc474b  wazuh-manager_4.8.0-1_amd64.deb
root@bookworm:~# dpkg -i wazuh-manager_4.8.0-1_amd64.deb 
Selecting previously unselected package wazuh-manager.
(Reading database ... 25530 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) ...
Setting up wazuh-manager (4.8.0-1) ...
```

<details><summary>ossec.conf</summary>

```
root@bookworm:~# cat /var/ossec/etc/ossec.conf 
<!--
  Wazuh - Manager - Default configuration for debian 12
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
    <update_check>yes</update_check>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>12</email_alert_level>
  </alerts>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
    <log_format>plain</log_format>
  </logging>

  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <queue_size>131072</queue_size>
  </remote>

  <!-- Policy monitoring -->
  <rootcheck>
    <disabled>no</disabled>
    <check_files>yes</check_files>
    <check_trojans>yes</check_trojans>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids>
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>

    <!-- Frequency that rootcheck is executed - every 12 hours -->
    <frequency>43200</frequency>

    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>

    <skip_nfs>yes</skip_nfs>
  </rootcheck>

  <wodle name="cis-cat">
    <disabled>yes</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>wodles/java</java_path>
    <ciscat_path>wodles/ciscat</ciscat_path>
  </wodle>

  <!-- Osquery integration -->
  <wodle name="osquery">
    <disabled>yes</disabled>
    <run_daemon>yes</run_daemon>
    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
    <config_path>/etc/osquery/osquery.conf</config_path>
    <add_labels>yes</add_labels>
  </wodle>

  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>yes</processes>

    <!-- Database synchronization settings -->
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
  </wodle>

  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>
  </sca>

  <vulnerability-detection>
    <enabled>yes</enabled>
    <index-status>yes</index-status>
    <feed-update-interval>60m</feed-update-interval>
  </vulnerability-detection>

  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://0.0.0.0:9200</host>
    </hosts>
    <username>admin</username>
    <password>admin</password>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
      <key>/etc/filebeat/certs/filebeat-key.pem</key>
    </ssl>
  </indexer>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Generate alert when new file detected -->
    <alert_new_files>yes</alert_new_files>

    <!-- Don't ignore files that change more than 'frequency' times -->
    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>50</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>

  <!-- Active response -->
  <global>
    <white_list>127.0.0.1</white_list>
    <white_list>^localhost.localdomain$</white_list>
    <white_list>192.168.31.1</white_list>
  </global>

  <command>
    <name>disable-account</name>
    <executable>disable-account</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>restart-wazuh</name>
    <executable>restart-wazuh</executable>
  </command>

  <command>
    <name>firewall-drop</name>
    <executable>firewall-drop</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>host-deny</name>
    <executable>host-deny</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>route-null</name>
    <executable>route-null</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>win_route-null</name>
    <executable>route-null.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>netsh</name>
    <executable>netsh.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <!--
  <active-response>
    active-response options here
  </active-response>
  -->

  <!-- Log analysis -->
  <localfile>
    <log_format>command</log_format>
    <command>df -P</command>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>last -n 20</command>
    <frequency>360</frequency>
  </localfile>

  <ruleset>
    <!-- Default ruleset -->
    <decoder_dir>ruleset/decoders</decoder_dir>
    <rule_dir>ruleset/rules</rule_dir>
    <rule_exclude>0215-policy_rules.xml</rule_exclude>
    <list>etc/lists/audit-keys</list>
    <list>etc/lists/amazon/aws-eventnames</list>
    <list>etc/lists/security-eventchannel</list>

    <!-- User-defined ruleset -->
    <decoder_dir>etc/decoders</decoder_dir>
    <rule_dir>etc/rules</rule_dir>
  </ruleset>

  <rule_test>
    <enabled>yes</enabled>
    <threads>1</threads>
    <max_sessions>64</max_sessions>
    <session_timeout>15m</session_timeout>
  </rule_test>

  <!-- Configuration for wazuh-authd -->
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>no</use_source_ip>
    <purge>yes</purge>
    <use_password>no</use_password>
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <!-- <ssl_agent_ca></ssl_agent_ca> -->
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>

  <cluster>
    <name>wazuh</name>
    <node_name>node01</node_name>
    <node_type>master</node_type>
    <key></key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>NODE_IP</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>yes</disabled>
  </cluster>

</ossec_config>

<ossec_config>
  <localfile>
    <log_format>syslog</log_format>
    <location>/var/ossec/logs/active-responses.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/auth.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/syslog</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/dpkg.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/kern.log</location>
  </localfile>

</ossec_config>

```
</details>

- Service start
```bash
root@bookworm:~# systemctl start wazuh-manager
root@bookworm:~# systemctl status wazuh-manager
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; enabled; preset: enabled)
     Active: active (running) since Thu 2023-12-21 11:21:36 UTC; 55s ago
      Tasks: 140 (limit: 9476)
     Memory: 455.9M
        CPU: 21.021s
     CGroup: /system.slice/wazuh-manager.service
             ├─45782 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─45822 /var/ossec/bin/wazuh-authd
             ├─45828 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─45831 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─45834 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─45847 /var/ossec/bin/wazuh-db
             ├─45872 /var/ossec/bin/wazuh-execd
             ├─45886 /var/ossec/bin/wazuh-analysisd
             ├─45929 /var/ossec/bin/wazuh-syscheckd
             ├─45950 /var/ossec/bin/wazuh-remoted
             ├─46002 /var/ossec/bin/wazuh-logcollector
             ├─46041 /var/ossec/bin/wazuh-monitord
             └─46081 /var/ossec/bin/wazuh-modulesd

Dec 21 11:21:29 bookworm env[45726]: Started wazuh-analysisd...
Dec 21 11:21:30 bookworm env[45726]: Started wazuh-syscheckd...
Dec 21 11:21:31 bookworm env[45726]: Started wazuh-remoted...
Dec 21 11:21:32 bookworm env[45726]: Started wazuh-logcollector...
Dec 21 11:21:33 bookworm env[45726]: Started wazuh-monitord...
Dec 21 11:21:33 bookworm env[46079]: 2023/12/21 11:21:33 wazuh-modulesd:router: INFO: Loaded router module.
Dec 21 11:21:33 bookworm env[46079]: 2023/12/21 11:21:33 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 21 11:21:34 bookworm env[45726]: Started wazuh-modulesd...
Dec 21 11:21:36 bookworm env[45726]: Completed.
Dec 21 11:21:36 bookworm systemd[1]: Started wazuh-manager.service - Wazuh manager.
```

### Upgrade from v4.7 to v4.8

<details><summary>v4.7 installation</summary>

```bash
root@bookworm:~# dpkg -i wazuh-manager_4.7.1-1_amd64.deb 
Selecting previously unselected package wazuh-manager.
(Reading database ... 25530 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.7.1-1_amd64.deb ...
Unpacking wazuh-manager (4.7.1-1) ...
Setting up wazuh-manager (4.7.1-1) ...
root@bookworm:~# 
```

</details>

<details><summary>v4.7 ossec.conf</summary>

```
root@bookworm:~# cat /var/ossec/etc/ossec.conf 
<!--
  Wazuh - Manager - Default configuration for debian 12
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>12</email_alert_level>
  </alerts>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
    <log_format>plain</log_format>
  </logging>

  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <queue_size>131072</queue_size>
  </remote>

  <!-- Policy monitoring -->
  <rootcheck>
    <disabled>no</disabled>
    <check_files>yes</check_files>
    <check_trojans>yes</check_trojans>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids>
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>

    <!-- Frequency that rootcheck is executed - every 12 hours -->
    <frequency>43200</frequency>

    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>

    <skip_nfs>yes</skip_nfs>
  </rootcheck>

  <wodle name="cis-cat">
    <disabled>yes</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>wodles/java</java_path>
    <ciscat_path>wodles/ciscat</ciscat_path>
  </wodle>

  <!-- Osquery integration -->
  <wodle name="osquery">
    <disabled>yes</disabled>
    <run_daemon>yes</run_daemon>
    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
    <config_path>/etc/osquery/osquery.conf</config_path>
    <add_labels>yes</add_labels>
  </wodle>

  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>yes</processes>

    <!-- Database synchronization settings -->
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
  </wodle>

  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>
  </sca>

  <vulnerability-detector>
    <enabled>no</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>no</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os>focal</os>
      <os>jammy</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>no</enabled>
      <os>buster</os>
      <os>bullseye</os>
      <os>bookworm</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>no</enabled>
      <os>5</os>
      <os>6</os>
      <os>7</os>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Amazon Linux OS vulnerabilities -->
    <provider name="alas">
      <enabled>no</enabled>
      <os>amazon-linux</os>
      <os>amazon-linux-2</os>
      <os>amazon-linux-2022</os>
      <os>amazon-linux-2023</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- SUSE OS vulnerabilities -->
    <provider name="suse">
      <enabled>no</enabled>
      <os>11-server</os>
      <os>11-desktop</os>
      <os>12-server</os>
      <os>12-desktop</os>
      <os>15-server</os>
      <os>15-desktop</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Arch OS vulnerabilities -->
    <provider name="arch">
      <enabled>no</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Alma Linux OS vulnerabilities -->
    <provider name="almalinux">
      <enabled>no</enabled>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Generate alert when new file detected -->
    <alert_new_files>yes</alert_new_files>

    <!-- Don't ignore files that change more than 'frequency' times -->
    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>50</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>

  <!-- Active response -->
  <global>
    <white_list>127.0.0.1</white_list>
    <white_list>^localhost.localdomain$</white_list>
    <white_list>192.168.31.1</white_list>
  </global>

  <command>
    <name>disable-account</name>
    <executable>disable-account</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>restart-wazuh</name>
    <executable>restart-wazuh</executable>
  </command>

  <command>
    <name>firewall-drop</name>
    <executable>firewall-drop</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>host-deny</name>
    <executable>host-deny</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>route-null</name>
    <executable>route-null</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>win_route-null</name>
    <executable>route-null.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>netsh</name>
    <executable>netsh.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <!--
  <active-response>
    active-response options here
  </active-response>
  -->

  <!-- Log analysis -->
  <localfile>
    <log_format>command</log_format>
    <command>df -P</command>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>last -n 20</command>
    <frequency>360</frequency>
  </localfile>

  <ruleset>
    <!-- Default ruleset -->
    <decoder_dir>ruleset/decoders</decoder_dir>
    <rule_dir>ruleset/rules</rule_dir>
    <rule_exclude>0215-policy_rules.xml</rule_exclude>
    <list>etc/lists/audit-keys</list>
    <list>etc/lists/amazon/aws-eventnames</list>
    <list>etc/lists/security-eventchannel</list>

    <!-- User-defined ruleset -->
    <decoder_dir>etc/decoders</decoder_dir>
    <rule_dir>etc/rules</rule_dir>
  </ruleset>

  <rule_test>
    <enabled>yes</enabled>
    <threads>1</threads>
    <max_sessions>64</max_sessions>
    <session_timeout>15m</session_timeout>
  </rule_test>

  <!-- Configuration for wazuh-authd -->
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>no</use_source_ip>
    <purge>yes</purge>
    <use_password>no</use_password>
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <!-- <ssl_agent_ca></ssl_agent_ca> -->
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>

  <cluster>
    <name>wazuh</name>
    <node_name>node01</node_name>
    <node_type>master</node_type>
    <key></key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>NODE_IP</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>yes</disabled>
  </cluster>

</ossec_config>

<ossec_config>
  <localfile>
    <log_format>syslog</log_format>
    <location>/var/ossec/logs/active-responses.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/auth.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/syslog</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/dpkg.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/kern.log</location>
  </localfile>

</ossec_config>

```
</details>

<details><summary>v4.7 service status</summary>

```
root@bookworm:~# systemctl start wazuh-manager.service 
root@bookworm:~# systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; preset: enabled)
     Active: active (running) since Thu 2023-12-21 11:29:26 UTC; 5s ago
    Process: 44261 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 115 (limit: 9476)
     Memory: 436.4M
        CPU: 20.826s
     CGroup: /system.slice/wazuh-manager.service
             ├─44317 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─44357 /var/ossec/bin/wazuh-authd
             ├─44372 /var/ossec/bin/wazuh-db
             ├─44387 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─44390 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─44393 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─44406 /var/ossec/bin/wazuh-execd
             ├─44420 /var/ossec/bin/wazuh-analysisd
             ├─44463 /var/ossec/bin/wazuh-syscheckd
             ├─44479 /var/ossec/bin/wazuh-remoted
             ├─44517 /var/ossec/bin/wazuh-logcollector
             ├─44562 /var/ossec/bin/wazuh-monitord
             └─44605 /var/ossec/bin/wazuh-modulesd

Dec 21 11:29:17 bookworm env[44261]: Started wazuh-db...
Dec 21 11:29:18 bookworm env[44261]: Started wazuh-execd...
Dec 21 11:29:19 bookworm env[44261]: Started wazuh-analysisd...
Dec 21 11:29:20 bookworm env[44261]: Started wazuh-syscheckd...
Dec 21 11:29:21 bookworm env[44261]: Started wazuh-remoted...
Dec 21 11:29:22 bookworm env[44261]: Started wazuh-logcollector...
Dec 21 11:29:23 bookworm env[44261]: Started wazuh-monitord...
Dec 21 11:29:24 bookworm env[44261]: Started wazuh-modulesd...
Dec 21 11:29:26 bookworm env[44261]: Completed.
Dec 21 11:29:26 bookworm systemd[1]: Started wazuh-manager.service - Wazuh manager.
```

</details>

- Upgrade
```bash
root@bookworm:~# dpkg -i wazuh-manager_4.8.0-1_amd64.deb 
(Reading database ... 46836 files and directories currently installed.)
Preparing to unpack wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) over (4.7.1-1) ...
Setting up wazuh-manager (4.8.0-1) ...
dpkg: error processing package wazuh-manager (--install):
 installed wazuh-manager package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 wazuh-manager
```
> [!NOTE]  
> The error encountered during upgrade is the one shown below (in the status) related to the presence of the `<vulnerability-detector>`. This will be fixed on a different issue.

- Status after upgrade
```bash
root@bookworm:~# systemctl status wazuh-manager.service 
× wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; preset: enabled)
     Active: failed (Result: exit-code) since Thu 2023-12-21 11:32:56 UTC; 9s ago
    Process: 88862 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=1/FAILURE)
        CPU: 1.379s

Dec 21 11:32:55 bookworm systemd[1]: Starting wazuh-manager.service - Wazuh manager...
Dec 21 11:32:56 bookworm env[88879]: 2023/12/21 11:32:56 wazuh-csyslogd: ERROR: (1230): Invalid element in the configuration: 'vulnerab>
Dec 21 11:32:56 bookworm env[88879]: 2023/12/21 11:32:56 wazuh-csyslogd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
Dec 21 11:32:56 bookworm env[88879]: 2023/12/21 11:32:56 wazuh-csyslogd: CRITICAL: (1202): Configuration error at 'etc/ossec.conf'.
Dec 21 11:32:56 bookworm env[88862]: wazuh-csyslogd: Configuration error. Exiting
Dec 21 11:32:56 bookworm systemd[1]: wazuh-manager.service: Control process exited, code=exited, status=1/FAILURE
Dec 21 11:32:56 bookworm systemd[1]: wazuh-manager.service: Failed with result 'exit-code'.
Dec 21 11:32:56 bookworm systemd[1]: Failed to start wazuh-manager.service - Wazuh manager.
Dec 21 11:32:56 bookworm systemd[1]: wazuh-manager.service: Consumed 1.379s CPU time.
```
> [!NOTE]  
> After manually removing the `<vulnerabilty-detector>` block from the ossec.conf file the manager starts correctly

<details><summary>ossec.conf after upgrade, with appended indexer config</summary>

```
root@bookworm:~# cat /var/ossec/etc/ossec.conf
<!--
  Wazuh - Manager - Default configuration for debian 12
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>12</email_alert_level>
  </alerts>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
    <log_format>plain</log_format>
  </logging>

  <remote>
    <connection>secure</connection>
    <port>1514</port>
    <protocol>tcp</protocol>
    <queue_size>131072</queue_size>
  </remote>

  <!-- Policy monitoring -->
  <rootcheck>
    <disabled>no</disabled>
    <check_files>yes</check_files>
    <check_trojans>yes</check_trojans>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids>
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>

    <!-- Frequency that rootcheck is executed - every 12 hours -->
    <frequency>43200</frequency>

    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>

    <skip_nfs>yes</skip_nfs>
  </rootcheck>

  <wodle name="cis-cat">
    <disabled>yes</disabled>
    <timeout>1800</timeout>
    <interval>1d</interval>
    <scan-on-start>yes</scan-on-start>

    <java_path>wodles/java</java_path>
    <ciscat_path>wodles/ciscat</ciscat_path>
  </wodle>

  <!-- Osquery integration -->
  <wodle name="osquery">
    <disabled>yes</disabled>
    <run_daemon>yes</run_daemon>
    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
    <config_path>/etc/osquery/osquery.conf</config_path>
    <add_labels>yes</add_labels>
  </wodle>

  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="no">yes</ports>
    <processes>yes</processes>

    <!-- Database synchronization settings -->
    <synchronization>
      <max_eps>10</max_eps>
    </synchronization>
  </wodle>

  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>
    <skip_nfs>yes</skip_nfs>
  </sca>

  <vulnerability-detector>
    <enabled>no</enabled>
    <interval>5m</interval>
    <min_full_scan_interval>6h</min_full_scan_interval>
    <run_on_start>yes</run_on_start>

    <!-- Ubuntu OS vulnerabilities -->
    <provider name="canonical">
      <enabled>no</enabled>
      <os>trusty</os>
      <os>xenial</os>
      <os>bionic</os>
      <os>focal</os>
      <os>jammy</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Debian OS vulnerabilities -->
    <provider name="debian">
      <enabled>no</enabled>
      <os>buster</os>
      <os>bullseye</os>
      <os>bookworm</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- RedHat OS vulnerabilities -->
    <provider name="redhat">
      <enabled>no</enabled>
      <os>5</os>
      <os>6</os>
      <os>7</os>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Amazon Linux OS vulnerabilities -->
    <provider name="alas">
      <enabled>no</enabled>
      <os>amazon-linux</os>
      <os>amazon-linux-2</os>
      <os>amazon-linux-2022</os>
      <os>amazon-linux-2023</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- SUSE OS vulnerabilities -->
    <provider name="suse">
      <enabled>no</enabled>
      <os>11-server</os>
      <os>11-desktop</os>
      <os>12-server</os>
      <os>12-desktop</os>
      <os>15-server</os>
      <os>15-desktop</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Arch OS vulnerabilities -->
    <provider name="arch">
      <enabled>no</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Alma Linux OS vulnerabilities -->
    <provider name="almalinux">
      <enabled>no</enabled>
      <os>8</os>
      <os>9</os>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Windows OS vulnerabilities -->
    <provider name="msu">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

    <!-- Aggregate vulnerabilities -->
    <provider name="nvd">
      <enabled>yes</enabled>
      <update_interval>1h</update_interval>
    </provider>

  </vulnerability-detector>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Generate alert when new file detected -->
    <alert_new_files>yes</alert_new_files>

    <!-- Don't ignore files that change more than 'frequency' times -->
    <auto_ignore frequency="10" timeframe="3600">no</auto_ignore>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>50</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>

  <!-- Active response -->
  <global>
    <white_list>127.0.0.1</white_list>
    <white_list>^localhost.localdomain$</white_list>
    <white_list>192.168.31.1</white_list>
  </global>

  <command>
    <name>disable-account</name>
    <executable>disable-account</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>restart-wazuh</name>
    <executable>restart-wazuh</executable>
  </command>

  <command>
    <name>firewall-drop</name>
    <executable>firewall-drop</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>host-deny</name>
    <executable>host-deny</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>route-null</name>
    <executable>route-null</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>win_route-null</name>
    <executable>route-null.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <command>
    <name>netsh</name>
    <executable>netsh.exe</executable>
    <timeout_allowed>yes</timeout_allowed>
  </command>

  <!--
  <active-response>
    active-response options here
  </active-response>
  -->

  <!-- Log analysis -->
  <localfile>
    <log_format>command</log_format>
    <command>df -P</command>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>last -n 20</command>
    <frequency>360</frequency>
  </localfile>

  <ruleset>
    <!-- Default ruleset -->
    <decoder_dir>ruleset/decoders</decoder_dir>
    <rule_dir>ruleset/rules</rule_dir>
    <rule_exclude>0215-policy_rules.xml</rule_exclude>
    <list>etc/lists/audit-keys</list>
    <list>etc/lists/amazon/aws-eventnames</list>
    <list>etc/lists/security-eventchannel</list>

    <!-- User-defined ruleset -->
    <decoder_dir>etc/decoders</decoder_dir>
    <rule_dir>etc/rules</rule_dir>
  </ruleset>

  <rule_test>
    <enabled>yes</enabled>
    <threads>1</threads>
    <max_sessions>64</max_sessions>
    <session_timeout>15m</session_timeout>
  </rule_test>

  <!-- Configuration for wazuh-authd -->
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>no</use_source_ip>
    <purge>yes</purge>
    <use_password>no</use_password>
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <!-- <ssl_agent_ca></ssl_agent_ca> -->
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>

  <cluster>
    <name>wazuh</name>
    <node_name>node01</node_name>
    <node_type>master</node_type>
    <key></key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>NODE_IP</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>yes</disabled>
  </cluster>

</ossec_config>

<ossec_config>
  <localfile>
    <log_format>syslog</log_format>
    <location>/var/ossec/logs/active-responses.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/auth.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/syslog</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/dpkg.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/kern.log</location>
  </localfile>

</ossec_config>

<ossec_config>

  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://0.0.0.0:9200</host>
    </hosts>
    <username>admin</username>
    <password>admin</password>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
      <key>/etc/filebeat/certs/filebeat-key.pem</key>
    </ssl>
  </indexer>

</ossec_config>
```
- Status after removing <vulnerability-detector> config block
```bash
root@bookworm:~# systemctl start wazuh-manager.service 
root@bookworm:~# systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; preset: enabled)
     Active: active (running) since Thu 2023-12-21 11:44:10 UTC; 57s ago
    Process: 88903 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 125 (limit: 9476)
     Memory: 262.5M
        CPU: 18.206s
     CGroup: /system.slice/wazuh-manager.service
             ├─88959 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─88960 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─88963 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─88966 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─89008 /var/ossec/bin/wazuh-authd
             ├─89024 /var/ossec/bin/wazuh-db
             ├─89049 /var/ossec/bin/wazuh-execd
             ├─89063 /var/ossec/bin/wazuh-analysisd
             ├─89080 /var/ossec/bin/wazuh-syscheckd
             ├─89127 /var/ossec/bin/wazuh-remoted
             ├─89188 /var/ossec/bin/wazuh-logcollector
             ├─89234 /var/ossec/bin/wazuh-monitord
             └─89284 /var/ossec/bin/wazuh-modulesd

Dec 21 11:44:03 bookworm env[88903]: Started wazuh-analysisd...
Dec 21 11:44:04 bookworm env[88903]: Started wazuh-syscheckd...
Dec 21 11:44:05 bookworm env[88903]: Started wazuh-remoted...
Dec 21 11:44:06 bookworm env[88903]: Started wazuh-logcollector...
Dec 21 11:44:07 bookworm env[88903]: Started wazuh-monitord...
Dec 21 11:44:07 bookworm env[89282]: 2023/12/21 11:44:07 wazuh-modulesd:router: INFO: Loaded router module.
Dec 21 11:44:07 bookworm env[89282]: 2023/12/21 11:44:07 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 21 11:44:08 bookworm env[88903]: Started wazuh-modulesd...
Dec 21 11:44:10 bookworm env[88903]: Completed.
Dec 21 11:44:10 bookworm systemd[1]: Started wazuh-manager.service - Wazuh manager.
```
</details>

### Reinstallation of v4.8

- Reinstallation
```bash
root@bookworm:~# dpkg -i ./wazuh-manager_4.8.0-1_amd64.deb
(Reading database ... 47574 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.8.0-1_amd64.deb ...
Unpacking wazuh-manager (4.8.0-1) over (4.8.0-1) ...
Setting up wazuh-manager (4.8.0-1) ...
```

- Service status
```bash
root@bookworm:~# systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; disabled; preset: enabled)
     Active: active (running) since Thu 2023-12-21 11:46:48 UTC; 2min 3s ago
    Process: 133498 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 125 (limit: 9476)
     Memory: 264.8M
        CPU: 18.597s
     CGroup: /system.slice/wazuh-manager.service
             ├─133554 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─133555 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─133558 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─133561 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh-apid.py
             ├─133603 /var/ossec/bin/wazuh-authd
             ├─133619 /var/ossec/bin/wazuh-db
             ├─133644 /var/ossec/bin/wazuh-execd
             ├─133658 /var/ossec/bin/wazuh-analysisd
             ├─133704 /var/ossec/bin/wazuh-syscheckd
             ├─133722 /var/ossec/bin/wazuh-remoted
             ├─133784 /var/ossec/bin/wazuh-logcollector
             ├─133831 /var/ossec/bin/wazuh-monitord
             └─133880 /var/ossec/bin/wazuh-modulesd

Dec 21 11:46:41 bookworm env[133498]: Started wazuh-analysisd...
Dec 21 11:46:42 bookworm env[133498]: Started wazuh-syscheckd...
Dec 21 11:46:43 bookworm env[133498]: Started wazuh-remoted...
Dec 21 11:46:44 bookworm env[133498]: Started wazuh-logcollector...
Dec 21 11:46:45 bookworm env[133498]: Started wazuh-monitord...
Dec 21 11:46:45 bookworm env[133877]: 2023/12/21 11:46:45 wazuh-modulesd:router: INFO: Loaded router module.
Dec 21 11:46:45 bookworm env[133877]: 2023/12/21 11:46:45 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Dec 21 11:46:46 bookworm env[133498]: Started wazuh-modulesd...
Dec 21 11:46:48 bookworm env[133498]: Completed.
Dec 21 11:46:48 bookworm systemd[1]: Started wazuh-manager.service - Wazuh manager.

```