### PR TITLE
Added `common_checkAptLock` function

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -7,6 +7,20 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
+function common_checkAptLock() {
+
+    attempt=0
+    seconds=30
+    max_attempts=10
+
+    while fuser "${apt_lockfile}" >/dev/null 2>&1 && [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt+1))
+        common_logger "Another process is using APT. Waiting for it to release the lock. Next retry in ${seconds} seconds (${attempt}/${max_attempts})"
+        sleep "${seconds}"
+    done
+
+}
+
 function common_logger() {
 
     now=$(date +'%d/%m/%Y %H:%M:%S')

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -98,7 +98,7 @@ function installCommon_aptInstall() {
         installer=${package}
     fi
     command="DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q"
-    installCommon_checkAptLock
+    common_checkAptLock
 
     if [ "${attempt}" -ne "${max_attempts}" ]; then
         apt_output=$(eval "${command} 2>&1")
@@ -545,7 +545,7 @@ function installCommon_rollBack() {
                 manager_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
             manager_installed=$(apt list --installed 2>/dev/null | grep wazuh-manager)
         fi
@@ -571,7 +571,7 @@ function installCommon_rollBack() {
                 indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
             indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
         fi
@@ -598,7 +598,7 @@ function installCommon_rollBack() {
                 filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
             filebeat_installed=$(apt list --installed 2>/dev/null | grep filebeat)
         fi
@@ -625,7 +625,7 @@ function installCommon_rollBack() {
                 dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
             dashboard_installed=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
         fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2686|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to fix the 4.8.0 WIA. This PR adds the `common_checkAptLock` function which was missing from https://github.com/wazuh/wazuh-packages/pull/2648/files#diff-31d5f1eaa91b837b7f91a80dbee9b531e84575ff1fcc23280e484ef223b7cadaL183-L196

## Testing

Testing is in: https://github.com/wazuh/wazuh-packages/issues/2686#issuecomment-1853664169

Automatic testing:
:green_circle: CentOS 8 https://ci.wazuh.info/job/Test_unattended/4719/
:green_circle: CentOS 7 https://ci.wazuh.info/job/Test_unattended/4718/
:green_circle: Ubuntu 18 https://ci.wazuh.info/job/Test_unattended/4720/
:green_circle: Ubuntu 16 https://ci.wazuh.info/job/Test_unattended/4721/
:green_circle: Ubuntu 20 https://ci.wazuh.info/job/Test_unattended/4722/
:green_circle: AL2 https://ci.wazuh.info/job/Test_unattended/4723/
:green_circle: RHEL7 https://ci.wazuh.info/job/Test_unattended/4724/
:green_circle: RHEL8 https://ci.wazuh.info/job/Test_unattended/4717/