### PR TITLE
Added offline installation feature to Installation Assistant

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -7,6 +7,20 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
+function common_checkAptLock() {
+
+    attempt=0
+    seconds=30
+    max_attempts=10
+
+    while fuser "${apt_lockfile}" >/dev/null 2>&1 && [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt+1))
+        common_logger "Another process is using APT. Waiting for it to release the lock. Next retry in ${seconds} seconds (${attempt}/${max_attempts})"
+        sleep "${seconds}"
+    done
+
+}
+
 function common_logger() {
 
     now=$(date +'%d/%m/%Y %H:%M:%S')

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -30,7 +30,7 @@ function checks_arguments() {
 
     # -------------- Offline installation ---------------------
 
-    if [ -n "${offline_installation}" ]; then
+    if [ -n "${offline_install}" ]; then
         if [ -z "${AIO}" ] && [ -z "${dashboard}" ] && [ -z "${indexer}" ] && [ -z "${wazuh}" ]; then
             common_logger -e "The -of|--offline-installation option must be used with -a, -ws, -wi, or -wd."
             exit 1

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -28,6 +28,15 @@ function checks_arguments() {
         fi
     fi
 
+    # -------------- Offline installation ---------------------
+
+    if [ -n "${offline_installation}" ]; then
+        if [ -z "${AIO}" ] && [ -z "${dashboard}" ] && [ -z "${indexer}" ] && [ -z "${wazuh}" ]; then
+            common_logger -e "The -of|--offline-installation option must be used with -a, -ws, -wi, or -wd."
+            exit 1
+        fi
+    fi
+
     # -------------- Configurations ---------------------------------
 
     if [ -f "${tar_file}" ]; then

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -205,8 +205,7 @@ function dashboard_install() {
 
     common_logger "Starting Wazuh dashboard installation."
     if [ "${sys_type}" == "yum" ]; then
-        eval "yum install wazuh-dashboard${sep}${wazuh_version} -y ${debug}"
-        install_result="${PIPESTATUS[0]}"
+        installCommon_yumInstall "wazuh-dashboard" "${wazuh_version}-*"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "wazuh-dashboard" "${wazuh_version}-*"
     fi

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -9,23 +9,29 @@
 function filebeat_configure(){
 
     common_logger -d "Configuring Filebeat."
-    eval "common_curl -sSo /etc/filebeat/wazuh-template.json ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 --fail"
-    if [ ! -f "/etc/filebeat/wazuh-template.json" ]; then
-        common_logger -e "Error downloading wazuh-template.json file."
-        installCommon_rollBack
-        exit 1
+
+    if [ -z "${offline_install}" ]; then
+        eval "common_curl -sSo /etc/filebeat/wazuh-template.json ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 --fail"
+        if [ ! -f "/etc/filebeat/wazuh-template.json" ]; then
+            common_logger -e "Error downloading wazuh-template.json file."
+            installCommon_rollBack
+            exit 1
+        fi
+        common_logger -d "Filebeat template was download successfully."
+
+        eval "(common_curl -sS ${filebeat_wazuh_module} --max-time 300 --retry 5 --retry-delay 5 --fail | tar -xvz -C /usr/share/filebeat/module) ${debug}"
+        if [ ! -d "/usr/share/filebeat/module" ]; then
+            common_logger -e "Error downloading wazuh filebeat module."
+            installCommon_rollBack
+            exit 1
+        fi
+        common_logger -d "Filebeat module was downloaded successfully."
+    else
+        eval "cp ${offline_files_path}/wazuh-template.json /etc/filebeat/wazuh-template.json ${debug}"
+        eval "tar -xvzf ${offline_files_path}/wazuh-filebeat-*.tar.gz -C /usr/share/filebeat/module ${debug}"
     fi
-    common_logger -d "Filebeat template was download successfully."
 
     eval "chmod go+r /etc/filebeat/wazuh-template.json ${debug}"
-    eval "(common_curl -sS ${filebeat_wazuh_module} --max-time 300 --retry 5 --retry-delay 5 --fail | tar -xvz -C /usr/share/filebeat/module) ${debug}"
-    if [ ! -d "/usr/share/filebeat/module" ]; then
-        common_logger -e "Error downloading wazuh filebeat module."
-        installCommon_rollBack
-        exit 1
-    fi
-    common_logger -d "Filebeat module was downloaded successfully."
-
     if [ -n "${AIO}" ]; then
         eval "installCommon_getConfig filebeat/filebeat_unattended.yml /etc/filebeat/filebeat.yml ${debug}"
     else

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -100,8 +100,7 @@ function filebeat_install() {
 
     common_logger "Starting Filebeat installation."
     if [ "${sys_type}" == "yum" ]; then
-        eval "yum install filebeat${sep}${filebeat_version} -y -q  ${debug}"
-        install_result="${PIPESTATUS[0]}"
+        installCommon_yumInstall "filebeat" "${filebeat_version}"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "filebeat" "${filebeat_version}"
     fi

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -144,8 +144,7 @@ function indexer_install() {
     common_logger "Starting Wazuh indexer installation."
 
     if [ "${sys_type}" == "yum" ]; then
-        eval "yum install wazuh-indexer-${wazuh_version} -y ${debug}"
-        install_result="${PIPESTATUS[0]}"
+        installCommon_yumInstall "wazuh-indexer" "${wazuh_version}-*"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "wazuh-indexer" "${wazuh_version}-*"
     fi

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -785,6 +785,12 @@ function installCommon_yumInstall() {
         installer="${package}"
     fi
 
+    # Offline installation case: get package name and install it
+    if [ -n "${offline_install}" ]; then
+        package_name=$(ls ${offline_packages_path} | grep ${package})
+        installer="${offline_packages_path}/${package_name}"
+    fi
+
     command="yum install ${installer} -y"
     common_checkYumLock
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -789,9 +789,10 @@ function installCommon_yumInstall() {
     if [ -n "${offline_install}" ]; then
         package_name=$(ls ${offline_packages_path} | grep ${package})
         installer="${offline_packages_path}/${package_name}"
+        command="rpm -ivh ${installer}"
+    else
+        command="yum install ${installer} -y"
     fi
-
-    command="yum install ${installer} -y"
     common_checkYumLock
 
     if [ "${attempt}" -ne "${max_attempts}" ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -105,7 +105,7 @@ function installCommon_aptInstall() {
     fi
 
     command="DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q"
-    installCommon_checkAptLock
+    common_checkAptLock
 
     if [ "${attempt}" -ne "${max_attempts}" ]; then
         apt_output=$(eval "${command} 2>&1")
@@ -551,7 +551,7 @@ function installCommon_rollBack() {
                 manager_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
             manager_installed=$(apt list --installed 2>/dev/null | grep wazuh-manager)
         fi
@@ -577,7 +577,7 @@ function installCommon_rollBack() {
                 indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
             indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
         fi
@@ -604,7 +604,7 @@ function installCommon_rollBack() {
                 filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
             filebeat_installed=$(apt list --installed 2>/dev/null | grep filebeat)
         fi
@@ -631,7 +631,7 @@ function installCommon_rollBack() {
                 dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
-            installCommon_checkAptLock
+            common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
             dashboard_installed=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
         fi

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -58,7 +58,13 @@ function installCommon_addWazuhRepo() {
 
     if [ ! -f "/etc/yum.repos.d/wazuh.repo" ] && [ ! -f "/etc/zypp/repos.d/wazuh.repo" ] && [ ! -f "/etc/apt/sources.list.d/wazuh.list" ] ; then
         if [ "${sys_type}" == "yum" ]; then
-            eval "rpm --import ${repogpg} ${debug}"
+
+            if [ -n "${offline_install}" ]; then
+                eval "rpm --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
+            else
+                eval "rpm --import ${repogpg} ${debug}"
+            fi
+            
             if [ "${PIPESTATUS[0]}" != 0 ]; then
                 common_logger -e "Cannot import Wazuh GPG key"
                 exit 1
@@ -66,7 +72,13 @@ function installCommon_addWazuhRepo() {
             eval "(echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo)" "${debug}"
             eval "chmod 644 /etc/yum.repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "common_curl -s ${repogpg} --max-time 300 --retry 5 --retry-delay 5 --fail | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
+
+            if [ -n "${offline_install}" ]; then
+                eval "gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
+            else
+                eval "common_curl -s ${repogpg} --max-time 300 --retry 5 --retry-delay 5 --fail | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
+            fi
+        
             if [ "${PIPESTATUS[0]}" != 0 ]; then
                 common_logger -e "Cannot import Wazuh GPG key"
                 exit 1
@@ -97,6 +109,13 @@ function installCommon_aptInstall() {
     else
         installer=${package}
     fi
+
+    # Offline installation case: get package name and install it
+    if [ -n "${offline_install}" ]; then
+        package_name=$(ls ${offline_packages_path} | grep ${package})
+        installer="${offline_packages_path}/${package_name}"
+    fi
+
     command="DEBIAN_FRONTEND=noninteractive apt-get install ${installer} -y -q"
     installCommon_checkAptLock
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -58,13 +58,7 @@ function installCommon_addWazuhRepo() {
 
     if [ ! -f "/etc/yum.repos.d/wazuh.repo" ] && [ ! -f "/etc/zypp/repos.d/wazuh.repo" ] && [ ! -f "/etc/apt/sources.list.d/wazuh.list" ] ; then
         if [ "${sys_type}" == "yum" ]; then
-
-            if [ -n "${offline_install}" ]; then
-                eval "rpm --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
-            else
-                eval "rpm --import ${repogpg} ${debug}"
-            fi
-            
+            eval "rpm --import ${repogpg} ${debug}"
             if [ "${PIPESTATUS[0]}" != 0 ]; then
                 common_logger -e "Cannot import Wazuh GPG key"
                 exit 1
@@ -72,13 +66,7 @@ function installCommon_addWazuhRepo() {
             eval "(echo -e '[wazuh]\ngpgcheck=1\ngpgkey=${repogpg}\nenabled=1\nname=EL-\${releasever} - Wazuh\nbaseurl='${repobaseurl}'/yum/\nprotect=1' | tee /etc/yum.repos.d/wazuh.repo)" "${debug}"
             eval "chmod 644 /etc/yum.repos.d/wazuh.repo ${debug}"
         elif [ "${sys_type}" == "apt-get" ]; then
-
-            if [ -n "${offline_install}" ]; then
-                eval "gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
-            else
-                eval "common_curl -s ${repogpg} --max-time 300 --retry 5 --retry-delay 5 --fail | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
-            fi
-        
+            eval "common_curl -s ${repogpg} --max-time 300 --retry 5 --retry-delay 5 --fail | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import - ${debug}"
             if [ "${PIPESTATUS[0]}" != 0 ]; then
                 common_logger -e "Cannot import Wazuh GPG key"
                 exit 1

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -790,6 +790,7 @@ function installCommon_yumInstall() {
         package_name=$(ls ${offline_packages_path} | grep ${package})
         installer="${offline_packages_path}/${package_name}"
         command="rpm -ivh ${installer}"
+        common_logger -d "Installing local package: ${installer}"
     else
         command="yum install ${installer} -y"
     fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -291,7 +291,9 @@ function main() {
             installCommon_installPrerequisites
         fi
         check_curlVersion
-        installCommon_addWazuhRepo
+        if [ -z "${offline_install}" ]; then
+            installCommon_addWazuhRepo
+        fi
     fi
 
 # -------------- Configuration creation case  -----------------------
@@ -391,7 +393,7 @@ function main() {
 
 # -------------------------------------------------------------------
 
-    if [ -z "${configurations}" ] && [ -z "${download}" ]; then
+    if [ -z "${configurations}" ] && [ -z "${download}" ] && [ -z "${offline_install}" ]; then
         installCommon_restoreWazuhrepo
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -118,7 +118,7 @@ function main() {
                 shift 1
                 ;;
             "-of"|"--offline-installation")
-                offline_installation=1
+                offline_install=1
                 shift 1
                 ;;
             "-p"|"--port")
@@ -224,9 +224,9 @@ function main() {
 
     common_checkSystem
 
-    if [ -z "${uninstall}" ] && [ -z "${offline_installation}" ]; then
+    if [ -z "${uninstall}" ] && [ -z "${offline_install}" ]; then
         installCommon_installCheckDependencies
-    elif [ -n "${offline_installation}" ]; then
+    elif [ -n "${offline_install}" ]; then
         offline_checkDependencies
     fi
     
@@ -281,13 +281,13 @@ function main() {
 # -------------- Prerequisites and Wazuh repo  ----------------------
 
     # Offline installation case: extract the compressed files,
-    if [ -n "${offline_installation}" ]; then
+    if [ -n "${offline_install}" ]; then
         offline_checkPreinstallation
         offline_extractFiles
     fi
 
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
-        if [ -z "${offline_installation}" ]; then
+        if [ -z "${offline_install}" ]; then
             installCommon_installPrerequisites
         fi
         check_curlVersion

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -280,7 +280,7 @@ function main() {
 
 # -------------- Prerequisites and Wazuh repo  ----------------------
 
-    # Offline installation case: extract the compressed files,
+    # Offline installation case: extract the compressed files
     if [ -n "${offline_install}" ]; then
         offline_checkPreinstallation
         offline_extractFiles

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -40,6 +40,9 @@ function getHelp() {
     echo -e "        -o,  --overwrite"
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
     echo -e ""
+    echo -e "        -of,  --offline-installation"
+    echo -e "                Perform an offline installation. This option must be used with -a, -ws, -wi, or -wd."
+    echo -e ""
     echo -e "        -p,  --port"
     echo -e "                Specifies the Wazuh web user interface port. By default is the 443 TCP port. Recommended ports are: 8443, 8444, 8080, 8888, 9000."
     echo -e ""
@@ -112,6 +115,10 @@ function main() {
                 ;;
             "-o"|"--overwrite")
                 overwrite=1
+                shift 1
+                ;;
+            "-of"|"--offline-installation")
+                offline_installation=1
                 shift 1
                 ;;
             "-p"|"--port")
@@ -217,8 +224,10 @@ function main() {
 
     common_checkSystem
 
-    if [ -z "${uninstall}" ]; then
+    if [ -z "${uninstall}" ] && [ -z "${offline_installation}" ]; then
         installCommon_installCheckDependencies
+    elif [ -n "${offline_installation}" ]; then
+        offline_checkDependencies
     fi
     
     if [ -z "${download}" ]; then
@@ -233,10 +242,6 @@ function main() {
     fi
 
 # -------------- Preliminary checks  --------------------------------
-
-    if [ -z "${uninstall}" ]; then
-        installCommon_installCheckDependencies
-    fi
 
     if [ -z "${configurations}" ] && [ -z "${AIO}" ] && [ -z "${download}" ]; then
         checks_previousCertificate
@@ -275,8 +280,16 @@ function main() {
 
 # -------------- Prerequisites and Wazuh repo  ----------------------
 
+    # Offline installation case: extract the compressed files,
+    if [ -n "${offline_installation}" ]; then
+        offline_checkPreinstallation
+        offline_extractFiles
+    fi
+
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then
-        installCommon_installPrerequisites
+        if [ -z "${offline_installation}" ]; then
+            installCommon_installPrerequisites
+        fi
         check_curlVersion
         installCommon_addWazuhRepo
     fi

--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -46,8 +46,7 @@ function manager_install() {
 
     common_logger "Starting the Wazuh manager installation."
     if [ "${sys_type}" == "yum" ]; then
-        eval "${sys_type} install wazuh-manager${sep}${wazuh_version} -y ${debug}"
-        install_result="${PIPESTATUS[0]}"
+        installCommon_yumInstall "wazuh-manager" "${wazuh_version}-*"
     elif [ "${sys_type}" == "apt-get" ]; then
         installCommon_aptInstall "wazuh-manager" "${wazuh_version}-*"
     fi

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -55,20 +55,20 @@ function offline_extractFiles() {
         exit 1
     fi
 
-    files_dir="${base_path}/wazuh-offline/wazuh-files"
-    packages_dir="${base_path}/wazuh-offline/wazuh-packages"
+    offline_files_path="${base_path}/wazuh-offline/wazuh-files"
+    offline_packages_path="${base_path}/wazuh-offline/wazuh-packages"
 
     required_files=(
-        "${files_dir}/filebeat.yml"
-        "${files_dir}/GPG-KEY-WAZUH"
-        "${files_dir}/wazuh-filebeat-*.tar.gz"
-        "${files_dir}/wazuh-template.json"
+        "${offline_files_path}/filebeat.yml"
+        "${offline_files_path}/GPG-KEY-WAZUH"
+        "${offline_files_path}/wazuh-filebeat-*.tar.gz"
+        "${offline_files_path}/wazuh-template.json"
     )
     
     if [ "${sys_type}" == "apt-get" ]; then
-        required_files+=("${packages_dir}/filebeat-oss-*.deb" "${packages_dir}/wazuh-dashboard_*.deb" "${packages_dir}/wazuh-indexer_*.deb" "${packages_dir}/wazuh-manager_*.deb")
+        required_files+=("${offline_packages_path}/filebeat-oss-*.deb" "${offline_packages_path}/wazuh-dashboard_*.deb" "${offline_packages_path}/wazuh-indexer_*.deb" "${offline_packages_path}/wazuh-manager_*.deb")
     elif [ "${sys_type}" == "rpm" ]; then
-        required_files+=("${packages_dir}/filebeat-oss-*.rpm" "${packages_dir}/wazuh-dashboard_*.rpm" "${packages_dir}/wazuh-indexer_*.rpm" "${packages_dir}/wazuh-manager_*.rpm")
+        required_files+=("${offline_packages_path}/filebeat-oss-*.rpm" "${offline_packages_path}/wazuh-dashboard_*.rpm" "${offline_packages_path}/wazuh-indexer_*.rpm" "${offline_packages_path}/wazuh-manager_*.rpm")
     fi
 
     for file in "${required_files[@]}"; do

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -47,12 +47,13 @@ function offline_checkPreinstallation() {
 function offline_extractFiles() {
 
     common_logger -d "Extracting files from ${offline_tarfile}"
-    eval "rm -rf ${base_path}/wazuh-offline/"
-    eval "tar -xzf ${offline_tarfile} ${debug}"
-
     if [ ! -d "${base_path}/wazuh-offline/" ]; then
-        common_logger -e "The ${offline_tarfile} file could not be decompressed."
-        exit 1
+        eval "tar -xzf ${offline_tarfile} ${debug}"
+
+        if [ ! -d "${base_path}/wazuh-offline/" ]; then
+            common_logger -e "The ${offline_tarfile} file could not be decompressed."
+            exit 1
+        fi
     fi
 
     offline_files_path="${base_path}/wazuh-offline/wazuh-files"

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Wazuh installer: offline download
+# Copyright (C) 2023, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Checks the necessary dependencies for the installation
+function offline_checkDependencies() {
+
+    dependencies=( curl tar gnupg openssl )
+
+    common_logger "Checking installed dependencies for Offline installation."
+    for dep in "${dependencies[@]}"; do
+        if [ "${sys_type}" == "yum" ]; then
+            eval "yum list installed 2>/dev/null | grep -q -E ^"${dep}"\\."
+        elif [ "${sys_type}" == "apt-get" ]; then
+            eval "apt list --installed 2>/dev/null | grep -q -E ^"${dep}"\/"
+        fi
+        
+        if [ "${PIPESTATUS[0]}" != 0 ]; then
+            common_logger -e "${dep} is necessary for the offline installation."
+            exit 1
+        fi
+    done
+    common_logger -d "Offline dependencies are installed."
+
+}
+
+# Checks the necessary files for the installation
+function offline_checkPreinstallation() {
+
+    offline_tarfile="${base_dest_folder}.tar.gz"
+    common_logger "Checking ${offline_tarfile} file."
+    if [ ! -f "${base_path}/${offline_tarfile}" ]; then
+        common_logger -e "The ${offline_tarfile} file was not found in ${base_path}."
+        exit 1
+    fi
+    common_logger -d "${offline_tarfile} was found correctly."
+
+}
+
+# Extracts the files for the offline installation and check its content
+function offline_extractFiles() {
+
+    common_logger -d "Extracting files from ${offline_tarfile}"
+    eval "rm -rf ${base_path}/wazuh-offline/"
+    eval "tar -xzf ${offline_tarfile} ${debug}"
+
+    if [ ! -d "${base_path}/wazuh-offline/" ]; then
+        common_logger -e "The ${offline_tarfile} file could not be decompressed."
+        exit 1
+    fi
+
+    files_dir="${base_path}/wazuh-offline/wazuh-files"
+    packages_dir="${base_path}/wazuh-offline/wazuh-packages"
+
+    required_files=(
+        "${files_dir}/filebeat.yml"
+        "${files_dir}/GPG-KEY-WAZUH"
+        "${files_dir}/wazuh-filebeat-*.tar.gz"
+        "${files_dir}/wazuh-template.json"
+    )
+    
+    if [ "${sys_type}" == "apt-get" ]; then
+        required_files+=("${packages_dir}/filebeat-oss-*.deb" "${packages_dir}/wazuh-dashboard_*.deb" "${packages_dir}/wazuh-indexer_*.deb" "${packages_dir}/wazuh-manager_*.deb")
+    elif [ "${sys_type}" == "rpm" ]; then
+        required_files+=("${packages_dir}/filebeat-oss-*.rpm" "${packages_dir}/wazuh-dashboard_*.rpm" "${packages_dir}/wazuh-indexer_*.rpm" "${packages_dir}/wazuh-manager_*.rpm")
+    fi
+
+    for file in "${required_files[@]}"; do
+        if ! compgen -G "${file}" > /dev/null; then
+            common_logger -e "Missing necessary offline file: ${file}"
+            exit 1
+        fi
+    done
+
+    common_logger -d "Offline files extracted successfully."
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/1422|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to add the offline installation option to the Wazuh installation assistant. This option complements the offline download option. With this, the Installation Assistant can automatically:
- Download the Wazuh packages with an internet connection.
- Install Wazuh (AIO or distributed) without an internet connection.

Now, with the packages installed, the WIA can be used as follows:
- `bash wazuh-install.sh -a -of`. AIO offline installation 
- `bash wazuh-install.sh -wi <node> -of`. Wazuh indexer offline installation 
- `bash wazuh-install.sh -ws <node> -of`. Wazuh manager offline installation 
- `bash wazuh-install.sh -wd <node> -of`. Wazuh dashboard offline installation 

## Tests


Complete testing is in: https://github.com/wazuh/wazuh-packages/issues/1422#issuecomment-1855639917

Automatic testing:
:green_circle: CentOS 8: https://ci.wazuh.info/job/Test_unattended/4751/
:green_circle: CentOS 7: https://ci.wazuh.info/job/Test_unattended/4750/
:green_circle: Ubuntu 18: https://ci.wazuh.info/job/Test_unattended/4752/
:green_circle: Ubuntu 16: https://ci.wazuh.info/job/Test_unattended/4753/
:green_circle: Ubuntu 20: https://ci.wazuh.info/job/Test_unattended/4754/
:green_circle: AL2: https://ci.wazuh.info/job/Test_unattended/4755/
:green_circle: RHEL7: https://ci.wazuh.info/job/Test_unattended/4748/
:green_circle: RHEL8: https://ci.wazuh.info/job/Test_unattended/4749/
