### PR TITLE
Add content database in RPM and DEB packages

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -73,6 +73,9 @@ case "$1" in
 
     if [ -f "${DIR}/vd.tar.xz" ]; then
         tar -xf ${DIR}/vd.tar.xz -C ${DIR}
+        chown ${USER}:${GROUP} ${DIR}/queue/vd
+        chown ${USER}:${GROUP} ${DIR}/queue/vd-updater
+        rm -rf ${DIR}/vd.tar.xz
     fi
 
     # Delete uncompatible DBs versions

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -15,6 +15,7 @@ case "$1" in
     OSMYSHELL="/sbin/nologin"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_installation_scripts"
     SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
+    VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
 
     if [ -d /run/systemd/system ]; then
         rm -f /etc/init.d/wazuh-manager
@@ -71,11 +72,11 @@ case "$1" in
         chown ${USER}:${GROUP} ${DIR}/queue/db/global.db*
     fi
 
-    if [ -f "${DIR}/vd.tar.xz" ]; then
-        tar -xf ${DIR}/vd.tar.xz -C ${DIR}
+    if [ -f "${DIR}/${VD_FILENAME}" ]; then
+        tar -xf ${DIR}/${VD_FILENAME} -C ${DIR}
         chown ${USER}:${GROUP} ${DIR}/queue/vd
         chown ${USER}:${GROUP} ${DIR}/queue/vd-updater
-        rm -rf ${DIR}/vd.tar.xz
+        rm -rf ${DIR}/${VD_FILENAME}
     fi
 
     # Delete uncompatible DBs versions

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -75,7 +75,7 @@ case "$1" in
     if [ -f "${DIR}/${VD_FILENAME}" ]; then
         tar -xf ${DIR}/${VD_FILENAME} -C ${DIR}
         chown ${USER}:${GROUP} ${DIR}/queue/vd
-        chown ${USER}:${GROUP} ${DIR}/queue/vd-updater
+        chown ${USER}:${GROUP} ${DIR}/queue/vd_updater
         rm -rf ${DIR}/${VD_FILENAME}
     fi
 

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -71,6 +71,10 @@ case "$1" in
         chown ${USER}:${GROUP} ${DIR}/queue/db/global.db*
     fi
 
+    if [ -f "${DIR}/vd.tar.xz" ]; then
+        tar -xf ${DIR}/vd.tar.xz -C ${DIR}
+    fi
+
     # Delete uncompatible DBs versions
     if [ ! -z $2 ]; then
 

--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -26,6 +26,7 @@ export JOBS="5"
 export DEBUG_ENABLED="no"
 export PATH="${PATH}"
 export LD_LIBRARY_PATH=""
+export DOWNLOAD_CONTENT_ENABLED="no"
 
 %:
 	dh $@
@@ -64,6 +65,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
+	DOWNLOAD_CONTENT="$(DOWNLOAD_CONTENT_ENABLED)" \
 	./install.sh
 
 	# Copying init.d script

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -23,6 +23,7 @@ wazuh_packages_branch=$9
 use_local_specs=${10}
 local_source_code=${11}
 future=${12}
+download_content=${13}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
@@ -87,6 +88,7 @@ cd ${build_dir}/${build_target} && tar -czf ${package_full_name}.orig.tar.gz "${
 sed -i "s:RELEASE:${package_release}:g" ${sources_dir}/debian/changelog
 sed -i "s:export JOBS=.*:export JOBS=${jobs}:g" ${sources_dir}/debian/rules
 sed -i "s:export DEBUG_ENABLED=.*:export DEBUG_ENABLED=${debug}:g" ${sources_dir}/debian/rules
+sed -i "s:export DOWNLOAD_CONTENT_ENABLED=.*:export DOWNLOAD_CONTENT_ENABLED=${download_content}:g" ${sources_dir}/debian/rules
 sed -i "s#export PATH=.*#export PATH=/usr/local/gcc-5.5.0/bin:${PATH}#g" ${sources_dir}/debian/rules
 sed -i "s#export LD_LIBRARY_PATH=.*#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}#g" ${sources_dir}/debian/rules
 sed -i "s:export INSTALLATION_DIR=.*:export INSTALLATION_DIR=${dir_path}:g" ${sources_dir}/debian/rules

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -15,6 +15,7 @@ REVISION="1"
 TARGET=""
 JOBS="2"
 DEBUG="no"
+DOWNLOAD_CONTENT="no"
 BUILD_DOCKER="yes"
 DOCKER_TAG="latest"
 INSTALLATION_PATH="/var/ossec"
@@ -84,7 +85,7 @@ build_deb() {
         ${CONTAINER_NAME}:${DOCKER_TAG} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
-        ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
+        ${USE_LOCAL_SOURCE_CODE} ${FUTURE} {DOWNLOAD_CONTENT}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -162,6 +163,7 @@ help() {
     echo "    -p, --path <path>          [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug                [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum <path>      [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
+    echo "    --download-content         [Optional] Download content and add it to the package."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --tag                      [Optional] Tag to use with the docker image."
     echo "    --sources <path>           [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
@@ -244,6 +246,10 @@ main() {
                 CHECKSUM="yes"
                 shift 1
             fi
+            ;;
+        "--download-content")
+            DOWNLOAD_CONTENT="yes"
+            shift 1
             ;;
         "--dont-build-docker")
             BUILD_DOCKER="no"

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -85,7 +85,7 @@ build_deb() {
         ${CONTAINER_NAME}:${DOCKER_TAG} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
-        ${USE_LOCAL_SOURCE_CODE} ${FUTURE} {DOWNLOAD_CONTENT}|| return 1
+        ${USE_LOCAL_SOURCE_CODE} ${FUTURE} ${DOWNLOAD_CONTENT}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -78,6 +78,7 @@ echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
+echo 'DOWNLOAD_CONTENT="%{_download_content_enabled}"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories
@@ -303,6 +304,13 @@ if [ $1 = 2 ]; then
   CONFIG_INDEXER_TEMPLATE="%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/generic/wodle-indexer.manager.template"
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/update-indexer.sh
   updateIndexerTemplate "%{_localstatedir}/etc/ossec.conf" $CONFIG_INDEXER_TEMPLATE
+fi
+
+if [ -f "%{_localstatedir}/vd.tar.xz" ]; then
+    tar -xf %{_localstatedir}/vd.tar.xz -C %{_localstatedir}
+    chown wazuh:wazuh %{_localstatedir}/queue/vd
+    chown wazuh:wazuh %{_localstatedir}/queue/vd-updater
+    rm -rf tar -xf %{_localstatedir}/vd.tar.xz
 fi
 
 # Fresh install code block
@@ -725,6 +733,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
+%attr(750, wazuh, wazuh) %{_localstatedir}/vd.tar.xz
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -306,12 +306,12 @@ if [ $1 = 2 ]; then
   updateIndexerTemplate "%{_localstatedir}/etc/ossec.conf" $CONFIG_INDEXER_TEMPLATE
 fi
 
-VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
-if [ -f "%{_localstatedir}/${VD_FILENAME}" ]; then
-    tar -xf %{_localstatedir}/${VD_FILENAME} -C %{_localstatedir}
+%define _vdfilename vd_1.0.0_vd_4.8.0.tar.xz
+if [ -f "%{_localstatedir}/%{_vdfilename}" ]; then
+    tar -xf %{_localstatedir}/%{_vdfilename} -C %{_localstatedir}
     chown wazuh:wazuh %{_localstatedir}/queue/vd
     chown wazuh:wazuh %{_localstatedir}/queue/vd_updater
-    rm -rf tar -xf %{_localstatedir}/${VD_FILENAME}
+    rm -rf tar -xf %{_localstatedir}/%{_vdfilename}
 fi
 
 # Fresh install code block
@@ -734,7 +734,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(750, wazuh, wazuh) %{_localstatedir}/${VD_FILENAME}
+%attr(750, wazuh, wazuh) %{_localstatedir}/%{_vdfilename}
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -306,11 +306,12 @@ if [ $1 = 2 ]; then
   updateIndexerTemplate "%{_localstatedir}/etc/ossec.conf" $CONFIG_INDEXER_TEMPLATE
 fi
 
-if [ -f "%{_localstatedir}/vd.tar.xz" ]; then
-    tar -xf %{_localstatedir}/vd.tar.xz -C %{_localstatedir}
+VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
+if [ -f "%{_localstatedir}/${VD_FILENAME}" ]; then
+    tar -xf %{_localstatedir}/${VD_FILENAME} -C %{_localstatedir}
     chown wazuh:wazuh %{_localstatedir}/queue/vd
     chown wazuh:wazuh %{_localstatedir}/queue/vd-updater
-    rm -rf tar -xf %{_localstatedir}/vd.tar.xz
+    rm -rf tar -xf %{_localstatedir}/${VD_FILENAME}
 fi
 
 # Fresh install code block

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -310,7 +310,7 @@ VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
 if [ -f "%{_localstatedir}/${VD_FILENAME}" ]; then
     tar -xf %{_localstatedir}/${VD_FILENAME} -C %{_localstatedir}
     chown wazuh:wazuh %{_localstatedir}/queue/vd
-    chown wazuh:wazuh %{_localstatedir}/queue/vd-updater
+    chown wazuh:wazuh %{_localstatedir}/queue/vd_updater
     rm -rf tar -xf %{_localstatedir}/${VD_FILENAME}
 fi
 
@@ -734,7 +734,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(750, wazuh, wazuh) %{_localstatedir}/vd.tar.xz
+%attr(750, wazuh, wazuh) %{_localstatedir}/${VD_FILENAME}
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -311,7 +311,7 @@ if [ -f "%{_localstatedir}/%{_vdfilename}" ]; then
     tar -xf %{_localstatedir}/%{_vdfilename} -C %{_localstatedir}
     chown wazuh:wazuh %{_localstatedir}/queue/vd
     chown wazuh:wazuh %{_localstatedir}/queue/vd_updater
-    rm -rf tar -xf %{_localstatedir}/%{_vdfilename}
+    rm -rf %{_localstatedir}/%{_vdfilename}
 fi
 
 # Fresh install code block

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -24,6 +24,7 @@ src=${11}
 legacy=${12}
 local_source_code=${13}
 future=${14}
+download_content=${15}
 wazuh_version=""
 rpmbuild="rpmbuild"
 
@@ -125,6 +126,7 @@ fi
 $linux $rpmbuild --define "_sysconfdir /etc" --define "_topdir ${rpm_build_dir}" \
         --define "_threads ${threads}" --define "_release ${package_release}" \
         --define "_localstatedir ${directory_base}" --define "_debugenabled ${debug}" \
+        --define "_download_content_enabled ${download_content}" \
         --target ${architecture_target} -ba ${rpm_build_dir}/SPECS/${package_name}.spec
 
 if [[ "${checksum}" == "yes" ]]; then

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -18,6 +18,7 @@ REVISION="1"
 TARGET=""
 JOBS="2"
 DEBUG="no"
+DOWNLOAD_CONTENT="no"
 BUILD_DOCKER="yes"
 DOCKER_TAG="latest"
 USER_PATH="no"
@@ -110,7 +111,7 @@ build_rpm() {
         ${CONTAINER_NAME}:${DOCKER_TAG} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
-        ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
+        ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE} ${DOWNLOAD_CONTENT}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -209,6 +210,7 @@ help() {
     echo "    -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
     echo "    -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
+    echo "    --download-content           [Optional] Download content and add it to the package."
     echo "    --dont-build-docker          [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --tag                        [Optional] Tag to use with the docker image."
     echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
@@ -285,6 +287,10 @@ main() {
             ;;
         "-d"|"--debug")
             DEBUG="yes"
+            shift 1
+            ;;
+        "--download-content")
+            DOWNLOAD_CONTENT="yes"
             shift 1
             ;;
         "--dont-build-docker")


### PR DESCRIPTION
|Related issue|
|---|
|[#20747](https://github.com/wazuh/wazuh/issues/20747)|

## Description

Adds the option to download the vulnerability detector content, compress it into a tar.xz file, add it to the installer, and unzip it at installation.

## Tests

* New flag --download-content in DEB

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/cb5d4c77-b12c-4148-a511-2fcf40b45f35)

* New flag  --download-content in RPM

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/c4ffdf59-7bf5-4645-8f02-abd2c6aae5f2)

* Generation DEB package successful

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/5f279ae6-92a9-41bb-8b58-95e1489e78c0)

* Installation from DEB packages successful

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/12d2c121-9163-4ec1-846a-4093a35e4f81)

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/257cfd62-582e-4465-8de3-6f0d487f26d5)

* Generation RPM package successful

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/44ccc37b-15e3-44ce-a511-20f90855ab4d)

* Installation from RPM packages successful

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/b4e56965-99f8-4687-88d6-91f9b6eaa918)

![image](https://github.com/wazuh/wazuh-packages/assets/13617613/efc8cfeb-511a-4862-a827-82c9518763e7)

