### PR TITLE
Updated Filebeat module version to 0.4 in WIA

### DIFF
--- a/.github/actions/offline-installation/common.sh
+++ b/.github/actions/offline-installation/common.sh
@@ -150,7 +150,7 @@ function filebeat_installation() {
     filebeat keystore create
     echo admin | filebeat keystore add username --stdin --force
     echo admin | filebeat keystore add password --stdin --force
-    tar -xzf ./wazuh-offline/wazuh-files/wazuh-filebeat-0.2.tar.gz -C /usr/share/filebeat/module
+    tar -xzf ./wazuh-offline/wazuh-files/wazuh-filebeat-0.4.tar.gz -C /usr/share/filebeat/module
 
     echo "INFO: Generating certificates of Filebeat..."
     NODE_NAME=wazuh-1

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -74,7 +74,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages-dev.wazuh.com/'${devrepo}'"' >> "${output_script_path}"
         echo 'readonly reporelease="unstable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.4.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
         sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
@@ -82,7 +82,7 @@ function buildInstaller() {
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
         echo 'readonly reporelease="stable"' >> "${output_script_path}"
-        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.3.tar.gz"' >> "${output_script_path}"
+        echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.4.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="4.x"' >> "${output_script_path}"
     fi


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/internal-devel-requests/issues/599
Related: https://github.com/wazuh/internal-devel-requests/issues/596

The aim of this PR is to update the Filebeat module version to 0.4 in the Wazuh installation assistant.
Also, the Filebeat module version has been updated in the Offline GitHub Action.

## Testing

To test this change, the Wazuh stack has been deployed using the `wazuh-single.yml` playbook.
<details><summary>:green_circle: Show log</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -v
18/12/2023 15:23:38 DEBUG: Checking root permissions.
18/12/2023 15:23:38 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
18/12/2023 15:23:38 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/12/2023 15:23:38 DEBUG: APT package manager will be used.
18/12/2023 15:23:38 DEBUG: Checking system distribution.
18/12/2023 15:23:38 DEBUG: Detected distribution name: ubuntu
18/12/2023 15:23:38 DEBUG: Detected distribution version: 22
18/12/2023 15:23:38 DEBUG: Checking Wazuh installation.
18/12/2023 15:23:40 DEBUG: Installing check dependencies.
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Reading package lists...
18/12/2023 15:23:47 DEBUG: Checking system architecture.
18/12/2023 15:23:47 INFO: Verifying that your system meets the recommended minimum hardware requirements.
18/12/2023 15:23:47 DEBUG: CPU cores detected: 2
18/12/2023 15:23:47 DEBUG: Free RAM memory detected: 3924
18/12/2023 15:23:47 INFO: Wazuh web interface port will be 443.
18/12/2023 15:23:47 DEBUG: Checking ports availability.
18/12/2023 15:23:49 DEBUG: Installing prerequisites dependencies.
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Reading package lists...
18/12/2023 15:23:53 DEBUG: Checking curl tool version.
18/12/2023 15:23:53 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [36.0 kB]
Fetched 53.3 kB in 2s (22.1 kB/s)
Reading package lists...
18/12/2023 15:23:58 INFO: Wazuh development repository added.
18/12/2023 15:23:58 INFO: --- Configuration files ---
18/12/2023 15:23:58 INFO: Generating configuration files.
18/12/2023 15:23:58 DEBUG: Creating Wazuh certificates.
18/12/2023 15:23:58 DEBUG: Reading configuration file.
18/12/2023 15:23:58 DEBUG: Creating the root certificate.
.......+......+...+..+......+...+.......+...+.........+...+........+......+...+.......+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*............+...+....+..+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*........+.+..+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.+.+......+...+..+......+....+.........+......+......+.........+........+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+.........+..+....+............+..+.......+.....+..................+.+..............+.......+.....................+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+..............+.+......+.....+....+..................+...+.........+...+............+...........+...+......+....+............+..+.+.....+................+.....+....+.........+..+...+.......+...+......+..+.......+...+..+.+...........+.+...............+............+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
18/12/2023 15:23:58 DEBUG: Generating Admin certificates.
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = admin
18/12/2023 15:23:59 DEBUG: Generating Wazuh indexer certificates.
18/12/2023 15:23:59 DEBUG: Creating the Wazuh indexer certificates.
18/12/2023 15:23:59 DEBUG: Generating certificate configuration.
.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*............+.......+.....+......+.+...+...+..+.+..+..........+..+.......+........+.......+.....+...+......+....+...+...+.....+.......+..+.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+......+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+......+........................+.....+......+...+....+..+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+..+...+....+...+..+...+...+....+........+.+..+....+......+..+.+......+.....+......+....+...............+...+........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-indexer
18/12/2023 15:23:59 DEBUG: Generating Filebeat certificates.
18/12/2023 15:23:59 DEBUG: Creating the Wazuh server certificates.
18/12/2023 15:23:59 DEBUG: Generating certificate configuration.
.+...+..............+...+.+..+....+.....+...+.+..+..........+...+..+....+.....+...+.+.....+......+..........+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+.....+...+...+....+......+..+...+.+...+....................+......+.+.....+......+.......+........+.......+...+..............+...+.......+..............+.........+.+...........+...+......+.+.....+..........+...+......+.........+...+..+................+.................+....+......+.................+......+......+..........+...+...+..............+.+.....+....+...+..+...+......+....+.....+...+.............+.....+................+......+.....+..........+.....+.......+........+.........+......+..................+.+.....+.+..+.............+..+.+..+.........+.........+.+....................+.+..+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
.+.................+.+..+...+......+.+..+...+.......+..+.............+.....+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+.....+......+.+........+............+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+....+..+...+.+...+...+...+..+...+......+..........+........+.......+.....+...+...+....+......+...+..+............................+..+....+......+..+...+....+........+......+.........+.+.....+.+...+..+.+........+....+...............+.....+.+....................+............+....+...+..+.+.........+........+...+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-server
18/12/2023 15:23:59 DEBUG: Generating Wazuh dashboard certificates.
18/12/2023 15:23:59 DEBUG: Creating the Wazuh dashboard certificates.
18/12/2023 15:23:59 DEBUG: Generating certificate configuration.
....+........+.........+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+.+............+...........+.........+.......+.....+....+..+....+...+.....+......+....+..+.........+.+......+...+..+.......+..+......+...+..........+.....+......+...................+.....+.+.........+............+........+.+......+..+.+...........+.+.....+....+.....+.+..............+....+...........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
...+.....+......+......+..................+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+.........+......+......+...+......+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*......+.....+..........+..+....+....................+.........+.+......+.....+....+..+.......+........+...+.....................+..........+.........+..+...+.........+............+....+..............+.+..+...................+...........+...+.......+...+......+...+....................+.+.....+.+...+..+.........+......+...+...+..................+...............+....+..+....+......+...+.....+.+..+...+..........+.....+.........+.+......+......+..+...+....+........................+.........+..+......+....+.....+......+....+...+.....+.+.........+...+...............+...............+..+......+......+....+..........................+.............+...+.....+....+........................+..+.........+.+.....+...+.+...+........+.......+.....+.+...............+..+.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Certificate request self-signature ok
subject=C = US, L = California, O = Wazuh, OU = Wazuh, CN = wazuh-dashboard
18/12/2023 15:24:00 DEBUG: Cleaning certificate files.
18/12/2023 15:24:00 DEBUG: Generating password file.
18/12/2023 15:24:00 DEBUG: Generating random passwords.
18/12/2023 15:24:00 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
18/12/2023 15:24:00 DEBUG: Extracting Wazuh configuration.
18/12/2023 15:24:00 DEBUG: Reading configuration file.
18/12/2023 15:24:00 INFO: --- Wazuh indexer ---
18/12/2023 15:24:00 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded. Need to get 0 B/752 MB of archives. After this operation, 1,050 MB of additional disk space will be used. Selecting previously unselected packag NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-69-generic NEEDRESTART-KEXP: 5.15.0-69-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
18/12/2023 15:24:59 DEBUG: Checking Wazuh installation.
18/12/2023 15:25:00 DEBUG: There are Wazuh indexer remaining files.
18/12/2023 15:25:01 INFO: Wazuh indexer installation finished.
18/12/2023 15:25:01 DEBUG: Configuring Wazuh indexer.
18/12/2023 15:25:01 DEBUG: Copying Wazuh indexer certificates.
18/12/2023 15:25:01 INFO: Wazuh indexer post-install configuration finished.
18/12/2023 15:25:01 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
18/12/2023 15:25:26 INFO: wazuh-indexer service started.
18/12/2023 15:25:26 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
Will create index templates to configure the alias
 SUCC: 'wazuh-alerts' template created or updated
 SUCC: 'wazuh-archives' template created or updated
Will create the 'rollover_policy' policy
  SUCC: 'rollover_policy' policy created
Will create initial indices for the aliases
  SUCC: 'wazuh-alerts' write index created
  SUCC: 'wazuh-archives' write index created
SUCC: Indexer ISM initialization finished successfully.
18/12/2023 15:25:40 INFO: The Wazuh indexer cluster ISM initialized.
18/12/2023 15:25:40 INFO: Wazuh indexer cluster initialized.
18/12/2023 15:25:40 INFO: --- Wazuh server ---
18/12/2023 15:25:40 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded. Need to get 0 B/117 MB of archives. After this operation, 702 MB of additional disk space will be used. Selecting pre NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-69-generic NEEDRESTART-KEXP: 5.15.0-69-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
18/12/2023 15:26:38 DEBUG: Checking Wazuh installation.
18/12/2023 15:26:38 DEBUG: There are Wazuh remaining files.
18/12/2023 15:26:39 DEBUG: There are Wazuh indexer remaining files.
18/12/2023 15:26:40 INFO: Wazuh manager installation finished.
18/12/2023 15:26:40 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
18/12/2023 15:27:03 INFO: wazuh-manager service started.
18/12/2023 15:27:03 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded. Need to get 0 B/22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Selecting previously unselected package fil NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-69-generic NEEDRESTART-KEXP: 5.15.0-69-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
18/12/2023 15:27:08 DEBUG: Checking Wazuh installation.
18/12/2023 15:27:09 DEBUG: There are Wazuh remaining files.
18/12/2023 15:27:09 DEBUG: There are Wazuh indexer remaining files.
18/12/2023 15:27:10 DEBUG: There are Filebeat remaining files.
18/12/2023 15:27:10 INFO: Filebeat installation finished.
18/12/2023 15:27:10 DEBUG: Configuring Filebeat.
18/12/2023 15:27:11 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/archives/
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/alerts/
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/module.yml
18/12/2023 15:27:12 DEBUG: Filebeat module was downloaded successfully.
18/12/2023 15:27:12 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
18/12/2023 15:27:13 INFO: Filebeat post-install configuration finished.
18/12/2023 15:27:13 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
18/12/2023 15:27:15 INFO: filebeat service started.
18/12/2023 15:27:15 INFO: --- Wazuh dashboard ---
18/12/2023 15:27:15 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 167 not upgraded. Need to get 0 B/186 MB of NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-69-generic NEEDRESTART-KEXP: 5.15.0-69-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
18/12/2023 15:28:15 DEBUG: Checking Wazuh installation.
18/12/2023 15:28:15 DEBUG: There are Wazuh remaining files.
18/12/2023 15:28:16 DEBUG: There are Wazuh indexer remaining files.
18/12/2023 15:28:16 DEBUG: There are Filebeat remaining files.
18/12/2023 15:28:17 DEBUG: There are Wazuh dashboard remaining files.
18/12/2023 15:28:17 INFO: Wazuh dashboard installation finished.
18/12/2023 15:28:17 DEBUG: Configuring Wazuh dashboard.
18/12/2023 15:28:17 DEBUG: Copying Wazuh dashboard certificates.
18/12/2023 15:28:17 DEBUG: Wazuh dashboard certificate setup finished.
18/12/2023 15:28:17 INFO: Wazuh dashboard post-install configuration finished.
18/12/2023 15:28:17 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
18/12/2023 15:28:19 INFO: wazuh-dashboard service started.
18/12/2023 15:28:19 DEBUG: Setting Wazuh indexer cluster passwords.
18/12/2023 15:28:19 DEBUG: Checking Wazuh installation.
18/12/2023 15:28:19 DEBUG: There are Wazuh remaining files.
18/12/2023 15:28:20 DEBUG: There are Wazuh indexer remaining files.
18/12/2023 15:28:20 DEBUG: There are Filebeat remaining files.
18/12/2023 15:28:21 DEBUG: There are Wazuh dashboard remaining files.
18/12/2023 15:28:22 INFO: Updating the internal users.
18/12/2023 15:28:22 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
18/12/2023 15:28:31 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
18/12/2023 15:28:31 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
18/12/2023 15:28:31 DEBUG: The internal users have been updated before changing the passwords.
18/12/2023 15:28:37 DEBUG: Generating password hashes.
18/12/2023 15:28:43 DEBUG: Password hashes generated.
18/12/2023 15:28:43 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
18/12/2023 15:28:47 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
18/12/2023 15:28:47 DEBUG: Restarting filebeat service...
18/12/2023 15:28:48 DEBUG: filebeat started.
18/12/2023 15:28:49 DEBUG: Restarting wazuh-dashboard service...
18/12/2023 15:28:50 DEBUG: wazuh-dashboard started.
18/12/2023 15:28:50 DEBUG: Running security admin tool.
18/12/2023 15:28:50 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to localhost:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: YELLOW
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/vagrant
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
18/12/2023 15:28:58 DEBUG: Passwords changed.
18/12/2023 15:28:58 DEBUG: Changing API passwords.
18/12/2023 15:29:06 INFO: Initializing Wazuh dashboard web application.
18/12/2023 15:29:08 INFO: Wazuh dashboard web application initialized.
18/12/2023 15:29:08 INFO: --- Summary ---
18/12/2023 15:29:08 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: 4qL9taUnz.gxAq2SrJCByU2NB04Jo9U0
18/12/2023 15:29:08 DEBUG: Restoring Wazuh repository.
18/12/2023 15:29:08 INFO: Installation finished.

```
</details>

Notice that the content of the module files has changed corresponding to the related PR changes https://github.com/wazuh/wazuh/pull/19819:
```console
root@ubuntu22:/home/vagrant# cat /usr/share/filebeat/module/wazuh/alerts/ingest/pipeline.json 
{
  "description": "Wazuh alerts pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "set": {
        "field": "_index",
        "value": "wazuh-alerts"
      }
    },
    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}
root@ubuntu22:/home/vagrant# cat /usr/share/filebeat/module/wazuh/archives/ingest/pipeline.json 
{
  "description": "Wazuh events pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "set": {
        "field": "_index",
        "value": "wazuh-archives"
      }
    },
    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}
root@ubuntu22:/home/vagrant# 

```