### PR TITLE
Add new Azure module files

### DIFF
--- a/solaris/solaris11/SPECS/template_agent.json
+++ b/solaris/solaris11/SPECS/template_agent.json
@@ -2047,7 +2047,79 @@
         "type": "file",
         "user": "root"
     },
-    "/var/ossec/wodles/azure/orm.py": {
+    "/var/ossec/wodles/azure/azure_utils.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure_services": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure_services/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure_services/analytics.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure_services/graph.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/azure_services/storage.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/db": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "drwxr-x---",
+        "type": "directory",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/db/__init__.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/db/orm.py": {
+        "class": "static",
+        "group": "wazuh",
+        "mode": "0750",
+        "prot": "-rwxr-x---",
+        "type": "file",
+        "user": "root"
+    },
+    "/var/ossec/wodles/azure/db/utils.py": {
         "class": "static",
         "group": "wazuh",
         "mode": "0750",


### PR DESCRIPTION
|Related issue|
|---|
| #2689 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Closes #2689. It modifies the Solaris11 SPEC file to include in the agents the latest modification of the Azure integration which separated the module in several files carried out in wazuh/wazuh#19576, which is expected to be released in 4.9.0.

## Logs example

<!--
Paste here related logs
-->

## Tests

Tested the modified package by creating a [Solaris11](https://packages-dev.wazuh.com/warehouse/test/4.9/solaris/i386/11/wazuh-agent_v4.9.0-2689.azure.refactor.v2-sol11-i386.p5p) package and installing it in a Solaris11 machine respectively. Everything worked as expected, as can be seen in the following output:

<details><summary>Package installation and file permissions</summary>
<p>

```bash
root@solaris11:~# pkg install -g wazuh-agent_v4.9.0-2689.azure.refactor.v2-sol11-i386.p5p  wazuh-agent
           Packages to install:  1
            Services to change:  1
       Create boot environment: No
Create backup boot environment: No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1       126/126      6.0/6.0 33.0M/s

PHASE                                          ITEMS
Installing new actions                       184/184
Updating package state database                 Done
Updating package cache                           0/0
Updating image state                            Done
Creating fast lookup database                   Done
Reading search index                            Done
Updating search index                            1/1
Updating package cache                           2/2
```

```bash
root@solaris11:~# tree /var/ossec/wodles/azure/ -L 2 -u -g
/var/ossec/wodles/azure/
├── [root     wazuh   ]  azure_services
│   ├── [root     wazuh   ]  __init__.py
│   ├── [root     wazuh   ]  analytics.py
│   ├── [root     wazuh   ]  graph.py
│   └── [root     wazuh   ]  storage.py
├── [root     wazuh   ]  azure_utils.py
├── [root     wazuh   ]  azure-logs
└── [root     wazuh   ]  db
    ├── [root     wazuh   ]  __init__.py
    ├── [root     wazuh   ]  orm.py
    └── [root     wazuh   ]  utils.py
```

</p>
</details> 

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [x] Test the package on Solaris 11
  - [x] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
