### PR TITLE
Update `indexer-ism-init.sh`

### DIFF
--- a/stack/indexer/indexer-ism-init.sh
+++ b/stack/indexer/indexer-ism-init.sh
@@ -12,7 +12,7 @@ INDEXER_PASSWORD="admin"
 INDEXER_HOSTNAME="localhost"
 
 POLICY_NAME="rollover_policy"
-LOG_FILE="/tmp/wazuh-indexer/ism-init.log"
+LOG_FILE="/var/log/wazuh-indexer/ism-init.log"
 
 INDEXER_URL="https://${INDEXER_HOSTNAME}:9200"
 
@@ -84,7 +84,24 @@ function generate_rollover_template() {
 # Loads the index templates for the rollover policy to the indexer.
 #########################################################################
 function load_templates() {
-    # Note: the wazuh-template.json could also be loaded here.
+    # Load wazuh-template.json, needed for initial indices creation.
+    local wazuh_template_path="/etc/wazuh-indexer/wazuh-template.json"
+    echo "Will create 'wazuh' index template"
+    if [ -f $wazuh_template_path ]; then
+        cat $wazuh_template_path |
+        if ! curl -s -k ${C_AUTH} \
+            -X PUT "${INDEXER_URL}/_template/wazuh" \
+            -o "${LOG_FILE}" --create-dirs \
+            -H 'Content-Type: application/json' -d @-; then
+            echo "  ERROR: 'wazuh' template creation failed"
+            exit 1
+        else
+            echo " SUCC: 'wazuh' template created or updated"
+        fi
+    else
+        echo "  ERROR: $wazuh_template_path not found"
+    fi
+
     echo "Will create index templates to configure the alias"
     for alias in "${aliases[@]}"; do
         generate_rollover_template "${alias}" |

--- a/stack/indexer/indexer-ism-init.sh
+++ b/stack/indexer/indexer-ism-init.sh
@@ -12,7 +12,7 @@ INDEXER_PASSWORD="admin"
 INDEXER_HOSTNAME="localhost"
 
 POLICY_NAME="rollover_policy"
-LOG_FILE="/var/log/wazuh-indexer/ism-init.log"
+LOG_FILE="/tmp/wazuh-indexer/ism-init.log"
 
 INDEXER_URL="https://${INDEXER_HOSTNAME}:9200"
 


### PR DESCRIPTION
## Description

Updates the script to upload the wazuh-template.json to the indexer.

Closes #2699 

## Logs example

```console
bash indexer-ism-init.sh -p $(cat password.txt)
Will create 'wazuh' index template
 SUCC: 'wazuh' template created or updated
Will create index templates to configure the alias
 SUCC: 'wazuh-alerts' template created or updated
 SUCC: 'wazuh-archives' template created or updated
Will create the 'rollover_policy' policy
  SUCC: 'rollover_policy' policy created
Will create initial indices for the aliases
  SUCC: 'wazuh-alerts' write index created
  SUCC: 'wazuh-archives' write index created
SUCC: Indexer ISM initialization finished successfully.
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
