### PR TITLE
Fixed `source_branch` variable definition

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,8 +16,8 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-readonly source_directory="$(git rev-parse --show-toplevel)"
-source_branch=`cat ${source_directory}/VERSION`
+readonly source_directory="$( cd $(dirname $0) ; pwd -P )"
+source_branch=$(cat ${source_directory}/../VERSION)
 
 function getHelp() {
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2702|

Related PR: https://github.com/wazuh/wazuh-packages/pull/2676
Related issue: https://github.com/wazuh/wazuh-packages/issues/2674

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to change how the `source_branch` variable is defined. Before, it used the `source_directory` variable which used the `git` command. This is supposed a problem in the CI processes and when executing the script from a directory other than the location of the repository of scripts.


## Testing

It has been tested that the `source_branch` variable is correctly fetched and the WIA is built:

From `wazuh-ppackages/unattended_installer`:
```console
 ~/Wazuh/packages/unattended_installer > bash builder.sh -i -d pre-release
+++ dirname builder.sh
++ cd .
++ pwd -P
+ readonly source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
+ source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
++ cat /home/davidcr01/Wazuh/packages/unattended_installer/../VERSION
+ source_branch=4.7.2
+ set +x
```

From `Wazuh` (personal parent directory):
```console
 ~/Wazuh > bash packages/unattended_installer/builder.sh -i -d staging
+++ dirname packages/unattended_installer/builder.sh
++ cd packages/unattended_installer
++ pwd -P
+ readonly source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
+ source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
++ cat /home/davidcr01/Wazuh/packages/unattended_installer/../VERSION
+ source_branch=4.7.2
+ set +x
```

From `wazuh-packages/unattended_installer/install_functions`:
```console
 ~/Wazuh/packages/unattended_installer/install_functions > bash ../builder.sh -i -d pre-release
+++ dirname ../builder.sh
++ cd ..
++ pwd -P
+ readonly source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
+ source_directory=/home/davidcr01/Wazuh/packages/unattended_installer
++ cat /home/davidcr01/Wazuh/packages/unattended_installer/../VERSION
+ source_branch=4.7.2
+ set +x
```