### PR TITLE
Fix `wazuh-indexer-performance-analyzer-cli` binary startup

### DIFF
--- a/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer-performance-analyzer.service
+++ b/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer-performance-analyzer.service
@@ -9,6 +9,7 @@ Restart=on-failure
 User=wazuh-indexer
 Group=wazuh-indexer
 Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
+Environment=OPENSEARCH_PATH_CONF=/etc/wazuh-indexer/
 WorkingDirectory=/usr/share/wazuh-indexer
 
 [Install]

--- a/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer-performance-analyzer.service
+++ b/stack/indexer/base/files/usr/lib/systemd/system/wazuh-indexer-performance-analyzer.service
@@ -4,7 +4,7 @@ PartOf=wazuh-indexer.service
 After=wazuh-indexer.service
 
 [Service]
-ExecStart=/usr/share/wazuh-indexer/bin/performance-analyzer-agent-cli
+ExecStart=/usr/share/wazuh-indexer/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli
 Restart=on-failure
 User=wazuh-indexer
 Group=wazuh-indexer

--- a/stack/indexer/deb/debian/rules
+++ b/stack/indexer/deb/debian/rules
@@ -167,6 +167,8 @@ override_dh_fixperms:
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/securityadmin.sh
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/wazuh-certs-tool.sh
 	chmod 740 $(TARGET_DIR)$(INSTALLATION_DIR)/plugins/opensearch-security/tools/wazuh-passwords-tool.sh
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)/bin/opensearch-performance-analyzer/performance-analyzer-agent
 
 	find "$(TARGET_DIR)$(INSTALLATION_DIR)" -type d -exec chmod 750 {} \;
 	find "$(TARGET_DIR)$(INSTALLATION_DIR)" -type f -perm 644 -exec chmod 640 {} \;


### PR DESCRIPTION
|Related issue|
|---|
|closes #2321|


## Description

This PR Fixes the Execution path for the `wazuh-indexer-performance-analyzer` binary and service.


## Evidence

- Build and Install Indexer package
```
   dh_builddeb
        dpkg-deb --build debian/wazuh-indexer ..
dpkg-deb: building package `wazuh-indexer' in `../wazuh-indexer_4.8.0-1_amd64.deb'.
 dpkg-genchanges -b >../wazuh-indexer_4.8.0-1_amd64.changes
dpkg-genchanges: binary-only upload (no source code included)
 dpkg-source --after-build wazuh-indexer-4.8.0
dpkg-buildpackage: binary-only upload (no source included)

WARNING generated by debuild:
Making debian/rules executable!

Package wazuh-indexer_4.8.0-1_amd64.deb.sha512 added to /home/qa/Descargas/wazuh-packages/stack/indexer/deb/output.

# apt install ./output/wazuh-indexer
Leyendo lista de paquetes... Hecho
E: Se ha suministrado el fichero no admitido ./output/wazuh-indexer en la línea de órdenes
root@pop-os:/home/qa/Descargas/wazuh-packages/stack/indexer/deb# apt install ./output/wazuh-indexer_4.8.0-1_amd64.deb
Leyendo lista de paquetes... Hecho
Creando árbol de dependencias... Hecho
Leyendo la información de estado... Hecho
Nota, seleccionando «wazuh-indexer» en lugar de «./output/wazuh-indexer_4.8.0-1_amd64.deb»
El paquete indicado a continuación se instaló de forma automática y ya no es necesario.
  nvidia-firmware-545-545.29.02
Utilice «sudo apt autoremove» para eliminarlo.
Se instalarán los siguientes paquetes NUEVOS:
  wazuh-indexer
0 actualizados, 1 nuevos se instalarán, 0 para eliminar y 61 no actualizados.
Se necesita descargar 0 B/752 MB de archivos.
Se utilizarán 1.050 MB de espacio de disco adicional después de esta operación.
Des:1 /home/qa/Descargas/wazuh-packages/stack/indexer/deb/output/wazuh-indexer_4.8.0-1_amd64.deb wazuh-indexer amd64 4.8.0-1 [752 MB]
Seleccionando el paquete wazuh-indexer previamente no seleccionado.
(Leyendo la base de datos ... 293559 ficheros o directorios instalados actualmente.)
Preparando para desempaquetar .../wazuh-indexer_4.8.0-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Desempaquetando wazuh-indexer (4.8.0-1) ...
Configurando wazuh-indexer (4.8.0-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
Procesando disparadores para libc-bin (2.35-0ubuntu3.5) ...
```

- Create and deploy certificates, then start wazuh-indexer
```
# curl -sO https://packages-dev.wazuh.com/4.8/wazuh-certs-tool.sh
# bash ./wazuh-certs-tool.sh -A
20/12/2023 11:42:32 INFO: Admin certificates created.
20/12/2023 11:42:33 INFO: Wazuh indexer certificates created.
20/12/2023 11:42:33 INFO: Wazuh server certificates created.
20/12/2023 11:42:33 INFO: Wazuh dashboard certificates created.
# tar -cvf ./wazuh-certificates.tar -C ./wazuh-certificates/ .
rm -rf ./wazuh-certificates
./
./node-1-key.pem
./admin-key.pem
./root-ca.pem
./node-1.pem
./admin.pem
./dashboard-key.pem
./wazuh-1-key.pem
./root-ca.key
./wazuh-1.pem
./dashboard.pem

# nano /etc/wazuh-indexer/opensearch.yml
# NODE_NAME=node-1
# mkdir /etc/wazuh-indexer/certs
tar -xf ./wazuh-certificates.tar -C /etc/wazuh-indexer/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./admin.pem ./admin-key.pem ./root-ca.pem
mv -n /etc/wazuh-indexer/certs/$NODE_NAME.pem /etc/wazuh-indexer/certs/indexer.pem
mv -n /etc/wazuh-indexer/certs/$NODE_NAME-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
chmod 500 /etc/wazuh-indexer/certs
chmod 400 /etc/wazuh-indexer/certs/*
chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs

# systemctl daemon-reload
# systemctl enable wazuh-indexer
# systemctl start wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.

# /usr/share/wazuh-indexer/bin/indexer-security-init.sh
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 10.10.0.96:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success

# curl -k -u admin:admin https://10.10.0.96:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "gMAumemiS-qRdaUsPaK6Nw",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "eee49cb340edc6c4d489bcd9324dda571fc8dc03",
    "build_date" : "2023-09-20T23:54:29.889267151Z",
    "build_snapshot" : false,
    "lucene_version" : "9.7.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

- Check `wazuh-indexer-performance-analyzer`service and start daemon
```
# cat /lib/systemd/system/wazuh-indexer-performance-analyzer.service 
[Unit]
Description=Wazuh-indexer Performance Analyzer
PartOf=wazuh-indexer.service
After=wazuh-indexer.service

[Service]
ExecStart=/usr/share/wazuh-indexer/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli
Restart=on-failure
User=wazuh-indexer
Group=wazuh-indexer
Environment=OPENSEARCH_HOME=/usr/share/wazuh-indexer
Environment=OPENSEARCH_PATH_CONF=/etc/wazuh-indexer/
WorkingDirectory=/usr/share/wazuh-indexer

[Install]
WantedBy=wazuh-indexer.service

# systemctl start wazuh-indexer-performance-analyzer
# systemctl status wazuh-indexer-performance-analyzer
● wazuh-indexer-performance-analyzer.service - Wazuh-indexer Performance Analyzer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer-performance-analyzer.service; disabled; vendor preset: enabled)
     Active: active (running) since Wed 2023-12-20 11:45:59 CET; 6s ago
   Main PID: 31898 (java)
      Tasks: 24 (limit: 21396)
     Memory: 131.4M
        CPU: 2.852s
     CGroup: /system.slice/wazuh-indexer-performance-analyzer.service
             └─31898 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Xms4m -Xmx64m -XX:+UseSerialGC -Dlog4j.configurationFile=/etc/wazuh-indexer//opensearch-performance-an>

dic 20 11:46:06 pop-os performance-analyzer-agent-cli[31898]: INFORMACIÓN: Single batch             : No bind variables have been provided with a single statement batch execut>
dic 20 11:46:06 pop-os performance-analyzer-agent-cli[31898]: dic 20, 2023 11:46:06 A. M. org.jooq.tools.JooqLogger info
```