### PR TITLE
Double quotes removed in Indexer IP

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -366,6 +366,9 @@ function passwords_getNetworkHost() {
     IP=$(grep -hr "^network.host:" /etc/wazuh-indexer/opensearch.yml)
     NH="network.host: "
     IP="${IP//$NH}"
+    
+    # Remove surrounding double quotes if present
+    IP="${IP//\"}"
 
     #allow to find ip with an interface
     if [[ ${IP} =~ _.*_ ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2705|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to remove the double quotes in the Wazuh indexer node, specified at the `/etc/wazuh-indexer/openseach.yml` file, if they exist.

Testing is in: https://github.com/wazuh/wazuh-packages/issues/2705#issuecomment-1866604241
