### PR TITLE
Fixed Filebeat template URL in Wazuh indexer

### DIFF
--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -65,7 +65,7 @@ mkdir -p ./etc/wazuh-indexer/
 cp -r ./config/* ./etc/wazuh-indexer/
 rm -rf ./config
 cp -r /root/stack/indexer/base/files/etc/wazuh-indexer/* ./etc/wazuh-indexer/
-curl -so ./etc/wazuh-indexer/wazuh-template.json "https://github.com/wazuh/wazuh/blob/${filebeat_module_reference}/extensions/elasticsearch/7.x/wazuh-template.json"
+curl -so ./etc/wazuh-indexer/wazuh-template.json "https://raw.githubusercontent.com/wazuh/wazuh/${filebeat_module_reference}/extensions/elasticsearch/7.x/wazuh-template.json"
 cp -r /root/stack/indexer/base/files/etc/sysconfig ./etc/
 cp -r /root/stack/indexer/base/files/etc/init.d ./etc/
 cp -r /root/stack/indexer/base/files/usr ./


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-packages/issues/2722|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the Filebeat template URL in the Wazuh indexer base package

## Tests

![image](https://github.com/wazuh/wazuh-packages/assets/14913942/8c1c9911-490f-4fcd-98dd-2d0095e9a3b4)

<details><summary>Install, configuration and cluster check logs</summary>

```
[root@centos7 vagrant]# yum localinstall wazuh-indexer-4.8.0-1.x86_64.rpm -y
Loaded plugins: fastestmirror
Examining wazuh-indexer-4.8.0-1.x86_64.rpm: wazuh-indexer-4.8.0-1.x86_64
Marking wazuh-indexer-4.8.0-1.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-indexer.x86_64 0:4.8.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

========================================================================================================
 Package                Arch            Version            Repository                              Size
========================================================================================================
Installing:
 wazuh-indexer          x86_64          4.8.0-1            /wazuh-indexer-4.8.0-1.x86_64          1.0 G

Transaction Summary
========================================================================================================
Install  1 Package

Total size: 1.0 G
Installed size: 1.0 G
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-indexer-4.8.0-1.x86_64                                                         1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
  Verifying  : wazuh-indexer-4.8.0-1.x86_64                                                         1/1 

Installed:
  wazuh-indexer.x86_64 0:4.8.0-1                                                                        

Complete!
[root@centos7 vagrant]# NODE^C
[root@centos7 vagrant]# nano config.yml 
[root@centos7 vagrant]# NODE_NAME=node-1
[root@centos7 vagrant]# mkdir /etc/wazuh-indexer/certs
[root@centos7 vagrant]# tar -xf ./wazuh-certificates.tar -C /etc/wazuh-indexer/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./admin.pem ./admin-key.pem ./root-ca.pem
[root@centos7 vagrant]# mv -n /etc/wazuh-indexer/certs/$NODE_NAME.pem /etc/wazuh-indexer/certs/indexer.pem
[root@centos7 vagrant]# mv -n /etc/wazuh-indexer/certs/$NODE_NAME-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
[root@centos7 vagrant]# chmod 500 /etc/wazuh-indexer/certs
[root@centos7 vagrant]# chmod 400 /etc/wazuh-indexer/certs/*
[root@centos7 vagrant]# chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs
[root@centos7 vagrant]# systemctl daemon-reload
[root@centos7 vagrant]# systemctl enable wazuh-indexer
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service to /usr/lib/systemd/system/wazuh-indexer.service.
[root@centos7 vagrant]# systemctl start wazuh-indexer
[root@centos7 vagrant]# /usr/share/wazuh-indexer/bin/indexer-
indexer-init.sh           indexer-ism-init.sh       indexer-security-init.sh
[root@centos7 vagrant]# /usr/share/wazuh-indexer/bin/indexer-init.sh 
Executing Wazuh indexer security init script...
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
Executing Wazuh indexer ISM init script...
Will create 'wazuh' index template
 SUCC: 'wazuh' template created or updated
Will create index templates to configure the alias
 SUCC: 'wazuh-alerts' template created or updated
 SUCC: 'wazuh-archives' template created or updated
Will create the 'rollover_policy' policy
  SUCC: 'rollover_policy' policy created
Will create initial indices for the aliases
  SUCC: 'wazuh-alerts' write index created
  SUCC: 'wazuh-archives' write index created
SUCC: Indexer ISM initialization finished successfully.
[root@centos7 vagrant]# curl -k -u admin:admin https://192.168.56.4:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "q2oTJY-5SmuaMPQOCsoiVQ",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "eee49cb340edc6c4d489bcd9324dda571fc8dc03",
    "build_date" : "2023-09-20T23:54:29.889267151Z",
    "build_snapshot" : false,
    "lucene_version" : "9.7.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
[root@centos7 vagrant]# curl -k -u admin:admin https://192.168.56.4:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                        cluster_manager name
10.0.2.15           54          94   1    0.09    0.16     0.08 dimr      cluster_manager,data,ingest,remote_cluster_client *               node-1
[root@centos7 vagrant]# curl -k -u admin:admin https://192.168.56.4:9200/_cluster/health?pretty
{
  "cluster_name" : "wazuh-cluster",
  "status" : "yellow",
  "timed_out" : false,
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "discovered_master" : true,
  "discovered_cluster_manager" : true,
  "active_primary_shards" : 11,
  "active_shards" : 11,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 1,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0,
  "task_max_waiting_in_queue_millis" : 0,
  "active_shards_percent_as_number" : 91.66666666666666
}
[root@centos7 vagrant]# curl -k -u admin:admin https://192.168.56.4:9200/_cat/indices?v
health status index                                uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .plugins-ml-config                   50Ij7i7EQPGmM88Ad0oZ7A   1   0          1            0      3.9kb          3.9kb
green  open   .opensearch-observability            6Pb2SOYuSW-GgksEJfqkmw   1   0          0            0       208b           208b
green  open   wazuh-alerts-4.x-2023.12.26-000001   m6n3LJ5hQa-GVNToO16Ivw   3   0          0            0       624b           624b
green  open   .opendistro_security                 4OT46enKRLiKKTDXlTDeFg   1   0         10            0     66.8kb         66.8kb
green  open   wazuh-archives-4.x-2023.12.26-000001 QZr8aAbDSpuA542uj-Nw3g   3   0          0            0       624b           624b

[root@centos7 vagrant]# head -10 /etc/wazuh-indexer/wazuh-template.json 
{
  "order": 0,
  "index_patterns": [
    "wazuh-alerts-4.x-*",
    "wazuh-archives-4.x-*"
  ],
  "settings": {
    "index.refresh_interval": "5s",
    "index.number_of_shards": "3",
    "index.number_of_replicas": "0",
```

</details>

- The URL is correct but some unassigned shards are present, this needs to be reviewed by the @wazuh/indexer team as it is probably related to the ISM init script.

---


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64