### PR TITLE
Update indexer-ism-init.sh

### DIFF
--- a/stack/indexer/indexer-ism-init.sh
+++ b/stack/indexer/indexer-ism-init.sh
@@ -81,6 +81,48 @@ function generate_rollover_template() {
 }
 
 #########################################################################
+# Creates an index template to disable replicas on ISM configurastion indices.
+# Returns:
+#   The index template as a JSON string.
+#########################################################################
+function generate_ism_config_template() {
+    cat <<-EOF
+        {
+            "order": 1,
+            "index_patterns": [
+                ".opendistro-ism-managed-index-history-*",
+                ".opendistro-ism-config",
+                ".opendistro-job-scheduler-lock"
+            ],
+            "settings": {
+                "number_of_replicas": 0
+            }
+        }
+	EOF
+}
+
+#########################################################################
+# Creates persistent cluster's settings to disable replicas for ISM history.
+# Returns:
+#   The setting as a JSON string.
+#########################################################################
+function generate_ism_config() {
+    cat <<-EOF
+    {
+        "persistent": {
+            "plugins": {
+                "index_state_management": {
+                    "history": {
+                        "number_of_replicas": "0"
+                    }
+                }
+            }
+        }
+    }
+	EOF
+}
+
+#########################################################################
 # Loads the index templates for the rollover policy to the indexer.
 #########################################################################
 function load_templates() {
@@ -89,18 +131,44 @@ function load_templates() {
     echo "Will create 'wazuh' index template"
     if [ -f $wazuh_template_path ]; then
         cat $wazuh_template_path |
-        if ! curl -s -k ${C_AUTH} \
-            -X PUT "${INDEXER_URL}/_template/wazuh" \
-            -o "${LOG_FILE}" --create-dirs \
-            -H 'Content-Type: application/json' -d @-; then
-            echo "  ERROR: 'wazuh' template creation failed"
-            exit 1
-        else
-            echo " SUCC: 'wazuh' template created or updated"
-        fi
+            if ! curl -s -k ${C_AUTH} \
+                -X PUT "${INDEXER_URL}/_template/wazuh" \
+                -o "${LOG_FILE}" --create-dirs \
+                -H 'Content-Type: application/json' -d @-; then
+                echo "  ERROR: 'wazuh' template creation failed"
+                return 1
+            else
+                echo " SUCC: 'wazuh' template created or updated"
+            fi
     else
         echo "  ERROR: $wazuh_template_path not found"
     fi
+
+    # Load template for ISM configuration indices
+    echo "Will create 'ism_history_indices' index template"
+    generate_ism_config_template |
+        if ! curl -s -k ${C_AUTH} \
+            -X PUT "${INDEXER_URL}/_template/ism_history_indices" \
+            -o "${LOG_FILE}" --create-dirs \
+            -H 'Content-Type: application/json' -d @-; then
+            echo "  ERROR: 'ism_history_indices' template creation failed"
+            return 1
+        else
+            echo " SUCC: 'ism_history_indices' template created or updated"
+        fi
+
+    # Make settings persistent
+    echo "Will disable replicas for 'plugins.index_state_management.history' indices"
+    generate_ism_config |
+        if ! curl -s -k ${C_AUTH} \
+            -X PUT "${INDEXER_URL}/_cluster/settings" \
+            -o "${LOG_FILE}" --create-dirs \
+            -H 'Content-Type: application/json' -d @-; then
+            echo "  ERROR: cluster's settings update failed"
+            return 1
+        else
+            echo " SUCC: cluster's settings saved"
+        fi
 
     echo "Will create index templates to configure the alias"
     for alias in "${aliases[@]}"; do
@@ -201,7 +269,7 @@ function create_write_index() {
         -H 'Content-Type: application/json' \
         -d "$(generate_write_index_alias "${1}")"; then
         echo "  ERROR: creating '${1}' write index"
-        exit 1
+        return 1
     else
         echo "  SUCC: '${1}' write index created"
     fi
@@ -263,7 +331,7 @@ function show_help() {
     echo -e "        -v, --verbose"
     echo -e "                Set verbose mode. Prints more information."
     echo -e ""
-    exit 1
+    return 1
 }
 
 #########################################################################
@@ -353,7 +421,7 @@ function main() {
         echo "SUCC: Indexer ISM initialization finished successfully."
     else
         echo "ERROR: Indexer ISM initialization failed. Check ${LOG_FILE} for more information."
-        exit 1
+        return 1
     fi
 }
 


### PR DESCRIPTION

|Related issue|
|---|
| https://github.com/wazuh/wazuh-indexer/issues/87 |

## Description

Fixes yellow cluster status on single node deployment caused by ISM plugin's configuration indices having 1 replica index.

This PR adds an index template and cluster's settings to disable replicas on ISM plugin internal indices.

```
".opendistro-ism-managed-index-history-*",
".opendistro-ism-config",
".opendistro-job-scheduler-lock"
```


## Logs example

```
health status index                                                   uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .opendistro-ism-managed-index-history-2023.12.27-000002 hNNlPdrTQxK_LV6rgiZ_JA   1   0          0            0       208b           208b
green  open   .opensearch-observability                               iM0dAYy_S1WbqtozBWKQ8w   1   0          0            0       208b           208b
green  open   .plugins-ml-config                                      cTgc6u4STOudZoopKIL6mw   1   0          1            0      3.9kb          3.9kb
green  open   .opensearch-sap-log-types-config                        ECAdYvtKR0OKANRTXFOP_g   1   0        440            0    241.4kb        241.4kb
green  open   .opendistro-ism-config                                  HbJ1aIzhTG-lbz7wvV1fpg   1   0          7           16     94.4kb         94.4kb
green  open   .opendistro-ism-managed-index-history-2023.12.27-1      4hC_5GiUR5mxo70wrq3VWw   1   0          1            0      8.4kb          8.4kb
green  open   .opendistro-job-scheduler-lock                          tMPAyL73S5Oi2EoVcGXEAw   1   0          2           10     13.1kb         13.1kb
green  open   .opendistro_security                                    jd9XbtApSZKybI0YUjVDrg   1   0         10            1     45.8kb         45.8kb
green  open   .kibana_1                                               o7L2KqA5SA2mPW4QDRLOjA   1   0          7            0     17.2kb         17.2kb
green  open   .opensearch-notifications-config                        rRlgE6-sQmK7Et-rM8oPbg   1   0          0            0       208b           208b

```


```json
{
  "cluster_name": "wazuh-cluster",
  "status": "green",
  "timed_out": false,
  "number_of_nodes": 1,
  "number_of_data_nodes": 1,
  "discovered_master": true,
  "discovered_cluster_manager": true,
  "active_primary_shards": 21,
  "active_shards": 21,
  "relocating_shards": 0,
  "initializing_shards": 0,
  "unassigned_shards": 0,
  "delayed_unassigned_shards": 0,
  "number_of_pending_tasks": 0,
  "number_of_in_flight_fetch": 0,
  "task_max_waiting_in_queue_millis": 0,
  "active_shards_percent_as_number": 100
}
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
