### PR TITLE
Fix wazuh-indexer ism  plugin log file path

### DIFF
--- a/stack/indexer/indexer-ism-init.sh
+++ b/stack/indexer/indexer-ism-init.sh
@@ -12,7 +12,7 @@ INDEXER_PASSWORD="admin"
 INDEXER_HOSTNAME="localhost"
 
 POLICY_NAME="rollover_policy"
-LOG_FILE="/tmp/wazuh-indexer/ism-init.log"
+LOG_FILE="/var/log/wazuh-indexer/ism-init.log"
 
 INDEXER_URL="https://${INDEXER_HOSTNAME}:9200"
 


### PR DESCRIPTION
|Related issue|
|---|
| #2657 |


## Description

This PR fixes the `wazuh-indexer` ism plugin log location from `tmp` to `/var/log.`

## Tests

- Build package and install package
```
        chmod 644 debian/wazuh-indexer/DEBIAN/md5sums
        chown 0:0 debian/wazuh-indexer/DEBIAN/md5sums
   dh_builddeb
        dpkg-deb --build debian/wazuh-indexer ..
dpkg-deb: building package `wazuh-indexer' in `../wazuh-indexer_4.8.1-1_amd64.deb'.
 dpkg-genchanges -b >../wazuh-indexer_4.8.1-1_amd64.changes
dpkg-genchanges: binary-only upload (no source code included)
 dpkg-source --after-build wazuh-indexer-4.8.1
dpkg-buildpackage: binary-only upload (no source included)

WARNING generated by debuild:
Making debian/rules executable!

Package wazuh-indexer_4.8.1-1_amd64.deb.sha512 added to /home/vagrant/wazuh-packages-enhancement-2657-fix-indexder-ism-log-path/stack/indexer/deb/output.

# apt-get install debconf adduser procps
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
debconf is already the newest version (1.5.77).
procps is already the newest version (2:3.3.17-5).
The following packages will be upgraded:
  adduser
1 upgraded, 0 newly installed, 0 to remove and 60 not upgraded.
Need to get 241 kB of archives.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://deb.debian.org/debian bullseye/main amd64 adduser all 3.118+deb11u1 [241 kB]
Fetched 241 kB in 0s (906 kB/s)
Reading changelogs... Done
Preconfiguring packages ...
(Reading database ... 69367 files and directories currently installed.)
Preparing to unpack .../adduser_3.118+deb11u1_all.deb ...
Unpacking adduser (3.118+deb11u1) over (3.118) ...
Setting up adduser (3.118+deb11u1) ...
Processing triggers for man-db (2.9.4-2) ...
root@debian11:/home/vagrant/wazuh-packages-enhancement-2657-fix-indexder-ism-log-path/stack/indexer/deb# apt-get install gnupg apt-transport-https
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
gnupg is already the newest version (2.2.27-2+deb11u2).
The following NEW packages will be installed:
  apt-transport-https
0 upgraded, 1 newly installed, 0 to remove and 60 not upgraded.
Need to get 160 kB of archives.
After this operation, 166 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://deb.debian.org/debian bullseye/main amd64 apt-transport-https all 2.2.4 [160 kB]
Fetched 160 kB in 0s (614 kB/s)
Selecting previously unselected package apt-transport-https.
(Reading database ... 69367 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_2.2.4_all.deb ...
Unpacking apt-transport-https (2.2.4) ...
Setting up apt-transport-https (2.2.4) ...


# dpkg -i output/wazuh-indexer_4.8.1-1_amd64.deb
Selecting previously unselected package wazuh-indexer.
(Reading database ... 69371 files and directories currently installed.)
Preparing to unpack .../wazuh-indexer_4.8.1-1_amd64.deb ...
Creating wazuh-indexer group... OK
Creating wazuh-indexer user... OK
Unpacking wazuh-indexer (4.8.1-1) ...
Setting up wazuh-indexer (4.8.1-1) ...
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore


# NODE_NAME=node-1
# mkdir /etc/wazuh-indexer/certs
tar -xf ./wazuh-certificates.tar -C /etc/wazuh-indexer/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./admin.pem ./admin-key.pem ./root-ca.pem
mv -n /etc/wazuh-indexer/certs/$NODE_NAME.pem /etc/wazuh-indexer/certs/indexer.pem
mv -n /etc/wazuh-indexer/certs/$NODE_NAME-key.pem /etc/wazuh-indexer/certs/indexer-key.pem
chmod 500 /etc/wazuh-indexer/certs
chmod 400 /etc/wazuh-indexer/certs/*
chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs


# systemctl daemon-reload
systemctl enable wazuh-indexer
systemctl start wazuh-indexer
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.

# /usr/share/wazuh-indexer/bin/indexer-security-init.sh
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success



# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2024-01-03 10:46:25 UTC; 1h 33min ago
       Docs: https://documentation.wazuh.com
   Main PID: 34506 (java)
      Tasks: 70 (limit: 4661)
     Memory: 1.3G
        CPU: 1min 16.552s
     CGroup: /system.slice/wazuh-indexer.service
             └─34506 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encodin>

Jan 03 10:46:06 debian11.localdomain systemd[1]: Starting Wazuh-indexer...
Jan 03 10:46:08 debian11.localdomain systemd-entrypoint[34506]: WARNING: A terminally deprecated method in java.lang.System has been called
Jan 03 10:46:08 debian11.localdomain systemd-entrypoint[34506]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
Jan 03 10:46:08 debian11.localdomain systemd-entrypoint[34506]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
Jan 03 10:46:08 debian11.localdomain systemd-entrypoint[34506]: WARNING: System::setSecurityManager will be removed in a future release
Jan 03 10:46:10 debian11.localdomain systemd-entrypoint[34506]: WARNING: A terminally deprecated method in java.lang.System has been called
Jan 03 10:46:10 debian11.localdomain systemd-entrypoint[34506]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
Jan 03 10:46:10 debian11.localdomain systemd-entrypoint[34506]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
Jan 03 10:46:10 debian11.localdomain systemd-entrypoint[34506]: WARNING: System::setSecurityManager will be removed in a future release
Jan 03 10:46:25 debian11.localdomain systemd[1]: Started Wazuh-indexer.


# curl -k -u admin:admin https://192.168.56.111:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "yee6KXaLQ8yin8TOliFrSg",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "eee49cb340edc6c4d489bcd9324dda571fc8dc03",
    "build_date" : "2023-09-20T23:54:29.889267151Z",
    "build_snapshot" : false,
    "lucene_version" : "9.7.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
```

- Start ISM plugin and check log file is created in correct location
```
# cat /tmp/wazuh-indexer/ism-init.log
cat: /tmp/wazuh-indexer/ism-init.log: No such file or directory

# cat /var/log/wazuh-indexer/ism-init.log
cat: /var/log/wazuh-indexer/ism-init.log: No such file or directory


# bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh
Will create 'wazuh' index template
  ERROR: /etc/wazuh-indexer/wazuh-template.json not found
Will create index templates to configure the alias
 SUCC: 'wazuh-alerts' template created or updated
 SUCC: 'wazuh-archives' template created or updated
Will create the 'rollover_policy' policy
  SUCC: 'rollover_policy' policy created
Will create initial indices for the aliases
  SUCC: 'wazuh-alerts' write index created
  SUCC: 'wazuh-archives' write index created
SUCC: Indexer ISM initialization finished successfully.

# cat /tmp/wazuh-indexer/ism-init.log
cat: /tmp/wazuh-indexer/ism-init.log: No such file or directory

# ls /var/log/wazuh-indexer/ism-init.log
/var/log/wazuh-indexer/ism-init.log

# cat /var/log/wazuh-indexer/ism-init.log
{"acknowledged":true,"shards_acknowledged":true,"index":"wazuh-archives-4.x-2024.01.03-000001"}
```

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Check log is created in correct location

