### PR TITLE
Add xz utils as requirement

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/control
+++ b/debs/SPECS/wazuh-manager/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.wazuh.com
 
 Package: wazuh-manager
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, xz-utils
 Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -22,7 +22,7 @@ Conflicts:   ossec-hids ossec-hids-agent wazuh-agent wazuh-local
 Obsoletes: wazuh-api < 4.0.0
 AutoReqProv: no
 
-Requires: coreutils
+Requires: coreutils xz
 BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python curl perl
 
 ExclusiveOS: linux


### PR DESCRIPTION
|Related issue|
|---|
|#2731|

## Description

Now the package needs to download and decompress the database content. Added `xz` dependency in RPM and `xz-utils` in DEB.

### Tests

- [x] Centos - OK
- [x] Ubuntu - OK