### PR TITLE
Remove flag --download-content

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -26,7 +26,6 @@ export JOBS="5"
 export DEBUG_ENABLED="no"
 export PATH="${PATH}"
 export LD_LIBRARY_PATH=""
-export DOWNLOAD_CONTENT_ENABLED="no"
 
 %:
 	dh $@
@@ -65,7 +64,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
-	DOWNLOAD_CONTENT="$(DOWNLOAD_CONTENT_ENABLED)" \
+	DOWNLOAD_CONTENT="yes" \
 	./install.sh
 
 	# Copying init.d script

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -23,7 +23,6 @@ wazuh_packages_branch=$9
 use_local_specs=${10}
 local_source_code=${11}
 future=${12}
-download_content=${13}
 
 if [ -z "${package_release}" ]; then
     package_release="1"
@@ -88,7 +87,6 @@ cd ${build_dir}/${build_target} && tar -czf ${package_full_name}.orig.tar.gz "${
 sed -i "s:RELEASE:${package_release}:g" ${sources_dir}/debian/changelog
 sed -i "s:export JOBS=.*:export JOBS=${jobs}:g" ${sources_dir}/debian/rules
 sed -i "s:export DEBUG_ENABLED=.*:export DEBUG_ENABLED=${debug}:g" ${sources_dir}/debian/rules
-sed -i "s:export DOWNLOAD_CONTENT_ENABLED=.*:export DOWNLOAD_CONTENT_ENABLED=${download_content}:g" ${sources_dir}/debian/rules
 sed -i "s#export PATH=.*#export PATH=/usr/local/gcc-5.5.0/bin:${PATH}#g" ${sources_dir}/debian/rules
 sed -i "s#export LD_LIBRARY_PATH=.*#export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}#g" ${sources_dir}/debian/rules
 sed -i "s:export INSTALLATION_DIR=.*:export INSTALLATION_DIR=${dir_path}:g" ${sources_dir}/debian/rules

--- a/debs/generate_debian_package.sh
+++ b/debs/generate_debian_package.sh
@@ -15,7 +15,6 @@ REVISION="1"
 TARGET=""
 JOBS="2"
 DEBUG="no"
-DOWNLOAD_CONTENT="no"
 BUILD_DOCKER="yes"
 DOCKER_TAG="latest"
 INSTALLATION_PATH="/var/ossec"
@@ -85,7 +84,7 @@ build_deb() {
         ${CONTAINER_NAME}:${DOCKER_TAG} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${REVISION} ${JOBS} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} \
-        ${USE_LOCAL_SOURCE_CODE} ${FUTURE} ${DOWNLOAD_CONTENT}|| return 1
+        ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -163,7 +162,6 @@ help() {
     echo "    -p, --path <path>          [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug                [Optional] Build the binaries with debug symbols. By default: no."
     echo "    -c, --checksum <path>      [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    --download-content         [Optional] Download content and add it to the package."
     echo "    --dont-build-docker        [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --tag                      [Optional] Tag to use with the docker image."
     echo "    --sources <path>           [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
@@ -246,10 +244,6 @@ main() {
                 CHECKSUM="yes"
                 shift 1
             fi
-            ;;
-        "--download-content")
-            DOWNLOAD_CONTENT="yes"
-            shift 1
             ;;
         "--dont-build-docker")
             BUILD_DOCKER="no"

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -78,7 +78,7 @@ echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
-echo 'DOWNLOAD_CONTENT="%{_download_content_enabled}"' >> ./etc/preloaded-vars.conf
+echo 'DOWNLOAD_CONTENT="yes"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -24,7 +24,6 @@ src=${11}
 legacy=${12}
 local_source_code=${13}
 future=${14}
-download_content=${15}
 wazuh_version=""
 rpmbuild="rpmbuild"
 
@@ -126,7 +125,6 @@ fi
 $linux $rpmbuild --define "_sysconfdir /etc" --define "_topdir ${rpm_build_dir}" \
         --define "_threads ${threads}" --define "_release ${package_release}" \
         --define "_localstatedir ${directory_base}" --define "_debugenabled ${debug}" \
-        --define "_download_content_enabled ${download_content}" \
         --target ${architecture_target} -ba ${rpm_build_dir}/SPECS/${package_name}.spec
 
 if [[ "${checksum}" == "yes" ]]; then

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -18,7 +18,6 @@ REVISION="1"
 TARGET=""
 JOBS="2"
 DEBUG="no"
-DOWNLOAD_CONTENT="no"
 BUILD_DOCKER="yes"
 DOCKER_TAG="latest"
 USER_PATH="no"
@@ -111,7 +110,7 @@ build_rpm() {
         ${CONTAINER_NAME}:${DOCKER_TAG} ${TARGET} ${BRANCH} ${ARCHITECTURE} \
         ${JOBS} ${REVISION} ${INSTALLATION_PATH} ${DEBUG} \
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
-        ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE} ${DOWNLOAD_CONTENT}|| return 1
+        ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
     echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
 
@@ -210,7 +209,6 @@ help() {
     echo "    -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec."
     echo "    -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no."
     echo "    -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."
-    echo "    --download-content           [Optional] Download content and add it to the package."
     echo "    --dont-build-docker          [Optional] Locally built docker image will be used instead of generating a new one."
     echo "    --tag                        [Optional] Tag to use with the docker image."
     echo "    --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub."
@@ -287,10 +285,6 @@ main() {
             ;;
         "-d"|"--debug")
             DEBUG="yes"
-            shift 1
-            ;;
-        "--download-content")
-            DOWNLOAD_CONTENT="yes"
             shift 1
             ;;
         "--dont-build-docker")


### PR DESCRIPTION
Always download content, it's mandatory

|Related issue|
|---|
|#2747|


## Description

Remove flag `--download-content` from `generate_debian_package.sh` and `generate_rpm_package.sh`.

By default, always download the content.