### PR TITLE
Adding support for Amazon Linux 1, 2, and 2023

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -197,9 +197,15 @@ function check_dist() {
     if { [ "${DIST_NAME}" == "centos" ] || [ "${DIST_NAME}" == "rhel" ]; } && { [ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ] && [ "${DIST_VER}" -ne "9" ]; }; then
         notsupported=1
     fi
-    if [ "${DIST_NAME}" == "amzn" ] && [ "${DIST_VER}" -ne "2" ]; then
-        notsupported=1
+
+    if [ "${DIST_NAME}" == "amzn" ]; then
+        if [ "${DIST_VER}" != "2" ] &&
+           [ "${DIST_VER}" != "2023" ] &&
+           [ "${DIST_VER}" != "2018.03" ]; then
+            notsupported=1
+        fi
     fi
+
     if [ "${DIST_NAME}" == "ubuntu" ]; then
         if  [ "${DIST_VER}" == "16" ] || [ "${DIST_VER}" == "18" ] ||
             [ "${DIST_VER}" == "20" ] || [ "${DIST_VER}" == "22" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|#2612|

### Objective
Add Amazon Linux 1 and Amazon Linux 2023 support in the distribution check script.

This is implemented by two scripts in different repositories.
a. wazuh/wazuh
b. wazuh/wazuh-packages

Therefore merge must be done "atomically". 

### Check

- [x] Local tests OK :green_circle: 
- [x] Verify Merge in wazuh/wazuh [PR 21287](https://github.com/wazuh/wazuh/pull/21287)