### PR TITLE
Removed PDF dependencies in OVA

### DIFF
--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -41,10 +41,6 @@ systemConfig() {
   # Edit system custom welcome messages
   bash ${CUSTOM_PATH}/messages.sh ${DEBUG} ${WAZUH_VERSION} ${SYSTEM_USER}
 
-  # Install dependencies
-  yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic \
-    xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype ipa-gothic-fonts open-vm-tools
-
 }
 
 # Edit unattended installer


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2737|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to remove the PDF Wazuh dashboard dependencies installed in the OVA generation. These dependencies were installed to generate the PDF reports in the Wazuh web interface. After previous research, these dependencies were removed from the installation alternatives, and so in the OVA generation.

## Testing 
The test performed was done [here](https://github.com/wazuh/wazuh-packages/issues/2737#issuecomment-1883352732):
- Generate the OVA.
- Generate a PDF report after creating a visualization.

