### PR TITLE
Updated Vagrantbox for OVA build

### DIFF
--- a/ova/Vagrantfile
+++ b/ova/Vagrantfile
@@ -3,8 +3,8 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box_url = "https://packages-dev.wazuh.com/vms/ova/amazonlinux-2.box"
-  config.vm.box = "amazonlinux-2"
+  config.vm.box_url = "https://packages-dev.wazuh.com/vms/ova/amznlinux-2.box"
+  config.vm.box = "amznlinux-2"
   config.vm.hostname = "wazuh-server"
   config.vm.provider "virtualbox" do |vb|
     vb.name = "vm_wazuh"


### PR DESCRIPTION
|Related issue|
|---|
|Related https://github.com/wazuh/wazuh-packages/issues/2744|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The `Vagrantbox` used for local build and the `AMI` used for Jenkins build are modified. With this, the OVA is built without the `/etc/redhat-release` file, allowing the `SCA` template to be configured correctly

## Logs example

<!--
Paste here related logs
-->

Build locally: https://github.com/wazuh/wazuh-packages/issues/2744#issuecomment-1885014453
