### PR TITLE
Include SCA policy for Oracle Linux 9 in SPECS

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -138,6 +138,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/10
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/11
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/12
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/9
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/5
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/6
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/7
@@ -191,6 +192,8 @@ override_dh_install:
 	cp etc/templates/config/centos/6/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/centos/6
 	cp etc/templates/config/centos/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/centos/7
 	cp etc/templates/config/centos/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/centos/8
+
+	cp etc/templates/config/ol/9/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/9
 
 	cp etc/templates/config/rhel/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel
 	cp etc/templates/config/rhel/5/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/5

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -112,7 +112,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/{29,30,31,32,33,34}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/{8,9}
 
-cp -r ruleset/sca/{generic,centos,rhel,sles,amazon,rocky} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{generic,centos,rhel,ol,sles,amazon,rocky} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -105,6 +105,7 @@ rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/{generic}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/{1,2,2023}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/{8,7,6,5}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/{9,8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/{11,12,15}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/{11,12}
@@ -124,6 +125,8 @@ cp etc/templates/config/centos/8/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 cp etc/templates/config/centos/7/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
 cp etc/templates/config/centos/6/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
 cp etc/templates/config/centos/5/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+
+cp etc/templates/config/ol/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
 
 cp etc/templates/config/rhel/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 cp etc/templates/config/rhel/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9
@@ -574,6 +577,8 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -282,6 +282,10 @@ elif [ -r "/etc/centos-release" ]; then
 elif [ -r "/etc/fedora-release" ]; then
     DIST_NAME="fedora"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/fedora-release`
+# Oracle Linux
+elif [ -r "/etc/oracle-release" ]; then
+    DIST_NAME="ol"
+    DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/oracle-release`
 # RedHat
 elif [ -r "/etc/redhat-release" ]; then
   if grep -q "AlmaLinux" /etc/redhat-release; then

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -115,6 +115,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/am
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/{8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/{15,16,17,18,19,20,21,22,23}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/{7,8,9,10,11,12}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/{12,14,16,18,20,22}/04
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/{9,8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/{11,12,15}
@@ -137,6 +138,8 @@ cp etc/templates/config/centos/8/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 cp etc/templates/config/centos/7/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
 cp etc/templates/config/centos/6/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
 cp etc/templates/config/centos/5/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
+
+cp etc/templates/config/ol/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
 
 cp etc/templates/config/rhel/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 cp etc/templates/config/rhel/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9
@@ -813,6 +816,8 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -125,7 +125,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/wi
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/{29,30,31,32,33,34}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/{8,9}
 
-cp -r ruleset/sca/{applications,generic,mongodb,nginx,oracledb,centos,darwin,debian,rhel,sles,sunos,windows,amazon,ubuntu,rocky} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+cp -r ruleset/sca/{applications,generic,mongodb,nginx,oracledb,centos,darwin,debian,ol,rhel,sles,sunos,windows,amazon,ubuntu,rocky} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
 cp etc/templates/config/generic/{sca.files,sca.manager.files} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -375,6 +375,10 @@ elif [ -r "/etc/centos-release" ]; then
 elif [ -r "/etc/fedora-release" ]; then
     DIST_NAME="fedora"
     DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/fedora-release`
+# Oracle Linux
+elif [ -r "/etc/oracle-release" ]; then
+    DIST_NAME="ol"
+    DIST_VER=`sed -rn 's/.* ([0-9]{1,2})\.*[0-9]{0,2}.*/\1/p' /etc/oracle-release`
 # RedHat
 elif [ -r "/etc/redhat-release" ]; then
   if grep -q "AlmaLinux" /etc/redhat-release; then


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2765 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR adds the necessary modifications to the SPECS to include the new Alma Linux 8 SCA policy.

## Logs example

<!--
Paste here related logs
-->

## Tests
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7

<details><summary>Manager</summary>

**Manager package build:** https://ci.wazuh.info/job/Packages_builder/180311

**Package installation:**
```
[root@localhost vagrant]# yum install -y https://packages-dev.wazuh.com/warehouse/test/4.8/rpm/var/wazuh-manager-4.8.1-ol9.x86_64.rpm
Oracle Linux 9 BaseOS Latest  (x86_64)                                                                  2.6 MB/s |  18 MB     00:07    
Oracle Linux 9 Application Stream Packages (x86_64)                                                      27 MB/s |  27 MB     00:00    
Oracle Linux 9 UEK Release 7 (x86_64)                                                                    26 MB/s |  25 MB     00:00    
Last metadata expiration check: 0:00:04 ago on Thu 11 Jan 2024 04:56:37 PM UTC.
wazuh-manager-4.8.1-ol9.x86_64.rpm                                                                       19 MB/s | 351 MB     00:18    
Dependencies resolved.
========================================================================================================================================
 Package                            Architecture                Version                         Repository                         Size
========================================================================================================================================
Installing:
 wazuh-manager                      x86_64                      4.8.1-ol9                       @commandline                      351 M

Transaction Summary
========================================================================================================================================
Install  1 Package

Total size: 351 M
Installed size: 856 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                1/1 
  Running scriptlet: wazuh-manager-4.8.1-ol9.x86_64                                                                                 1/1 
  Installing       : wazuh-manager-4.8.1-ol9.x86_64                                                                                 1/1 
  Running scriptlet: wazuh-manager-4.8.1-ol9.x86_64                                                                                 1/1 
  Verifying        : wazuh-manager-4.8.1-ol9.x86_64                                                                                 1/1 

Installed:
  wazuh-manager-4.8.1-ol9.x86_64                                                                                                        

Complete!
```

**SCA file found:**
```
[root@localhost vagrant]# ls /var/ossec/ruleset/sca
cis_amazon_linux_1.yml.disabled     cis_debian8.yml.disabled              cis_solaris11.yml.disabled
cis_amazon_linux_2023.yml.disabled  cis_debian9.yml.disabled              cis_sqlserver_2012.yml.disabled
cis_amazon_linux_2.yml.disabled     cis_iis_10.yml.disabled               cis_sqlserver_2014.yml.disabled
cis_apache_24.yml.disabled          cis_mongodb_36.yml.disabled           cis_sqlserver_2016.yml.disabled
cis_apple_macOS_10.11.yml.disabled  cis_mysql5-6_community.yml.disabled   cis_sqlserver_2017.yml.disabled
cis_apple_macOS_10.12.yml.disabled  cis_mysql5-6_enterprise.yml.disabled  cis_sqlserver_2019.yml.disabled
cis_apple_macOS_10.13.yml.disabled  cis_nginx_1.yml.disabled              cis_ubuntu14-04.yml.disabled
cis_apple_macOS_10.14.yml.disabled  cis_oracle_database_19c.yml.disabled  cis_ubuntu16-04.yml.disabled
cis_apple_macOS_10.15.yml.disabled  cis_oracle_linux_9.yml                cis_ubuntu18-04.yml.disabled
cis_apple_macOS_11.1.yml.disabled   cis_postgre-sql-13.yml.disabled       cis_ubuntu20-04.yml.disabled
cis_apple_macOS_12.0.yml.disabled   cis_rhel5_linux.yml.disabled          cis_ubuntu22-04.yml.disabled
cis_apple_macOS_13.x.yml.disabled   cis_rhel6_linux.yml.disabled          cis_win10_enterprise.yml.disabled
cis_apple_macOS_14.0.yml.disabled   cis_rhel7_linux.yml.disabled          cis_win11_enterprise.yml.disabled
cis_centos6_linux.yml.disabled      cis_rhel8_linux.yml.disabled          cis_win2012r2.yml.disabled
cis_centos7_linux.yml.disabled      cis_rhel9_linux.yml.disabled          cis_win2016.yml.disabled
cis_centos8_linux.yml.disabled      cis_rocky_linux_8.yml.disabled        cis_win2019.yml.disabled
cis_debian10.yml.disabled           cis_sles11_linux.yml.disabled         cis_win2022.yml.disabled
cis_debian11.yml.disabled           cis_sles12_linux.yml.disabled         sca_unix_audit.yml.disabled
cis_debian12.yml.disabled           cis_sles15_linux.yml.disabled         web_vulnerabilities.yml.disabled
cis_debian7.yml.disabled            cis_solaris11.4.yml.disabled

```
</details>

<details><summary>Agent</summary>

**Agent package build:** https://ci.wazuh.info/job/Packages_builder/180342

**Package installation:**
```
[root@localhost vagrant]# yum install -y https://packages-dev.wazuh.com/warehouse/test/4.8/rpm/var/wazuh-agent-4.8.1-ol9.x86_64.rpm
Oracle Linux 9 BaseOS Latest  (x86_64)                                                                   23 MB/s |  18 MB     00:00    
Oracle Linux 9 Application Stream Packages (x86_64)                                                      28 MB/s |  27 MB     00:00    
Oracle Linux 9 UEK Release 7 (x86_64)                                                                    24 MB/s |  25 MB     00:01    
Last metadata expiration check: 0:00:04 ago on Thu 11 Jan 2024 05:13:32 PM UTC.
wazuh-agent-4.8.1-ol9.x86_64.rpm                                                                        3.7 MB/s | 9.3 MB     00:02    
Dependencies resolved.
========================================================================================================================================
 Package                          Architecture                Version                           Repository                         Size
========================================================================================================================================
Installing:
 wazuh-agent                      x86_64                      4.8.1-ol9                         @commandline                      9.3 M

Transaction Summary
========================================================================================================================================
Install  1 Package

Total size: 9.3 M
Installed size: 27 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                1/1 
  Running scriptlet: wazuh-agent-4.8.1-ol9.x86_64                                                                                   1/1 
  Installing       : wazuh-agent-4.8.1-ol9.x86_64                                                                                   1/1 
  Running scriptlet: wazuh-agent-4.8.1-ol9.x86_64                                                                                   1/1 
  Verifying        : wazuh-agent-4.8.1-ol9.x86_64                                                                                   1/1 

Installed:
  wazuh-agent-4.8.1-ol9.x86_64                                                                                                          

Complete!


```

**SCA file found:**
```
[root@localhost vagrant]# ls /var/ossec/ruleset/sca
cis_oracle_linux_9.yml
```
</details>