### PR TITLE
Split CentOS and RHEL check

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -194,7 +194,10 @@ function check_dist() {
     if [ "${DIST_NAME}" != "centos" ] && [ "${DIST_NAME}" != "rhel" ] && [ "${DIST_NAME}" != "amzn" ] && [ "${DIST_NAME}" != "ubuntu" ]; then
         notsupported=1
     fi
-    if { [ "${DIST_NAME}" == "centos" ] || [ "${DIST_NAME}" == "rhel" ]; } && { [ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ] && [ "${DIST_VER}" -ne "9" ]; }; then
+    if [ "${DIST_NAME}" == "centos" ] && { [ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ]; }; then
+        notsupported=1
+    fi
+    if [ "${DIST_NAME}" == "rhel" ] && { [ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ] && [ "${DIST_VER}" -ne "9" ]; }; then
         notsupported=1
     fi
     if [ "${DIST_NAME}" == "amzn" ] && [ "${DIST_VER}" -ne "2" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2778|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR splits the CentOS and RHEL version check, because is needed to check different versions for each OS.


## Logs example

<!--
Paste here related logs
-->

Centos 9:

```
[root@server1 wazuh-packages]# git checkout 2778-wia-accepts-centos-9-as-a-recommended-system
branch '2778-wia-accepts-centos-9-as-a-recommended-system' set up to track 'origin/2778-wia-accepts-centos-9-as-a-recommended-system'.
Switched to a new branch '2778-wia-accepts-centos-9-as-a-recommended-system'
[root@server1 wazuh-packages]# bash unattended_installer/builder.sh -i -d
[root@server1 wazuh-packages]# cd unattended_installer/
[root@server1 unattended_installer]# ls -ltr
total 216
-rw-r--r--. 1 root root   2397 Jan 18 13:11 Development-guide.md
drwxr-xr-x. 6 root root     73 Jan 18 13:11 config
drwxr-xr-x. 2 root root     49 Jan 18 13:11 common_functions
drwxr-xr-x. 2 root root     73 Jan 18 13:11 cert_tool
drwxr-xr-x. 2 root root     88 Jan 18 13:23 passwords_tool
-rwxr-xr-x. 1 root root  12956 Jan 18 13:23 builder.sh
-r-x------. 1 root root 174673 Jan 18 13:24 wazuh-install.sh
drwxr-xr-x. 2 root root   4096 Jan 18 13:24 install_functions
[root@server1 unattended_installer]# cat /etc/os-release
NAME="CentOS Stream"
VERSION="9"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="9"
PLATFORM_ID="platform:el9"
PRETTY_NAME="CentOS Stream 9"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:centos:centos:9"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
[root@server1 unattended_installer]# sudo bash ./wazuh-install.sh -a
18/01/2024 13:24:55 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
18/01/2024 13:24:55 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/01/2024 13:24:55 ERROR: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check.
[root@server1 unattended_installer]#
```

Centos 7:

```
[root@server1 wazuh-packages]# git checkout 2778-wia-accepts-centos-9-as-a-recommended-system
Branch 2778-wia-accepts-centos-9-as-a-recommended-system set up to track remote branch 2778-wia-accepts-centos-9-as-a-recommended-system from origin.
Switched to a new branch '2778-wia-accepts-centos-9-as-a-recommended-system'
[root@server1 wazuh-packages]# bash unattended_installer/builder.sh -i -d
[root@server1 wazuh-packages]# cd unattended_installer/
[root@server1 unattended_installer]# ls -ltr
total 212
-rw-r--r--. 1 root root   2397 Jan 18 14:34 Development-guide.md
drwxr-xr-x. 6 root root     73 Jan 18 14:34 config
drwxr-xr-x. 2 root root     49 Jan 18 14:34 common_functions
drwxr-xr-x. 2 root root     73 Jan 18 14:34 cert_tool
-rwxr-xr-x. 1 root root  12956 Jan 18 14:34 builder.sh
drwxr-xr-x. 2 root root     88 Jan 18 14:34 passwords_tool
-r-x------. 1 root root 174673 Jan 18 14:35 wazuh-install.sh
drwxr-xr-x. 2 root root    204 Jan 18 14:35 install_functions
[root@server1 unattended_installer]# cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

[root@server1 unattended_installer]# sudo bash ./wazuh-install.sh -a
18/01/2024 14:35:49 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
18/01/2024 14:35:49 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/01/2024 14:35:55 INFO: --- Dependencies ---
18/01/2024 14:35:55 INFO: Installing lsof.
18/01/2024 14:35:56 INFO: Verifying that your system meets the recommended minimum hardware requirements.
18/01/2024 14:35:56 INFO: Wazuh web interface port will be 443.
18/01/2024 14:35:59 INFO: Wazuh development repository added.
18/01/2024 14:35:59 INFO: --- Configuration files ---
18/01/2024 14:35:59 INFO: Generating configuration files.
18/01/2024 14:35:59 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
18/01/2024 14:35:59 INFO: --- Wazuh indexer ---
18/01/2024 14:35:59 INFO: Starting Wazuh indexer installation.
18/01/2024 14:38:57 INFO: Wazuh indexer installation finished.
18/01/2024 14:38:57 INFO: Wazuh indexer post-install configuration finished.
18/01/2024 14:38:57 INFO: Starting service wazuh-indexer.
18/01/2024 14:39:14 INFO: wazuh-indexer service started.
18/01/2024 14:39:14 INFO: Initializing Wazuh indexer cluster security settings.
18/01/2024 14:39:27 INFO: The Wazuh indexer cluster ISM initialized.
18/01/2024 14:39:27 INFO: Wazuh indexer cluster initialized.
18/01/2024 14:39:27 INFO: --- Wazuh server ---
18/01/2024 14:39:27 INFO: Starting the Wazuh manager installation.
18/01/2024 14:41:21 INFO: Wazuh manager installation finished.
18/01/2024 14:41:21 INFO: Starting service wazuh-manager.
18/01/2024 14:41:36 INFO: wazuh-manager service started.
18/01/2024 14:41:36 INFO: Starting Filebeat installation.
18/01/2024 14:41:47 INFO: Filebeat installation finished.
18/01/2024 14:41:48 INFO: Filebeat post-install configuration finished.
18/01/2024 14:41:48 INFO: Starting service filebeat.
18/01/2024 14:41:48 INFO: filebeat service started.
18/01/2024 14:41:48 INFO: --- Wazuh dashboard ---
18/01/2024 14:41:48 INFO: Starting Wazuh dashboard installation.
18/01/2024 14:44:04 INFO: Wazuh dashboard installation finished.
18/01/2024 14:44:04 INFO: Wazuh dashboard post-install configuration finished.
18/01/2024 14:44:04 INFO: Starting service wazuh-dashboard.
18/01/2024 14:44:04 INFO: wazuh-dashboard service started.
18/01/2024 14:44:06 INFO: Updating the internal users.
18/01/2024 14:44:12 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
18/01/2024 14:44:33 INFO: Initializing Wazuh dashboard web application.
18/01/2024 14:44:34 INFO: Wazuh dashboard web application initialized.
18/01/2024 14:44:34 INFO: --- Summary ---
18/01/2024 14:44:34 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: pAe0m2.tIu4.*3wZzxsssDi14lBbdqX2
18/01/2024 14:44:34 INFO: --- Dependencies ---
18/01/2024 14:44:34 INFO: Removing lsof.
18/01/2024 14:44:35 INFO: Installation finished.
[root@server1 unattended_installer]#
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
