### PR TITLE
Added roll back and exit in case the Wazuh indexer security admin fails

### DIFF
--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -128,6 +128,7 @@ function indexer_initialize() {
             installCommon_rollBack
             exit 1
         else
+            common_logger "Wazuh indexer cluster security configuration initialized."
             eval "bash /usr/share/wazuh-indexer/bin/indexer-ism-init.sh ${debug}"
             if [  "${PIPESTATUS[0]}" != 0  ]; then
                 common_logger -w "The Wazuh indexer cluster ISM policy could not be created."


### PR DESCRIPTION
|Related issue|
|---|
|close https://github.com/wazuh/wazuh-packages/issues/2781|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds the necessary roll backs in the event of failures in the execution of the security admin and the ISM policy. This improves waiting time and makes it easier to debug the installation without having to wait for the WIA to move forward with the rest of the components.

## Logs example

<!--
Paste here related logs
-->

### Tested in Debian 12

#### Security admin fail:

```console
vagrant@bookworm:~$ sudo bash wazuh-install.sh -i -a
18/01/2024 19:02:41 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
18/01/2024 19:02:41 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/01/2024 19:02:45 WARNING: Hardware and system checks ignored.
18/01/2024 19:02:45 INFO: Wazuh web interface port will be 443.
18/01/2024 19:02:51 INFO: Wazuh development repository added.
18/01/2024 19:02:51 INFO: --- Configuration files ---
18/01/2024 19:02:51 INFO: Generating configuration files.
18/01/2024 19:02:52 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
18/01/2024 19:02:53 INFO: --- Wazuh indexer ---
18/01/2024 19:02:53 INFO: Starting Wazuh indexer installation.
18/01/2024 19:03:30 INFO: Wazuh indexer installation finished.
18/01/2024 19:03:30 INFO: Wazuh indexer post-install configuration finished.
18/01/2024 19:03:30 INFO: Starting service wazuh-indexer.
18/01/2024 19:03:40 INFO: wazuh-indexer service started.
18/01/2024 19:03:40 INFO: Initializing Wazuh indexer cluster security settings.
18/01/2024 19:03:41 ERROR: The Wazuh indexer cluster security configuration could not be initialized.
18/01/2024 19:03:41 INFO: --- Removing existing Wazuh installation ---
18/01/2024 19:03:41 INFO: Removing Wazuh indexer.
18/01/2024 19:03:43 INFO: Wazuh indexer removed.
18/01/2024 19:03:43 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```


#### ISM policy fail:

```console
vagrant@bookworm:~$ sudo bash wazuh-install.sh -i -a
18/01/2024 19:05:28 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
18/01/2024 19:05:28 INFO: Verbose logging redirected to /var/log/wazuh-install.log
18/01/2024 19:05:32 WARNING: Hardware and system checks ignored.
18/01/2024 19:05:32 INFO: Wazuh web interface port will be 443.
18/01/2024 19:05:38 INFO: Wazuh development repository added.
18/01/2024 19:05:38 INFO: --- Configuration files ---
18/01/2024 19:05:38 INFO: Generating configuration files.
18/01/2024 19:05:40 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
18/01/2024 19:05:40 INFO: --- Wazuh indexer ---
18/01/2024 19:05:40 INFO: Starting Wazuh indexer installation.
18/01/2024 19:06:18 INFO: Wazuh indexer installation finished.
18/01/2024 19:06:18 INFO: Wazuh indexer post-install configuration finished.
18/01/2024 19:06:18 INFO: Starting service wazuh-indexer.
18/01/2024 19:06:28 INFO: wazuh-indexer service started.
18/01/2024 19:06:28 INFO: Initializing Wazuh indexer cluster security settings.
18/01/2024 19:06:40 WARNING: The Wazuh indexer cluster ISM policy could not be created.
18/01/2024 19:06:40 INFO: --- Removing existing Wazuh installation ---
18/01/2024 19:06:40 INFO: Removing Wazuh indexer.
18/01/2024 19:06:42 INFO: Wazuh indexer removed.
18/01/2024 19:06:42 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```