### PR TITLE
Improved certificates generation output when using WIA/WCT

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -60,17 +60,34 @@ function cert_checkRootCA() {
 
 }
 
+# Executes and analyze the output of the command. It prints the output
+# in case of an error
+function cert_executeAndValidate() {
+
+    command_output=$(eval "$@" 2>&1)
+    e_code="${PIPESTATUS[0]}"
+
+    if [ "${e_code}" -ne 0 ]; then
+        common_logger -e "Error generating the certificates."
+        common_logger -d "Error executing command: $@"
+        common_logger -d "Error output: ${command_output}"
+        cert_cleanFiles
+        exit 1
+    fi
+
+}
+
 function cert_generateAdmincertificate() {
 
     common_logger "Generating Admin certificates."
     common_logger -d "Generating Admin private key."
-    eval "openssl genrsa -out ${cert_tmp_path}/admin-key-temp.pem 2048 ${debug}"
+    cert_executeAndValidate "openssl genrsa -out ${cert_tmp_path}/admin-key-temp.pem 2048 ${debug}"
     common_logger -d "Converting Admin private key to PKCS8 format."
-    eval "openssl pkcs8 -inform PEM -outform PEM -in ${cert_tmp_path}/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${cert_tmp_path}/admin-key.pem ${debug}"
+    cert_executeAndValidate "openssl pkcs8 -inform PEM -outform PEM -in ${cert_tmp_path}/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${cert_tmp_path}/admin-key.pem"
     common_logger -d "Generating Admin CSR."
-    eval "openssl req -new -key ${cert_tmp_path}/admin-key.pem -out ${cert_tmp_path}/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin' ${debug}"
+    cert_executeAndValidate "openssl req -new -key ${cert_tmp_path}/admin-key.pem -out ${cert_tmp_path}/admin.csr -batch -subj '/C=US/L=California/O=Wazuh/OU=Wazuh/CN=admin'"
     common_logger -d "Creating Admin certificate."
-    eval "openssl x509 -days 3650 -req -in ${cert_tmp_path}/admin.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -sha256 -out ${cert_tmp_path}/admin.pem ${debug}"
+    cert_executeAndValidate "openssl x509 -days 3650 -req -in ${cert_tmp_path}/admin.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -sha256 -out ${cert_tmp_path}/admin.pem"
 
 }
 
@@ -138,9 +155,9 @@ function cert_generateIndexercertificates() {
             common_logger -d "Creating the certificates for ${indexer_node_name} indexer node."
             cert_generateCertificateconfiguration "${indexer_node_name}" "${indexer_node_ips[i]}"
             common_logger -d "Creating the Wazuh indexer tmp key pair."
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_name}-key.pem -out ${cert_tmp_path}/${indexer_node_name}.csr -config ${cert_tmp_path}/${indexer_node_name}.conf ${debug}"
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${indexer_node_name}-key.pem -out ${cert_tmp_path}/${indexer_node_name}.csr -config ${cert_tmp_path}/${indexer_node_name}.conf"
             common_logger -d "Creating the Wazuh indexer certificates."
-            eval "openssl x509 -req -in ${cert_tmp_path}/${indexer_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${indexer_node_name}.pem -extfile ${cert_tmp_path}/${indexer_node_name}.conf -extensions v3_req -days 3650 ${debug}"
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${indexer_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${indexer_node_name}.pem -extfile ${cert_tmp_path}/${indexer_node_name}.conf -extensions v3_req -days 3650"
         done
     else
         return 1
@@ -160,9 +177,9 @@ function cert_generateFilebeatcertificates() {
             declare -a server_ips=(server_node_ip_"$j"[@])
             cert_generateCertificateconfiguration "${server_name}" "${!server_ips}"
             common_logger -d "Creating the Wazuh server tmp key pair."
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_name}-key.pem -out ${cert_tmp_path}/${server_name}.csr  -config ${cert_tmp_path}/${server_name}.conf ${debug}"
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${server_name}-key.pem -out ${cert_tmp_path}/${server_name}.csr  -config ${cert_tmp_path}/${server_name}.conf"
             common_logger -d "Creating the Wazuh server certificates."
-            eval "openssl x509 -req -in ${cert_tmp_path}/${server_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${server_name}.pem -extfile ${cert_tmp_path}/${server_name}.conf -extensions v3_req -days 3650 ${debug}"
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${server_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${server_name}.pem -extfile ${cert_tmp_path}/${server_name}.conf -extensions v3_req -days 3650"
         done
     else
         return 1
@@ -179,9 +196,9 @@ function cert_generateDashboardcertificates() {
             dashboard_node_name="${dashboard_node_names[i]}"
             cert_generateCertificateconfiguration "${dashboard_node_name}" "${dashboard_node_ips[i]}"
             common_logger -d "Creating the Wazuh dashboard tmp key pair."
-            eval "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_name}-key.pem -out ${cert_tmp_path}/${dashboard_node_name}.csr -config ${cert_tmp_path}/${dashboard_node_name}.conf ${debug}"
+            cert_executeAndValidate "openssl req -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/${dashboard_node_name}-key.pem -out ${cert_tmp_path}/${dashboard_node_name}.csr -config ${cert_tmp_path}/${dashboard_node_name}.conf"
             common_logger -d "Creating the Wazuh dashboard certificates."
-            eval "openssl x509 -req -in ${cert_tmp_path}/${dashboard_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${dashboard_node_name}.pem -extfile ${cert_tmp_path}/${dashboard_node_name}.conf -extensions v3_req -days 3650 ${debug}"
+            cert_executeAndValidate "openssl x509 -req -in ${cert_tmp_path}/${dashboard_node_name}.csr -CA ${cert_tmp_path}/root-ca.pem -CAkey ${cert_tmp_path}/root-ca.key -CAcreateserial -out ${cert_tmp_path}/${dashboard_node_name}.pem -extfile ${cert_tmp_path}/${dashboard_node_name}.conf -extensions v3_req -days 3650"
         done
     else
         return 1
@@ -193,7 +210,7 @@ function cert_generateRootCAcertificate() {
 
     common_logger "Generating the root certificate."
     common_logger -d "Creating the root certificate."
-    eval "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/root-ca.key -out ${cert_tmp_path}/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650 ${debug}"
+    cert_executeAndValidate "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/root-ca.key -out ${cert_tmp_path}/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650"
 
 }
 

--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -209,7 +209,6 @@ function cert_generateDashboardcertificates() {
 function cert_generateRootCAcertificate() {
 
     common_logger "Generating the root certificate."
-    common_logger -d "Creating the root certificate."
     cert_executeAndValidate "openssl req -x509 -new -nodes -newkey rsa:2048 -keyout ${cert_tmp_path}/root-ca.key -out ${cert_tmp_path}/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650"
 
 }

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -193,7 +193,7 @@ function main() {
                 common_logger "Wazuh indexer certificates created."
             fi
             if cert_generateFilebeatcertificates; then
-                common_logger "Wazuh server certificates created."
+                common_logger "Wazuh Filebeat certificates created."
             fi
             if cert_generateDashboardcertificates; then
                 common_logger "Wazuh dashboard certificates created."
@@ -228,7 +228,7 @@ function main() {
             if [ ${#server_node_names[@]} -gt 0 ]; then
                 cert_checkRootCA
                 cert_generateFilebeatcertificates
-                common_logger "Wazuh server certificates created."
+                common_logger "Wazuh Filebeat certificates created."
                 cert_cleanFiles
                 cert_setpermisions
                 eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2787|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to add more debug messages and information to the certificate creation process. We decided to silence the output of the commands because they produced so much noise. 
As compensation for this, more information has been added to the log in order to understand and follow the script execution, and also if an error is generated it will be displayed in the output.

 

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

### Success case
<!--
Paste here related logs
-->

**Without verbose option:**
```console
> bash wazuh-certs-tool.sh -A
23/01/2024 18:13:41 INFO: Generating the root certificate.
23/01/2024 18:13:41 INFO: Generating Admin certificates.
23/01/2024 18:13:42 INFO: Admin certificates created.
23/01/2024 18:13:42 INFO: Generating Wazuh indexer certificates.
23/01/2024 18:13:43 INFO: Wazuh indexer certificates created.
23/01/2024 18:13:43 INFO: Generating Filebeat certificates.
23/01/2024 18:13:43 INFO: Wazuh server certificates created.
23/01/2024 18:13:43 INFO: Generating Wazuh dashboard certificates.
23/01/2024 18:13:43 INFO: Wazuh dashboard certificates created.
```

**With verbose option:**
```console
> bash wazuh-certs-tool.sh -A -v
29/01/2024 14:17:32 DEBUG: Reading configuration file.
29/01/2024 14:17:32 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 14:17:32 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 14:17:32 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 14:17:32 DEBUG: Checking if the root CA exists.
29/01/2024 14:17:32 INFO: Generating the root certificate.
29/01/2024 14:17:32 DEBUG: Creating the root certificate.
29/01/2024 14:17:33 INFO: Generating Admin certificates.
29/01/2024 14:17:33 DEBUG: Generating Admin private key.
29/01/2024 14:17:33 DEBUG: Converting Admin private key to PKCS8 format.
29/01/2024 14:17:33 DEBUG: Generating Admin CSR.
29/01/2024 14:17:33 DEBUG: Creating Admin certificate.
29/01/2024 14:17:33 INFO: Admin certificates created.
29/01/2024 14:17:33 INFO: Generating Wazuh indexer certificates.
29/01/2024 14:17:33 DEBUG: Creating the certificates for node-1 indexer node.
29/01/2024 14:17:33 DEBUG: Generating certificate configuration.
29/01/2024 14:17:33 DEBUG: Creating the Wazuh indexer tmp key pair.
29/01/2024 14:17:33 DEBUG: Creating the Wazuh indexer certificates.
29/01/2024 14:17:33 INFO: Wazuh indexer certificates created.
29/01/2024 14:17:33 INFO: Generating Filebeat certificates.
29/01/2024 14:17:33 DEBUG: Generating the certificates for wazuh-1 server node.
29/01/2024 14:17:33 DEBUG: Generating certificate configuration.
29/01/2024 14:17:33 DEBUG: Creating the Wazuh server tmp key pair.
29/01/2024 14:17:34 DEBUG: Creating the Wazuh server certificates.
29/01/2024 14:17:34 INFO: Wazuh server certificates created.
29/01/2024 14:17:34 INFO: Generating Wazuh dashboard certificates.
29/01/2024 14:17:34 DEBUG: Generating certificate configuration.
29/01/2024 14:17:34 DEBUG: Creating the Wazuh dashboard tmp key pair.
29/01/2024 14:17:34 DEBUG: Creating the Wazuh dashboard certificates.
29/01/2024 14:17:34 INFO: Wazuh dashboard certificates created.
29/01/2024 14:17:34 DEBUG: Cleaning certificate files.
```
### Error case
In case of an error, its information is displayed depending on the verbose option:

**Error case - With verbose**

```console
root@ubuntu22:/home/vagrant# bash wazuh-certs-tool.sh -A -v
29/01/2024 13:55:48 DEBUG: Reading configuration file.
29/01/2024 13:55:48 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 13:55:48 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 13:55:48 DEBUG: Checking if 127.0.0.1 is private.
29/01/2024 13:55:48 DEBUG: Checking if the root CA exists.
29/01/2024 13:55:48 INFO: Generating the root certificate.
29/01/2024 13:55:48 DEBUG: Creating the root certificate.
29/01/2024 13:55:48 ERROR: Error generating the certificates.
29/01/2024 13:55:48 DEBUG: Error executing command: openssl req -x509 -new -nodes rsa:2048 -keyout /tmp/wazuh-certificates/root-ca.key -out /tmp/wazuh-certificates/root-ca.pem -batch -subj '/OU=Wazuh/O=Wazuh/L=California/' -days 3650
29/01/2024 13:55:48 DEBUG: Error output: req: Use -help for summary.
29/01/2024 13:55:48 DEBUG: Cleaning certificate files.
```



**Error case - Without verbose**

```console
root@ubuntu22:/home/vagrant# bash wazuh-certs-tool.sh -A
29/01/2024 11:49:11 INFO: Generating the root certificate.
29/01/2024 11:49:11 ERROR: Error generating the certificates.
```

## Automatic testing

The following testing have been performed in Jenkins to ensure the development: 
:green_circle: CentOS 8: https://ci.wazuh.info/job/Test_unattended/5179/
:green_circle: CentOS 7: https://ci.wazuh.info/job/Test_unattended/5178/
:green_circle: Ubuntu 18: https://ci.wazuh.info/job/Test_unattended/5186/
:green_circle: Ubuntu 16: https://ci.wazuh.info/job/Test_unattended/5181/
:green_circle: Ubuntu 20: https://ci.wazuh.info/job/Test_unattended/5182/
:green_circle: AL2: https://ci.wazuh.info/job/Test_unattended/5183/
:green_circle: RHEL7: https://ci.wazuh.info/job/Test_unattended/5187/
:green_circle: RHEL8: https://ci.wazuh.info/job/Test_unattended/5185/