### PR TITLE
WIA uses `127.0.0.1` instead of `localhost`

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -106,8 +106,7 @@ function cert_generateCertificateconfiguration() {
         sed -i '/IP.1/d' "${cert_tmp_path}/${1}.conf"
         for (( i=2; i<=${#@}; i++ )); do
             isIP=$(echo "${!i}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
-            isDNS=$(echo "${!i}" | grep -P "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$" )
-            j=$((i-1))
+            isDNS=$(echo "${!i}" | grep -P "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.([A-Za-z]{2,})$" )            j=$((i-1))
             if [ "${isIP}" ]; then
                 printf '%s\n' "        IP.${j} = ${!i}" >> "${cert_tmp_path}/${1}.conf"
             elif [ "${isDNS}" ]; then
@@ -355,7 +354,7 @@ function cert_readConfig() {
 
         for i in $(seq 1 "${number_server_ips}"); do
             nodes_server="nodes[_]+server[_]+${i}[_]+ip"
-            eval "server_node_ip_$i=( $( cert_parseYaml "${config_file}" | grep -E "${nodes_server}" | cut -d = -f 2 | sed -r 's/\s+//g' | sed -E '/nodes_/d') )"
+            eval "server_node_ip_$i=( $( cert_parseYaml "${config_file}" | grep -E "${nodes_server}" | sed '/\./!d' | cut -d = -f 2 | sed -r 's/\s+//g') )"
         done
 
         unique_names=($(echo "${indexer_node_names[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))

--- a/unattended_installer/config/certificate/config_aio.yml
+++ b/unattended_installer/config/certificate/config_aio.yml
@@ -1,10 +1,10 @@
 nodes:
   indexer:
     - name: wazuh-indexer
-      ip: localhost
+      ip: 127.0.0.1
   server:
     - name: wazuh-server
-      ip: localhost
+      ip: 127.0.0.1
   dashboard:
     - name: wazuh-dashboard
-      ip: localhost
+      ip: 127.0.0.1

--- a/unattended_installer/config/dashboard/dashboard_unattended.yml
+++ b/unattended_installer/config/dashboard/dashboard_unattended.yml
@@ -1,5 +1,5 @@
 server.host: 0.0.0.0
-opensearch.hosts: https://localhost:9200
+opensearch.hosts: https://127.0.0.1:9200
 server.port: 443
 opensearch.ssl.verificationMode: certificate
 # opensearch.username: kibanaserver

--- a/unattended_installer/config/filebeat/filebeat_all_in_one.yml
+++ b/unattended_installer/config/filebeat/filebeat_all_in_one.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch:
-  hosts: ["localhost:9200"]
+  hosts: ["127.0.0.1:9200"]
   protocol: https
   username: ${username}
   password: ${password}

--- a/unattended_installer/config/filebeat/filebeat_unattended.yml
+++ b/unattended_installer/config/filebeat/filebeat_unattended.yml
@@ -1,6 +1,6 @@
 # Wazuh - Filebeat configuration file
 output.elasticsearch.hosts:
-        - localhost:9200
+        - 127.0.0.1:9200
 #        - <elasticsearch_ip_node_2>:9200 
 #        - <elasticsearch_ip_node_3>:9200
 

--- a/unattended_installer/config/indexer/indexer_all_in_one.yml
+++ b/unattended_installer/config/indexer/indexer_all_in_one.yml
@@ -1,4 +1,4 @@
-network.host: "localhost"
+network.host: "127.0.0.1"
 node.name: "node-1"
 cluster.initial_master_nodes:
 - "node-1"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -178,6 +178,7 @@ function dashboard_initialize() {
 
 function dashboard_initializeAIO() {
 
+    wazuh_api_address=${server_node_ips[0]}
     common_logger "Initializing Wazuh dashboard web application."
     installCommon_getPass "admin"
     http_code=$(curl -XGET https://localhost:"${http_port}"/status -uadmin:"${u_pass}" -k -w %"{http_code}" -s -o /dev/null)
@@ -192,7 +193,7 @@ function dashboard_initializeAIO() {
     done
     if [ "${http_code}" -eq "200" ]; then
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
-            eval "sed -i 's,url: https://localhost,url: https://127.0.0.1,g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+            eval "sed -i 's,url: https://localhost,url: https://${wazuh_api_address},g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
         fi
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"

--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -191,6 +191,9 @@ function dashboard_initializeAIO() {
         sleep 15
     done
     if [ "${http_code}" -eq "200" ]; then
+        if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
+            eval "sed -i 's,url: https://localhost,url: https://127.0.0.1,g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+        fi
         common_logger "Wazuh dashboard web application initialized."
         common_logger -nl "--- Summary ---"
         common_logger -nl "You can access the web interface https://<wazuh-dashboard-ip>:${http_port}\n    User: admin\n    Password: ${u_pass}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2771|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to revert the changes of the following PR: https://github.com/wazuh/wazuh-packages/pull/2422

Besides, this PR makes the `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` file point to `127.0.0.1` IP address instead of `localhost` when an AIO installation is performed using the WIA.

This fix avoids:
- The WIA getting stuck in the Wazuh indexer installation.
- Error of the API reported in: https://github.com/wazuh/wazuh-dashboard-plugins/issues/6312 

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

```yml
hosts:
  - default:
      url: https://127.0.0.1
      port: 55000
      username: wazuh-wui
      password: "TCHJrSVBdonZpe7DXL+N4lzv*kzZMHWr"
      run_as: false
```

![image](https://github.com/wazuh/wazuh-packages/assets/72193239/f3e25714-a8b6-4a46-a85c-aec0b0847d4e)

## Tests

Currently working on tests.