### PR TITLE
Add compression for wazuh-manager due to inclusion of vulnerability d…

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -27,6 +27,8 @@ BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-p
 
 ExclusiveOS: linux
 
+%define _source_payload w9.xzdio
+%define _binary_payload w9.xzdio
 
 %description
 Wazuh helps you to gain security visibility into your infrastructure by monitoring


### PR DESCRIPTION
|Related issue|
|---|
|#2769|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the same compression used for wazuh-dashboard. The motivation is to mitigate the disparity between package size between rpm and deb due to the inclusion of the vulnerability detector databases. 

## Logs example

![image](https://github.com/wazuh/wazuh-packages/assets/13010397/ec0517a0-610d-4a12-9516-563e6b22d455)

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
