### PR TITLE
Added sudo check to WIA

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -75,7 +75,7 @@ function common_checkRoot() {
 
     common_logger -d "Checking sudo package."
     if ! command -v sudo; then 
-        common_logger -e "The sudo package is not installed and necessary for the installation."
+        common_logger -e "The sudo package is not installed and it is necessary for the installation."
         exit 1;
     fi
 }

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -73,6 +73,11 @@ function common_checkRoot() {
         exit 1;
     fi
 
+    common_logger -d "Checking sudo package."
+    if ! command -v sudo; then 
+        common_logger -e "The sudo package is not installed and necessary for the installation."
+        exit 1;
+    fi
 }
 
 function common_checkInstalled() {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2776|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to add a check to the Wazuh installation assistant that ensures that the sudo package is installed in the system. We found that in some systems, the sudo is not installed by default and it is necessary for the Wazuh installation.
However, it has not been included as a depenency. Therefore, if this tool is not installed the Wazuh installation is stopped informing with an error

```console
root@debian11sudo:/home/vagrant# bash wazuh-install.sh -a -i -v
29/01/2024 16:40:00 DEBUG: Checking root permissions.
29/01/2024 16:40:00 DEBUG: Checking sudo package.
29/01/2024 16:40:00 ERROR: The sudo package is not installed and it is necessary for the installation.
```



## Tests

:green_circle: CentOS 8: https://ci.wazuh.info/job/Test_unattended/5190/
:green_circle: CentOS 7: https://ci.wazuh.info/job/Test_unattended/5189/
:green_circle: Ubuntu 18: https://ci.wazuh.info/job/Test_unattended/5191/
:green_circle: Ubuntu 16: https://ci.wazuh.info/job/Test_unattended/5192/
:green_circle: Ubuntu 20: https://ci.wazuh.info/job/Test_unattended/5193/
:green_circle: AL2: https://ci.wazuh.info/job/Test_unattended/5194/
:green_circle: RHEL7: https://ci.wazuh.info/job/Test_unattended/5195/
:green_circle: RHEL8: https://ci.wazuh.info/job/Test_unattended/5188/