### PR TITLE
keystore tool RPM and DEB packages creation

### DIFF
--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -654,6 +654,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-modulesd
 %attr(750, root, wazuh) %{_localstatedir}/bin/rbac_control
+%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-keystore
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
 %attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
@@ -757,6 +758,7 @@ rm -fr %{buildroot}
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/indexer
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/router
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/logcollector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/keystore
 %dir %attr(750, root, wazuh) %{_localstatedir}/ruleset
 %dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/sca
 %dir %attr(750, root, wazuh) %{_localstatedir}/ruleset/decoders


### PR DESCRIPTION
|Related issue|
|---|
|Closes #2791|

## Description
The objective is to include the installation of the wazuh-keystore tool, which will be located in the bin directory. This tool is essential for managing the keystore within the Wazuh environment.

This PR is related to [#21680](https://github.com/wazuh/wazuh/pull/21680) which complies with the necessary changes in https://github.com/wazuh/wazuh/

## Tests

Centos test
```shell
[root@44fc8ae8f64c /]# cat /etc/os-release 
NAME="CentOS Linux"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"
CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
[root@44fc8ae8f64c /]# cd /var/ossec/bin/
[root@44fc8ae8f64c bin]# ./wazuh-keystore -h

Usage: wazuh-keystore <option(s)>
Options:
        -h                      Show this help message
        -f COLUMN_FAMILY        Specifies the target column family for the insertion.
        -k KEY                  Specifies the key for the key-value pair.
        -v VALUE                Specifies the value associated with the key.

Example:
        ./wazuh-keystore -f indexer -k username -v admin

[root@44fc8ae8f64c bin]# ./wazuh-keystore -f indexer -k username -v admin
[root@44fc8ae8f64c bin]# ls -l ../queue/keystore/
total 80
-rw-r--r-- 1 root root     0 Jan 31 14:10 000004.log
-rw-r--r-- 1 root root  1307 Jan 31 14:10 000012.sst
-rw-r--r-- 1 root root    16 Jan 31 14:10 CURRENT
-rw-r--r-- 1 root root    36 Jan 31 14:10 IDENTITY
-rw-r--r-- 1 root root     0 Jan 31 14:10 LOCK
-rw-r--r-- 1 root root 44845 Jan 31 14:10 LOG
-rw-r--r-- 1 root root   258 Jan 31 14:10 MANIFEST-000005
-rw-r--r-- 1 root root  7080 Jan 31 14:10 OPTIONS-000009
-rw-r--r-- 1 root root 11466 Jan 31 14:10 OPTIONS-000011

``` 
Ubuntu Test
```shell
✔ 14:12 $ ./docker\ exec\ -it\ determined_borg\ bash 
root@72a10253b9d0:/# cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@72a10253b9d0:/# cd /var/ossec/bin/
root@72a10253b9d0:/var/ossec/bin# ./wazuh-keystore -h

Usage: wazuh-keystore <option(s)>
Options:
        -h                      Show this help message
        -f COLUMN_FAMILY        Specifies the target column family for the insertion.
        -k KEY                  Specifies the key for the key-value pair.
        -v VALUE                Specifies the value associated with the key.

Example:
        ./wazuh-keystore -f indexer -k username -v admin

root@72a10253b9d0:/var/ossec/bin# ./wazuh-keystore -f indexer -k username -v admin
root@72a10253b9d0:/var/ossec/bin# ll ../queue/keystore/
total 88
drwxr-x---  2 wazuh wazuh  4096 Jan 31 14:14 ./
drwxr-x--- 19 root  wazuh  4096 Jan 30 00:38 ../
-rw-r--r--  1 root  root      0 Jan 31 14:14 000004.log
-rw-r--r--  1 root  root   1307 Jan 31 14:14 000012.sst
-rw-r--r--  1 root  root     16 Jan 31 14:14 CURRENT
-rw-r--r--  1 root  root     36 Jan 31 14:14 IDENTITY
-rw-r--r--  1 root  root      0 Jan 31 14:14 LOCK
-rw-r--r--  1 root  root  44850 Jan 31 14:14 LOG
-rw-r--r--  1 root  root    258 Jan 31 14:14 MANIFEST-000005
-rw-r--r--  1 root  root   7080 Jan 31 14:14 OPTIONS-000009
-rw-r--r--  1 root  root  11466 Jan 31 14:14 OPTIONS-000011

``` 
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7