### PR TITLE
Silenced sudo package check

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -74,7 +74,7 @@ function common_checkRoot() {
     fi
 
     common_logger -d "Checking sudo package."
-    if ! command -v sudo; then 
+    if ! command -v sudo > /dev/null; then 
         common_logger -e "The sudo package is not installed and it is necessary for the installation."
         exit 1;
     fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2776|

Complementary PR of https://github.com/wazuh/wazuh-packages/pull/2801.

The aim of this PR is to silence the output of the sudo packages check. I noticed that, when the sudo package is installed, the output of the `command -v` command is displayed in the prompt.

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -g -v
01/02/2024 12:07:58 DEBUG: Checking root permissions.
01/02/2024 12:07:58 DEBUG: Checking sudo package.
/usr/bin/sudo
01/02/2024 12:07:58 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
```
With this change, the output is the following:
```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -g -v
01/02/2024 15:31:52 DEBUG: Checking root permissions.
01/02/2024 15:31:52 DEBUG: Checking sudo package.
01/02/2024 12:07:58 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
```
