### PR TITLE
Fixed VD-indexer configuration in AIO deployment

### DIFF
--- a/unattended_installer/install_functions/manager.sh
+++ b/unattended_installer/install_functions/manager.sh
@@ -46,22 +46,18 @@ function manager_configure(){
 
     common_logger -d "Configuring Wazuh manager."
 
-    if [ -n "${AIO}" ]; then
-        eval "sed -i 's/<host>.*<\/host>/<host>https:\/\/localhost:9200<\/host>/g' /var/ossec/etc/ossec.conf ${debug}"
+    if [ ${#indexer_node_names[@]} -eq 1 ]; then
+        eval "sed -i 's/<host>.*<\/host>/<host>https:\/\/${indexer_node_ips[0]}:9200<\/host>/g' /var/ossec/etc/ossec.conf ${debug}"
     else
-        if [ ${#indexer_node_names[@]} -eq 1 ]; then
-            eval "sed -i 's/<host>.*<\/host>/<host>https:\/\/${indexer_node_ips[0]}:9200<\/host>/g' /var/ossec/etc/ossec.conf ${debug}"
-        else
-            lstart=$(grep -n "<hosts>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
-            lend=$(grep -n "</hosts>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
-            for i in "${!indexer_node_ips[@]}"; do
-                if [ $i -eq 0 ]; then
-                    eval "sed -i 's/<host>.*<\/host>/<host>https:\/\/${indexer_node_ips[0]}:9200<\/host>/g' /var/ossec/etc/ossec.conf ${debug}"
-                else
-                    eval "sed -i '/<hosts>/a\      <host>https:\/\/${indexer_node_ips[$i]}:9200<\/host>' /var/ossec/etc/ossec.conf"
-                fi
-            done
-        fi
+        lstart=$(grep -n "<hosts>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+        lend=$(grep -n "</hosts>" /var/ossec/etc/ossec.conf | cut -d : -f 1)
+        for i in "${!indexer_node_ips[@]}"; do
+            if [ $i -eq 0 ]; then
+                eval "sed -i 's/<host>.*<\/host>/<host>https:\/\/${indexer_node_ips[0]}:9200<\/host>/g' /var/ossec/etc/ossec.conf ${debug}"
+            else
+                eval "sed -i '/<hosts>/a\      <host>https:\/\/${indexer_node_ips[$i]}:9200<\/host>' /var/ossec/etc/ossec.conf"
+            fi
+        done
     fi
     eval "sed -i s/filebeat.pem/${server_node_names[0]}.pem/ /var/ossec/etc/ossec.conf ${debug}"
     eval "sed -i s/filebeat-key.pem/${server_node_names[0]}-key.pem/ /var/ossec/etc/ossec.conf ${debug}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2794|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to fix this warning:
```console
2024/02/02 12:57:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/02 12:58:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/02 12:59:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/02 13:00:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/02 13:01:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/02 13:02:20 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
```

This is caused because in the `indexer` configuration of the VD, in single-node deployments, `localhost` is specified instead of `127.0.0.1`

```xml
<indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://127.0.0.1:9200</host>
    </hosts>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/wazuh-server.pem</certificate>
      <key>/etc/filebeat/certs/wazuh-server-key.pem</key>
    </ssl>
  </indexer>

```

We tested this behavior in the following pipeline: https://ci.wazuh.info/job/Test_unattended_distributed/641/console.
The pipeline itself failed, but the Wazuh indexer and manager were installed correclty and the VD config was right. The pipeline failed because the spot instances died before the complete installation was performed:
```xml
<vulnerability-detection>
    <enabled>yes</enabled>
    <index-status>yes</index-status>
    <feed-update-interval>60m</feed-update-interval>
  </vulnerability-detection>

  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://172.31.89.139:9200</host>
      <host>https://172.31.87.65:9200</host>
      <host>https://172.31.95.73:9200</host>
      <host>https://172.31.89.217:9200</host>
      <host>https://172.31.94.181:9200</host>
      <host>https://172.31.89.151:9200</host>
      <host>https://172.31.94.174:9200</host>
      <host>https://172.31.90.213:9200</host>
      <host>https://172.31.88.135:9200</host>
      <host>https://172.31.82.105:9200</host>
    </hosts>
    <ssl>
      <certificate_authorities>
        <ca>/etc/filebeat/certs/root-ca.pem</ca>
      </certificate_authorities>
      <certificate>/etc/filebeat/certs/centos_7-wazuh.pem</certificate>
      <key>/etc/filebeat/certs/centos_7-wazuh-key.pem</key>
    </ssl>
  </indexer>
```

With this change, the `wazuh-states-vulnerabilities` is created successfully and this warning is generated again, but it connects successfully.

```console
[root@ip-172-31-41-201 ec2-user]# cat /var/ossec/logs/ossec.log | grep ERROR
[root@ip-172-31-41-201 ec2-user]# cat /var/ossec/logs/ossec.log | grep WARNING
2024/02/02 13:14:08 indexer-connector: WARNING: Error initializing IndexerConnector: Problem with the local SSL certificate, we will try again after 2 seconds.
2024/02/02 13:14:10 indexer-connector: WARNING: Error initializing IndexerConnector: Problem with the local SSL certificate, we will try again after 4 seconds.
2024/02/02 13:14:14 indexer-connector: WARNING: Error initializing IndexerConnector: Problem with the local SSL certificate, we will try again after 8 seconds.
2024/02/02 13:16:02 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 2 seconds.
2024/02/02 13:16:04 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 4 seconds.
2024/02/02 13:16:09 indexer-connector: WARNING: Error initializing IndexerConnector: HTTP response code said error: 401, we will try again after 8 seconds.

```
<!--
Add a clear description of how the problem has been solved.
-->


## Logs example


<details><summary>Installation log</summary>

```console
[root@ip-172-31-41-201 ec2-user]# bash wazuh-install.sh -a -i -v
02/02/2024 13:10:22 DEBUG: Checking root permissions.
02/02/2024 13:10:22 DEBUG: Checking sudo package.
02/02/2024 13:10:22 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
02/02/2024 13:10:22 INFO: Verbose logging redirected to /var/log/wazuh-install.log
02/02/2024 13:10:22 DEBUG: YUM package manager will be used.
02/02/2024 13:10:22 DEBUG: Checking system distribution.
02/02/2024 13:10:22 DEBUG: Detected distribution name: amzn
02/02/2024 13:10:22 DEBUG: Detected distribution version: 2
02/02/2024 13:10:22 DEBUG: Checking Wazuh installation.
02/02/2024 13:10:25 DEBUG: Installing check dependencies.
02/02/2024 13:10:31 DEBUG: Checking system architecture.
02/02/2024 13:10:31 WARNING: Hardware and system checks ignored.
02/02/2024 13:10:31 INFO: Wazuh web interface port will be 443.
02/02/2024 13:10:31 DEBUG: Checking ports availability.
02/02/2024 13:10:33 DEBUG: Installing prerequisites dependencies.
02/02/2024 13:10:33 DEBUG: Checking curl tool version.
02/02/2024 13:10:33 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/staging/yum/
protect=1
02/02/2024 13:10:33 INFO: Wazuh development repository added.
02/02/2024 13:10:33 INFO: --- Configuration files ---
02/02/2024 13:10:33 INFO: Generating configuration files.
02/02/2024 13:10:33 DEBUG: Creating Wazuh certificates.
02/02/2024 13:10:34 DEBUG: Reading configuration file.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:34 INFO: Generating the root certificate.
02/02/2024 13:10:34 INFO: Generating Admin certificates.
02/02/2024 13:10:34 DEBUG: Generating Admin private key.
02/02/2024 13:10:34 DEBUG: Converting Admin private key to PKCS8 format.
02/02/2024 13:10:34 DEBUG: Generating Admin CSR.
02/02/2024 13:10:34 DEBUG: Creating Admin certificate.
02/02/2024 13:10:34 INFO: Generating Wazuh indexer certificates.
02/02/2024 13:10:34 DEBUG: Creating the certificates for wazuh-indexer indexer node.
02/02/2024 13:10:34 DEBUG: Generating certificate configuration.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh indexer tmp key pair.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh indexer certificates.
02/02/2024 13:10:34 INFO: Generating Filebeat certificates.
02/02/2024 13:10:34 DEBUG: Generating the certificates for wazuh-server server node.
02/02/2024 13:10:34 DEBUG: Generating certificate configuration.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh server tmp key pair.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh server certificates.
02/02/2024 13:10:34 INFO: Generating Wazuh dashboard certificates.
02/02/2024 13:10:34 DEBUG: Generating certificate configuration.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh dashboard tmp key pair.
02/02/2024 13:10:34 DEBUG: Creating the Wazuh dashboard certificates.
02/02/2024 13:10:34 DEBUG: Cleaning certificate files.
02/02/2024 13:10:34 DEBUG: Generating password file.
02/02/2024 13:10:34 DEBUG: Generating random passwords.
02/02/2024 13:10:34 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
02/02/2024 13:10:34 DEBUG: Extracting Wazuh configuration.
02/02/2024 13:10:34 DEBUG: Reading configuration file.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:34 DEBUG: Checking if 127.0.0.1 is private.
02/02/2024 13:10:35 INFO: --- Wazuh indexer ---
02/02/2024 13:10:35 INFO: Starting Wazuh indexer installation.
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Resolving Dependencies
--> Running transaction check
---> Package wazuh-indexer.x86_64 0:4.8.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch            Version            Repository      Size
================================================================================
Installing:
 wazuh-indexer          x86_64          4.8.0-1            wazuh          743 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 743 M
Installed size: 1.0 G
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-indexer-4.8.0-1.x86_64                                 1/1 
Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore
  Verifying  : wazuh-indexer-4.8.0-1.x86_64                                 1/1 

Installed:
  wazuh-indexer.x86_64 0:4.8.0-1                                                

Complete!
02/02/2024 13:11:58 DEBUG: Checking Wazuh installation.
02/02/2024 13:11:59 DEBUG: There are Wazuh indexer remaining files.
02/02/2024 13:12:08 INFO: Wazuh indexer installation finished.
02/02/2024 13:12:08 DEBUG: Configuring Wazuh indexer.
02/02/2024 13:12:08 DEBUG: Copying Wazuh indexer certificates.
02/02/2024 13:12:08 INFO: Wazuh indexer post-install configuration finished.
02/02/2024 13:12:08 INFO: Starting service wazuh-indexer.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service to /usr/lib/systemd/system/wazuh-indexer.service.
02/02/2024 13:12:26 INFO: wazuh-indexer service started.
02/02/2024 13:12:26 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
02/02/2024 13:12:38 INFO: Wazuh indexer cluster security configuration initialized.
Will create 'wazuh' index template
 SUCC: 'wazuh' template created or updated
Will create 'ism_history_indices' index template
 SUCC: 'ism_history_indices' template created or updated
Will disable replicas for 'plugins.index_state_management.history' indices
 SUCC: cluster's settings saved
Will create index templates to configure the alias
 SUCC: 'wazuh-alerts' template created or updated
 SUCC: 'wazuh-archives' template created or updated
Will create the 'rollover_policy' policy
  SUCC: 'rollover_policy' policy created
Will create initial indices for the aliases
  SUCC: 'wazuh-alerts' write index created
  SUCC: 'wazuh-archives' write index created
SUCC: Indexer ISM initialization finished successfully.
02/02/2024 13:12:39 INFO: The Wazuh indexer cluster ISM initialized.
02/02/2024 13:12:39 INFO: Wazuh indexer cluster initialized.
02/02/2024 13:12:39 INFO: --- Wazuh server ---
02/02/2024 13:12:39 INFO: Starting the Wazuh manager installation.
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Resolving Dependencies
--> Running transaction check
---> Package wazuh-manager.x86_64 0:4.8.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch            Version            Repository      Size
================================================================================
Installing:
 wazuh-manager          x86_64          4.8.0-1            wazuh          270 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 270 M
Installed size: 855 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-manager-4.8.0-1.x86_64                                 1/1 
  Verifying  : wazuh-manager-4.8.0-1.x86_64                                 1/1 

Installed:
  wazuh-manager.x86_64 0:4.8.0-1                                                

Complete!
02/02/2024 13:13:45 DEBUG: Checking Wazuh installation.
02/02/2024 13:13:46 DEBUG: There are Wazuh remaining files.
02/02/2024 13:13:57 DEBUG: There are Wazuh indexer remaining files.
02/02/2024 13:13:58 INFO: Wazuh manager installation finished.
02/02/2024 13:13:58 DEBUG: Configuring Wazuh manager.
02/02/2024 13:13:58 DEBUG: Setting provisional Wazuh indexer password.
02/02/2024 13:13:58 INFO: Wazuh manager vulnerability detection configuration finished.
02/02/2024 13:13:58 INFO: Starting service wazuh-manager.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-manager.service to /usr/lib/systemd/system/wazuh-manager.service.
02/02/2024 13:14:11 INFO: wazuh-manager service started.
02/02/2024 13:14:11 INFO: Starting Filebeat installation.
02/02/2024 13:14:17 DEBUG: Checking Wazuh installation.
02/02/2024 13:14:18 DEBUG: There are Wazuh remaining files.
02/02/2024 13:14:18 DEBUG: There are Wazuh indexer remaining files.
02/02/2024 13:14:19 DEBUG: There are Filebeat remaining files.
02/02/2024 13:14:20 INFO: Filebeat installation finished.
02/02/2024 13:14:20 DEBUG: Configuring Filebeat.
02/02/2024 13:14:20 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/archives/
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/_meta/
wazuh/_meta/config.yml
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/alerts/
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/module.yml
02/02/2024 13:14:20 DEBUG: Filebeat module was downloaded successfully.
02/02/2024 13:14:20 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
02/02/2024 13:14:20 INFO: Filebeat post-install configuration finished.
02/02/2024 13:14:20 INFO: Starting service filebeat.
Created symlink from /etc/systemd/system/multi-user.target.wants/filebeat.service to /usr/lib/systemd/system/filebeat.service.
02/02/2024 13:14:21 INFO: filebeat service started.
02/02/2024 13:14:21 INFO: --- Wazuh dashboard ---
02/02/2024 13:14:21 INFO: Starting Wazuh dashboard installation.
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Existing lock /var/run/yum.pid: another copy is running as pid 28231.
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory : 118 M RSS (336 MB VSZ)
    Started: Fri Feb  2 13:14:17 2024 - 00:04 ago
    State  : Running, pid: 28231
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory : 178 M RSS (396 MB VSZ)
    Started: Fri Feb  2 13:14:17 2024 - 00:06 ago
    State  : Running, pid: 28231
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory : 194 M RSS (413 MB VSZ)
    Started: Fri Feb  2 13:14:17 2024 - 00:08 ago
    State  : Running, pid: 28231
Another app is currently holding the yum lock; waiting for it to exit...
  The other application is: yum
    Memory : 194 M RSS (413 MB VSZ)
    Started: Fri Feb  2 13:14:17 2024 - 00:10 ago
    State  : Running, pid: 28231
Resolving Dependencies
--> Running transaction check
---> Package wazuh-dashboard.x86_64 0:4.8.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                  Arch            Version          Repository      Size
================================================================================
Installing:
 wazuh-dashboard          x86_64          4.8.0-1          wazuh          273 M

Transaction Summary
================================================================================
Install  1 Package

Total download size: 273 M
Installed size: 902 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-dashboard-4.8.0-1.x86_64                               1/1 
  Verifying  : wazuh-dashboard-4.8.0-1.x86_64                               1/1 

Installed:
  wazuh-dashboard.x86_64 0:4.8.0-1                                              

Complete!
02/02/2024 13:15:15 DEBUG: Checking Wazuh installation.
02/02/2024 13:15:16 DEBUG: There are Wazuh remaining files.
02/02/2024 13:15:17 DEBUG: There are Wazuh indexer remaining files.
02/02/2024 13:15:17 DEBUG: There are Filebeat remaining files.
02/02/2024 13:15:18 DEBUG: There are Wazuh dashboard remaining files.
02/02/2024 13:15:18 INFO: Wazuh dashboard installation finished.
02/02/2024 13:15:18 DEBUG: Configuring Wazuh dashboard.
02/02/2024 13:15:18 DEBUG: Copying Wazuh dashboard certificates.
02/02/2024 13:15:18 DEBUG: Wazuh dashboard certificate setup finished.
02/02/2024 13:15:18 INFO: Wazuh dashboard post-install configuration finished.
02/02/2024 13:15:18 INFO: Starting service wazuh-dashboard.
Created symlink from /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service to /etc/systemd/system/wazuh-dashboard.service.
02/02/2024 13:15:18 INFO: wazuh-dashboard service started.
02/02/2024 13:15:18 DEBUG: Setting Wazuh indexer cluster passwords.
02/02/2024 13:15:18 DEBUG: Checking Wazuh installation.
02/02/2024 13:15:29 DEBUG: There are Wazuh remaining files.
02/02/2024 13:15:30 DEBUG: There are Wazuh indexer remaining files.
02/02/2024 13:15:31 DEBUG: There are Filebeat remaining files.
02/02/2024 13:15:31 DEBUG: There are Wazuh dashboard remaining files.
02/02/2024 13:15:31 INFO: Updating the internal users.
02/02/2024 13:15:31 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
02/02/2024 13:15:35 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
02/02/2024 13:15:35 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
02/02/2024 13:15:35 DEBUG: The internal users have been updated before changing the passwords.
02/02/2024 13:15:35 DEBUG: Generating password hashes.
02/02/2024 13:15:41 DEBUG: Password hashes generated.
02/02/2024 13:15:41 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
02/02/2024 13:15:44 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
02/02/2024 13:15:44 DEBUG: Restarting filebeat service...
02/02/2024 13:15:45 DEBUG: filebeat started.
02/02/2024 13:15:45 DEBUG: Restarting wazuh-manager service...
02/02/2024 13:16:04 DEBUG: wazuh-manager started.
02/02/2024 13:16:05 DEBUG: Restarting wazuh-dashboard service...
02/02/2024 13:16:06 DEBUG: wazuh-dashboard started.
02/02/2024 13:16:06 DEBUG: Running security admin tool.
02/02/2024 13:16:06 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/ec2-user
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
02/02/2024 13:16:10 DEBUG: Passwords changed.
02/02/2024 13:16:10 DEBUG: Changing API passwords.
02/02/2024 13:16:18 INFO: Initializing Wazuh dashboard web application.
02/02/2024 13:16:18 INFO: Wazuh dashboard web application initialized.
02/02/2024 13:16:18 INFO: --- Summary ---
02/02/2024 13:16:18 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: EgWe9+z8?4ZDP4dLY8hLMfisBt59HtC8
02/02/2024 13:16:18 DEBUG: Restoring Wazuh repository.
02/02/2024 13:16:18 INFO: Installation finished.
```
</details>

![image](https://github.com/wazuh/wazuh-packages/assets/72193239/167c5b1b-61e4-40ad-8801-fba9993b1157)

