### PR TITLE
WIA uses `rpm` instead of `yum` in packages check 

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -84,8 +84,9 @@ function common_checkInstalled() {
     dashboard_installed=""
 
     if [ "${sys_type}" == "yum" ]; then
-        common_checkYumLock
-        wazuh_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
+        if rpm -q wazuh-manager --quiet; then
+            wazuh_installed=1
+        fi
     elif [ "${sys_type}" == "apt-get" ]; then
         wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
     fi
@@ -96,8 +97,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        common_checkYumLock
-        indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
+        if rpm -q wazuh-indexer --quiet; then
+            indexer_installed=1
+        fi
     elif [ "${sys_type}" == "apt-get" ]; then
         indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
     fi
@@ -108,8 +110,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        common_checkYumLock
-        filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
+        if rpm -q filebeat --quiet; then
+            filebeat_installed=1
+        fi
     elif [ "${sys_type}" == "apt-get" ]; then
         filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
     fi
@@ -120,8 +123,9 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        common_checkYumLock
-        dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
+        if rpm -q wazuh-dashboard 2>/dev/null; then
+            dashboard_installed=1
+        fi
     elif [ "${sys_type}" == "apt-get" ]; then
         dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
     fi

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -84,9 +84,7 @@ function common_checkInstalled() {
     dashboard_installed=""
 
     if [ "${sys_type}" == "yum" ]; then
-        if rpm -q wazuh-manager --quiet; then
-            wazuh_installed=1
-        fi
+        eval "rpm -q wazuh-manager --quiet && wazuh_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
         wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
     fi
@@ -97,9 +95,8 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        if rpm -q wazuh-indexer --quiet; then
-            indexer_installed=1
-        fi
+        eval "rpm -q wazuh-indexer --quiet && indexer_installed=1"
+
     elif [ "${sys_type}" == "apt-get" ]; then
         indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
     fi
@@ -110,9 +107,7 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        if rpm -q filebeat --quiet; then
-            filebeat_installed=1
-        fi
+        eval "rpm -q filebeat --quiet && filebeat_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
         filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
     fi
@@ -123,9 +118,7 @@ function common_checkInstalled() {
     fi
 
     if [ "${sys_type}" == "yum" ]; then
-        if rpm -q wazuh-dashboard 2>/dev/null; then
-            dashboard_installed=1
-        fi
+        eval "rpm -q wazuh-dashboard --quiet && dashboard_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
         dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
     fi

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -416,12 +416,8 @@ function checks_firewall(){
 
     # Check if the firewall is installed
     if [ "${sys_type}" == "yum" ]; then
-        if rpm -q firewalld --quiet;then
-            firewalld_installed=1
-        fi
-        if rpm -q ufw --quiet;then
-            ufw_installed=1
-        fi
+        eval "rpm -q firewalld --quiet && firewalld_installed=1"
+        eval "rpm -q ufw --quiet && ufw_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
         if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
             firewalld_installed=1

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -416,10 +416,10 @@ function checks_firewall(){
 
     # Check if the firewall is installed
     if [ "${sys_type}" == "yum" ]; then
-        if yum list installed 2>/dev/null | grep -q -E ^"firewalld"\\.;then
+        if rpm -q firewalld --quiet;then
             firewalld_installed=1
         fi
-        if yum list installed 2>/dev/null | grep -q -E ^"ufw"\\.;then
+        if rpm -q ufw --quiet;then
             ufw_installed=1
         fi
     elif [ "${sys_type}" == "apt-get" ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -569,7 +569,9 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-manager -y ${debug}"
-                manager_installed=$(yum list installed 2>/dev/null | grep wazuh-manager)
+                if rpm -q wazuh-manager --quiet; then
+                    manager_installed=1
+                fi
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -595,7 +597,9 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-indexer -y ${debug}"
-                indexer_installed=$(yum list installed 2>/dev/null | grep wazuh-indexer)
+                if rpm -q wazuh-indexer --quiet; then
+                    indexer_installed=1
+                fi
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -622,7 +626,9 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove filebeat -y ${debug}"
-                filebeat_installed=$(yum list installed 2>/dev/null | grep filebeat)
+                if rpm -q filebeat --quiet; then
+                    filebeat_installed=1
+                fi
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -649,7 +655,9 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-dashboard -y ${debug}"
-                dashboard_installed=$(yum list installed 2>/dev/null | grep wazuh-dashboard)
+                if rpm -q wazuh-dashboard --quiet; then
+                    dashboard_installed=1
+                fi
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -763,7 +771,7 @@ function installCommon_yumInstallList(){
     not_installed=()
     for dep in "${dependencies[@]}"; do
         common_checkYumLock
-        if ! yum list installed 2>/dev/null | grep -q -E ^"${dep}"\\.;then
+        if ! rpm -q "${dep}" 2>/dev/null;then
             not_installed+=("${dep}")
             for wia_dep in "${wia_yum_dependencies[@]}"; do
                 if [ "${wia_dep}" == "${dep}" ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -569,9 +569,7 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-manager -y ${debug}"
-                if rpm -q wazuh-manager --quiet; then
-                    manager_installed=1
-                fi
+                eval "rpm -q wazuh-manager --quiet && manager_installed=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -597,9 +595,7 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-indexer -y ${debug}"
-                if rpm -q wazuh-indexer --quiet; then
-                    indexer_installed=1
-                fi
+                eval "rpm -q wazuh-indexer --quiet && indexer_installed=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -626,9 +622,7 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove filebeat -y ${debug}"
-                if rpm -q filebeat --quiet; then
-                    filebeat_installed=1
-                fi
+                eval "rpm -q filebeat --quiet && filebeat_installed=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -655,9 +649,7 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-dashboard -y ${debug}"
-                if rpm -q wazuh-dashboard --quiet; then
-                    dashboard_installed=1
-                fi
+                eval "rpm -q wazuh-dashboard --quiet && dashboard_installed=1"
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -770,8 +762,7 @@ function installCommon_yumInstallList(){
     dependencies=("$@")
     not_installed=()
     for dep in "${dependencies[@]}"; do
-        common_checkYumLock
-        if ! rpm -q "${dep}" 2>/dev/null;then
+        if ! rpm -q "${dep}" --quiet;then
             not_installed+=("${dep}")
             for wia_dep in "${wia_yum_dependencies[@]}"; do
                 if [ "${wia_dep}" == "${dep}" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2587|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to make the WIA use the `rpm` command instead of the `yum` command to check the installed packages. This avoids the use the `yum` command, which is slower than the RPM tool in this cases, avoids the use of the `grep` command, and avoids the YUM lock.

## Tests

Testing is in: https://github.com/wazuh/wazuh-packages/issues/2587#issuecomment-1921081066

:green_circle: CentOS 8: https://ci.wazuh.info/job/Test_unattended/5206/
:green_circle: CentOS 7: https://ci.wazuh.info/job/Test_unattended/5205/
:green_circle: Ubuntu 18: https://ci.wazuh.info/job/Test_unattended/5207/
:green_circle: Ubuntu 16: https://ci.wazuh.info/job/Test_unattended/5208/
:green_circle: Ubuntu 20: https://ci.wazuh.info/job/Test_unattended/5209/
:green_circle: AL2: https://ci.wazuh.info/job/Test_unattended/5210/
:green_circle: RHEL7: https://ci.wazuh.info/job/Test_unattended/5204/
:green_circle: RHEL8: https://ci.wazuh.info/job/Test_unattended/5211/