### PR TITLE
Removed debug variable in Admin certificate generation

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -81,7 +81,7 @@ function cert_generateAdmincertificate() {
 
     common_logger "Generating Admin certificates."
     common_logger -d "Generating Admin private key."
-    cert_executeAndValidate "openssl genrsa -out ${cert_tmp_path}/admin-key-temp.pem 2048 ${debug}"
+    cert_executeAndValidate "openssl genrsa -out ${cert_tmp_path}/admin-key-temp.pem 2048"
     common_logger -d "Converting Admin private key to PKCS8 format."
     cert_executeAndValidate "openssl pkcs8 -inform PEM -outform PEM -in ${cert_tmp_path}/admin-key-temp.pem -topk8 -nocrypt -v1 PBE-SHA1-3DES -out ${cert_tmp_path}/admin-key.pem"
     common_logger -d "Generating Admin CSR."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2815|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to remove a `debug` variable added in the Admin certificate generation. This generated the `++--++` output which was silenced in: https://github.com/wazuh/wazuh-packages/issues/2787.

Before:
```console
07/02/2024 13:18:27 INFO: Generating Admin certificates.
Generating RSA private key, 2048 bit long modulus
..................+++
..+++
```

After:
```console
09/02/2024 11:07:17 INFO: Generating Admin certificates.
09/02/2024 11:07:17 INFO: Generating Wazuh indexer certificates.
```

Complete log:
```console
[root@al2 vagrant]# cat /var/log/wazuh-install.log 
09/02/2024 11:07:12 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
09/02/2024 11:07:12 INFO: Verbose logging redirected to /var/log/wazuh-install.log
09/02/2024 11:07:16 INFO: Verifying that your system meets the recommended minimum hardware requirements.
09/02/2024 11:07:16 INFO: --- Configuration files ---
09/02/2024 11:07:16 INFO: Generating configuration files.
09/02/2024 11:07:17 INFO: Generating the root certificate.
09/02/2024 11:07:17 INFO: Generating Admin certificates.
09/02/2024 11:07:17 INFO: Generating Wazuh indexer certificates.
09/02/2024 11:07:17 INFO: Generating Filebeat certificates.
09/02/2024 11:07:17 INFO: Generating Wazuh dashboard certificates.
09/02/2024 11:07:17 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
[root@al2 vagrant]# 
```

