### PR TITLE
Do not decompress .tar.xz file, remove xz dependency

### DIFF
--- a/debs/SPECS/wazuh-manager/debian/control
+++ b/debs/SPECS/wazuh-manager/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.wazuh.com
 
 Package: wazuh-manager
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, xz-utils
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api

--- a/debs/SPECS/wazuh-manager/debian/postinst
+++ b/debs/SPECS/wazuh-manager/debian/postinst
@@ -15,7 +15,6 @@ case "$1" in
     OSMYSHELL="/sbin/nologin"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_installation_scripts"
     SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
-    VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
 
     if [ -d /run/systemd/system ]; then
         rm -f /etc/init.d/wazuh-manager
@@ -70,13 +69,6 @@ case "$1" in
     if [ -f ${DIR}/queue/db/global.db ]; then
         chmod 640 ${DIR}/queue/db/global.db*
         chown ${USER}:${GROUP} ${DIR}/queue/db/global.db*
-    fi
-
-    if [ -f "${DIR}/${VD_FILENAME}" ]; then
-        tar -xf ${DIR}/${VD_FILENAME} -C ${DIR}
-        chown ${USER}:${GROUP} ${DIR}/queue/vd
-        chown ${USER}:${GROUP} ${DIR}/queue/vd_updater
-        rm -rf ${DIR}/${VD_FILENAME}
     fi
 
     # Delete uncompatible DBs versions
@@ -274,7 +266,7 @@ case "$1" in
             find ${DIR}/ -group ossec -user ossecr -print0 | xargs -0 chown ${USER}:${GROUP} > /dev/null 2>&1 || true
             deluser ossecr > /dev/null 2>&1
         fi
-        if getent group ossec > /dev/null 2>&1; then 
+        if getent group ossec > /dev/null 2>&1; then
             delgroup ossec > /dev/null 2>&1
         fi
     fi
@@ -311,7 +303,7 @@ case "$1" in
     if [ -z "$(ls -A ${WAZUH_GLOBAL_TMP_DIR})" ]; then
         rm -rf ${WAZUH_GLOBAL_TMP_DIR}
     fi
-   
+
     ;;
 
 

--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -64,7 +64,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
-	DOWNLOAD_CONTENT="yes" \
+	DOWNLOAD_CONTENT="y" \
 	./install.sh
 
 	# Copying init.d script

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -22,7 +22,7 @@ Conflicts:   ossec-hids ossec-hids-agent wazuh-agent wazuh-local
 Obsoletes: wazuh-api < 4.0.0
 AutoReqProv: no
 
-Requires: coreutils xz
+Requires: coreutils
 BuildRequires: coreutils glibc-devel automake autoconf libtool policycoreutils-python curl perl
 
 ExclusiveOS: linux
@@ -80,7 +80,7 @@ echo 'USER_CA_STORE="/path/to/my_cert.pem"' >> ./etc/preloaded-vars.conf
 echo 'USER_GENERATE_AUTHD_CERT="y"' >> ./etc/preloaded-vars.conf
 echo 'USER_AUTO_START="n"' >> ./etc/preloaded-vars.conf
 echo 'USER_CREATE_SSL_CERT="n"' >> ./etc/preloaded-vars.conf
-echo 'DOWNLOAD_CONTENT="yes"' >> ./etc/preloaded-vars.conf
+echo 'DOWNLOAD_CONTENT="y"' >> ./etc/preloaded-vars.conf
 ./install.sh
 
 # Create directories
@@ -309,12 +309,6 @@ if [ $1 = 2 ]; then
 fi
 
 %define _vdfilename vd_1.0.0_vd_4.8.0.tar.xz
-if [ -f "%{_localstatedir}/%{_vdfilename}" ]; then
-    tar -xf %{_localstatedir}/%{_vdfilename} -C %{_localstatedir}
-    chown wazuh:wazuh %{_localstatedir}/queue/vd
-    chown wazuh:wazuh %{_localstatedir}/queue/vd_updater
-    rm -rf %{_localstatedir}/%{_vdfilename}
-fi
 
 # Fresh install code block
 if [ $1 = 1 ]; then
@@ -737,7 +731,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(750, wazuh, wazuh) %{_localstatedir}/%{_vdfilename}
+%attr(750, wazuh, wazuh) %{_localstatedir}/tmp/%{_vdfilename}
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21800|

## Description

Decompression will take place once the vulnerability scanner module has started to avoid decompression during installation.

These are the implementation that were reverted/modified

https://github.com/wazuh/wazuh-packages/pull/2695
https://github.com/wazuh/wazuh-packages/pull/2738  

## Logs example

- RPM package 
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/63785ffd-b510-4d37-a375-d22037e71d55)
![2024-02-14_16-34](https://github.com/wazuh/wazuh-packages/assets/13010397/7f56242f-900f-4d31-89b2-a6c10efd388f)
![2024-02-14_16-36](https://github.com/wazuh/wazuh-packages/assets/13010397/86f0c86d-11b4-45e1-92fd-0ac461e70f22)
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/d2b12dcd-e468-4bea-b84c-dd12e0d806f9)
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/d6785fbc-a315-44f4-af4a-9e96712a78f2)

- DEB package
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/72582c11-a92c-4dd3-9d92-69f1aec5e706)
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/27c02003-fd60-486b-8294-493a32c14fda)
![2024-02-14_16-51](https://github.com/wazuh/wazuh-packages/assets/13010397/c03cc1c4-e7a8-4dea-89bb-4462d7bb3c61)
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/7dc46710-45c5-4d79-b959-b94f23baeb7c)
![image](https://github.com/wazuh/wazuh-packages/assets/13010397/36c1664f-42db-4170-aa34-d7fa8d1abaf1)

## Tests

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package remove

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
- Tests for Linux deb
  - [x] Build the package for x86_64
