### PR TITLE
Fix passwords parser

### DIFF
--- a/.github/actions/passwords-tool/tests-stack-success.sh
+++ b/.github/actions/passwords-tool/tests-stack-success.sh
@@ -22,7 +22,7 @@ echo '::endgroup::'
 
 echo '::group:: Change all passwords except Wazuh API ones.'
 
-mapfile -t pass < <(bash wazuh-passwords-tool.sh -a | awk '{ print $NF }' | sed \$d | sed '1d' )
+mapfile -t pass < <(bash wazuh-passwords-tool.sh -a | grep 'The password for' | awk '{ print $NF }')
 for i in "${!users[@]}"; do
     if curl -s -XGET https://localhost:9200/ -u "${users[i]}":"${pass[i]}" -k -w %{http_code} | grep "401"; then
         exit 1
@@ -35,7 +35,7 @@ echo '::group:: Change all passwords.'
 
 wazuh_pass="$(cat wazuh-install-files/wazuh-passwords.txt | awk "/username: 'wazuh'/{getline;print;}" | awk '{ print $2 }' | tr -d \' )"
 
-mapfile -t passall < <(bash wazuh-passwords-tool.sh -a -au wazuh -ap "${wazuh_pass}" | awk '{ print $NF }' | sed \$d ) 
+mapfile -t passall < <(bash wazuh-passwords-tool.sh -a -au wazuh -ap "${wazuh_pass}" | grep 'The password for' | awk '{ print $NF }' ) 
 passindexer=("${passall[@]:0:6}")
 passapi=("${passall[@]:(-2)}")
 
@@ -63,7 +63,7 @@ echo '::endgroup::'
 
 echo '::group:: Change all passwords except Wazuh API ones using a file.'
 
-mapfile -t passfile < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt | awk '{ print $NF }' | sed \$d | sed '1d' )
+mapfile -t passfile < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt | grep 'The password for' | awk '{ print $NF }' ) 
 for i in "${!users[@]}"; do
     if curl -s -XGET https://localhost:9200/ -u "${users[i]}":"${passfile[i]}" -k -w %{http_code} | grep "401"; then
         exit 1
@@ -72,7 +72,7 @@ done
 echo '::endgroup::'
 
 echo '::group:: Change all passwords from a file.'
-mapfile -t passallf < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt -au wazuh -ap BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 | awk '{ print $NF }' | sed \$d ) 
+mapfile -t passallf < <(bash wazuh-passwords-tool.sh -f wazuh-install-files/wazuh-passwords.txt -au wazuh -ap BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63 | grep 'The password for' | awk '{ print $NF }' )
 passindexerf=("${passallf[@]:0:6}")
 passapif=("${passallf[@]:(-2)}")
 


### PR DESCRIPTION
|Related issue|
|---|
|#2818|

## Description
regarding the gihub-actions tests referred to in the related issue
the parser that interprets the `wazuh-passwords-tool.sh` output is corrected in `tests-stack-success.sh`

## Logs output
```shell
$ tests-stack-success.sh 
::group:: Change indexer password, password providing it.
19/02/2024 17:47:04 INFO: Updating the internal users.
19/02/2024 17:47:06 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
19/02/2024 17:47:06 INFO: Generating password hash
19/02/2024 17:47:28 WARNING: Password changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
::endgroup::
::group:: Change indexer password without providing it.
::endgroup::
::group:: Change all passwords except Wazuh API ones.
::endgroup::
::group:: Change all passwords.
::endgroup::
::group:: Change single Wazuh API user.
19/02/2024 17:49:29 INFO: The password for Wazuh API user wazuh is BkJt92r*ndzN.CkCYWn?d7i5Z7EaUt63
::endgroup::
::group:: Change all passwords except Wazuh API ones using a file.
::endgroup::
::group:: Change all passwords from a file.
::endgroup::