### PR TITLE
Move Vulnerability Detection Template to Templates Folder

### DIFF
--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   Wazuh-agent-rpm-package-build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,8 +70,13 @@ jobs:
         if : steps.changes.outputs.rpm_packages == 'true' || (steps.changes.outputs.rpm_images_agent_i386 == 'true' && matrix.ARCHITECTURE == 'i386') || ((steps.changes.outputs.rpm_images_manager_x86_64 == 'true' || steps.changes.outputs.rpm_images_agent_x86_64 == 'true') && matrix.ARCHITECTURE == 'x86_64')
         working-directory: ./rpms
         run: |
+          if [ "X`git ls-remote --heads https://github.com/wazuh/wazuh.git ${BRANCH_NAME}`" != "X" ]; then
+              W_BRANCH=${BRANCH_NAME}
+          else
+              W_BRANCH=${{ env.VERSION }}
+          fi
           REVISION=$( echo ${{ github.head_ref }} | sed 's/-/./g; s/\//./g' )
-          bash generate_rpm_package.sh -b ${{ env.VERSION }} -t ${{ matrix.TYPE }} -a ${{ matrix.ARCHITECTURE }} --dev -j 2 --dont-build-docker --tag ${{ env.TAG }} -r $REVISION
+          bash generate_rpm_package.sh -b ${W_BRANCH} -t ${{ matrix.TYPE }} -a ${{ matrix.ARCHITECTURE }} --dev -j 2 --dont-build-docker --tag ${{ env.TAG }} -r $REVISION
           echo "PACKAGE_NAME=$(ls ./output | grep .rpm | head -n 1)" >> $GITHUB_ENV
 
       - name: Upload Wazuh ${{ matrix.TYPE }} ${{ matrix.ARCHITECTURE }} package as artifact

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -713,7 +713,8 @@ rm -fr %{buildroot}
 %attr(640, wazuh, wazuh) %ghost %{_localstatedir}/logs/integrations.log
 %attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.log
 %attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.json
-%attr(0440, root, wazuh) %{_localstatedir}/queue/indexer/vd_states_template.json
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}/templates
+%attr(0440, root, wazuh) %{_localstatedir}/templates/vd_states_template.json
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/api
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/archives
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/alerts


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#21955|

## Description

This PR aims to move the Vulnerability Detection template `vd_states_template.json` from `/var/ossec/queue/indexer/` to a `templates` folder located in `/var/ossec/` and update its references.

Related PR for Wazuh-Wazuh: https://github.com/wazuh/wazuh/pull/21985

## Logs/Alerts example

```console
root@ubuntu:/# ls /var/ossec/
active-response  agentless  api  backup  bin  etc  framework  integrations  lib  logs  queue  ruleset  stats  templates  tmp  var  wodles
root@ubuntu:/# ls /var/ossec/templates/
vd_states_template.json
```

## Extra changes

The workflow `build-rpm-packages.yml` was modified in a way that it takes the wazuh build branch with the same name as the current PR. If there is no branch, then it will take the name it was using before.

This change was necessary because the test was using a branch without the changes needed by this PR.

**Before**: https://github.com/wazuh/wazuh-packages/actions/runs/7976772784/job/21778103562?pr=2836
<details>

```console
Run REVISION=$( echo 21955-move-vd-template | sed 's/-/./g; s/\//./g' )
  REVISION=$( echo 21955-move-vd-template | sed 's/-/./g; s/\//./g' )
  bash generate_rpm_package.sh -b master -t manager -a x86_64 --dev -j 2 --dont-build-docker --tag 5.0 -r $REVISION
  echo "PACKAGE_NAME=$(ls ./output | grep .rpm | head -n 1)" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    TAG: 5.0
    VERSION: master
    CONTAINER_NAME: rpm_manager_builder_x86
+ build_target=manager
+ wazuh_branch=master
+ architecture_target=x86_64
```
...

```console
Processing files: wazuh-manager-5.0.0-21955.move.vd.template.x86_64
error: Directory not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-5.0.0-21955.move.vd.template.x86_64/var/ossec/templates
error: File not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-5.0.0-21955.move.vd.template.x86_64/var/ossec/templates/vd_states_template.json


RPM build errors:
    Directory not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-5.0.0-21955.move.vd.template.x86_64/var/ossec/templates
    File not found: /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-5.0.0-21955.move.vd.template.x86_64/var/ossec/templates/vd_states_template.json
Error: Process completed with exit code 1.  
```
</details>

**After**: https://github.com/wazuh/wazuh-packages/actions/runs/7977777570/job/21781434613?pr=2836
<details>

```console
Run if [ "X`git ls-remote --heads https://github.com/wazuh/wazuh.git ${BRANCH_NAME}`" != "X" ]; then
  if [ "X`git ls-remote --heads https://github.com/wazuh/wazuh.git ${BRANCH_NAME}`" != "X" ]; then
      W_BRANCH=${BRANCH_NAME}
  else
      W_BRANCH=4.8.0
  fi
  REVISION=$( echo 21955-move-vd-template | sed 's/-/./g; s/\//./g' )
  bash generate_rpm_package.sh -b ${W_BRANCH} -t manager -a x86_64 --dev -j 2 --dont-build-docker --tag 4.8 -r $REVISION
  echo "PACKAGE_NAME=$(ls ./output | grep .rpm | head -n 1)" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    BRANCH_NAME: 21955-move-vd-template
    TAG: 4.8
    VERSION: 4.8.0
    CONTAINER_NAME: rpm_manager_builder_x86
  
+ build_target=manager
+ wazuh_branch=21955-move-vd-template
+ architecture_target=x86_64
```
...

```console
Processing files: wazuh-manager-4.8.0-21955.move.vd.template.x86_64
warning: File listed twice: /var/ossec/wodles/aws
warning: File listed twice: /var/ossec/wodles/aws/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/aws-s3
warning: File listed twice: /var/ossec/wodles/aws/aws-s3.py
warning: File listed twice: /var/ossec/wodles/aws/aws_tools.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/aws_bucket.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/cloudtrail.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/config.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/guardduty.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/load_balancers.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/server_access.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/umbrella.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/vpcflow.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/waf.py
warning: File listed twice: /var/ossec/wodles/aws/services
warning: File listed twice: /var/ossec/wodles/aws/services/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/services/aws_service.py
warning: File listed twice: /var/ossec/wodles/aws/services/cloudwatchlogs.py
warning: File listed twice: /var/ossec/wodles/aws/services/inspector.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers
warning: File listed twice: /var/ossec/wodles/aws/subscribers/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/s3_log_handler.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/sqs_message_processor.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/sqs_queue.py
warning: File listed twice: /var/ossec/wodles/aws/wazuh_integration.py
warning: File listed twice: /var/ossec/wodles/azure
warning: File listed twice: /var/ossec/wodles/azure/azure-logs
warning: File listed twice: /var/ossec/wodles/azure/azure-logs.py
warning: File listed twice: /var/ossec/wodles/azure/orm.py
warning: File listed twice: /var/ossec/wodles/docker
warning: File listed twice: /var/ossec/wodles/docker/DockerListener
warning: File listed twice: /var/ossec/wodles/docker/DockerListener.py
warning: File listed twice: /var/ossec/wodles/gcloud
warning: File listed twice: /var/ossec/wodles/gcloud/buckets
warning: File listed twice: /var/ossec/wodles/gcloud/buckets/access_logs.py
warning: File listed twice: /var/ossec/wodles/gcloud/buckets/bucket.py
warning: File listed twice: /var/ossec/wodles/gcloud/exceptions.py
warning: File listed twice: /var/ossec/wodles/gcloud/gcloud
warning: File listed twice: /var/ossec/wodles/gcloud/gcloud.py
warning: File listed twice: /var/ossec/wodles/gcloud/integration.py
warning: File listed twice: /var/ossec/wodles/gcloud/pubsub
warning: File listed twice: /var/ossec/wodles/gcloud/pubsub/subscriber.py
warning: File listed twice: /var/ossec/wodles/gcloud/tools.py
Provides: wazuh-manager = 4.8.0-21955.move.vd.template wazuh-manager(x86-64) = 4.8.0-21955.move.vd.template
Requires(interp): /bin/sh /bin/sh /bin/sh /bin/sh /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(pre): /bin/sh /usr/sbin/groupadd /usr/sbin/useradd
Requires(post): /bin/sh
Requires(preun): /bin/sh
Requires(postun): /bin/sh /usr/sbin/groupdel /usr/sbin/userdel
Requires(posttrans): /bin/sh
Conflicts: ossec-hids ossec-hids-agent wazuh-agent wazuh-local
Obsoletes: wazuh-api < 4.0.0
Checking for unpackaged file(s): /usr/local/lib/rpm/check-files /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-4.8.0-21955.move.vd.template.x86_64
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-manager-4.8.0-21955.move.vd.template.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/x86_64/wazuh-manager-4.8.0-21955.move.vd.template.x86_64.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.Vhobso
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-manager-4.8.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-4.8.0-21955.move.vd.template.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ find /build_wazuh/rpmbuild/RPMS/x86_64 -maxdepth 3 -type f -name 'wazuh-manager-4.8.0-21955.move.vd.template*' -exec mv '{}' /var/local/wazuh ';'
Package wazuh-manager-4.8.0-21955.move.vd.template.x86_64.rpm added to /home/runner/work/wazuh-packages/wazuh-packages/rpms/output/.
```
</details>


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [x] Build the package for i386
  - [x] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package