### PR TITLE
Fixed certificates generation output

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -146,8 +146,8 @@ function cert_generateCertificateconfiguration() {
 
 function cert_generateIndexercertificates() {
 
-    common_logger "Generating Wazuh indexer certificates."
     if [ ${#indexer_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Wazuh indexer certificates."
 
         for i in "${!indexer_node_names[@]}"; do
             indexer_node_name=${indexer_node_names[$i]}
@@ -166,8 +166,8 @@ function cert_generateIndexercertificates() {
 
 function cert_generateFilebeatcertificates() {
 
-    common_logger "Generating Filebeat certificates."
     if [ ${#server_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Filebeat certificates."
 
         for i in "${!server_node_names[@]}"; do
             server_name="${server_node_names[i]}"
@@ -187,9 +187,8 @@ function cert_generateFilebeatcertificates() {
 }
 
 function cert_generateDashboardcertificates() {
-
-    common_logger "Generating Wazuh dashboard certificates."
     if [ ${#dashboard_node_names[@]} -gt 0 ]; then
+        common_logger "Generating Wazuh dashboard certificates."
 
         for i in "${!dashboard_node_names[@]}"; do
             dashboard_node_name="${dashboard_node_names[i]}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2837|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to fix the output generated in the certificate generation using the Wazuh certificates tool. The bug consisted in showing generated certificates when they were not created.


## Tests

1. :green_circle: Testing the reported case:

```console
root@ubuntu221:/home/vagrant# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: node-1
      ip: "192.168.56.44"

root@ubuntu221:/home/vagrant# bash wazuh-certs-tool.sh -A
23/02/2024 12:50:27 INFO: Generating the root certificate.
23/02/2024 12:50:27 INFO: Generating Admin certificates.
23/02/2024 12:50:28 INFO: Admin certificates created.
23/02/2024 12:50:28 INFO: Generating Wazuh indexer certificates.
23/02/2024 12:50:28 INFO: Wazuh indexer certificates created.

root@ubuntu221:/home/vagrant# ls wazuh-certificates/
admin-key.pem  admin.pem  node-1-key.pem  node-1.pem  root-ca.key  root-ca.pem
root@ubuntu221:/home/vagrant# 
```

Only the indexer certificates are created and the output confirms it.

2. :green_circle: Testing the reported case with the Installation Assistant:

```console
root@ubuntu221:/home/vagrant# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: node-1
      ip: "192.168.56.44"

root@ubuntu221:/home/vagrant# bash wazuh-install.sh -g
23/02/2024 12:52:16 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
23/02/2024 12:52:16 INFO: Verbose logging redirected to /var/log/wazuh-install.log
23/02/2024 12:52:49 INFO: Verifying that your system meets the recommended minimum hardware requirements.
23/02/2024 12:52:49 INFO: --- Configuration files ---
23/02/2024 12:52:49 INFO: Generating configuration files.
23/02/2024 12:52:49 INFO: Generating the root certificate.
23/02/2024 12:52:50 INFO: Generating Admin certificates.
23/02/2024 12:52:50 INFO: Generating Wazuh indexer certificates.
23/02/2024 12:52:50 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.

root@ubuntu221:/home/vagrant# tar -xvf wazuh-install-files.tar 
wazuh-install-files/
wazuh-install-files/root-ca.key
wazuh-install-files/admin-key.pem
wazuh-install-files/wazuh-passwords.txt
wazuh-install-files/config.yml
wazuh-install-files/root-ca.pem
wazuh-install-files/admin.pem
wazuh-install-files/node-1-key.pem
wazuh-install-files/node-1.pem
root@ubuntu221:/home/vagrant# 
```

Only the indexer certificates are created and the output confirms it.


3. :green_circle: Testing the reported case with the Cert tool - uncomplete configuration:

```console
root@ubuntu221:/home/vagrant# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: node-1
      ip: "192.168.56.44"
    - name: node-2
   
root@ubuntu221:/home/vagrant# bash wazuh-certs-tool.sh -A
23/02/2024 13:03:05 INFO: Generating the root certificate.
23/02/2024 13:03:06 INFO: Generating Admin certificates.
23/02/2024 13:03:06 INFO: Admin certificates created.
23/02/2024 13:03:06 INFO: Generating Wazuh indexer certificates.
23/02/2024 13:03:07 ERROR: Invalid IP or DNS 

root@ubuntu221:/home/vagrant# ls wazuh-certificates/
ls: cannot access 'wazuh-certificates/': No such file or directory
root@ubuntu221:/home/vagrant# 
```

No certificates are created and the output confirms it.

4. :green_circle: Testing the reported case with the Installation Assistant - uncomplete configuration:

```console
root@ubuntu221:/home/vagrant# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: node-1
      ip: "192.168.56.44"
    - name: node-2
    
root@ubuntu221:/home/vagrant# bash wazuh-install.sh -g
23/02/2024 13:04:28 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
23/02/2024 13:04:28 INFO: Verbose logging redirected to /var/log/wazuh-install.log
23/02/2024 13:04:45 INFO: Verifying that your system meets the recommended minimum hardware requirements.
23/02/2024 13:04:45 INFO: --- Configuration files ---
23/02/2024 13:04:45 INFO: Generating configuration files.
23/02/2024 13:04:46 INFO: Generating the root certificate.
23/02/2024 13:04:46 INFO: Generating Admin certificates.
23/02/2024 13:04:46 INFO: Generating Wazuh indexer certificates.
23/02/2024 13:04:47 ERROR: Invalid IP or DNS 

root@ubuntu221:/home/vagrant# tar -xvf wazuh-install-files.tar 
tar: wazuh-install-files.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
root@ubuntu221:/home/vagrant# 
```

No certificates are created and the output confirms it.