### PR TITLE
Wazuh 4.9.0 - Modify OpenSearch version to 2.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,24 @@ The following table shows the references for the versions of each component.
 ### Wazuh dashboard
 
 | Wazuh dashboard | Opensearch dashboards |
-|-----------------|-----------------------|
+| --------------- | --------------------- |
 | 4.3.x           | 1.2.0                 |
 | 4.4.0           | 2.4.1                 |
 | 4.4.1 - 4.5.x   | 2.6.0                 |
 | 4.6.x - 4.7.x   | 2.8.0                 |
-| 4.8.x - current | 2.10.0                |
+| 4.8.x           | 2.10.0                |
+| 4.9.x - current | 2.12.0                |
 
 ### Wazuh indexer
 
-| Wazuh indexer   | Opensearch            |
-|-----------------|-----------------------|
-| 4.3.x           | 1.2.4                 |
-| 4.4.0           | 2.4.1                 |
-| 4.4.1 - 4.5.x   | 2.6.0                 |
-| 4.6.x - 4.7.x   | 2.8.0                 |
-| 4.8.x - current | 2.10.0                |
+| Wazuh indexer   | Opensearch |
+| --------------- | ---------- |
+| 4.3.x           | 1.2.4      |
+| 4.4.0           | 2.4.1      |
+| 4.4.1 - 4.5.x   | 2.6.0      |
+| 4.6.x - 4.7.x   | 2.8.0      |
+| 4.8.x           | 2.10.0     |
+| 4.9.x - current | 2.12.0     |
 
 ## Contribute
 
@@ -57,4 +59,4 @@ If you want to contribute to our project please don't hesitate to send a pull re
 ## License and copyright
 
 WAZUH
-Copyright (C) 2015 Wazuh Inc.  (License GPLv2)
+Copyright (C) 2015 Wazuh Inc. (License GPLv2)

--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -16,7 +16,7 @@ revision="$2"
 future="$3"
 repository="$4"
 reference="$5"
-opensearch_version="2.10.0"
+opensearch_version="2.12.0"
 base_dir=/opt/wazuh-dashboard-base
 
 # -----------------------------------------------------------------------------

--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -17,7 +17,7 @@ revision="$2"
 filebeat_module_reference="$3"
 future="$4"
 reference="$5"
-opensearch_version="2.10.0"
+opensearch_version="2.10.2"
 base_dir=/opt/wazuh-indexer-base
 
 # -----------------------------------------------------------------------------

--- a/stack/indexer/base/builder.sh
+++ b/stack/indexer/base/builder.sh
@@ -17,7 +17,7 @@ revision="$2"
 filebeat_module_reference="$3"
 future="$4"
 reference="$5"
-opensearch_version="2.10.2"
+opensearch_version="2.12.0"
 base_dir=/opt/wazuh-indexer-base
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR aims to modify the Opensearch version to 2.12.0 for Wazuh 4.9.0 to allow compatibility

Related issues
https://github.com/wazuh/wazuh-dashboard-plugins/issues/6439



<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
