### PR TITLE
2871 add debug symbols to DEBs packages

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/control
+++ b/debs/SPECS/wazuh-agent/debian/control
@@ -12,3 +12,10 @@ Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-agent-dbg
+Section: debug
+Priority: optional
+Architecture: any
+Depends: wazuh-agent
+Description: Debug symbols for wazuh-agent, this package contains debug symbols for debugging wazuh-agent.

--- a/debs/SPECS/wazuh-agent/debian/rules
+++ b/debs/SPECS/wazuh-agent/debian/rules
@@ -156,6 +156,6 @@ override_dh_auto_clean:
 
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym
+	dh_strip --dbg-package=wazuh-agent-dbg
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure

--- a/debs/SPECS/wazuh-manager/debian/control
+++ b/debs/SPECS/wazuh-manager/debian/control
@@ -13,3 +13,10 @@ Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-manager-dbg
+Section: debug
+Priority: optional
+Architecture: any
+Depends: wazuh-manager
+Description: Debug symbols for wazuh-manager, this package contains debug symbols for debugging wazuh-manager.

--- a/debs/SPECS/wazuh-manager/debian/rules
+++ b/debs/SPECS/wazuh-manager/debian/rules
@@ -240,6 +240,6 @@ override_dh_auto_clean:
 	$(MAKE) -C src clean
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
+	dh_strip --dbg-package=wazuh-manager-dbg --exclude=dh_strip --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure override_dh_fixperms

--- a/debs/build.sh
+++ b/debs/build.sh
@@ -117,14 +117,19 @@ else
 fi
 
 deb_file="wazuh-${build_target}_${wazuh_version}-${package_release}"
+symbols_deb_file="wazuh-${build_target}-dbg_${wazuh_version}-${package_release}"
 if [[ "${architecture_target}" == "ppc64le" ]]; then
   deb_file="${deb_file}_ppc64el.deb"
+  symbols_deb_file="${symbols_deb_file}_ppc64el.deb"
 else
   deb_file="${deb_file}_${architecture_target}.deb"
+  symbols_deb_file="${symbols_deb_file}_${architecture_target}.deb"
 fi
 pkg_path="${build_dir}/${build_target}"
 
 if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${deb_file} > /var/local/checksum/${deb_file}.sha512
+    cd ${pkg_path} && sha512sum ${symbols_deb_file} > /var/local/checksum/${symbols_deb_file}.sha512
 fi
 mv ${pkg_path}/${deb_file} /var/local/wazuh
+mv ${pkg_path}/${symbols_deb_file} /var/local/wazuh


### PR DESCRIPTION
|Related issue|
|---|
|#2871|

## Description
It is intended to implement the necessary changes to create the new symbol packages for manager and agent, which can be installed on the endpoint when appropriate.
## Logs example

## Tests
tail of build output
```shell
.
.
.
Finished running lintian.

WARNING generated by debuild:                                                                                                                                                                                      
Making debian/rules executable!

+ deb_file=wazuh-agent_4.9.0-test-local                                                                                                                                                                            
+ symbols_deb_file=wazuh-agent-dbg_4.9.0-test-local                                                                                                                                                                
+ [[ amd64 == \p\p\c\6\4\l\e ]]                                                                                                                                                                                    
+ deb_file=wazuh-agent_4.9.0-test-local_amd64.deb                                                                                                                                                                  
+ symbols_deb_file=wazuh-agent-dbg_4.9.0-test-local_amd64.deb                                                                                                                                                      
+ pkg_path=/build_wazuh/agent                                                                                                                                                                                      
+ [[ no == \y\e\s ]]                                                                                                                                                                                               
+ mv /build_wazuh/agent/wazuh-agent_4.9.0-test-local_amd64.deb /var/local/wazuh                                                                                                                                    
+ mv /build_wazuh/agent/wazuh-agent-dbg_4.9.0-test-local_amd64.deb /var/local/wazuh                                                                                                                                
Package wazuh-agent-dbg_4.9.0-test-local_amd64.deb added to /tmp.              
``` 
packages files generated
```shell
✔ 12:06 $ ll -tr /tmp/*.deb                                                                                                                                                                                        
-rw-r--r-- 1 root root 308313194 Mar  7 00:39 /tmp/wazuh-manager_4.9.0-test-local_amd64.deb                                                                                                                        
-rw-r--r-- 1 root root   6511018 Mar  7 00:39 /tmp/wazuh-manager-dbg_4.9.0-test-local_amd64.deb                                                                                                                    
-rw-r--r-- 1 root root  10542740 Mar  7 11:45 /tmp/wazuh-agent_4.9.0-test-local_amd64.deb                                                                                                                          
-rw-r--r-- 1 root root   1577522 Mar  7 11:45 /tmp/wazuh-agent-dbg_4.9.0-test-local_amd64.deb                                                                                                                      
``` 
wazuh-manager-dbg install example
```shell
root@9eeb6e4fe461:/# dpkg -l wazuh-manager-dbg                                                                                                                                                                     
Desired=Unknown/Install/Remove/Purge/Hold                                                                                                                                                                          
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend                                                                                                                                     
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)                                                                                                                                                         
||/ Name              Version          Architecture Description                                                                                                                                                    
+++-=================-================-============-=================================================================================================                                                              
ii  wazuh-manager-dbg 4.9.0-test-local amd64        Debug symbols for wazuh-manager, this package contains debug symbols for debugging wazuh-manager.                                                              
root@9eeb6e4fe461:/# dpkg -L wazuh-manager-dbg                                                                                                                                                                     
/.                                                                                                                                                                                                                 
/usr                                                                                                                                                                                                               
/usr/lib                                                                                                                                                                                                           
/usr/lib/debug                                                                                                                                                                                                     
/usr/lib/debug/var                                                                                                                                                                                                 
/usr/lib/debug/var/ossec                                                                                                                                                                                           
/usr/lib/debug/var/ossec/lib                                                                                                                                                                                       
/usr/lib/debug/var/ossec/lib/librocksdb.so.8                                                                                                                                                                       
/usr/lib/debug/var/ossec/lib/libpython3.10.so.1.0                                                                                                                                                                  
/usr/lib/debug/var/ossec/lib/libcontent_manager.so                                                                                                                                                                 
/usr/lib/debug/var/ossec/lib/libindexer_connector.so                                                                                                                                                               
/usr/lib/debug/var/ossec/lib/libvulnerability_scanner.so                                                                                                                                                           
/usr/lib/debug/var/ossec/lib/libstdc++.so.6                                                                                                                                                                        
/usr/lib/debug/var/ossec/lib/libwazuhshared.so                                                                                                                                                                     
/usr/lib/debug/var/ossec/lib/libwazuhext.so                                                                                                                                                                        
/usr/lib/debug/var/ossec/lib/libgcc_s.so.1                                                                                                                                                                         
/usr/lib/debug/var/ossec/lib/librouter.so                                                                                                                                                                          
/usr/lib/debug/var/ossec/bin                                                                                                                                                                                       
/usr/lib/debug/var/ossec/bin/verify-agent-conf                                                                                                                                                                     
/usr/lib/debug/var/ossec/bin/wazuh-db                                                                                                                                                                              
/usr/lib/debug/var/ossec/bin/wazuh-analysisd                                                                                                                                                                       
/usr/lib/debug/var/ossec/bin/wazuh-execd                                                                                                                                                                           
/usr/lib/debug/var/ossec/bin/wazuh-syscheckd                                                                                                                                                                       
/usr/lib/debug/var/ossec/bin/clear_stats                                                                                                                                                                           
/usr/lib/debug/var/ossec/bin/wazuh-remoted                                                                                                                                                                         
/usr/lib/debug/var/ossec/bin/wazuh-maild                                                                                                                                                                           
/usr/lib/debug/var/ossec/bin/wazuh-csyslogd                                                                                                                                                                        
/usr/lib/debug/var/ossec/bin/wazuh-regex                                                                                                                                                                           
/usr/lib/debug/var/ossec/bin/wazuh-integratord                                                                                                                                                                     
/usr/lib/debug/var/ossec/bin/wazuh-agentlessd                                                                                                                                                                      
/usr/lib/debug/var/ossec/bin/wazuh-dbd                                                                                                                                                                             
/usr/lib/debug/var/ossec/bin/wazuh-logtest-legacy                                                                                                                                                                  
/usr/lib/debug/var/ossec/bin/wazuh-authd                                                                                                                                                                           
/usr/lib/debug/var/ossec/bin/wazuh-monitord                                                                                                                                                                        
/usr/lib/debug/var/ossec/bin/wazuh-logcollector                                                                                                                                                                    
/usr/lib/debug/var/ossec/bin/wazuh-modulesd                                                                                                                                                                        
/usr/lib/debug/var/ossec/bin/wazuh-keystore                                                                                                                                                                        
/usr/lib/debug/var/ossec/bin/manage_agents                                                                                                                                                                         
/usr/lib/debug/var/ossec/bin/wazuh-reportd                                                                                                                                                                         
/usr/lib/debug/var/ossec/bin/agent_control                                                                                                                                                                         
/usr/share                                                                                                                                                                                                         
/usr/share/doc                                                                                                                                                                                                     
/usr/share/doc/wazuh-manager-dbg                                                                                                                                                                                   
/usr/share/doc/wazuh-manager-dbg/copyright                                                                                                                                                                         
/usr/share/doc/wazuh-manager-dbg/changelog.gz                                                                                                                                                                      
/usr/share/doc/wazuh-manager-dbg/changelog.Debian.gz                                                                                                                                                               
``` 
<!-- Minimum checks required -->
- Build the package in any supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [X] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [X] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary