### PR TITLE
Add debug symbols to RPMs packages

### DIFF
--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -1,6 +1,6 @@
 %if %{_debugenabled} == yes
-  %global _enable_debug_package 0
-  %global debug_package %{nil}
+  %global _enable_debug_package 1
+  %global debug_package %{_rpmfilename debuginfo}
   %global __os_install_post %{nil}
   %define __strip /bin/true
 %endif
@@ -34,6 +34,11 @@ ExclusiveOS: linux
 Wazuh helps you to gain security visibility into your infrastructure by monitoring
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+%package debuginfo
+Summary: Debug information for package %{name}
+%description debuginfo
+This package provides debug information for package %{name}
 
 %prep
 %setup -q

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -35,7 +35,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %package wazuh-agent-debuginfo
 Summary: Debug information for package %{name}.
 %description wazuh-agent-debuginfo
-his package provides debug information for package %{name}.
+This package provides debug information for package %{name}.
 
 %prep
 %setup -q

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -1,9 +1,4 @@
-%if %{_debugenabled} == yes
-  %global _enable_debug_package 1
-  %global debug_package %{_rpmfilename debuginfo}
-  %global __os_install_post %{nil}
-  %define __strip /bin/true
-%endif
+%define _debugenabled yes
 
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-agent
@@ -35,10 +30,12 @@ Wazuh helps you to gain security visibility into your infrastructure by monitori
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 
-%package debuginfo
-Summary: Debug information for package %{name}
-%description debuginfo
-This package provides debug information for package %{name}
+# Build debuginfo package
+%debug_package
+%package wazuh-agent-debuginfo
+Summary: Debug information for package %{name}.
+%description wazuh-agent-debuginfo
+his package provides debug information for package %{name}.
 
 %prep
 %setup -q
@@ -193,6 +190,8 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 # Add installation scripts
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
+
+%{_rpmconfigdir}/find-debuginfo.sh
 
 exit 0
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -38,8 +38,8 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %debug_package
 %package wazuh-manager-debuginfo
 Summary: Debug information for package %{name}.
-%description wazuh-agent-debuginfo
-his package provides debug information for package %{name}.
+%description wazuh-manager-debuginfo
+This package provides debug information for package %{name}.
 
 %prep
 %setup -q

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -1,7 +1,4 @@
-%global _enable_debug_package 1
-%global debug_package %{_rpmfilename debuginfo}
-%global __os_install_post %{nil}
-%define __strip /bin/true
+%define _debugenabled yes
 
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-manager
@@ -37,10 +34,12 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 # packages.
 %global _build_id_links none
 
-%package debuginfo
-Summary: Debug information for package %{name}
-%description debuginfo
-This package provides debug information for package %{name}
+# Build debuginfo package
+%debug_package
+%package wazuh-manager-debuginfo
+Summary: Debug information for package %{name}.
+%description wazuh-agent-debuginfo
+his package provides debug information for package %{name}.
 
 %prep
 %setup -q
@@ -191,6 +190,8 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 # Add installation scripts
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
+
+%{_rpmconfigdir}/find-debuginfo.sh
 
 exit 0
 

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -1,6 +1,6 @@
 %if %{_debugenabled} == yes
-  %global _enable_debug_package 0
-  %global debug_package %{nil}
+  %global _enable_debug_package 1
+  %global debug_package %{_rpmfilename debuginfo}
   %global __os_install_post %{nil}
   %define __strip /bin/true
 %endif
@@ -38,6 +38,11 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 # Don't generate build_id links to prevent conflicts with other
 # packages.
 %global _build_id_links none
+
+%package debuginfo
+Summary: Debug information for package %{name}
+%description debuginfo
+This package provides debug information for package %{name}
 
 %prep
 %setup -q

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -1,9 +1,7 @@
-%if %{_debugenabled} == yes
-  %global _enable_debug_package 1
-  %global debug_package %{_rpmfilename debuginfo}
-  %global __os_install_post %{nil}
-  %define __strip /bin/true
-%endif
+%global _enable_debug_package 1
+%global debug_package %{_rpmfilename debuginfo}
+%global __os_install_post %{nil}
+%define __strip /bin/true
 
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-manager

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -31,11 +31,6 @@ if [ -z "${package_release}" ]; then
     package_release="1"
 fi
 
-if [ "${debug}" = "no" ]; then
-    disable_debug_flag='%debug_package %{nil}'
-    echo ${disable_debug_flag} > /etc/rpm/macros
-fi
-
 if [ ${build_target} = "api" ]; then
     if [ "${local_source_code}" = "no" ]; then
         curl -sL https://github.com/wazuh/wazuh-api/tarball/${wazuh_branch} | tar zx
@@ -52,9 +47,9 @@ fi
 build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
-symbols_file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+symbols_file_name="wazuh-${build_target}-${wazuh_version}-${package_release}-debuginfo"
 rpm_file="${file_name}.${architecture_target}.rpm"
-symbols_rpm_file="${symbols_file_name}-dbg.${architecture_target}.rpm"
+symbols_rpm_file="${symbols_file_name}.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
 pkg_path="${rpm_build_dir}/RPMS/${architecture_target}"
 src_path="${rpm_build_dir}/SRPMS"
@@ -141,3 +136,4 @@ if [[ "${src}" == "yes" ]]; then
 fi
 
 find ${extract_path} -maxdepth 3 -type f -name "${file_name}*" -exec mv {} /var/local/wazuh \;
+find ${extract_path} -type f -name "*-debuginfo*" -exec mv {} /var/local/wazuh \;

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -47,7 +47,7 @@ fi
 build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
-symbols_file_name="wazuh-${build_target}-${wazuh_version}-${package_release}-debuginfo"
+symbols_file_name="wazuh-${build_target}-debuginfo-${wazuh_version}-${package_release}"
 rpm_file="${file_name}.${architecture_target}.rpm"
 symbols_rpm_file="${symbols_file_name}.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
@@ -136,4 +136,4 @@ if [[ "${src}" == "yes" ]]; then
 fi
 
 find ${extract_path} -maxdepth 3 -type f -name "${file_name}*" -exec mv {} /var/local/wazuh \;
-find ${extract_path} -type f -name "*-debuginfo*" -exec mv {} /var/local/wazuh \;
+find ${extract_path} -maxdepth 3 -type f -name "${symbols_file_name}*" -exec mv {} /var/local/wazuh \;

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -52,8 +52,9 @@ fi
 build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
+symbols_file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
 rpm_file="${file_name}.${architecture_target}.rpm"
-symbols_rpm_file="${file_name}-dbg.${architecture_target}.rpm"
+symbols_rpm_file="${symbols_file_name}-dbg.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
 pkg_path="${rpm_build_dir}/RPMS/${architecture_target}"
 src_path="${rpm_build_dir}/SRPMS"

--- a/rpms/build.sh
+++ b/rpms/build.sh
@@ -27,13 +27,12 @@ future=${14}
 wazuh_version=""
 rpmbuild="rpmbuild"
 
-disable_debug_flag='%debug_package %{nil}'
-
 if [ -z "${package_release}" ]; then
     package_release="1"
 fi
 
 if [ "${debug}" = "no" ]; then
+    disable_debug_flag='%debug_package %{nil}'
     echo ${disable_debug_flag} > /etc/rpm/macros
 fi
 
@@ -54,6 +53,7 @@ build_dir=/build_wazuh
 rpm_build_dir=${build_dir}/rpmbuild
 file_name="wazuh-${build_target}-${wazuh_version}-${package_release}"
 rpm_file="${file_name}.${architecture_target}.rpm"
+symbols_rpm_file="${file_name}-dbg.${architecture_target}.rpm"
 src_file="${file_name}.src.rpm"
 pkg_path="${rpm_build_dir}/RPMS/${architecture_target}"
 src_path="${rpm_build_dir}/SRPMS"
@@ -129,6 +129,7 @@ $linux $rpmbuild --define "_sysconfdir /etc" --define "_topdir ${rpm_build_dir}"
 
 if [[ "${checksum}" == "yes" ]]; then
     cd ${pkg_path} && sha512sum ${rpm_file} > /var/local/checksum/${rpm_file}.sha512
+    cd ${pkg_path} && sha512sum ${symbols_rpm_file} > /var/local/checksum/${symbols_rpm_file}.sha512
     if [[ "${src}" == "yes" ]]; then
         cd ${src_path} && sha512sum ${src_file} > /var/local/checksum/${src_file}.sha512
     fi

--- a/rpms/generate_rpm_package.sh
+++ b/rpms/generate_rpm_package.sh
@@ -112,7 +112,7 @@ build_rpm() {
         ${CHECKSUM} ${PACKAGES_BRANCH} ${USE_LOCAL_SPECS} ${SRC} \
         ${LEGACY} ${USE_LOCAL_SOURCE_CODE} ${FUTURE}|| return 1
 
-    echo "Package $(ls -Art ${OUTDIR} | tail -n 1) added to ${OUTDIR}."
+    echo "Package $(ls -Art ${OUTDIR} | tail -n 2 | tr '\n' ' ') added to ${OUTDIR}."
 
     return 0
 }


### PR DESCRIPTION
|Related issue|
|---|
|#2866|

## Description
It is intended to implement the necessary changes to create the new symbol packages for manager and agent, which can be installed on the endpoint when appropriate.

## Logs example
tail of build output `./generate_rpm_package.sh -b 4.9.0 --packages-branch 2866-add-debug-symbols-to-rpms -t agent `
```shell
.
.
.
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-agent-4.9.0-1.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/x86_64/wazuh-agent-4.9.0-1.x86_64.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/x86_64/wazuh-agent-debuginfo-4.9.0-1.x86_64.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.KmjjIm
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-agent-4.9.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.9.0-1.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ find /build_wazuh/rpmbuild/RPMS/x86_64 -maxdepth 3 -type f -name 'wazuh-agent-4.9.0-1*' -exec mv '{}' /var/local/wazuh ';'
+ find /build_wazuh/rpmbuild/RPMS/x86_64 -maxdepth 3 -type f -name 'wazuh-agent-debuginfo-4.9.0-1*' -exec mv '{}' /var/local/wazuh ';'
Package wazuh-agent-4.9.0-1.x86_64.rpm wazuh-agent-debuginfo-4.9.0-1.x86_64.rpm  added to /wazuh-packages/rpms/output/.         
``` 
packages files generated
```shell
-rw-r--r-- 1 root root  33341592 mar 13 23:00 wazuh-manager-debuginfo-4.9.0-1.x86_64.rpm
-rw-r--r-- 1 root root 290462588 mar 13 23:03 wazuh-manager-4.9.0-1.x86_64.rpm
-rw-r--r-- 1 root root  10928373 mar 14 00:35 wazuh-agent-4.9.0-1.x86_64.rpm
-rw-r--r-- 1 root root  15109004 mar 14 00:35 wazuh-agent-debuginfo-4.9.0-1.x86_64.rpm                                                                                                                    
``` 
wazuh-agent-debuginfo install example
```shell
[vagrant@localhost ~]$ rpm -qil wazuh-agent-debuginfo-4.9.0-1.x86_64
Name        : wazuh-agent-debuginfo
Version     : 4.9.0
Release     : 1
Architecture: x86_64
Install Date: Thu Mar 14 06:10:19 2024
Group       : Development/Debug
Size        : 58253512
License     : GPL
Signature   : (none)
Source RPM  : wazuh-agent-4.9.0-1.src.rpm
Build Date  : Thu Mar 14 05:33:56 2024
Build Host  : 40005129ff86
Relocations : (not relocatable)
Packager    : Wazuh, Inc <info@wazuh.com>
Vendor      : Wazuh, Inc <info@wazuh.com>
URL         : https://www.wazuh.com/
Summary     : Debug information for package wazuh-agent
Description :
This package provides debug information for package wazuh-agent.
Debug information is useful when developing applications that use this
package or when debugging this package.
/usr/lib/debug
/usr/lib/debug/var
/usr/lib/debug/var/ossec
/usr/lib/debug/var/ossec/active-response
/usr/lib/debug/var/ossec/active-response/bin
/usr/lib/debug/var/ossec/active-response/bin/default-firewall-drop.debug
/usr/lib/debug/var/ossec/active-response/bin/disable-account.debug
/usr/lib/debug/var/ossec/active-response/bin/firewall-drop.debug
/usr/lib/debug/var/ossec/active-response/bin/firewalld-drop.debug
/usr/lib/debug/var/ossec/active-response/bin/host-deny.debug
/usr/lib/debug/var/ossec/active-response/bin/ip-customblock.debug
/usr/lib/debug/var/ossec/active-response/bin/ipfw.debug
/usr/lib/debug/var/ossec/active-response/bin/kaspersky.debug
/usr/lib/debug/var/ossec/active-response/bin/npf.debug
/usr/lib/debug/var/ossec/active-response/bin/pf.debug
/usr/lib/debug/var/ossec/active-response/bin/restart-wazuh.debug
/usr/lib/debug/var/ossec/active-response/bin/route-null.debug
/usr/lib/debug/var/ossec/active-response/bin/wazuh-slack.debug
/usr/lib/debug/var/ossec/bin
/usr/lib/debug/var/ossec/bin/agent-auth.debug
/usr/lib/debug/var/ossec/bin/manage_agents.debug
/usr/lib/debug/var/ossec/bin/wazuh-agentd.debug
/usr/lib/debug/var/ossec/bin/wazuh-execd.debug
/usr/lib/debug/var/ossec/bin/wazuh-logcollector.debug
/usr/lib/debug/var/ossec/bin/wazuh-modulesd.debug
/usr/lib/debug/var/ossec/bin/wazuh-syscheckd.debug
/usr/lib/debug/var/ossec/lib
/usr/lib/debug/var/ossec/lib/libdbsync.so.debug
/usr/lib/debug/var/ossec/lib/libfimdb.so.debug
/usr/lib/debug/var/ossec/lib/libgcc_s.so.1.debug
/usr/lib/debug/var/ossec/lib/librsync.so.debug
/usr/lib/debug/var/ossec/lib/libstdc++.so.6.debug
/usr/lib/debug/var/ossec/lib/libsyscollector.so.debug
/usr/lib/debug/var/ossec/lib/libsysinfo.so.debug
/usr/lib/debug/var/ossec/lib/libwazuhext.so.debug
/usr/lib/debug/var/ossec/lib/libwazuhshared.so.debug
/usr/src/debug/wazuh-agent-4.9.0
/usr/src/debug/wazuh-agent-4.9.0/src
/usr/src/debug/wazuh-agent-4.9.0/src/active-response
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/active_responses.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/active_responses.h
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/disable-account.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalld-drop.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalls
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalls/default-firewall-drop.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalls/ipfw.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalls/npf.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/firewalls/pf.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/host-deny.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/ip-customblock.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/kaspersky.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/restart-wazuh.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/route-null.c
/usr/src/debug/wazuh-agent-4.9.0/src/active-response/wazuh-slack.c
/usr/src/debug/wazuh-agent-4.9.0/src/addagent
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/main.c
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/manage_agents.c
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/manage_agents.h
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/manage_keys.c
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/read_from_user.c
/usr/src/debug/wazuh-agent-4.9.0/src/addagent/validate.c
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/active-response.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/cdb
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/cdb/cdb.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/cdb/uint32.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/decoders
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/decoders/decoder.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/eventinfo.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/lists.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/logmsg.c
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/logmsg.h
/usr/src/debug/wazuh-agent-4.9.0/src/analysisd/rules.h
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/agcom.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/agentd.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/agentd.h
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/buffer.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/config.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/event-forward.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/main.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/notify.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/receiver.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/request.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/restart_agent.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/rotate_log.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/sendmsg.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/start_agent.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/state.c
/usr/src/debug/wazuh-agent-4.9.0/src/client-agent/state.h
/usr/src/debug/wazuh-agent-4.9.0/src/config
/usr/src/debug/wazuh-agent-4.9.0/src/config/active-response.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/active-response.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/agentlessd-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/agentlessd-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/alerts-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/authd-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/authd-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/buffer-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/client-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/client-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/cluster-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/csyslogd-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/csyslogd-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/dbd-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/dbd-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/email-alerts-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/global-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/global-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/integrator-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/integrator-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/labels-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/localfile-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/localfile-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/logtest-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/logtest-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/mail-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/remote-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/remote-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/reports-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/reports-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/rootcheck-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/rootcheck-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/rules-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/socket-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/syscheck-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/syscheck-config.h
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-agent-upgrade.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-aws.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-azure.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-ciscat.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-command.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-config.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-docker.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-fluent.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-gcp.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-github.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-ms-graph.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-office365.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-oscap.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-osquery-monitor.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-sca.c
/usr/src/debug/wazuh-agent-4.9.0/src/config/wmodules-syscollector.c
/usr/src/debug/wazuh-agent-4.9.0/src/data_provider
.
.
.                                                                                                                                                            
``` 


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [x] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [x] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary