### PR TITLE
Added rollBack to several exit points

### DIFF
--- a/unattended_installer/install_functions/dashboard.sh
+++ b/unattended_installer/install_functions/dashboard.sh
@@ -85,6 +85,7 @@ function dashboard_copyCertificates() {
         common_logger -d "Wazuh dashboard certificate setup finished."
     else
         common_logger -e "No certificates found. Wazuh dashboard  could not be initialized."
+        installCommon_rollBack
         exit 1
     fi
 

--- a/unattended_installer/install_functions/filebeat.sh
+++ b/unattended_installer/install_functions/filebeat.sh
@@ -91,6 +91,7 @@ function filebeat_copyCertificates() {
         eval "chown root:root ${filebeat_cert_path}/* ${debug}"
     else
         common_logger -e "No certificates found. Could not initialize Filebeat"
+        installCommon_rollBack
         exit 1
     fi
 

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -138,6 +138,7 @@ function installCommon_aptInstallList(){
             installCommon_aptInstall "${dep}"
             if [ "${install_result}" != 0 ]; then
                 common_logger -e "Cannot install dependency: ${dep}."
+                installCommon_rollBack
                 exit 1
             fi
         done
@@ -277,6 +278,7 @@ function installCommon_changePasswords() {
         installCommon_readPasswordFileUsers
     else
         common_logger -e "Cannot find passwords file. Exiting"
+        installCommon_rollBack
         exit 1
     fi
     if [ -n "${start_indexer_cluster}" ] || [ -n "${AIO}" ]; then
@@ -801,6 +803,7 @@ function installCommon_yumInstallList(){
             eval "echo \${yum_output} ${debug}"
             if [  "${yum_code}" != 0  ]; then
                 common_logger -e "Cannot install dependency: ${dep}."
+                installCommon_rollBack
                 exit 1
             fi
         done

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -594,9 +594,6 @@ function passwords_runSecurityAdmin() {
     eval "OPENSEARCH_CONF_DIR=/etc/wazuh-indexer /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -f /etc/wazuh-indexer/backup/internal_users.yml -t internalusers -p 9200 -nhnv -cacert ${capem} -cert ${adminpem} -key ${adminkey} -icl -h ${IP} ${debug}"
     if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "Could not load the changes."
-        if [[ $(type -t installCommon_rollBack) == "function" ]]; then
-            installCommon_rollBack
-        fi
         exit 1;
     fi
     eval "cp /etc/wazuh-indexer/backup/internal_users.yml /etc/wazuh-indexer/opensearch-security/internal_users.yml"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2785|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to call the rollback function to several exit points in the Wazuh installation assistant. These rollbacks prevent having Wazuh installed wrongly or incompletely in the system.

Some rollback functions have been called in the Password tool. To avoid performing an undesired rollback, a check has been added to perform the rollback only when the Installation Assistant is being used. In other words, when the rollback function is available.

The research of all the exit points is in: https://github.com/wazuh/wazuh-packages/issues/2785#issuecomment-1994743111

 

## Tests

### :green_circle: Normal rollback in Assistant

The Wazuh manager is installed. The Filebeat installation fails and the Wazuh manager is uninstalled in the removal.

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -g
13/03/2024 18:15:32 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/03/2024 18:15:32 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/03/2024 18:15:38 INFO: Verifying that your system meets the recommended minimum hardware requirements.
13/03/2024 18:15:39 INFO: --- Configuration files ---
13/03/2024 18:15:39 INFO: Generating configuration files.
13/03/2024 18:15:39 INFO: Generating the root certificate.
13/03/2024 18:15:39 INFO: Generating Admin certificates.
13/03/2024 18:15:39 INFO: Generating Wazuh indexer certificates.
13/03/2024 18:15:40 INFO: Generating Filebeat certificates.
13/03/2024 18:15:40 INFO: Generating Wazuh dashboard certificates.
13/03/2024 18:15:40 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.

root@ubuntu22:/home/vagrant# bash wazuh-install.sh -ws wazuh-server -i
13/03/2024 18:17:11 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/03/2024 18:17:11 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/03/2024 18:17:18 WARNING: Hardware and system checks ignored.
13/03/2024 18:17:23 INFO: --- Dependencies ----
13/03/2024 18:17:23 INFO: Installing apt-transport-https.
13/03/2024 18:17:43 INFO: Wazuh development repository added.
13/03/2024 18:17:44 INFO: --- Wazuh server ---
13/03/2024 18:17:44 INFO: Starting the Wazuh manager installation.
13/03/2024 18:21:33 INFO: Wazuh manager installation finished.
13/03/2024 18:21:33 INFO: Wazuh manager vulnerability detection configuration finished.
13/03/2024 18:21:33 INFO: Starting service wazuh-manager.
13/03/2024 18:21:55 INFO: wazuh-manager service started.
13/03/2024 18:21:55 INFO: Starting Filebeat installation.
13/03/2024 18:22:33 INFO: Filebeat installation finished.
13/03/2024 18:22:34 ERROR: No certificates found. Could not initialize Filebeat
13/03/2024 18:22:34 INFO: --- Removing existing Wazuh installation ---
13/03/2024 18:22:34 INFO: Removing Wazuh manager.
13/03/2024 18:22:56 INFO: Wazuh manager removed.
13/03/2024 18:22:56 INFO: Removing Filebeat.
13/03/2024 18:23:00 INFO: Filebeat removed.
13/03/2024 18:23:00 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
root@ubuntu22:/home/vagrant# 
```


### :green_circle: Password function rollback using Assistant

Notice that the backup can not be created: `ERROR: The backup could not be created`, and every component installed is removed using the rollback function.

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i
14/03/2024 12:38:48 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
14/03/2024 12:38:48 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/03/2024 12:38:56 WARNING: Hardware and system checks ignored.
14/03/2024 12:38:56 INFO: Wazuh web interface port will be 443.
14/03/2024 12:39:09 INFO: Wazuh development repository added.
14/03/2024 12:39:09 INFO: --- Configuration files ---
14/03/2024 12:39:09 INFO: Generating configuration files.
14/03/2024 12:39:10 INFO: Generating the root certificate.
14/03/2024 12:39:10 INFO: Generating Admin certificates.
14/03/2024 12:39:10 INFO: Generating Wazuh indexer certificates.
14/03/2024 12:39:10 INFO: Generating Filebeat certificates.
14/03/2024 12:39:11 INFO: Generating Wazuh dashboard certificates.
14/03/2024 12:39:11 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
14/03/2024 12:39:12 INFO: --- Wazuh indexer ---
14/03/2024 12:39:12 INFO: Starting Wazuh indexer installation.
14/03/2024 12:40:09 INFO: Wazuh indexer installation finished.
14/03/2024 12:40:09 INFO: Wazuh indexer post-install configuration finished.
14/03/2024 12:40:09 INFO: Starting service wazuh-indexer.
14/03/2024 12:40:37 INFO: wazuh-indexer service started.
14/03/2024 12:40:37 INFO: Initializing Wazuh indexer cluster security settings.
14/03/2024 12:40:51 INFO: Wazuh indexer cluster security configuration initialized.
14/03/2024 12:40:51 INFO: Wazuh indexer cluster initialized.
14/03/2024 12:40:51 INFO: --- Wazuh server ---
14/03/2024 12:40:51 INFO: Starting the Wazuh manager installation.
14/03/2024 12:42:03 INFO: Wazuh manager installation finished.
14/03/2024 12:42:04 INFO: Wazuh manager vulnerability detection configuration finished.
14/03/2024 12:42:04 INFO: Starting service wazuh-manager.
14/03/2024 12:42:26 INFO: wazuh-manager service started.
14/03/2024 12:42:26 INFO: Starting Filebeat installation.
14/03/2024 12:42:53 INFO: Filebeat installation finished.
14/03/2024 12:43:01 INFO: Filebeat post-install configuration finished.
14/03/2024 12:43:01 INFO: Starting service filebeat.
14/03/2024 12:43:04 INFO: filebeat service started.
14/03/2024 12:43:04 INFO: --- Wazuh dashboard ---
14/03/2024 12:43:04 INFO: Starting Wazuh dashboard installation.
14/03/2024 12:44:58 INFO: Wazuh dashboard installation finished.
14/03/2024 12:44:59 INFO: Wazuh dashboard post-install configuration finished.
14/03/2024 12:44:59 INFO: Starting service wazuh-dashboard.
14/03/2024 12:45:01 INFO: wazuh-dashboard service started.
14/03/2024 12:45:06 INFO: Updating the internal users.
14/03/2024 12:45:17 ERROR: The backup could not be created
14/03/2024 12:45:17 INFO: --- Removing existing Wazuh installation ---
14/03/2024 12:45:17 INFO: Removing Wazuh manager.
14/03/2024 12:45:38 INFO: Wazuh manager removed.
14/03/2024 12:45:38 INFO: Removing Wazuh indexer.
14/03/2024 12:45:44 INFO: Wazuh indexer removed.
14/03/2024 12:45:44 INFO: Removing Filebeat.
14/03/2024 12:45:48 INFO: Filebeat removed.
14/03/2024 12:45:48 INFO: Removing Wazuh dashboard.
14/03/2024 12:46:01 INFO: Wazuh dashboard removed.
14/03/2024 12:46:02 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.

```

### :green_circle: Password function rollback using password tool

The Wazuh indexer is installed and the cluster is initialized. 
After changing the passwords and failing, the Wazuh indexer that is installed is not uninstalled, as the Wazuh password tool does not have the rollback function.

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -wi wazuh-indexer -i && bash wazuh-install.sh -s
14/03/2024 12:59:40 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
14/03/2024 12:59:40 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/03/2024 12:59:46 WARNING: Hardware and system checks ignored.
14/03/2024 12:59:56 INFO: Wazuh development repository added.
14/03/2024 12:59:56 INFO: --- Wazuh indexer ---
14/03/2024 12:59:56 INFO: Starting Wazuh indexer installation.
14/03/2024 13:00:52 INFO: Wazuh indexer installation finished.
14/03/2024 13:00:52 INFO: Wazuh indexer post-install configuration finished.
14/03/2024 13:00:52 INFO: Starting service wazuh-indexer.
14/03/2024 13:01:11 INFO: wazuh-indexer service started.
14/03/2024 13:01:11 INFO: Initializing Wazuh indexer cluster security settings.
14/03/2024 13:01:14 INFO: Wazuh indexer cluster initialized.
14/03/2024 13:01:14 INFO: Installation finished.
14/03/2024 13:01:14 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
14/03/2024 13:01:14 INFO: Verbose logging redirected to /var/log/wazuh-install.log
14/03/2024 13:01:21 INFO: Verifying that your system meets the recommended minimum hardware requirements.
14/03/2024 13:01:35 INFO: Wazuh indexer cluster security configuration initialized.
14/03/2024 13:02:02 INFO: Updating the internal users.
14/03/2024 13:02:06 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
14/03/2024 13:02:18 INFO: Wazuh indexer cluster started.
root@ubuntu22:/home/vagrant# bash wazuh-passwords-tool.sh -a
14/03/2024 13:02:28 INFO: Updating the internal users.
14/03/2024 13:02:32 ERROR: The backup could not be created
root@ubuntu22:/home/vagrant# 

```

