### PR TITLE
Allow downgrades using RPM and DEB packages

### DIFF
--- a/debs/SPECS/wazuh-agent/debian/postinst
+++ b/debs/SPECS/wazuh-agent/debian/postinst
@@ -40,7 +40,6 @@ case "$1" in
 
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf
         ${SCRIPTS_DIR}/add_localfiles.sh ${DIR} >> ${DIR}/etc/ossec.conf
-
     else
         ${SCRIPTS_DIR}/gen_ossec.sh conf agent ${OS} ${VER} ${DIR} > ${DIR}/etc/ossec.conf.new
         chmod 660 ${DIR}/etc/ossec.conf.new
@@ -68,7 +67,6 @@ case "$1" in
 
     # Install the SCA files
     if [ -d "${SCA_BASE_DIR}" ]; then
-
         . ${SCRIPTS_DIR}/src/init/dist-detect.sh
 
         SCA_DIR="${DIST_NAME}/${DIST_VER}"
@@ -90,7 +88,6 @@ case "$1" in
         SCA_TMP_FILE="${SCA_TMP_DIR}/sca.files"
 
         if [ -r ${SCA_TMP_FILE} ]; then
-
             rm -f ${DIR}/ruleset/sca/* || true
 
             for sca_file in $(cat ${SCA_TMP_FILE}); do
@@ -142,8 +139,8 @@ case "$1" in
             systemctl daemon-reload > /dev/null 2>&1
         fi
     fi
-    # Remove old ossec user and group if exists and change ownwership of files
 
+    # Remove old ossec user and group if exists and change ownwership of files
     if getent group ossec > /dev/null 2>&1; then
         find ${DIR}/ -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
         if getent passwd ossec > /dev/null 2>&1; then
@@ -158,10 +155,13 @@ case "$1" in
             find ${DIR}/ -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
             deluser ossecr > /dev/null 2>&1
         fi
-        if getent group ossec > /dev/null 2>&1; then 
+        if getent group ossec > /dev/null 2>&1; then
             delgroup ossec > /dev/null 2>&1
         fi
     fi
+
+    find ${DIR} -nogroup -exec chgrp ${GROUP} {} \; > /dev/null 2>&1
+    find ${DIR} -nouser -exec chown ${USER} {} \; > /dev/null 2>&1
 
     if [ ! -z "$2" ]; then
         if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then

--- a/debs/SPECS/wazuh-agent/debian/postrm
+++ b/debs/SPECS/wazuh-agent/debian/postrm
@@ -51,6 +51,40 @@ case "$1" in
     ;;
 
     upgrade)
+        # If the upgrade downgrades to earlier versions, restore ownership
+        if command -v ${DIR}/bin/ossec-control > /dev/null 2>&1; then
+
+            OSMYSHELL="/sbin/nologin"
+
+            if [ -f ${DIR}/queue/sockets/.agent_info ]; then
+                mv ${DIR}/queue/sockets/.agent_info ${DIR}/queue/ossec/
+            fi
+
+            rm -rf ${DIR}/queue/sockets > /dev/null 2>&1
+
+            if ! getent group ossec > /dev/null 2>&1; then
+                addgroup --system ossec > /dev/null 2>&1
+            fi
+
+            if ! getent passwd ossec > /dev/null 2>&1; then
+                adduser --system --home /var/ossec --shell ${OSMYSHELL} --ingroup ossec ossec > /dev/null 2>&1
+            fi
+
+            # Set the correct permissions to orphaned files (not owned by root)
+            find ${DIR} ! -group root -exec chgrp ossec {} \; > /dev/null 2>&1
+            find ${DIR} ! -user root -exec chown ossec {} \; > /dev/null 2>&1
+
+            # delete wazuh user and group
+            if getent passwd wazuh > /dev/null 2>&1; then
+                deluser wazuh
+            fi
+
+            if getent group wazuh > /dev/null 2>&1; then
+                delgroup wazuh
+            fi
+        fi
+
+        exit 0
 
     ;;
 

--- a/debs/SPECS/wazuh-agent/debian/prerm
+++ b/debs/SPECS/wazuh-agent/debian/prerm
@@ -8,6 +8,64 @@ DIR="/var/ossec"
 case "$1" in
     upgrade|deconfigure)
 
+      # Stop the services before uninstalling the package
+      systemctl stop wazuh-agent || true
+      service wazuh-agent stop || true
+      ${DIR}/bin/wazuh-control stop || true
+
+      # Process: wazuh-execd
+      if pgrep -f "wazuh-execd" > /dev/null 2>&1; then
+        kill -15 $(pgrep -f "wazuh-execd") > /dev/null 2>&1
+      fi
+
+      if pgrep -f "wazuh-execd" > /dev/null 2>&1; then
+        kill -9 $(pgrep -f "wazuh-execd") > /dev/null 2>&1
+      fi
+
+      # Process: wazuh-agentd
+      if pgrep -f "wazuh-agentd" > /dev/null 2>&1; then
+        kill -15 $(pgrep -f "wazuh-agentd") > /dev/null 2>&1
+      fi
+
+      if pgrep -f "wazuh-agentd" > /dev/null 2>&1; then
+        kill -9 $(pgrep -f "wazuh-agentd") > /dev/null 2>&1
+      fi
+
+      # Process: wazuh-syscheckd
+      if pgrep -f "wazuh-syscheckd" > /dev/null 2>&1; then
+        kill -15 $(pgrep -f "wazuh-syscheckd") > /dev/null 2>&1
+      fi
+
+      if pgrep -f "wazuh-syscheckd" > /dev/null 2>&1; then
+        kill -9 $(pgrep -f "wazuh-syscheckd") > /dev/null 2>&1
+      fi
+
+      # Process: wazuh-logcollector
+      if pgrep -f "wazuh-logcollector" > /dev/null 2>&1; then
+        kill -15 $(pgrep -f "wazuh-logcollector") > /dev/null 2>&1
+      fi
+
+      if pgrep -f "wazuh-logcollector" > /dev/null 2>&1; then
+        kill -9 $(pgrep -f "wazuh-logcollector") > /dev/null 2>&1
+      fi
+
+      # Process: wazuh-modulesd
+      if pgrep -f "wazuh-modulesd" > /dev/null 2>&1; then
+        kill -15 $(pgrep -f "wazuh-modulesd") > /dev/null 2>&1
+      fi
+
+      if pgrep -f "wazuh-modulesd" > /dev/null 2>&1; then
+        kill -9 $(pgrep -f "wazuh-modulesd") > /dev/null 2>&1
+      fi
+
+      if [ -d ${DIR}/logs/wazuh ]; then
+        mv ${DIR}/logs/wazuh ${DIR}/logs/ossec
+      fi
+
+      if [ -d ${DIR}/queue/sockets ]; then
+        mv ${DIR}/queue/sockets ${DIR}/queue/ossec
+      fi
+
     ;;
 
     remove)

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -446,8 +446,28 @@ fi
 
 %postun
 
-# If the package is been uninstalled
-if [ $1 = 0 ];then
+DELETE_WAZUH_USER_AND_GROUP=0
+
+# If the upgrade downgrades to earlier versions, it will create the ossec
+# group and user, we need to delete wazuh ones
+if [ $1 = 1 ]; then
+  if command -v %{_localstatedir}/bin/ossec-control > /dev/null 2>&1; then
+    find %{_localstatedir} -group wazuh -exec chgrp ossec {} +
+    find %{_localstatedir} -user wazuh -exec chown ossec {} +
+    DELETE_WAZUH_USER_AND_GROUP=1
+  fi
+
+  if [ ! -f %{_localstatedir}/etc/client.keys ]; then
+    if [ -f %{_localstatedir}/etc/client.keys.rpmsave ]; then
+      mv %{_localstatedir}/etc/client.keys.rpmsave %{_localstatedir}/etc/client.keys
+    elif [ -f %{_localstatedir}/etc/client.keys.rpmnew ]; then
+      mv %{_localstatedir}/etc/client.keys.rpmnew %{_localstatedir}/etc/client.keys
+    fi
+  fi
+fi
+
+# If the package is been uninstalled or we want to delete wazuh user and group
+if [ $1 = 0 ] || [ $DELETE_WAZUH_USER_AND_GROUP = 1 ]; then
   # Remove the wazuh user if it exists
   if getent passwd wazuh > /dev/null 2>&1; then
     userdel wazuh >/dev/null 2>&1
@@ -459,15 +479,17 @@ if [ $1 = 0 ];then
     groupdel wazuh >/dev/null 2>&1
   fi
 
-  # Remove lingering folders and files
-  rm -rf %{_localstatedir}/etc/shared/
-  rm -rf %{_localstatedir}/queue/
-  rm -rf %{_localstatedir}/var/
-  rm -rf %{_localstatedir}/bin/
-  rm -rf %{_localstatedir}/logs/
-  rm -rf %{_localstatedir}/backup/
-  rm -rf %{_localstatedir}/ruleset/
-  rm -rf %{_localstatedir}/tmp
+  if [ $1 = 0 ];then
+    # Remove lingering folders and files
+    rm -rf %{_localstatedir}/etc/shared/
+    rm -rf %{_localstatedir}/queue/
+    rm -rf %{_localstatedir}/var/
+    rm -rf %{_localstatedir}/bin/
+    rm -rf %{_localstatedir}/logs/
+    rm -rf %{_localstatedir}/backup/
+    rm -rf %{_localstatedir}/ruleset/
+    rm -rf %{_localstatedir}/tmp
+  fi
 fi
 
 # posttrans code is the last thing executed in a install/upgrade

--- a/wpk/generate_wpk_package.sh
+++ b/wpk/generate_wpk_package.sh
@@ -324,21 +324,24 @@ function main() {
     fi
 
     if [[ "${HAVE_TARGET}" == true ]] && [[ "${HAVE_BRANCH}" == true ]] && [[ "${HAVE_DESTINATION}" == true ]] && [[ "${HAVE_OUT_NAME}" == true ]]; then
-        if [[ "${TARGET}" == "windows" || "${TARGET}" == "macos" ]]; then
+        if [[ "${TARGET}" == "linux" || "${TARGET}" == "windows" || "${TARGET}" == "macos" ]]; then
             if [[ "${HAVE_PKG_NAME}" == true ]]; then
                 build_container ${COMMON_BUILDER} ${COMMON_BUILDER_DOCKERFILE} || clean ${COMMON_BUILDER_DOCKERFILE} 1
                 local CONTAINER_NAME="${COMMON_BUILDER}"
                 pack_wpk ${BRANCH} ${DESTINATION} ${CONTAINER_NAME} ${JOBS} ${PKG_NAME} ${OUT_NAME} ${CHECKSUM} ${CHECKSUMDIR} ${INSTALLATION_PATH} ${AWS_REGION} ${WPK_KEY} ${WPK_CERT} || clean ${COMMON_BUILDER_DOCKERFILE} 1
                 clean ${COMMON_BUILDER_DOCKERFILE} 0
+            elif [[ "${TARGET}" == "linux" ]]; then
+                build_container ${LINUX_BUILDER} ${LINUX_BUILDER_DOCKERFILE} || clean ${LINUX_BUILDER_DOCKERFILE} 1
+                local CONTAINER_NAME="${LINUX_BUILDER}"
+                build_wpk_linux ${BRANCH} ${DESTINATION} ${CONTAINER_NAME} ${JOBS} ${OUT_NAME} ${CHECKSUM} ${CHECKSUMDIR} ${INSTALLATION_PATH} ${AWS_REGION} ${WPK_KEY} ${WPK_CERT} || clean ${LINUX_BUILDER_DOCKERFILE} 1
+                clean ${LINUX_BUILDER_DOCKERFILE} 0
             else
-                echo "ERROR: No MSI/PKG package name specified for Windows or macOS WPK"
+                echo "ERROR: Only Linux can be built without a package name."
                 help 1
             fi
         else
-            build_container ${LINUX_BUILDER} ${LINUX_BUILDER_DOCKERFILE} || clean ${LINUX_BUILDER_DOCKERFILE} 1
-            local CONTAINER_NAME="${LINUX_BUILDER}"
-            build_wpk_linux ${BRANCH} ${DESTINATION} ${CONTAINER_NAME} ${JOBS} ${OUT_NAME} ${CHECKSUM} ${CHECKSUMDIR} ${INSTALLATION_PATH} ${AWS_REGION} ${WPK_KEY} ${WPK_CERT} || clean ${LINUX_BUILDER_DOCKERFILE} 1
-            clean ${LINUX_BUILDER_DOCKERFILE} 0
+            echo "ERROR: Target system must be linux, windows or macos."
+            help 1
         fi
     else
         echo "ERROR: Need more parameters"

--- a/wpk/run.sh
+++ b/wpk/run.sh
@@ -90,6 +90,8 @@ main() {
                     HAVE_PKG_NAME_LINUX=true
                 elif [ "${PKG_NAME: -4}" == ".deb" ]; then
                     HAVE_PKG_NAME_LINUX=true
+                elif [ "${PKG_NAME: -4}" == ".apk" ]; then
+                    HAVE_PKG_NAME_LINUX=true
                 fi
                 shift 2
             fi


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22522|

## Description

This PR modifies RPM and DEB scripts for Wazuh agent's packages.

The modifications make it possible to downgrade Wazuh to earlier versions, allowing to rollback upgrades or to undo transactions via package managers across more versions.


## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] Linux
- [x] Package installation
- [x] Package upgrade
- [x] Package downgrade
- [x] Package remove
- [x] Package install/remove/install
- [x] Change added to CHANGELOG.md
