### PR TITLE
HW checks is done before dependencies installation

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -224,8 +224,6 @@ function check_dist() {
 
 function checks_health() {
 
-    common_logger "Verifying that your system meets the recommended minimum hardware requirements."
-
     checks_specifications
 
     common_logger -d "CPU cores detected: ${cores}"

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -228,7 +228,15 @@ function main() {
         exit 0
     fi
 
-# -------------- Preliminary checks  --------------------------------
+    checks_arch
+    if [ -n "${ignore}" ]; then
+        common_logger -w "Hardware and system checks ignored."
+    else
+        common_logger "Verifying that your system meets the recommended minimum hardware requirements."
+        checks_health
+    fi
+
+# -------------- Preliminary checks and Prerequisites --------------------------------
 
     if [ -z "${uninstall}" ]; then
         installCommon_installCheckDependencies
@@ -236,12 +244,6 @@ function main() {
 
     if [ -z "${configurations}" ] && [ -z "${AIO}" ] && [ -z "${download}" ]; then
         checks_previousCertificate
-    fi
-    checks_arch
-    if [ -n "${ignore}" ]; then
-        common_logger -w "Hardware and system checks ignored."
-    else
-        checks_health
     fi
 
     if [ -n "${port_specified}" ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2905|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->


## Description

The aim of this PR is to change the order when the HW check is performed. Now, it is done before the dependencies installation. This PR fixes the installation of the dependencies before the HW check, which leads to having some dependencies installed in the system if the HW check fails.

<!--
Add a clear description of how the problem has been solved.
-->


## Local testing

<details><summary>AIO installation log</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -v
10/04/2024 08:17:26 DEBUG: Checking root permissions.
10/04/2024 08:17:26 DEBUG: Checking sudo package.
10/04/2024 08:17:26 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
10/04/2024 08:17:26 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/04/2024 08:17:26 DEBUG: APT package manager will be used.
10/04/2024 08:17:26 DEBUG: Checking system distribution.
10/04/2024 08:17:26 DEBUG: Detected distribution name: ubuntu
10/04/2024 08:17:26 DEBUG: Detected distribution version: 22
10/04/2024 08:17:26 DEBUG: Checking Wazuh installation.
10/04/2024 08:17:28 DEBUG: Checking system architecture.
10/04/2024 08:17:28 WARNING: Hardware and system checks ignored.
10/04/2024 08:17:28 DEBUG: Installing check dependencies.
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
10/04/2024 08:17:34 INFO: Wazuh web interface port will be 443.
10/04/2024 08:17:34 DEBUG: Checking ports availability.
10/04/2024 08:17:34 DEBUG: Installing prerequisites dependencies.
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
10/04/2024 08:17:38 INFO: --- Dependencies ----
10/04/2024 08:17:38 INFO: Installing apt-transport-https.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: apt-transport-https 0 upgraded, 1 newly installed, 0 to remove and 72 not upgraded. Need to get 1510 B of archives. After this operation, 170 kB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 apt-transport-https all 2.4.12 [1510 B] Fetched 1510 B in 0s (13.9 kB/s) Selecting previ NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
10/04/2024 08:17:43 DEBUG: Checking curl tool version.
10/04/2024 08:17:43 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: directory '/root/.gnupg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [37.1 kB]
Fetched 54.4 kB in 2s (27.4 kB/s)
Reading package lists...
10/04/2024 08:17:49 INFO: Wazuh development repository added.
10/04/2024 08:17:49 INFO: --- Configuration files ---
10/04/2024 08:17:49 INFO: Generating configuration files.
10/04/2024 08:17:49 DEBUG: Creating Wazuh certificates.
10/04/2024 08:17:49 DEBUG: Reading configuration file.
10/04/2024 08:17:49 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:49 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:49 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:49 INFO: Generating the root certificate.
10/04/2024 08:17:50 INFO: Generating Admin certificates.
10/04/2024 08:17:50 DEBUG: Generating Admin private key.
10/04/2024 08:17:50 DEBUG: Converting Admin private key to PKCS8 format.
10/04/2024 08:17:50 DEBUG: Generating Admin CSR.
10/04/2024 08:17:50 DEBUG: Creating Admin certificate.
10/04/2024 08:17:50 INFO: Generating Wazuh indexer certificates.
10/04/2024 08:17:50 DEBUG: Creating the certificates for wazuh-indexer indexer node.
10/04/2024 08:17:50 DEBUG: Generating certificate configuration.
10/04/2024 08:17:50 DEBUG: Creating the Wazuh indexer tmp key pair.
10/04/2024 08:17:50 DEBUG: Creating the Wazuh indexer certificates.
10/04/2024 08:17:50 INFO: Generating Filebeat certificates.
10/04/2024 08:17:50 DEBUG: Generating the certificates for wazuh-server server node.
10/04/2024 08:17:50 DEBUG: Generating certificate configuration.
10/04/2024 08:17:50 DEBUG: Creating the Wazuh server tmp key pair.
10/04/2024 08:17:50 DEBUG: Creating the Wazuh server certificates.
10/04/2024 08:17:50 INFO: Generating Wazuh dashboard certificates.
10/04/2024 08:17:50 DEBUG: Generating certificate configuration.
10/04/2024 08:17:50 DEBUG: Creating the Wazuh dashboard tmp key pair.
10/04/2024 08:17:51 DEBUG: Creating the Wazuh dashboard certificates.
10/04/2024 08:17:51 DEBUG: Cleaning certificate files.
10/04/2024 08:17:51 DEBUG: Generating password file.
10/04/2024 08:17:51 DEBUG: Generating random passwords.
10/04/2024 08:17:51 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
10/04/2024 08:17:51 DEBUG: Extracting Wazuh configuration.
10/04/2024 08:17:51 DEBUG: Reading configuration file.
10/04/2024 08:17:51 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:51 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:51 DEBUG: Checking if 127.0.0.1 is private.
10/04/2024 08:17:51 INFO: --- Wazuh indexer ---
10/04/2024 08:17:51 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 72 not upgraded. Need to get 757 MB of archives. After this operation, 1050 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-indexer amd64 4.8.0-1 [757 MB] Fetched 757 MB in 2min 15s (5613 kB/s) Selecting pr NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
10/04/2024 08:21:07 DEBUG: Checking Wazuh installation.
10/04/2024 08:21:08 DEBUG: There are Wazuh indexer remaining files.
10/04/2024 08:21:09 INFO: Wazuh indexer installation finished.
10/04/2024 08:21:09 DEBUG: Configuring Wazuh indexer.
10/04/2024 08:21:09 DEBUG: Copying Wazuh indexer certificates.
10/04/2024 08:21:09 INFO: Wazuh indexer post-install configuration finished.
10/04/2024 08:21:09 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
10/04/2024 08:21:32 INFO: wazuh-indexer service started.
10/04/2024 08:21:32 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
10/04/2024 08:21:43 INFO: Wazuh indexer cluster security configuration initialized.
10/04/2024 08:21:43 INFO: Wazuh indexer cluster initialized.
10/04/2024 08:21:43 INFO: --- Wazuh server ---
10/04/2024 08:21:43 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 72 not upgraded. Need to get 311 MB of archives. After this operation, 914 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-manager amd64 4.8.0-1 [311 MB] Fetched 311 MB in 49s (63 NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
10/04/2024 08:23:40 DEBUG: Checking Wazuh installation.
10/04/2024 08:23:40 DEBUG: There are Wazuh remaining files.
10/04/2024 08:23:40 DEBUG: There are Wazuh indexer remaining files.
10/04/2024 08:23:41 INFO: Wazuh manager installation finished.
10/04/2024 08:23:41 DEBUG: Configuring Wazuh manager.
10/04/2024 08:23:41 DEBUG: Setting provisional Wazuh indexer password.
10/04/2024 08:23:41 INFO: Wazuh manager vulnerability detection configuration finished.
10/04/2024 08:23:41 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
10/04/2024 08:24:04 INFO: wazuh-manager service started.
10/04/2024 08:24:04 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 72 not upgraded. Need to get 22.1 MB of archives. After this operation, 73.6 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 filebeat amd64 7.10.2 [22.1 MB] Fetched 22.1 MB in 8s (2912 kB/s) Selecting previously unsel NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
10/04/2024 08:24:47 DEBUG: Checking Wazuh installation.
10/04/2024 08:24:48 DEBUG: There are Wazuh remaining files.
10/04/2024 08:24:49 DEBUG: There are Wazuh indexer remaining files.
10/04/2024 08:24:50 DEBUG: There are Filebeat remaining files.
10/04/2024 08:24:50 INFO: Filebeat installation finished.
10/04/2024 08:24:50 DEBUG: Configuring Filebeat.
10/04/2024 08:24:52 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
10/04/2024 08:24:53 DEBUG: Filebeat module was downloaded successfully.
10/04/2024 08:24:53 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
10/04/2024 08:24:56 INFO: Filebeat post-install configuration finished.
10/04/2024 08:24:56 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
10/04/2024 08:24:58 INFO: filebeat service started.
10/04/2024 08:24:58 INFO: --- Wazuh dashboard ---
10/04/2024 08:24:58 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 72 not upgraded. Need to get 186 MB of archives. After this operation, 988 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.8.0-1 [186 MB] Fetched 186 MB in 36s (5167 kB/s) Selecting prev NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
10/04/2024 08:26:58 DEBUG: Checking Wazuh installation.
10/04/2024 08:26:59 DEBUG: There are Wazuh remaining files.
10/04/2024 08:26:59 DEBUG: There are Wazuh indexer remaining files.
10/04/2024 08:27:00 DEBUG: There are Filebeat remaining files.
10/04/2024 08:27:00 DEBUG: There are Wazuh dashboard remaining files.
10/04/2024 08:27:00 INFO: Wazuh dashboard installation finished.
10/04/2024 08:27:00 DEBUG: Configuring Wazuh dashboard.
10/04/2024 08:27:00 DEBUG: Copying Wazuh dashboard certificates.
10/04/2024 08:27:00 DEBUG: Wazuh dashboard certificate setup finished.
10/04/2024 08:27:00 INFO: Wazuh dashboard post-install configuration finished.
10/04/2024 08:27:00 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
10/04/2024 08:27:01 INFO: wazuh-dashboard service started.
10/04/2024 08:27:01 DEBUG: Setting Wazuh indexer cluster passwords.
10/04/2024 08:27:01 DEBUG: Checking Wazuh installation.
10/04/2024 08:27:02 DEBUG: There are Wazuh remaining files.
10/04/2024 08:27:03 DEBUG: There are Wazuh indexer remaining files.
10/04/2024 08:27:03 DEBUG: There are Filebeat remaining files.
10/04/2024 08:27:04 DEBUG: There are Wazuh dashboard remaining files.
10/04/2024 08:27:04 INFO: Updating the internal users.
10/04/2024 08:27:04 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
10/04/2024 08:27:13 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
10/04/2024 08:27:13 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
10/04/2024 08:27:13 DEBUG: The internal users have been updated before changing the passwords.
10/04/2024 08:27:15 DEBUG: Generating password hashes.
10/04/2024 08:27:24 DEBUG: Password hashes generated.
10/04/2024 08:27:24 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
10/04/2024 08:27:28 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
10/04/2024 08:27:29 DEBUG: Restarting filebeat service...
10/04/2024 08:27:29 DEBUG: filebeat started.
10/04/2024 08:27:30 DEBUG: Restarting wazuh-manager service...
10/04/2024 08:28:03 DEBUG: wazuh-manager started.
10/04/2024 08:28:05 DEBUG: Restarting wazuh-dashboard service...
10/04/2024 08:28:06 DEBUG: wazuh-dashboard started.
10/04/2024 08:28:06 DEBUG: Running security admin tool.
10/04/2024 08:28:06 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/vagrant
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
10/04/2024 08:28:13 DEBUG: Passwords changed.
10/04/2024 08:28:13 DEBUG: Changing API passwords.
10/04/2024 08:28:22 INFO: Initializing Wazuh dashboard web application.
10/04/2024 08:28:22 INFO: Wazuh dashboard web application not yet initialized. Waiting...
10/04/2024 08:28:38 INFO: Wazuh dashboard web application not yet initialized. Waiting...
10/04/2024 08:28:53 INFO: Wazuh dashboard web application initialized.
10/04/2024 08:28:53 INFO: --- Summary ---
10/04/2024 08:28:53 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: EcHQL03hFCaGVWo+iXi.zvh?*mLdUZsZ
10/04/2024 08:28:53 DEBUG: Restoring Wazuh repository.
10/04/2024 08:28:53 INFO: Installation finished.
root@ubuntu22:/home/vagrant# 
```
</details>

<details><summary>Uninstallation log</summary>
```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -u
10/04/2024 08:38:08 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
10/04/2024 08:38:08 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/04/2024 08:38:13 INFO: Removing Wazuh manager.
10/04/2024 08:38:43 INFO: Wazuh manager removed.
10/04/2024 08:38:43 INFO: Removing Wazuh indexer.
10/04/2024 08:38:51 INFO: Wazuh indexer removed.
10/04/2024 08:38:51 INFO: Removing Filebeat.
10/04/2024 08:38:56 INFO: Filebeat removed.
10/04/2024 08:38:56 INFO: Removing Wazuh dashboard.
10/04/2024 08:39:12 INFO: Wazuh dashboard removed.
root@ubuntu22:/home/vagrant# 
```
</details>


## Automatic testing

The automatic testing failed because of: https://github.com/wazuh/wazuh/issues/22835. But the AIO installation is performed successfully.

:green_circle: CentOS 7 - https://ci.wazuh.info/job/Test_unattended/5525/ 
:green_circle: CentOS 8 - https://ci.wazuh.info/job/Test_unattended/5526/
:green_circle: Ubuntu Bionic - https://ci.wazuh.info/job/Test_unattended/5527/
:green_circle: Ubuntu Xenial - https://ci.wazuh.info/job/Test_unattended/5528/
:green_circle: Ubuntu Focal - https://ci.wazuh.info/job/Test_unattended/5529/
:green_circle: Amazon Linux 2 - https://ci.wazuh.info/job/Test_unattended/5530/
:green_circle: RHEL 7 - https://ci.wazuh.info/job/Test_unattended/5531/
:green_circle: RHEL 8 - https://ci.wazuh.info/job/Test_unattended/5532/

