### PR TITLE
Add bash dependency to Wazuh agent RPM for AIX

### DIFF
--- a/aix/SPECS/wazuh-agent-aix.spec
+++ b/aix/SPECS/wazuh-agent-aix.spec
@@ -14,6 +14,7 @@ Source0: %{name}-%{version}.tar.gz
 Conflicts: ossec-hids ossec-hids-agent wazuh-manager wazuh-local
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+Requires: bash
 BuildRequires: coreutils automake autoconf libtool
 
 %description


### PR DESCRIPTION
|Related issue|
|---|
https://github.com/wazuh/wazuh-packages/issues/2878
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
It was found that Wazuh agent RPM package for AIX has a runtime dependency on bash that shows the following error during package installation on a clean AIX 6.1 TL9 requested to SiteOx

```bash
# WAZUH_MANAGER="10.0.0.2" rpm -ivh wazuh-agent-4.7.3-1.aix.ppc.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-4.7.3-1              ################################# [100%]
/var/tmp/rpm-tmp.teEaab[40]: /var/ossec/tmp/src/init/register_configure_agent.sh:  not found

```

<!--
Add a clear description of how the problem has been solved.
-->


## Logs example

<!--
Paste here related logs
-->

## Tests

```
# rpm -e --nodeps bash
# cd /opt/freeware/src/packages/RPMS/ppc/
# WAZUH_MANAGER="10.0.0.2" rpm -ivh wazuh-agent-4.9.0-1.aix6.1.ppc.rpm
error: failed dependencies:
        bash is needed by wazuh-agent-4.9.0-1
# rpm -Uvh --nodeps http://packages-dev.wazuh.com/deps/aix/bash-4.4-4.aix6.1.ppc.rpm
Retrieving http://packages-dev.wazuh.com/deps/aix/bash-4.4-4.aix6.1.ppc.rpm

# WAZUH_MANAGER="10.0.0.2" rpm -ivh wazuh-agent-4.9.0-1.aix6.1.ppc.rpm 
wazuh-agent                 ##################################################
# WAZUH_MANAGER="10.0.0.2" rpm -ivh wazuh-agent-4.9.0-1.aix6.1.ppc.rpm 
package wazuh-agent-4.9.0-1 is already installed

```

<!-- Minimum checks required -->
- Build the package in any supported platform
  - [x] AIX
- [x] Package installation
- [x] Package install/remove/install
