### PR TITLE
Prevent failed checks related to dashboard and indexer

### DIFF
--- a/.github/workflows/password-tool.yml
+++ b/.github/workflows/password-tool.yml
@@ -1,8 +1,9 @@
-name: Password tool script tests
-on:
-  pull_request:
-    paths:
-      - 'unattended_installer/passwords_tool/**'
+# Because from 4.9.0 this script is migrated to a new repository, the tests of this script will not be executed.
+# name: Password tool script tests
+# on:
+#   pull_request:
+#     paths:
+#       - 'unattended_installer/passwords_tool/**'
 
 jobs:
   Build-password-tool-and-wazuh-install-scripts:
@@ -14,15 +15,15 @@ jobs:
         run: |
           bash builder.sh -p
           bash builder.sh -i -d staging
-        shell: bash 
+        shell: bash
       - uses: actions/upload-artifact@v3
         with:
           name: scripts
-          path: | 
+          path: |
             unattended_installer/wazuh-install.sh
             unattended_installer/wazuh-passwords-tool.sh
-          if-no-files-found: error 
-          
+          if-no-files-found: error
+
   test-password-tool-success:
     runs-on: ubuntu-latest
     needs: Build-password-tool-and-wazuh-install-scripts
@@ -34,11 +35,11 @@ jobs:
       - name: Install wazuh
         run: |
           sudo bash wazuh-install.sh -a -v
-      - name: Uncompress wazuh install files 
+      - name: Uncompress wazuh install files
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script
         run: sudo bash .github/actions/passwords-tool/tests-stack-success.sh
-          
+
   test-password-tool-failure:
     runs-on: ubuntu-latest
     needs: Build-password-tool-and-wazuh-install-scripts
@@ -50,7 +51,7 @@ jobs:
       - name: Install wazuh
         run: |
           sudo bash wazuh-install.sh -a -v
-      - name: Uncompress wazuh install files 
+      - name: Uncompress wazuh install files
         run: sudo tar -xvf wazuh-install-files.tar
       - name: Run script
         run: sudo bash .github/actions/passwords-tool/tests-stack-failure.sh


### PR DESCRIPTION
|Related issue|
|---|
|#2901|

## Description

This PR aims to temporarily disable the tests for the password tool script, so that we prevent those checks from running in the PR, so that they are not displayed in :red_circle: due to the dashboard and indexer migration.
- The tests for the password tool script, located at the path 'unattended_installer/passwords_tool/**', have been commented out and therefore will not run.


