### PR TITLE
Check Wazuh installation folder exists before upgrading

### DIFF
--- a/alpine/SPECS/wazuh-agent/wazuh-agent.pre-upgrade
+++ b/alpine/SPECS/wazuh-agent/wazuh-agent.pre-upgrade
@@ -4,6 +4,11 @@
 
 directory_base="DIRECTORY_BASE"
 
+if [ ! -d "${directory_base}" ]; then
+    echo "Error: Directory ${directory_base} does not exist. Cannot perform upgrade" >&2
+    exit 1
+fi
+
 if [ -f /var/ossec/var/run/wazuh-execd-*.pid ]; then
     touch ${directory_base}/tmp/wazuh.restart
     ${directory_base}/bin/wazuh-control stop > /dev/null 2>&1

--- a/debs/SPECS/wazuh-agent/debian/postrm
+++ b/debs/SPECS/wazuh-agent/debian/postrm
@@ -56,6 +56,14 @@ case "$1" in
 
             OSMYSHELL="/sbin/nologin"
 
+            if [ -d ${DIR}/logs/wazuh ]; then
+                mv ${DIR}/logs/wazuh ${DIR}/logs/ossec
+            fi
+
+            if [ -d ${DIR}/queue/sockets ]; then
+                mv ${DIR}/queue/sockets ${DIR}/queue/ossec
+            fi
+
             if [ -f ${DIR}/queue/sockets/.agent_info ]; then
                 mv ${DIR}/queue/sockets/.agent_info ${DIR}/queue/ossec/
             fi

--- a/debs/SPECS/wazuh-agent/debian/preinst
+++ b/debs/SPECS/wazuh-agent/debian/preinst
@@ -19,6 +19,12 @@ case "$1" in
     install|upgrade)
 
         if [ "$1" = "upgrade" ]; then
+
+            if [ ! -d "$DIR" ]; then
+                echo "Error: Directory $DIR does not exist. Cannot perform upgrade" >&2
+                exit 1
+            fi
+
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
                 systemctl stop wazuh-agent.service > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart

--- a/debs/SPECS/wazuh-agent/debian/prerm
+++ b/debs/SPECS/wazuh-agent/debian/prerm
@@ -9,9 +9,12 @@ case "$1" in
     upgrade|deconfigure)
 
       # Stop the services before uninstalling the package
-      systemctl stop wazuh-agent || true
-      service wazuh-agent stop || true
-      ${DIR}/bin/wazuh-control stop || true
+      if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
+          systemctl stop wazuh-agent > /dev/null 2>&1
+      elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
+          service wazuh-agent stop > /dev/null 2>&1
+      fi
+      ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
       # Process: wazuh-execd
       if pgrep -f "wazuh-execd" > /dev/null 2>&1; then
@@ -56,14 +59,6 @@ case "$1" in
 
       if pgrep -f "wazuh-modulesd" > /dev/null 2>&1; then
         kill -9 $(pgrep -f "wazuh-modulesd") > /dev/null 2>&1
-      fi
-
-      if [ -d ${DIR}/logs/wazuh ]; then
-        mv ${DIR}/logs/wazuh ${DIR}/logs/ossec
-      fi
-
-      if [ -d ${DIR}/queue/sockets ]; then
-        mv ${DIR}/queue/sockets ${DIR}/queue/ossec
       fi
 
     ;;

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -205,6 +205,11 @@ fi
 
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
+  if [ ! -d "%{_localstatedir}" ]; then
+    echo "Error: Directory %{_localstatedir} does not exist. Cannot perform upgrade" >&2
+    exit 1
+  fi
+
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
     systemctl stop wazuh-agent.service > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22670|

This PR makes a small improvement in the upgrade process of RPM, DEB and APK packages: it checks that Wazuh's installation folder exists prior to attempting an upgrade.