### PR TITLE
Cert-tool logfile added. Modified common_logger function to write on files without root permission.

### DIFF
--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -158,6 +158,8 @@ function main() {
             esac
         done
 
+        common_logger "Verbose logging redirected to ${logfile}"
+
         if [[ -d "${base_path}"/wazuh-certificates ]]; then
             if [ -n "$(ls -A "${base_path}"/wazuh-certificates)" ]; then
                 common_logger -e "Directory wazuh-certificates already exists in the same path as the script. Please, remove the certs directory to create new certificates."

--- a/unattended_installer/cert_tool/certVariables.sh
+++ b/unattended_installer/cert_tool/certVariables.sh
@@ -6,8 +6,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-base_path="$(dirname "$(readlink -f "$0")")"
-readonly base_path
+readonly base_path="$(dirname "$(readlink -f "$0")")"
 readonly config_file="${base_path}/config.yml"
 readonly logfile="${base_path}/wazuh-certificates-tool.log"
 cert_tmp_path="/tmp/wazuh-certificates"

--- a/unattended_installer/cert_tool/certVariables.sh
+++ b/unattended_installer/cert_tool/certVariables.sh
@@ -9,6 +9,7 @@
 base_path="$(dirname "$(readlink -f "$0")")"
 readonly base_path
 readonly config_file="${base_path}/config.yml"
-readonly logfile=""
+readonly logfile="${base_path}/wazuh-certificates-tool.log"
 cert_tmp_path="/tmp/wazuh-certificates"
-debug=">> /dev/null 2>&1"
+debug=">> ${logfile} 2>&1"
+readonly cert_tool_script_name=".*certs.*\.sh"

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -56,7 +56,7 @@ function common_logger() {
     fi
 
     if [ -z "${debugLogger}" ] || { [ -n "${debugLogger}" ] && [ -n "${debugEnabled}" ]; }; then
-        if { [ "$EUID" -eq 0 ] && [ -z "${nolog}" ]; } || [[ "$(basename "$0")" =~ $cert_tool_script_name ]]; then
+        if [ -z "${nolog}" ] && { [ "$EUID" -eq 0 ] || [[ "$(basename "$0")" =~ $cert_tool_script_name ]]; }; then
             printf "%s\n" "${now} ${mtype} ${message}" | tee -a ${logfile}
         else
             printf "%b\n" "${now} ${mtype} ${message}"

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -56,7 +56,7 @@ function common_logger() {
     fi
 
     if [ -z "${debugLogger}" ] || { [ -n "${debugLogger}" ] && [ -n "${debugEnabled}" ]; }; then
-        if [ "$EUID" -eq 0 ] && [ -z "${nolog}" ]; then
+        if { [ "$EUID" -eq 0 ] && [ -z "${nolog}" ]; } || [[ "$(basename "$0")" =~ $cert_tool_script_name ]]; then
             printf "%s\n" "${now} ${mtype} ${message}" | tee -a ${logfile}
         else
             printf "%b\n" "${now} ${mtype} ${message}"


### PR DESCRIPTION
|Related issue|
|---|
#2536
||

## Description

The first problem to be solved was to add a path to write the logfile. The logfiles is going now to be created on the same directory where the wazuh-certs-tool.sh is executed.

I have left a comment [here](https://github.com/wazuh/wazuh-packages/issues/2536?notification_referrer_id=NT_kwDOBZURI7M4MDk5ODAyOTg5OjkzNjU1MzMx&notifications_query=reason%3Aassign#issuecomment-2061057128) explaining in detail the issues we were having during the process of solving the primary issue and how we solved them.

## Logs example

The tests that have been done are the following.

### Build and execute the cert tool

Build and execute with `-v` option

![Captura desde 2024-04-17 10-33-05](https://github.com/wazuh/wazuh-packages/assets/93655331/077b68a1-d4f8-4a8b-a659-72c5d92bb639)

Build and execute without `-v` option

![Captura desde 2024-04-17 10-33-44](https://github.com/wazuh/wazuh-packages/assets/93655331/360bf316-f34d-4c1b-a814-581b6f6e62c8)

Folder wazuh-certificates created

![Captura desde 2024-04-17 10-42-32](https://github.com/wazuh/wazuh-packages/assets/93655331/496236c2-8c45-4929-bb08-3952cfdef360)

### Build the necessary files with `wazuh-install.sh -g`

Wazuh install tool was launched and the files on `wazuh-install-files.tar` are listed.

```
17/04/2024 10:49:56 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
17/04/2024 10:49:56 INFO: Verbose logging redirected to /var/log/wazuh-install.log
17/04/2024 10:50:02 INFO: --- Dependencies ----
17/04/2024 10:50:02 INFO: Installing gawk.
17/04/2024 10:50:05 INFO: Verifying that your system meets the recommended minimum hardware requirements.
17/04/2024 10:50:05 INFO: --- Configuration files ---
17/04/2024 10:50:05 INFO: Generating configuration files.
17/04/2024 10:50:06 INFO: Generating the root certificate.
17/04/2024 10:50:06 INFO: Generating Admin certificates.
17/04/2024 10:50:06 INFO: Generating Wazuh indexer certificates.
17/04/2024 10:50:06 INFO: Generating Filebeat certificates.
17/04/2024 10:50:06 INFO: Generating Wazuh dashboard certificates.
17/04/2024 10:50:07 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
17/04/2024 10:50:07 INFO: --- Dependencies ----
17/04/2024 10:50:07 INFO: Removing gawk.
root@carlos-laptop:/home/carlos/Documentos/wazuh/wazuh-packages/unattended_installer# tar -tf wazuh-install-files.tar 
wazuh-install-files/
wazuh-install-files/config.yml
wazuh-install-files/dashboard-1-key.pem
wazuh-install-files/wazuh-passwords.txt
wazuh-install-files/server-1-key.pem
wazuh-install-files/dashboard-1.pem
wazuh-install-files/root-ca.key
wazuh-install-files/admin.pem
wazuh-install-files/admin-key.pem
wazuh-install-files/indexer-1-key.pem
wazuh-install-files/root-ca.pem
wazuh-install-files/server-1.pem
wazuh-install-files/indexer-1.pem
```

## CentOs test fail
On the automated tests, it's detected that the installation of wazuh-dashboard component fails because it's not still available for CentOs. As seen on the logs:
`download.cf.centos.org No package wazuh-dashboard-4.9.0-* available. Error: Nothing to do`

## New issue

While doing this issue I noticed that when the `wazuh-certs-tool.sh` is created it doesn't have execute permissions so you have to manually give them. We are going to open a new issue for this to grant execute permissions when the tool is builded.
