### PR TITLE
Changed log message when not `yum` nor `apt-get` are found. Added clearer instructions on following steps.

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -146,7 +146,7 @@ function common_checkSystem() {
         sep="="
         common_logger -d "APT package manager will be used."
     else
-        common_logger -e "Couldn't find type of system"
+        common_logger -e "Couldn't find YUM or APT package manager. Try to install one of them with your current package manager. Then, launch the installation assistant again."
         exit 1
     fi
 

--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -146,7 +146,7 @@ function common_checkSystem() {
         sep="="
         common_logger -d "APT package manager will be used."
     else
-        common_logger -e "Couldn't find YUM or APT package manager. Try to install one of them with your current package manager. Then, launch the installation assistant again."
+        common_logger -e "Couldn't find YUM or APT package manager. Try installing the one corresponding to your operating system and then, launch the installation assistant again."
         exit 1
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
#2444
||

## Description

The previous log message was:
`ERROR: Couldn't find type of system`

This message has been changed to a more descriptive message:
`Couldn't find YUM or APT package manager. Try to install one of them with your current package manager. Then, launch the installation assistant again.`

## Log file
```
localhost:/home/vagrant/wazuh-packages # ./unattended_installer/wazuh-install.sh -a
22/04/2024 08:11:29 INFO: Starting Wazuh installation assistant. Wazuh version: 4.6.0
22/04/2024 08:11:29 INFO: Verbose logging redirected to /var/log/wazuh-install.log
22/04/2024 08:11:29 ERROR: Couldn't find YUM or APT package manager. Try installing the one corresponding to your operating system and then, launch the installation assistant again.
```
