### PR TITLE
Set v7 theme as default

### DIFF
--- a/stack/dashboard/base/builder.sh
+++ b/stack/dashboard/base/builder.sh
@@ -110,6 +110,11 @@ cp ./etc/styles.js ./src/core/server/rendering/views/styles.js
 # Customize OpenSearch Dashboards with Wazuh
 # -----------------------------------------------------------------------------
 
+# Set v7 theme as default
+sed -i "s|value: 'Next (preview)',|value: 'v7',|g" ./src/core/server/ui_settings/settings/theme.js
+sed -i "s|defaultValue: 'v8'|defaultValue: 'v7'|g" ./src/core/server/ui_settings/ui_settings_config.js
+
+
 # Replace App Title
 sed -i "s|defaultValue: ''|defaultValue: \'Wazuh\'|g" ./src/core/server/opensearch_dashboards_config.js
 sed -i "90s|defaultValue: true|defaultValue: false|g" ./src/core/server/opensearch_dashboards_config.js


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-dashboard/issues/173|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR modifies the Wazuh Dashboard to select the `v7` theme as default instead of the `Next`. 
<!--
Add a clear description of how the problem has been solved.
-->

## Evidence

A package was built using the tools. Testing it, the correct theme was selected
![image](https://github.com/wazuh/wazuh-packages/assets/42900763/1ae9717a-3c40-4eb4-a2b8-521a92e98d99)

## Logs example

<!--
Paste here related logs
-->

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [ ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ ] Package installation
- [ ] Package upgrade
- [ ] Package downgrade
- [ ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ ] Test the package on Solaris 11
  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
