### PR TITLE
Fixed false negative messages in installation assistant whe uninstalling on YUM and unifying solution for APT-GET

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -596,7 +596,8 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
-            manager_installed=$(apt list --installed 2>/dev/null | grep wazuh-manager)
+            eval "apt list --installed 2>/dev/null | grep wazuh-manager"
+            manager_installed="${PIPESTATUS[1]}"
         fi
 
         if [ "${manager_installed}" -eq 0 ]; then
@@ -623,7 +624,8 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
-            indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
+            eval "apt list --installed 2>/dev/null | grep wazuh-indexer"
+            indexer_installed="${PIPESTATUS[1]}"
         fi
 
         if [ "${indexer_installed}" -eq 0 ]; then
@@ -651,7 +653,8 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
-            filebeat_installed=$(apt list --installed 2>/dev/null | grep filebeat)
+            eval "apt list --installed 2>/dev/null | grep filebeat"
+            filebeat_installed="${PIPESTATUS[1]}"
         fi
 
         if [ "${filebeat_installed}" -eq 0 ]; then
@@ -679,7 +682,8 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
-            dashboard_installed=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
+            eval "apt list --installed 2>/dev/null | grep wazuh-dashboard"
+            dashboard_installed="${PIPESTATUS[1]}"
         fi
 
         if [ "${dashboard_installed}" -eq 0 ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -591,14 +591,14 @@ function installCommon_rollBack() {
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-manager -y ${debug}"
                 eval "rpm -q wazuh-manager --quiet"
-                manager_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-manager"
-            manager_installed=${PIPESTATUS[0]}
         fi
+
+        manager_installed=${PIPESTATUS[0]}
 
         if [ "${manager_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh manager package could not be removed."
@@ -619,14 +619,14 @@ function installCommon_rollBack() {
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-indexer -y ${debug}"
                 eval "rpm -q wazuh-indexer --quiet"
-                indexer_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-indexer"
-            indexer_installed=${PIPESTATUS[0]}
         fi
+
+        indexer_installed=${PIPESTATUS[0]}
 
         if [ "${indexer_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh indexer package could not be removed."
@@ -648,14 +648,14 @@ function installCommon_rollBack() {
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove filebeat -y ${debug}"
                 eval "rpm -q filebeat --quiet"
-                filebeat_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep filebeat"
-            filebeat_installed=${PIPESTATUS[0]}
         fi
+
+        filebeat_installed=${PIPESTATUS[0]}
 
         if [ "${filebeat_installed}" -eq 0 ]; then
             common_logger -w "The Filebeat package could not be removed."
@@ -677,14 +677,14 @@ function installCommon_rollBack() {
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-dashboard -y ${debug}"
                 eval "rpm -q wazuh-dashboard --quiet"
-                dashboard_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-dashboard"
-            dashboard_installed=${PIPESTATUS[0]}
         fi
+
+        dashboard_installed=${PIPESTATUS[0]}
 
         if [ "${dashboard_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh dashboard package could not be removed."

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -597,7 +597,7 @@ function installCommon_rollBack() {
             common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-manager"
-            manager_installed="${PIPESTATUS[1]}"
+            manager_installed=${PIPESTATUS[0]}
         fi
 
         if [ "${manager_installed}" -eq 0 ]; then
@@ -625,7 +625,7 @@ function installCommon_rollBack() {
             common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-indexer"
-            indexer_installed="${PIPESTATUS[1]}"
+            indexer_installed=${PIPESTATUS[0]}
         fi
 
         if [ "${indexer_installed}" -eq 0 ]; then
@@ -654,7 +654,7 @@ function installCommon_rollBack() {
             common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep filebeat"
-            filebeat_installed="${PIPESTATUS[1]}"
+            filebeat_installed=${PIPESTATUS[0]}
         fi
 
         if [ "${filebeat_installed}" -eq 0 ]; then
@@ -683,7 +683,7 @@ function installCommon_rollBack() {
             common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
             eval "apt list --installed 2>/dev/null | grep wazuh-dashboard"
-            dashboard_installed="${PIPESTATUS[1]}"
+            dashboard_installed=${PIPESTATUS[0]}
         fi
 
         if [ "${dashboard_installed}" -eq 0 ]; then

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -590,7 +590,8 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-manager -y ${debug}"
-                eval "rpm -q wazuh-manager --quiet && manager_installed=1"
+                eval "rpm -q wazuh-manager --quiet"
+                manager_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -616,7 +617,8 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-indexer -y ${debug}"
-                eval "rpm -q wazuh-indexer --quiet && indexer_installed=1"
+                eval "rpm -q wazuh-indexer --quiet"
+                indexer_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -643,7 +645,8 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove filebeat -y ${debug}"
-                eval "rpm -q filebeat --quiet && filebeat_installed=1"
+                eval "rpm -q filebeat --quiet"
+                filebeat_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
@@ -670,7 +673,8 @@ function installCommon_rollBack() {
             common_checkYumLock
             if [ "${attempt}" -ne "${max_attempts}" ]; then
                 eval "yum remove wazuh-dashboard -y ${debug}"
-                eval "rpm -q wazuh-dashboard --quiet && dashboard_installed=1"
+                eval "rpm -q wazuh-dashboard --quiet"
+                dashboard_installed=${PIPESTATUS[0]}
             fi
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -599,7 +599,7 @@ function installCommon_rollBack() {
             manager_installed=$(apt list --installed 2>/dev/null | grep wazuh-manager)
         fi
 
-        if [ -n "${manager_installed}" ]; then
+        if [ "${manager_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh manager package could not be removed."
         else
             common_logger "Wazuh manager removed."
@@ -626,7 +626,7 @@ function installCommon_rollBack() {
             indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
         fi
 
-        if [ -n "${indexer_installed}" ]; then
+        if [ "${indexer_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh indexer package could not be removed."
         else
             common_logger "Wazuh indexer removed."
@@ -654,7 +654,7 @@ function installCommon_rollBack() {
             filebeat_installed=$(apt list --installed 2>/dev/null | grep filebeat)
         fi
 
-        if [ -n "${filebeat_installed}" ]; then
+        if [ "${filebeat_installed}" -eq 0 ]; then
             common_logger -w "The Filebeat package could not be removed."
         else
             common_logger "Filebeat removed."
@@ -682,7 +682,7 @@ function installCommon_rollBack() {
             dashboard_installed=$(apt list --installed 2>/dev/null | grep wazuh-dashboard)
         fi
 
-        if [ -n "${dashboard_installed}" ]; then
+        if [ "${dashboard_installed}" -eq 0 ]; then
             common_logger -w "The Wazuh dashboard package could not be removed."
         else
             common_logger "Wazuh dashboard removed."


### PR DESCRIPTION
|Related issue|
|---|
 #2898

## Description

The problem was the installation assistant tool was giving false negative logs when uninstalling Wazuh components.
This problem was being generated by the comparative if that generated the log message, which compared that the variable had a length greater than 0.
This variable was being initialized/updated elsewhere in the script and because of this, the if was not working correctly. 

We have thought that the best solution to this problem is to filter if the package has been correctly uninstalled by evaluating the list of installed packages looking for the one we are interested in and store the output code of that `eval` function with the `$PIPESTATUS}` array.

## Logs example

The solution we propose is this, for example, for the Wazuh Indexer component:
```
if [[ -n "${indexer_installed}" && ( -n "${indexer}" || -n "${AIO}" || -n "${uninstall}" ) ]]; then
    common_logger "Removing Wazuh indexer."
    if [ "${sys_type}" == "yum" ]; then
        common_checkYumLock
        if [ "${attempt}" -ne "${max_attempts}" ]; then
            eval "yum remove wazuh-indexer -y ${debug}"
            eval "rpm -q wazuh-indexer --quiet"
        fi
    elif [ "${sys_type}" == "apt-get" ]; then
        common_checkAptLock
        eval "apt-get remove --purge wazuh-indexer -y ${debug}"
        eval "apt list --installed 2>/dev/null | grep wazuh-indexer"
    fi

    indexer_installed=${PIPESTATUS[0]}

    if [ "${indexer_installed}" -eq 0 ]; then
        common_logger -w "The Wazuh indexer package could not be removed."
    else
        common_logger "Wazuh indexer removed."
    fi
fi
```

As you can see, we take the exit code with execute the `eval` command to check if the component is installed and then we get the exit code with `${PIPESTATUS[0]}`. Then, on the final comparison, we check, and if the variable is `0` it means the `eval` command has finished with success so the package is installed. Otherwise, the package isn't installed.

## Tests

Finally, we've tested these changes with both package managers, YUM and APT-GET.
For testing the YUM we used a VM with AmazonLinux. The exit logs from the uninstalling are the following ones:
```
[root@vagrant vagrant]# ./wazuh-packages/unattended_installer/wazuh-install.sh -u -v
30/04/2024 11:55:55 DEBUG: Checking root permissions.
30/04/2024 11:55:55 DEBUG: Checking sudo package.
30/04/2024 11:55:55 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
30/04/2024 11:55:55 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/04/2024 11:55:55 DEBUG: YUM package manager will be used.
30/04/2024 11:55:55 DEBUG: Checking system distribution.
30/04/2024 11:55:55 DEBUG: Detected distribution name: amzn
30/04/2024 11:55:55 DEBUG: Detected distribution version: 2
30/04/2024 11:55:55 DEBUG: Checking Wazuh installation.
30/04/2024 11:55:55 DEBUG: There are Wazuh remaining files.
30/04/2024 11:55:56 DEBUG: There are Wazuh indexer remaining files.
30/04/2024 11:55:56 DEBUG: There are Filebeat remaining files.
30/04/2024 11:55:56 DEBUG: There are Wazuh dashboard remaining files.
30/04/2024 11:55:56 INFO: Removing Wazuh manager.
Complementos cargados:langpacks, priorities, update-motd
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-manager.x86_64 0:4.8.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión           Repositorio     Tamaño
================================================================================
Eliminando:
 wazuh-manager          x86_64          4.8.0-1           @wazuh          878 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 878 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Eliminando    : wazuh-manager-4.8.0-1.x86_64                              1/1 
advertencia:archivo /var/ossec/tmp/vd_1.0.0_vd_4.8.0.tar.xz: falló al eliminar: No such file or directory
advertencia:/var/ossec/etc/ossec.conf guardado como /var/ossec/etc/ossec.conf.rpmsave
  Comprobando   : wazuh-manager-4.8.0-1.x86_64                              1/1 

Eliminado(s):
  wazuh-manager.x86_64 0:4.8.0-1                                                

¡Listo!
30/04/2024 11:56:01 INFO: Wazuh manager removed.
30/04/2024 11:56:01 INFO: Removing Wazuh indexer.
Complementos cargados:langpacks, priorities, update-motd
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-indexer.x86_64 0:4.8.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                Arquitectura    Versión           Repositorio     Tamaño
================================================================================
Eliminando:
 wazuh-indexer          x86_64          4.8.0-1           @wazuh          1.0 G

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 1.0 G
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Stopping wazuh-indexer service... OK
  Eliminando    : wazuh-indexer-4.8.0-1.x86_64                              1/1 
advertencia:/etc/wazuh-indexer/opensearch.yml guardado como /etc/wazuh-indexer/opensearch.yml.rpmsave
advertencia:/etc/wazuh-indexer/opensearch-security/internal_users.yml guardado como /etc/wazuh-indexer/opensearch-security/internal_users.yml.rpmsave
advertencia:/etc/wazuh-indexer/jvm.options guardado como /etc/wazuh-indexer/jvm.options.rpmsave
  Comprobando   : wazuh-indexer-4.8.0-1.x86_64                              1/1 

Eliminado(s):
  wazuh-indexer.x86_64 0:4.8.0-1                                                

¡Listo!
30/04/2024 11:56:02 INFO: Wazuh indexer removed.
30/04/2024 11:56:02 INFO: Removing Filebeat.
Complementos cargados:langpacks, priorities, update-motd
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete filebeat.x86_64 0:7.10.2-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package            Arquitectura     Versión             Repositorio      Tamaño
================================================================================
Eliminando:
 filebeat           x86_64           7.10.2-1            @wazuh            70 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 70 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Eliminando    : filebeat-7.10.2-1.x86_64                                  1/1 
advertencia:/etc/filebeat/filebeat.yml guardado como /etc/filebeat/filebeat.yml.rpmsave
  Comprobando   : filebeat-7.10.2-1.x86_64                                  1/1 

Eliminado(s):
  filebeat.x86_64 0:7.10.2-1                                                    

¡Listo!
30/04/2024 11:56:02 INFO: Filebeat removed.
30/04/2024 11:56:02 INFO: Removing Wazuh dashboard.
Complementos cargados:langpacks, priorities, update-motd
Resolviendo dependencias
--> Ejecutando prueba de transacción
---> Paquete wazuh-dashboard.x86_64 0:4.8.0-1 debe ser eliminado
--> Resolución de dependencias finalizada

Dependencias resueltas

================================================================================
 Package                 Arquitectura   Versión            Repositorio    Tamaño
================================================================================
Eliminando:
 wazuh-dashboard         x86_64         4.8.0-1            @wazuh         902 M

Resumen de la transacción
================================================================================
Eliminar  1 Paquete

Tamaño instalado: 902 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Stopping wazuh-dashboard service...  Eliminando    : wazuh-dashboard-4.8.0-1.x86_64                            1/1 
advertencia:/etc/wazuh-dashboard/opensearch_dashboards.yml guardado como /etc/wazuh-dashboard/opensearch_dashboards.yml.rpmsave
  Comprobando   : wazuh-dashboard-4.8.0-1.x86_64                            1/1 

Eliminado(s):
  wazuh-dashboard.x86_64 0:4.8.0-1                                              

¡Listo!
30/04/2024 11:56:09 INFO: Wazuh dashboard removed.
30/04/2024 11:56:09 DEBUG: Removing GPG key from system.
```
For testing with APT-GET we used a VM with Ubuntu 22.04. The exit logs from the uninstalling are the following ones:
```
root@ubuntu2204:/home/vagrant# ./wazuh-packages/unattended_installer/wazuh-install.sh -u -v
30/04/2024 11:50:27 DEBUG: Checking root permissions.
30/04/2024 11:50:27 DEBUG: Checking sudo package.
30/04/2024 11:50:27 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
30/04/2024 11:50:27 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/04/2024 11:50:27 DEBUG: APT package manager will be used.
30/04/2024 11:50:27 DEBUG: Checking system distribution.
30/04/2024 11:50:27 DEBUG: Detected distribution name: ubuntu
30/04/2024 11:50:27 DEBUG: Detected distribution version: 22
30/04/2024 11:50:27 DEBUG: Checking Wazuh installation.
30/04/2024 11:50:28 DEBUG: There are Wazuh remaining files.
30/04/2024 11:50:28 DEBUG: There are Wazuh indexer remaining files.
30/04/2024 11:50:29 DEBUG: There are Filebeat remaining files.
30/04/2024 11:50:29 DEBUG: There are Wazuh dashboard remaining files.
30/04/2024 11:50:29 INFO: Removing Wazuh manager.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-manager*
0 upgraded, 0 newly installed, 1 to remove and 107 not upgraded.
After this operation, 909 MB disk space will be freed.
(Readi(Reading database ... 195555 files and directories currently installed.)
Removing wazuh-manager (4.8.0-1) ...
(Reading database ... 173543 files and directories currently installed.)
Purging configuration files for wazuh-manager (4.8.0-1) ...
30/04/2024 11:50:35 INFO: Wazuh manager removed.
30/04/2024 11:50:35 INFO: Removing Wazuh indexer.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 107 not upgraded.
After this operation, 1,050 MB disk space will be freed.
(Rea(Reading database ... 173523 files and directories currently installed.)
Removing wazuh-indexer (4.8.0-1) ...
Stopping wazuh-indexer service... OK
(Reading database ... 172389 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.8.0-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/usr/lib/systemd/system' not empty so not removed
30/04/2024 11:50:37 INFO: Wazuh indexer removed.
30/04/2024 11:50:37 INFO: Removing Filebeat.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  filebeat*
0 upgraded, 0 newly installed, 1 to remove and 107 not upgraded.
After this operation, 73.6 MB disk space will be freed.
(Read(Reading database ... 172350 files and directories currently installed.)
Removing filebeat (7.10.2) ...
(Reading database ... 172058 files and directories currently installed.)
Purging configuration files for filebeat (7.10.2) ...
dpkg: warning: while removing filebeat, directory '/etc/filebeat' not empty so not removed
dpkg: warning: while removing filebeat, directory '/usr/share/filebeat/module' not empty so not removed
30/04/2024 11:50:38 INFO: Filebeat removed.
30/04/2024 11:50:38 INFO: Removing Wazuh dashboard.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-dashboard*
0 upgraded, 0 newly installed, 1 to remove and 107 not upgraded.
After this operation, 987 MB disk space will be freed.
(Readi(Reading database ... 172031 files and directories currently installed.)
Removing wazuh-dashboard (4.8.0-1) ...
Stopping wazuh-dashboard service... OK
Deleting PID directory... OK
Deleting installation directory... OK
(Reading database ... 83243 files and directories currently installed.)
Purging configuration files for wazuh-dashboard (4.8.0-1) ...
 OK
30/04/2024 11:50:44 INFO: Wazuh dashboard removed.
30/04/2024 11:50:44 DEBUG: Removing GPG key from system.
```

