### PR TITLE
Fixed API password change to match the user in wazuh.yml

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -82,7 +82,7 @@ function passwords_changePassword() {
 function passwords_changePasswordApi() {
     #Change API password tool
     if [ -n "${changeall}" ]; then
-        wazuh_yml_user=$(grep "username:" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml | awk -F ': ' '{print $2}')
+        wazuh_yml_user=$(awk '/- default:/ {flag=1} flag && /username:/ {print $2; exit} /hosts:/ {flag=0}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
         for i in "${!api_passwords[@]}"; do
             if [ -n "${wazuh_installed}" ]; then
                 passwords_getApiUserId "${api_users[i]}"

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -82,7 +82,7 @@ function passwords_changePassword() {
 function passwords_changePasswordApi() {
     #Change API password tool
     if [ -n "${changeall}" ]; then
-        wazuh_yml_user=$(awk '/- default:/ {flag=1} flag && /username:/ {print $2; exit} /hosts:/ {flag=0}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
+        wazuh_yml_user=$(awk '/- default:/ {found=1} found && /username:/ {print $2}' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml)
         for i in "${!api_passwords[@]}"; do
             if [ -n "${wazuh_installed}" ]; then
                 passwords_getApiUserId "${api_users[i]}"

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -120,7 +120,7 @@ function passwords_changeDashboardApiPassword() {
     j=0
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
-            eval "sed -i 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+            eval "sed -i -e 's|username: .*|username: wazuh-wui|g' -e 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
                 common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
             fi

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -82,6 +82,7 @@ function passwords_changePassword() {
 function passwords_changePasswordApi() {
     #Change API password tool
     if [ -n "${changeall}" ]; then
+        wazuh_yml_user=$(grep "username:" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml | awk -F ': ' '{print $2}')
         for i in "${!api_passwords[@]}"; do
             if [ -n "${wazuh_installed}" ]; then
                 passwords_getApiUserId "${api_users[i]}"
@@ -96,7 +97,7 @@ function passwords_changePasswordApi() {
                     common_logger -nl $"The password for Wazuh API user ${api_users[i]} is ${api_passwords[i]}"
                 fi
             fi
-            if [ "${api_users[i]}" == "wazuh-wui" ] && [ -n "${dashboard_installed}" ]; then
+            if [ "${api_users[i]}" == "${wazuh_yml_user}" ] && [ -n "${dashboard_installed}" ]; then
                 passwords_changeDashboardApiPassword "${api_passwords[i]}"
             fi
         done
@@ -109,7 +110,7 @@ function passwords_changePasswordApi() {
                 common_logger -nl $"The password for Wazuh API user ${nuser} is ${password}"
             fi
         fi
-        if [ "${nuser}" == "wazuh-wui" ] && [ -n "${dashboard_installed}" ]; then
+        if [ "${nuser}" == "${wazuh_yml_user}" ] && [ -n "${dashboard_installed}" ]; then
                 passwords_changeDashboardApiPassword "${password}"
         fi
     fi
@@ -120,7 +121,7 @@ function passwords_changeDashboardApiPassword() {
     j=0
     until [ -n "${file_exists}" ] || [ "${j}" -eq "12" ]; do
         if [ -f "/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml" ]; then
-            eval "sed -i -e 's|username: .*|username: wazuh-wui|g' -e 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
+            eval "sed -i 's|password: .*|password: \"${1}\"|g' /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml ${debug}"
             if [ -z "${AIO}" ] && [ -z "${indexer}" ] && [ -z "${dashboard}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
                 common_logger "Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service."
             fi


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh/issues/22751

## Description

The problem was that the Password Tool modified the password on `wazuh.yml` always to the one used by the user `wazuh-wui`.
Now, the fix done is that the Password Tool takes into account which user appears on `wazuh.yml` and updates the password to match the user.

## Logs example

These changes have been done by storing a variable with the username on the wazuh.yml with the following line:
```
wazuh_yml_user=$(grep "username:" /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml | awk -F ': ' '{print $2}')
```
Then, the condition to update the Api Password has been changed for matching the user recovered from the file:
```
if [ "${api_users[i]}" == "${wazuh_yml_user}" ] && [ -n "${dashboard_installed}" ]; then
    passwords_changeDashboardApiPassword "${api_passwords[i]}"
fi
```

## Tests

To test the changes I used a VM with Ubuntu 22.04 and updated the Password Tool with the changes mentioned above. Then I ran the script with the username on `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` equal to `wazuh` and checked that the password on the file is the one correspondent to `wazuh` user and not to `wazuh-wui` like it was before.

I ran the Password Tool with the user `wazuh` in the `wazuh.yml` file. The output was the following:
![imagen](https://github.com/wazuh/wazuh-packages/assets/93655331/264a742a-c54f-4b12-a44f-235fcfe31aa8)

And the `wazuh.yml` file contains the password matching the user `wazuh`:
![imagen](https://github.com/wazuh/wazuh-packages/assets/93655331/cb881220-04d7-413e-94e7-3a2e9948da8b)


I did the same verification with the `wazuh-wui` user. I ran the Password Tool. The output was this:
![imagen](https://github.com/wazuh/wazuh-packages/assets/93655331/51ce7e69-a7fc-4f0e-a312-a8c26ca7d978)

And the `wazuh.yml` file contains the password matching the user `wazuh-wui`:
![imagen](https://github.com/wazuh/wazuh-packages/assets/93655331/f8ff1dd5-9b48-461c-973a-dc6e57f8b6f8)

