### PR TITLE
Improved service status and output management in Installation assistant

### DIFF
--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -742,8 +742,10 @@ function installCommon_startService() {
     if [[ -d /run/systemd/system ]]; then
         eval "systemctl daemon-reload ${debug}"
         eval "systemctl enable ${1}.service ${debug}"
-        eval "systemctl start ${1}.service ${debug}"
-        if [  "${PIPESTATUS[0]}" != 0  ]; then
+        service_output=$(eval "systemctl start ${1}.service 2>&1")
+        e_code="${PIPESTATUS[0]}"
+        [ -n "${service_output}" ] && eval "echo \${service_output} ${debug}"
+        if [  "${e_code}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"

--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -526,8 +526,10 @@ function passwords_restartService() {
 
     if [[ -d /run/systemd/system ]]; then
         eval "systemctl daemon-reload ${debug}"
-        eval "systemctl restart ${1}.service ${debug}"
-        if [  "${PIPESTATUS[0]}" != 0  ]; then
+        service_output=$(eval "systemctl restart ${1}.service 2>&1")
+        e_code="${PIPESTATUS[0]}"
+        [ -n "${service_output}" ] && eval "echo \${service_output} ${debug}"
+        if [  "${e_code}" != 0  ]; then
             common_logger -e "${1} could not be started."
             if [ -n "$(command -v journalctl)" ]; then
                 eval "journalctl -u ${1} >> ${logfile}"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2867|
## Description

The aim of this PR is to improve the management of the service exit code and output. This PR fix a bug: the Installation assistant didn't stop when a service failed. This is caused when using the verbose option. The `systemctl` command is concatenated with a tee comand `| tee` and the exit code is always 0, even if the `systemctl` command fails.

This PR separates the evaluation of the `systemctl` command and the print of the output of the command.

## Manual testing

An AIO installation has been performed to test the changes:

<details><summary>:green_circle: AIO installation log</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -a -i -v
16/05/2024 13:51:41 DEBUG: Checking root permissions.
16/05/2024 13:51:41 DEBUG: Checking sudo package.
16/05/2024 13:51:41 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
16/05/2024 13:51:41 INFO: Verbose logging redirected to /var/log/wazuh-install.log
16/05/2024 13:51:41 DEBUG: APT package manager will be used.
16/05/2024 13:51:41 DEBUG: Checking system distribution.
16/05/2024 13:51:41 DEBUG: Detected distribution name: ubuntu
16/05/2024 13:51:41 DEBUG: Detected distribution version: 22
16/05/2024 13:51:41 DEBUG: Installing check dependencies.
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:3 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [14.1 MB]
Get:6 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1467 kB]
Get:7 http://security.ubuntu.com/ubuntu jammy-security/main Translation-en [252 kB]
Get:8 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [1866 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/universe Translation-en [5652 kB]
Get:10 http://security.ubuntu.com/ubuntu jammy-security/restricted Translation-en [317 kB]
Get:11 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [852 kB]
Get:12 http://security.ubuntu.com/ubuntu jammy-security/universe Translation-en [164 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy/universe amd64 c-n-f Metadata [286 kB]
Get:14 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 c-n-f Metadata [16.8 kB]
Get:15 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [37.2 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [217 kB]
Get:17 http://security.ubuntu.com/ubuntu jammy-security/multiverse Translation-en [7588 B]
Get:18 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 c-n-f Metadata [260 B]
Get:19 http://archive.ubuntu.com/ubuntu jammy/multiverse Translation-en [112 kB]
Get:20 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 c-n-f Metadata [8372 B]
Get:21 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1678 kB]
Get:22 http://archive.ubuntu.com/ubuntu jammy-updates/main Translation-en [311 kB]
Get:23 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [1923 kB]
Get:24 http://archive.ubuntu.com/ubuntu jammy-updates/restricted Translation-en [327 kB]
Get:25 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1074 kB]
Get:26 http://archive.ubuntu.com/ubuntu jammy-updates/universe Translation-en [246 kB]
Get:27 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 c-n-f Metadata [22.1 kB]
Get:28 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [42.7 kB]
Get:29 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse Translation-en [10.4 kB]
Get:30 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 c-n-f Metadata [472 B]
Get:31 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [67.1 kB]
Get:32 http://archive.ubuntu.com/ubuntu jammy-backports/main Translation-en [11.0 kB]
Get:33 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 c-n-f Metadata [388 B]
Get:34 http://archive.ubuntu.com/ubuntu jammy-backports/restricted amd64 c-n-f Metadata [116 B]
Get:35 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [27.2 kB]
Get:36 http://archive.ubuntu.com/ubuntu jammy-backports/universe Translation-en [16.2 kB]
Get:37 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 c-n-f Metadata [644 B]
Get:38 http://archive.ubuntu.com/ubuntu jammy-backports/multiverse amd64 c-n-f Metadata [116 B]
Fetched 31.4 MB in 7s (4423 kB/s)
Reading package lists...
16/05/2024 13:52:02 DEBUG: Checking Wazuh installation.
16/05/2024 13:52:05 DEBUG: Checking system architecture.
16/05/2024 13:52:05 WARNING: Hardware and system checks ignored.
16/05/2024 13:52:05 DEBUG: Installing check dependencies.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
16/05/2024 13:52:10 INFO: Wazuh web interface port will be 443.
16/05/2024 13:52:11 DEBUG: Checking ports availability.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
16/05/2024 13:52:14 DEBUG: Installing prerequisites dependencies.
16/05/2024 13:52:18 INFO: --- Dependencies ----
16/05/2024 13:52:18 INFO: Installing apt-transport-https.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: apt-transport-https 0 upgraded, 1 newly installed, 0 to remove and 90 not upgraded. Need to get 1510 B of archives. After this operation, 170 kB of additional disk space will be used. Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 apt-transport-https all 2.4.12 [1510 B] Fetched 1510 B in 0s (3601 B/s)  NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1
16/05/2024 13:52:23 INFO: Installing debhelper.

16/05/2024 13:52:59 DEBUG: Checking curl tool version.
16/05/2024 13:52:59 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: directory '/root/.gnupg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [37.8 kB]
Fetched 55.1 kB in 2s (27.3 kB/s)
Reading package lists...
16/05/2024 13:53:03 INFO: Wazuh development repository added.
16/05/2024 13:53:03 INFO: --- Configuration files ---
16/05/2024 13:53:03 INFO: Generating configuration files.
16/05/2024 13:53:04 DEBUG: Creating Wazuh certificates.
16/05/2024 13:53:04 DEBUG: Reading configuration file.
16/05/2024 13:53:04 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:04 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:04 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:04 INFO: Generating the root certificate.
16/05/2024 13:53:04 INFO: Generating Admin certificates.
16/05/2024 13:53:04 DEBUG: Generating Admin private key.
16/05/2024 13:53:05 DEBUG: Converting Admin private key to PKCS8 format.
16/05/2024 13:53:05 DEBUG: Generating Admin CSR.
16/05/2024 13:53:05 DEBUG: Creating Admin certificate.
16/05/2024 13:53:05 INFO: Generating Wazuh indexer certificates.
16/05/2024 13:53:05 DEBUG: Creating the certificates for wazuh-indexer indexer node.
16/05/2024 13:53:05 DEBUG: Generating certificate configuration.
16/05/2024 13:53:05 DEBUG: Creating the Wazuh indexer tmp key pair.
16/05/2024 13:53:05 DEBUG: Creating the Wazuh indexer certificates.
16/05/2024 13:53:05 INFO: Generating Filebeat certificates.
16/05/2024 13:53:05 DEBUG: Generating the certificates for wazuh-server server node.
16/05/2024 13:53:05 DEBUG: Generating certificate configuration.
16/05/2024 13:53:05 DEBUG: Creating the Wazuh server tmp key pair.
16/05/2024 13:53:05 DEBUG: Creating the Wazuh server certificates.
16/05/2024 13:53:05 INFO: Generating Wazuh dashboard certificates.
16/05/2024 13:53:05 DEBUG: Generating certificate configuration.
16/05/2024 13:53:05 DEBUG: Creating the Wazuh dashboard tmp key pair.
16/05/2024 13:53:06 DEBUG: Creating the Wazuh dashboard certificates.
16/05/2024 13:53:06 DEBUG: Cleaning certificate files.
16/05/2024 13:53:06 DEBUG: Generating password file.
16/05/2024 13:53:06 DEBUG: Generating random passwords.
16/05/2024 13:53:06 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
16/05/2024 13:53:06 DEBUG: Extracting Wazuh configuration.
16/05/2024 13:53:06 DEBUG: Reading configuration file.
16/05/2024 13:53:06 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:06 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:06 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 13:53:06 INFO: --- Wazuh indexer ---
16/05/2024 13:53:06 INFO: Starting Wazuh indexer installation.
16/05/2024 14:01:20 DEBUG: Checking Wazuh installation.
16/05/2024 14:01:21 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:01:21 INFO: Wazuh indexer installation finished.
16/05/2024 14:01:21 DEBUG: Configuring Wazuh indexer.
16/05/2024 14:01:22 DEBUG: Copying Wazuh indexer certificates.
16/05/2024 14:01:22 INFO: Wazuh indexer post-install configuration finished.
16/05/2024 14:01:22 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.

16/05/2024 14:01:44 INFO: wazuh-indexer service started.
16/05/2024 14:01:44 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
16/05/2024 14:01:55 INFO: Wazuh indexer cluster security configuration initialized.
16/05/2024 14:01:55 INFO: Wazuh indexer cluster initialized.
16/05/2024 14:01:55 INFO: --- Wazuh server ---
16/05/2024 14:01:55 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 89 not upgraded. Need to get 316 MB of archives. After this operation, 916 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-manager amd64 4.8.0-1 [316 MB] Fetched 3 NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-timesyncd.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
16/05/2024 14:04:02 DEBUG: Checking Wazuh installation.
16/05/2024 14:04:02 DEBUG: There are Wazuh remaining files.
16/05/2024 14:04:03 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:04:03 INFO: Wazuh manager installation finished.
16/05/2024 14:04:03 DEBUG: Configuring Wazuh manager.
16/05/2024 14:04:03 DEBUG: Setting provisional Wazuh indexer password.
16/05/2024 14:04:04 INFO: Wazuh manager vulnerability detection configuration finished.
16/05/2024 14:04:04 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.

16/05/2024 14:04:25 INFO: wazuh-manager service started.
16/05/2024 14:04:25 INFO: Starting Filebeat installation.
16/05/2024 14:05:15 DEBUG: Checking Wazuh installation.
16/05/2024 14:05:16 DEBUG: There are Wazuh remaining files.
16/05/2024 14:05:16 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:05:17 DEBUG: There are Filebeat remaining files.
16/05/2024 14:05:17 INFO: Filebeat installation finished.
16/05/2024 14:05:17 DEBUG: Configuring Filebeat.
16/05/2024 14:05:18 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
16/05/2024 14:05:19 DEBUG: Filebeat module was downloaded successfully.
16/05/2024 14:05:19 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
16/05/2024 14:05:21 INFO: Filebeat post-install configuration finished.
16/05/2024 14:05:21 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.

16/05/2024 14:05:23 INFO: filebeat service started.
16/05/2024 14:05:23 INFO: --- Wazuh dashboard ---
16/05/2024 14:05:23 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 89 not upgraded. Need to get 186 MB of archives. After this operation, 987 MB of additional disk space will be used. Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-dashboard amd64 4.8.0-1 [186 MB] Fetched 186 MB in 2min 13s (1401 NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-timesyncd.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
16/05/2024 14:08:39 DEBUG: Checking Wazuh installation.
16/05/2024 14:08:39 DEBUG: There are Wazuh remaining files.
16/05/2024 14:08:40 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:08:40 DEBUG: There are Filebeat remaining files.
16/05/2024 14:08:41 DEBUG: There are Wazuh dashboard remaining files.
16/05/2024 14:08:41 INFO: Wazuh dashboard installation finished.
16/05/2024 14:08:41 DEBUG: Configuring Wazuh dashboard.
16/05/2024 14:08:41 DEBUG: Copying Wazuh dashboard certificates.
16/05/2024 14:08:41 DEBUG: Wazuh dashboard certificate setup finished.
16/05/2024 14:08:41 INFO: Wazuh dashboard post-install configuration finished.
16/05/2024 14:08:41 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.

16/05/2024 14:08:41 INFO: wazuh-dashboard service started.
16/05/2024 14:08:41 DEBUG: Setting Wazuh indexer cluster passwords.
16/05/2024 14:08:41 DEBUG: Checking Wazuh installation.
16/05/2024 14:08:42 DEBUG: There are Wazuh remaining files.
16/05/2024 14:08:42 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:08:43 DEBUG: There are Filebeat remaining files.
16/05/2024 14:08:43 DEBUG: There are Wazuh dashboard remaining files.
16/05/2024 14:08:43 INFO: Updating the internal users.
16/05/2024 14:08:43 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
16/05/2024 14:08:52 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
16/05/2024 14:08:52 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
16/05/2024 14:08:52 DEBUG: The internal users have been updated before changing the passwords.
16/05/2024 14:08:55 DEBUG: Generating password hashes.
16/05/2024 14:09:05 DEBUG: Password hashes generated.
16/05/2024 14:09:05 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
16/05/2024 14:09:11 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
16/05/2024 14:09:12 DEBUG: Restarting filebeat service...

16/05/2024 14:09:12 DEBUG: filebeat started.
16/05/2024 14:09:12 DEBUG: Restarting wazuh-manager service...

16/05/2024 14:09:39 DEBUG: wazuh-manager started.
16/05/2024 14:09:43 DEBUG: Restarting wazuh-dashboard service...

16/05/2024 14:09:44 DEBUG: wazuh-dashboard started.
16/05/2024 14:09:44 DEBUG: Running security admin tool.
16/05/2024 14:09:44 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/vagrant
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
16/05/2024 14:09:54 DEBUG: Passwords changed.
16/05/2024 14:09:54 DEBUG: Changing API passwords.
16/05/2024 14:10:06 INFO: Initializing Wazuh dashboard web application.
16/05/2024 14:10:06 INFO: Wazuh dashboard web application not yet initialized. Waiting...
16/05/2024 14:10:22 INFO: Wazuh dashboard web application not yet initialized. Waiting...
16/05/2024 14:10:37 INFO: Wazuh dashboard web application initialized.
16/05/2024 14:10:37 INFO: --- Summary ---
16/05/2024 14:10:37 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: CKVkk25*hrJuThDYLeKbgXpBUYAn?k*.
16/05/2024 14:10:37 DEBUG: Restoring Wazuh repository.
16/05/2024 14:10:37 INFO: Installation finished.
root@ubuntu22:/home/vagrant# 
```
</details>


<details><summary>Service failed - with verbose option</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -t wazuh-install-files.tar -wi node-1 -i -v
16/05/2024 14:47:25 DEBUG: Checking root permissions.
16/05/2024 14:47:25 DEBUG: Checking sudo package.
16/05/2024 14:47:25 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
16/05/2024 14:47:25 INFO: Verbose logging redirected to /var/log/wazuh-install.log
16/05/2024 14:47:25 DEBUG: APT package manager will be used.
16/05/2024 14:47:25 DEBUG: Checking system distribution.
16/05/2024 14:47:25 DEBUG: Detected distribution name: ubuntu
16/05/2024 14:47:25 DEBUG: Detected distribution version: 22
16/05/2024 14:47:25 DEBUG: Installing check dependencies.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
16/05/2024 14:47:31 DEBUG: Checking Wazuh installation.
16/05/2024 14:47:32 DEBUG: Checking system architecture.
16/05/2024 14:47:33 WARNING: Hardware and system checks ignored.
16/05/2024 14:47:33 DEBUG: Installing check dependencies.
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
16/05/2024 14:47:38 DEBUG: Checking previous certificate existence.
16/05/2024 14:47:38 DEBUG: Checking ports availability.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
16/05/2024 14:47:42 DEBUG: Installing prerequisites dependencies.
16/05/2024 14:47:44 DEBUG: Checking curl tool version.
16/05/2024 14:47:44 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [37.8 kB]
Fetched 55.1 kB in 2s (27.8 kB/s)
Reading package lists...
16/05/2024 14:47:48 INFO: Wazuh development repository added.
16/05/2024 14:47:48 DEBUG: Extracting Wazuh configuration.
16/05/2024 14:47:48 DEBUG: Reading configuration file.
16/05/2024 14:47:49 DEBUG: Checking if 127.0.0.1 is private.
16/05/2024 14:47:49 DEBUG: Checking node names in the configuration file.
16/05/2024 14:47:49 INFO: --- Wazuh indexer ---
16/05/2024 14:47:49 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 89 not upgraded. Need to get 0 B/759 MB of archives. After this operation, 1050 MB of additional disk space will be used. Selecting previously unselec NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: filebeat.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-timesyncd.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
16/05/2024 14:48:47 DEBUG: Checking Wazuh installation.
16/05/2024 14:48:48 DEBUG: There are Wazuh indexer remaining files.
16/05/2024 14:48:49 INFO: Wazuh indexer installation finished.
16/05/2024 14:48:49 DEBUG: Configuring Wazuh indexer.
16/05/2024 14:48:49 DEBUG: Copying Wazuh indexer certificates.
16/05/2024 14:48:49 INFO: Wazuh indexer post-install configuration finished.
16/05/2024 14:48:49 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
Job for wazuh-indexer.service failed because the control process exited with error code. See "systemctl status wazuh-indexer.service" and "journalctl -xeu wazuh-indexer.service" for details.
16/05/2024 14:48:57 ERROR: wazuh-indexer could not be started.
16/05/2024 14:48:57 INFO: --- Removing existing Wazuh installation ---
16/05/2024 14:48:57 INFO: Removing Wazuh indexer.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 89 not upgraded.
                                                               After this operation, 1050 MB disk space will be freed.
(Reading database ... 72091 files and directories currently installed.)
Removing wazuh-indexer (4.8.0-1) ...
Stopping wazuh-indexer service... OK
Deleting installation directory... OK
(Reading database ... 70958 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.8.0-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/usr/lib/systemd/system' not empty so not removed
16/05/2024 14:49:05 INFO: Wazuh indexer removed.
16/05/2024 14:49:05 DEBUG: Removing GPG key from system.
16/05/2024 14:49:05 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```
</details>


<details><summary>Service failed - without verbose option</summary>

```console
root@ubuntu22:/home/vagrant# bash wazuh-install.sh -t wazuh-install-files.tar -wi node-1 -i
16/05/2024 15:04:31 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
16/05/2024 15:04:31 INFO: Verbose logging redirected to /var/log/wazuh-install.log
16/05/2024 15:04:41 WARNING: Hardware and system checks ignored.
16/05/2024 15:05:03 INFO: Wazuh development repository added.
16/05/2024 15:05:03 INFO: --- Wazuh indexer ---
16/05/2024 15:05:03 INFO: Starting Wazuh indexer installation.
16/05/2024 15:06:08 INFO: Wazuh indexer installation finished.
16/05/2024 15:06:08 INFO: Wazuh indexer post-install configuration finished.
16/05/2024 15:06:08 INFO: Starting service wazuh-indexer.
16/05/2024 15:06:19 ERROR: wazuh-indexer could not be started.
16/05/2024 15:06:19 INFO: --- Removing existing Wazuh installation ---
16/05/2024 15:06:19 INFO: Removing Wazuh indexer.
16/05/2024 15:06:29 INFO: Wazuh indexer removed.
16/05/2024 15:06:29 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```


```console
root@ubuntu22:/home/vagrant# cat /var/log/wazuh-install.log 
16/05/2024 15:04:31 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
16/05/2024 15:04:31 INFO: Verbose logging redirected to /var/log/wazuh-install.log
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
16/05/2024 15:04:41 WARNING: Hardware and system checks ignored.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [37.8 kB]
Fetched 55.1 kB in 2s (27.8 kB/s)
Reading package lists...
16/05/2024 15:05:03 INFO: Wazuh development repository added.
16/05/2024 15:05:03 INFO: --- Wazuh indexer ---
16/05/2024 15:05:03 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 89 not upgraded. Need to get 0 B/759 MB of archives. After this operation, 1050 MB of additional disk space will be used. Selecting previously unselec NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.15.0-92-generic NEEDRESTART-KEXP: 5.15.0-92-generic NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: cron.service NEEDRESTART-SVC: dbus.service NEEDRESTART-SVC: filebeat.service NEEDRESTART-SVC: getty@tty1.service NEEDRESTART-SVC: irqbalance.service NEEDRESTART-SVC: multipathd.service NEEDRESTART-SVC: networkd-dispatcher.service NEEDRESTART-SVC: packagekit.service NEEDRESTART-SVC: polkit.service NEEDRESTART-SVC: rsyslog.service NEEDRESTART-SVC: serial-getty@ttyS0.service NEEDRESTART-SVC: snapd.service NEEDRESTART-SVC: ssh.service NEEDRESTART-SVC: systemd-journald.service NEEDRESTART-SVC: systemd-logind.service NEEDRESTART-SVC: systemd-networkd.service NEEDRESTART-SVC: systemd-resolved.service NEEDRESTART-SVC: systemd-timesyncd.service NEEDRESTART-SVC: systemd-udevd.service NEEDRESTART-SVC: unattended-upgrades.service NEEDRESTART-SVC: user@1000.service
16/05/2024 15:06:08 INFO: Wazuh indexer installation finished.
16/05/2024 15:06:08 INFO: Wazuh indexer post-install configuration finished.
16/05/2024 15:06:08 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
Job for wazuh-indexer.service failed because the control process exited with error code. See "systemctl status wazuh-indexer.service" and "journalctl -xeu wazuh-indexer.service" for details.
16/05/2024 15:06:19 ERROR: wazuh-indexer could not be started.
May 16 14:01:22 ubuntu22 systemd[1]: Starting Wazuh-indexer...
May 16 14:01:25 ubuntu22 systemd-entrypoint[6381]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:01:25 ubuntu22 systemd-entrypoint[6381]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:01:25 ubuntu22 systemd-entrypoint[6381]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
May 16 14:01:25 ubuntu22 systemd-entrypoint[6381]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:01:26 ubuntu22 systemd-entrypoint[6381]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:01:26 ubuntu22 systemd-entrypoint[6381]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:01:26 ubuntu22 systemd-entrypoint[6381]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
May 16 14:01:26 ubuntu22 systemd-entrypoint[6381]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:01:44 ubuntu22 systemd[1]: Started Wazuh-indexer.
May 16 14:12:54 ubuntu22 systemd[1]: Stopping Wazuh-indexer...
May 16 14:12:55 ubuntu22 systemd[1]: wazuh-indexer.service: Deactivated successfully.
May 16 14:12:55 ubuntu22 systemd[1]: Stopped Wazuh-indexer.
May 16 14:12:55 ubuntu22 systemd[1]: wazuh-indexer.service: Consumed 1min 28.659s CPU time.
May 16 14:27:04 ubuntu22 systemd[1]: Starting Wazuh-indexer...
May 16 14:27:07 ubuntu22 systemd-entrypoint[60434]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:27:07 ubuntu22 systemd-entrypoint[60434]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:27:07 ubuntu22 systemd-entrypoint[60434]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
May 16 14:27:07 ubuntu22 systemd-entrypoint[60434]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:27:09 ubuntu22 systemd-entrypoint[60434]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:27:09 ubuntu22 systemd-entrypoint[60434]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:27:09 ubuntu22 systemd-entrypoint[60434]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
May 16 14:27:09 ubuntu22 systemd-entrypoint[60434]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:27:24 ubuntu22 systemd[1]: Started Wazuh-indexer.
May 16 14:35:06 ubuntu22 systemd[1]: Stopping Wazuh-indexer...
May 16 14:35:07 ubuntu22 systemd[1]: wazuh-indexer.service: Deactivated successfully.
May 16 14:35:07 ubuntu22 systemd[1]: Stopped Wazuh-indexer.
May 16 14:35:07 ubuntu22 systemd[1]: wazuh-indexer.service: Consumed 1min 25.304s CPU time.
May 16 14:46:10 ubuntu22 systemd[1]: Starting Wazuh-indexer...
May 16 14:46:13 ubuntu22 systemd-entrypoint[114926]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:46:13 ubuntu22 systemd-entrypoint[114926]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:46:13 ubuntu22 systemd-entrypoint[114926]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
May 16 14:46:13 ubuntu22 systemd-entrypoint[114926]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:46:15 ubuntu22 systemd-entrypoint[114926]: WARNING: A terminally deprecated method in java.lang.System has been called
May 16 14:46:15 ubuntu22 systemd-entrypoint[114926]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.10.0.jar)
May 16 14:46:15 ubuntu22 systemd-entrypoint[114926]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
May 16 14:46:15 ubuntu22 systemd-entrypoint[114926]: WARNING: System::setSecurityManager will be removed in a future release
May 16 14:46:30 ubuntu22 systemd[1]: Started Wazuh-indexer.
May 16 14:46:54 ubuntu22 systemd[1]: Stopping Wazuh-indexer...
May 16 14:46:54 ubuntu22 systemd[1]: wazuh-indexer.service: Deactivated successfully.
May 16 14:46:54 ubuntu22 systemd[1]: Stopped Wazuh-indexer.
May 16 14:46:54 ubuntu22 systemd[1]: wazuh-indexer.service: Consumed 42.321s CPU time.
May 16 14:48:50 ubuntu22 systemd[1]: Starting Wazuh-indexer...
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]: Exception in thread "main" SettingsException[Failed to load settings from /etc/wazuh-indexer/opensearch.yml]; nested: AccessDeniedException[/etc/wazuh-indexer/opensearch.yml];
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:98)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:118)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:109)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.cli.Command.main(Command.java:101)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.common.settings.KeyStoreCli.main(KeyStoreCli.java:56)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]: Caused by: java.nio.file.AccessDeniedException: /etc/wazuh-indexer/opensearch.yml
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at java.base/java.nio.file.Files.newInputStream(Files.java:160)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.common.settings.Settings$Builder.loadFromPath(Settings.java:1117)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         at org.opensearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:96)
May 16 14:48:51 ubuntu22 systemd-entrypoint[117937]:         ... 8 more
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]: uncaught exception in thread [main]
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]: java.lang.IllegalStateException: failed to load plugin class [org.opensearch.security.OpenSearchSecurityPlugin]
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]: Likely root cause: OpenSearchException[plugins.security.ssl.transport.keystore_filepath or plugins.security.ssl.transport.server.pemcert_filepath and plugins.security.ssl.transport.client.pemcert_filepath must be set if transport ssl is requested.]
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.initTransportSSLConfig(DefaultSecurityKeyStore.java:485)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.initSSLConfig(DefaultSecurityKeyStore.java:296)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.<init>(DefaultSecurityKeyStore.java:202)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.security.ssl.OpenSearchSecuritySSLPlugin.<init>(OpenSearchSecuritySSLPlugin.java:231)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.security.OpenSearchSecurityPlugin.<init>(OpenSearchSecurityPlugin.java:269)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.plugins.PluginsService.loadPlugin(PluginsService.java:782)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.plugins.PluginsService.loadBundle(PluginsService.java:731)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.plugins.PluginsService.loadBundles(PluginsService.java:533)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.plugins.PluginsService.<init>(PluginsService.java:195)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.node.Node.<init>(Node.java:474)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.node.Node.<init>(Node.java:401)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:242)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:242)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.cli.Command.main(Command.java:101)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]:         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103)
May 16 14:48:57 ubuntu22 systemd-entrypoint[117874]: For complete error details, refer to the log at /usr/share/wazuh-indexer/logs/opensearch.log
May 16 14:48:57 ubuntu22 systemd[1]: wazuh-indexer.service: Main process exited, code=exited, status=1/FAILURE
May 16 14:48:57 ubuntu22 systemd[1]: wazuh-indexer.service: Failed with result 'exit-code'.
May 16 14:48:57 ubuntu22 systemd[1]: Failed to start Wazuh-indexer.
May 16 14:48:57 ubuntu22 systemd[1]: wazuh-indexer.service: Consumed 11.208s CPU time.
May 16 15:06:09 ubuntu22 systemd[1]: Starting Wazuh-indexer...
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]: java.lang.IllegalStateException: failed to load plugin class [org.opensearch.security.OpenSearchSecurityPlugin]
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]: Likely root cause: OpenSearchException[plugins.security.ssl.transport.keystore_filepath or plugins.security.ssl.transport.server.pemcert_filepath and plugins.security.ssl.transport.client.pemcert_filepath must be set if transport ssl is requested.]
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.initTransportSSLConfig(DefaultSecurityKeyStore.java:485)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.initSSLConfig(DefaultSecurityKeyStore.java:296)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.security.ssl.DefaultSecurityKeyStore.<init>(DefaultSecurityKeyStore.java:202)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.security.ssl.OpenSearchSecuritySSLPlugin.<init>(OpenSearchSecuritySSLPlugin.java:231)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.security.OpenSearchSecurityPlugin.<init>(OpenSearchSecurityPlugin.java:269)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.plugins.PluginsService.loadPlugin(PluginsService.java:782)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.plugins.PluginsService.loadBundle(PluginsService.java:731)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.plugins.PluginsService.loadBundles(PluginsService.java:533)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.plugins.PluginsService.<init>(PluginsService.java:195)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.node.Node.<init>(Node.java:474)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.node.Node.<init>(Node.java:401)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:242)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:242)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.cli.Command.main(Command.java:101)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]:         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103)
May 16 15:06:19 ubuntu22 systemd-entrypoint[120701]: For complete error details, refer to the log at /usr/share/wazuh-indexer/logs/opensearch.log
May 16 15:06:19 ubuntu22 systemd[1]: wazuh-indexer.service: Main process exited, code=exited, status=1/FAILURE
May 16 15:06:19 ubuntu22 systemd[1]: wazuh-indexer.service: Failed with result 'exit-code'.
May 16 15:06:19 ubuntu22 systemd[1]: Failed to start Wazuh-indexer.
May 16 15:06:19 ubuntu22 systemd[1]: wazuh-indexer.service: Consumed 16.195s CPU time.
16/05/2024 15:06:19 INFO: --- Removing existing Wazuh installation ---
16/05/2024 15:06:19 INFO: Removing Wazuh indexer.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  wazuh-indexer*
0 upgraded, 0 newly installed, 1 to remove and 89 not upgraded.
After this operation, 1050 MB disk space will be freed.
(Reading database ... 72091 files and directories currently installed.)
Removing wazuh-indexer (4.8.0-1) ...
Stopping wazuh-indexer service... OK
Deleting installation directory... OK
(Reading database ... 70958 files and directories currently installed.)
Purging configuration files for wazuh-indexer (4.8.0-1) ...
Deleting configuration directory... OK
dpkg: warning: while removing wazuh-indexer, directory '/var/log/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/var/lib/wazuh-indexer' not empty so not removed
dpkg: warning: while removing wazuh-indexer, directory '/usr/lib/systemd/system' not empty so not removed
16/05/2024 15:06:29 INFO: Wazuh indexer removed.
16/05/2024 15:06:29 INFO: Installation cleaned. Check the /var/log/wazuh-install.log file to learn more about the issue.
```
</details>


## Automatic testing

- :green_circle: CentOS 7: https://ci.wazuh.info/job/Test_unattended/5594/
- :green_circle: CentOS 8: https://ci.wazuh.info/job/Test_unattended/5595/
- :green_circle: Ubuntu 18: https://ci.wazuh.info/job/Test_unattended/5596/
- :green_circle: Ubuntu 16: https://ci.wazuh.info/job/Test_unattended/5597/
- :green_circle: Ubuntu 20: https://ci.wazuh.info/job/Test_unattended/5598/
- :green_circle: AL2: https://ci.wazuh.info/job/Test_unattended/5599/
- :green_circle: RHEL7: https://ci.wazuh.info/job/Test_unattended/5600/