### PR TITLE
Fixed `check_log_errors` function of unattended pytest

### DIFF
--- a/tests/unattended/install/test_unattended.py
+++ b/tests/unattended/install/test_unattended.py
@@ -208,10 +208,17 @@ def test_check_wazuh_api_status():
 @pytest.mark.wazuh
 def test_check_log_errors():
     found_error = False
+    exceptions = [
+        'WARNING: Cluster error detected',
+        'agent-upgrade: ERROR: (8123): There has been an error executing the request in the tasks manager.',
+        "ERROR: Could not send message through the cluster after '10' attempts"
+
+    ]
+    
     with open('/var/ossec/logs/ossec.log', 'r') as f:
         for line in f.readlines():
             if 'ERROR' in line:
-                if 'ERROR: Cluster error detected' not in line and 'agent-upgrade: ERROR: (8123): There has been an error executing the request in the tasks manager.' not in line:
+                if not any(exception in line for exception in exceptions):
                     found_error = True
                     break
     assert found_error == False, line


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2952|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

The aim of this PR is to fix the `test_check_log_errors` function of the `test_unattended.py` pytest. The following exception has been added in order to make the pipeline not fail by mistake: `ERROR: Could not send message through the cluster after '10' attempts`. 

Also, the checks of the exception have been reworked, and the exceptions have been added to the list for better coding and look.
Related issues:
- https://github.com/wazuh/wazuh/issues/20790
- https://github.com/wazuh/wazuh/issues/11794

## Tests

:green_circle: The `Test_unattended_distributed` pipeline has been launched to test the new development. The pipeline succeeded after the change: https://ci.wazuh.info/job/Test_unattended_distributed/700/console

:green_circle: The `Test_unattended` pipeline has been tested launching the `Test_unattended_tier` pipeline:  if not any(exception in line for exception in exceptions):