### PR TITLE
Fix css selector to login button

### DIFF
--- a/stack/dashboard/base/files/etc/custom_welcome/light_theme.style.css
+++ b/stack/dashboard/base/files/etc/custom_welcome/light_theme.style.css
@@ -4473,7 +4473,7 @@ input:focus {
   margin-top: 32px;
 }
 
-div.euiFormRow > div.euiFormRow__fieldWrapper > button {
+.wz-login .btn-login {
   background-color: #3595F9!important;
   border-color: #3595F9!important;
   color: #fff;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-dashboard-plugins/issues/6571|

## Description

This PR improves the CSS selector for the login button to apply Wazuh branding colors. Previously, the CSS selector was less specific, so the style was incorrectly applied to other buttons like `App Settings > Miscellaneous`.

## Evidence

## Test

1. Generate the package
2. Go to `Login` and check the button color. The button must have the color of the brand.
3. Go to `App Settings > Miscellaneous` and check the button color. The button must have the color of the theme.