### PR TITLE
Fixed typo in Wazuh Installation Assistant

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -213,7 +213,7 @@ function main() {
     if [ -n "${showVersion}" ]; then
         common_logger "Wazuh version: ${wazuh_version}"
         common_logger "Filebeat version: ${filebeat_version}"
-        common_logger "Wazuh installation assistant version: ${wazuh_install_vesion}"
+        common_logger "Wazuh installation assistant version: ${wazuh_install_version}"
         exit 0
     fi
 

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -10,7 +10,7 @@
 readonly wazuh_major="5.0"
 readonly wazuh_version="5.0.0"
 readonly filebeat_version="7.10.2"
-readonly wazuh_install_vesion="0.1"
+readonly wazuh_install_version="0.1"
 readonly source_branch="v${wazuh_version}"
 
 ## Links and paths to resources


### PR DESCRIPTION
|Related issue|
|---|
|Related: https://github.com/wazuh/wazuh-packages/issues/2951|

## Description

This issue's objective is to fix a typo in Wazuh Installation Assistant.
The typo is on the variable `wazuh_install_vesion` and it's fixed to be `wazuh_install_version`.
This variable is used on the `installMain.sh` file in the case the Installation Assistant is run with the `-V` option.

## Tests

I made a test with the changes and the output is the following:
```shellsession
[root@centos7 unattended_installer]# bash wazuh-install.sh -V
23/05/2024 10:42:10 INFO: Wazuh version: 4.7.3
23/05/2024 10:42:10 INFO: Filebeat version: 7.10.2
23/05/2024 10:42:10 INFO: Wazuh installation assistant version: 0.1
```
