### PR TITLE
Update 4.8.0 release date

### DIFF
--- a/aix/SPECS/wazuh-agent-aix.spec
+++ b/aix/SPECS/wazuh-agent-aix.spec
@@ -290,7 +290,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 
 %changelog
-* Thu May 16 2024 support <info@wazuh.com> - 4.8.0
+* Thu May 30 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Mon May 27 2024 support <info@wazuh.com> - 4.7.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html

--- a/debs/SPECS/wazuh-agent/debian/changelog
+++ b/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,7 +2,7 @@ wazuh-agent (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 16 May 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
 
 wazuh-agent (4.7.5-RELEASE) stable; urgency=low
 

--- a/debs/SPECS/wazuh-agent/debian/copyright
+++ b/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Thu, 16 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Thu, 30 May 2024 00:00:00 +0000
 
 It was downloaded from:
 

--- a/debs/SPECS/wazuh-manager/debian/changelog
+++ b/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,7 +2,7 @@ wazuh-manager (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 16 May 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
 
 wazuh-manager (4.7.5-RELEASE) stable; urgency=low
 

--- a/debs/SPECS/wazuh-manager/debian/copyright
+++ b/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Thu, 16 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Thu, 30 May 2024 00:00:00 +0000
 
 It was downloaded from:
 

--- a/rpms/SPECS/wazuh-agent.spec
+++ b/rpms/SPECS/wazuh-agent.spec
@@ -610,7 +610,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Thu May 16 2024 support <info@wazuh.com> - 4.8.0
+* Thu May 30 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Mon May 27 2024 support <info@wazuh.com> - 4.7.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html

--- a/rpms/SPECS/wazuh-manager.spec
+++ b/rpms/SPECS/wazuh-manager.spec
@@ -855,7 +855,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Thu May 16 2024 support <info@wazuh.com> - 4.8.0
+* Thu May 30 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Mon May 27 2024 support <info@wazuh.com> - 4.7.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html

--- a/stack/dashboard/deb/debian/changelog
+++ b/stack/dashboard/deb/debian/changelog
@@ -2,7 +2,7 @@ wazuh-dashboard (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 16 May 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
 
 wazuh-dashboard (4.7.5-RELEASE) stable; urgency=low
 

--- a/stack/dashboard/deb/debian/copyright
+++ b/stack/dashboard/deb/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Thu, 16 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Thu, 30 May 2024 00:00:00 +0000
 
 It was downloaded from:
 

--- a/stack/dashboard/rpm/wazuh-dashboard.spec
+++ b/stack/dashboard/rpm/wazuh-dashboard.spec
@@ -346,7 +346,7 @@ rm -fr %{buildroot}
 %config(noreplace) %attr(640, %{USER}, %{GROUP}) "%{CONFIG_DIR}/opensearch_dashboards.yml"
 
 %changelog
-* Thu May 16 2024 support <info@wazuh.com> - 4.8.0
+* Thu May 30 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Mon May 27 2024 support <info@wazuh.com> - 4.7.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html

--- a/stack/indexer/deb/debian/changelog
+++ b/stack/indexer/deb/debian/changelog
@@ -2,7 +2,7 @@ wazuh-indexer (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Thu, 16 May 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
 
 wazuh-indexer (4.7.5-RELEASE) stable; urgency=low
 

--- a/stack/indexer/deb/debian/copyright
+++ b/stack/indexer/deb/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Thu, 16 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Thu, 30 May 2024 00:00:00 +0000
 
 It was downloaded from:
 

--- a/stack/indexer/rpm/wazuh-indexer.spec
+++ b/stack/indexer/rpm/wazuh-indexer.spec
@@ -681,7 +681,7 @@ rm -fr %{buildroot}
 
 
 %changelog
-* Thu May 16 2024 support <info@wazuh.com> - 4.8.0
+* Thu May 30 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Mon May 27 2024 support <info@wazuh.com> - 4.7.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/23564 |

This PR aims to fix the following build error, by updating the 4.8.0 release date:

```
error: %changelog not in descending chronological order
```