### PR TITLE
Solve bugs when changing passwords in the manager, indexer and dashboard services

### DIFF
--- a/unattended_installer/passwords_tool/passwordsMain.sh
+++ b/unattended_installer/passwords_tool/passwordsMain.sh
@@ -224,7 +224,7 @@ function main() {
                 passwords_getApiIds
             elif [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; then
                 passwords_readDashboardUsers
-            elif [ -n "${indexer_installed}" ]; then
+            elif [ -n "${indexer_installed}" ] || [ -n "${wazuh_installed}" ]; then
                 passwords_readUsers
             fi
             passwords_checkUser
@@ -241,7 +241,7 @@ function main() {
         
 
         if [ -n "${changeall}" ] || [ -n "${p_file}" ]; then
-            if [ -n "${indexer_installed}" ]; then
+            if [ -n "${indexer_installed}" ] || [ -n "${wazuh_installed}" ]; then
                 passwords_readUsers
             fi
 
@@ -273,12 +273,15 @@ function main() {
             passwords_runSecurityAdmin
         fi
 
-        if [ -n "${api}" ] || [ -n "${changeall}" ] || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
+        # Call the function to change the password for filebeat and/or kibanaserver
+        if [ -z "${indexer_installed}" ] && { [ -n "${wazuh_installed}" ] || [ -n "${dashboard_installed}" ]; }; then
+            passwords_changePassword
+        fi
+
+        if [ -n "${api}" ] || [ -n "${changeall}" ]; then
             if { [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; } || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
                 passwords_changePasswordApi
-            fi
-            if [ -z "${wazuh_installed}" ] && [ -z "${indexer_installed}" ] && [ -n "${dashboard_installed}" ]; then
-                passwords_changePassword
+
             fi
         fi
 

--- a/unattended_installer/passwords_tool/passwordsMain.sh
+++ b/unattended_installer/passwords_tool/passwordsMain.sh
@@ -222,6 +222,8 @@ function main() {
                 passwords_getApiToken
                 passwords_getApiUsers
                 passwords_getApiIds
+            elif [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; then
+                passwords_readDashboardUsers
             elif [ -n "${indexer_installed}" ]; then
                 passwords_readUsers
             fi
@@ -242,12 +244,17 @@ function main() {
             if [ -n "${indexer_installed}" ]; then
                 passwords_readUsers
             fi
-            if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
-                passwords_getApiToken
-                passwords_getApiUsers
-                passwords_getApiIds
-            else
-                common_logger "Wazuh API admin credentials not provided, Wazuh API passwords not changed."
+
+            if [ -n "${wazuh_installed}" ]; then
+                if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+                    passwords_getApiToken
+                    passwords_getApiUsers
+                    passwords_getApiIds
+                else
+                    common_logger "Wazuh API admin credentials not provided, Wazuh API passwords not changed."
+                fi
+            elif  [ -n "${dashboard_installed}" ]; then
+                passwords_readDashboardUsers
             fi
             if [ -n "${changeall}" ]; then
                 passwords_generatePassword
@@ -266,9 +273,12 @@ function main() {
             passwords_runSecurityAdmin
         fi
 
-        if [ -n "${api}" ] || [ -n "${changeall}" ]; then
-            if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; then
+        if [ -n "${api}" ] || [ -n "${changeall}" ] || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
+            if { [ -n "${adminUser}" ] && [ -n "${adminPassword}" ]; } || { [ -z "${wazuh_installed}" ] && [ -n "${dashboard_installed}" ]; }; then
                 passwords_changePasswordApi
+            fi
+            if [ -z "${wazuh_installed}" ] && [ -z "${indexer_installed}" ] && [ -n "${dashboard_installed}" ]; then
+                passwords_changePassword
             fi
         fi
 


### PR DESCRIPTION
|Related issue| 
|---|
|#1854|

## Description

When changing the passwords for the different services, neither the Filebeat password in the manager nor the wazuh-wui password in the dashboard were updated. Also in the indexer there was a message indicating that there were no API users, which was a bit confusing. The steps to solve this problem have been:

### Password file

In order to be able to change the filebeat password in the wazuh-manager, a new user `admin` has been created in the API users section. This user will have the same password as the `admin` user in the indexer section. This provides a way to manage the Filebeat password from the manager.

#### Tests

When generating the passwords we can see how a new API user `admin` is generated with the same password as indexer `admin` user.

```
root@debian10:/home/vagrant/passwords_good# bash wazuh-passwords-tool2.sh -gf wazuh-passwords_update.txt
root@debian10:/home/vagrant/passwords_good# cat wazuh-passwords_update.txt
# Admin user for the web user interface and Wazuh indexer. Use this user to log in to Wazuh dashboard
  indexer_username: 'admin'
  indexer_password: 'VpSUav82Y8x05AT*+*sqU406mAKIq8.g'

# Wazuh dashboard user for establishing the connection with Wazuh indexer
  indexer_username: 'kibanaserver'
  indexer_password: 'EKf49pm3QtqszKgWiz.HRfEc5adN7QFY'

# Regular Dashboard user, only has read permissions to all indices and all permissions on the .kibana index
  indexer_username: 'kibanaro'
  indexer_password: 'AO6TqgWcSLi?C5JL*3hL8Lklrmbr9+XT'

# Filebeat user for CRUD operations on Wazuh indices
  indexer_username: 'logstash'
  indexer_password: 'Pp21DOyGGgCpVUqy9*FabHC41udZqPOO'

# User with READ access to all indices
  indexer_username: 'readall'
  indexer_password: 'Zr42iiK1?5H3Zta7IlEuly224?NqPtwm'

# User with permissions to perform snapshot and restore operations
  indexer_username: 'snapshotrestore'
  indexer_password: '.cLInM3Pxb4KsOGGuP.4rvOZiiuJ7*ws'

# Password for wazuh API user
  api_username: 'wazuh'
  api_password: '9qdiBXzBX?hpXACy3W1r2h8Jjq5keEMn'

# Password for wazuh-wui API user
  api_username: 'wazuh-wui'
  api_password: 'r7jH.SQ4SMqbzVXcbJrkiyrwvWd+G*w8'

# Password for filebeat admin user
  api_username: 'admin'
  api_password: 'VpSUav82Y8x05AT*+*sqU406mAKIq8.g'
```

### Wazuh indexer

In the indexer section we had the problem that a message appeared regarding the change of API user passwords: `INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.` Which was a bit confusing if the manager was not installed on the machine.
Now every time we try to change the indexer passwords without having the manager installed, we won't get the message again.

#### Tests

```
root@debian10:/home/vagrant/passwords_good# bash wazuh-passwords-tool2.sh --change-all -f wazuh-passwords_update.txt
29/05/2024 09:45:01 INFO: Updating the internal users.
29/05/2024 09:45:11 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
29/05/2024 09:45:34 INFO: The password for user admin is VpSUav82Y8x05AT*+*sqU406mAKIq8.g
29/05/2024 09:45:34 INFO: The password for user kibanaserver is EKf49pm3QtqszKgWiz.HRfEc5adN7QFY
29/05/2024 09:45:34 INFO: The password for user kibanaro is AO6TqgWcSLi?C5JL*3hL8Lklrmbr9+XT
29/05/2024 09:45:34 INFO: The password for user logstash is Pp21DOyGGgCpVUqy9*FabHC41udZqPOO
29/05/2024 09:45:34 INFO: The password for user readall is Zr42iiK1?5H3Zta7IlEuly224?NqPtwm
29/05/2024 09:45:34 INFO: The password for user snapshotrestore is .cLInM3Pxb4KsOGGuP.4rvOZiiuJ7*ws
29/05/2024 09:45:34 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
``` 

### Wazuh manager

Regarding the manager, the problem was that when we changed the passwords with the `--changeall` option, the Filebeat password was not changed. 
Now, a new user has been added to the users section of the API called `Filebeat`. With these changes, if we put this user with his password in the password file, it will be changed correctly in the manager.
Also, being a manager user, we can change the Filebeat password with the `--user` and `--password` option as well.

#### Tests

When executing the `filebeat test output` command we see that the filebeat password is wrong and therefore we get the error `ERROR 401 Unauthorized: Unauthorized`.

```
[root@localhost passwords_good]# filebeat test output
elasticsearch: https://192.168.56.13:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 192.168.56.13
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... ERROR 401 Unauthorized: Unauthorized
```
- Change Filebeat password with the `--changeall` option:
```
[root@localhost passwords_good]# bash wazuh-passwords-tool2.sh --change-all --admin-user wazuh --admin-password 7vSm?eM.PZSe7+1zyMpZRPPaQcH5YW3p -f wazuh-passwords_update.txt
28/05/2024 09:48:06 INFO: The password for Wazuh API user wazuh is 9qdiBXzBX?hpXACy3W1r2h8Jjq5keEMn
28/05/2024 09:48:07 INFO: The password for Wazuh API user wazuh-wui is r7jH.SQ4SMqbzVXcbJrkiyrwvWd+G*w8
28/05/2024 09:49:07 INFO: The new password for Filebeat is VpSUav82Y8x05AT*+*sqU406mAKIq8.g
```

If we check the connection again, it reconnects:

```
[root@localhost passwords_good]# filebeat test output
elasticsearch: https://192.168.56.13:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 192.168.56.13
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
  version: 7.10.2
```

- We can also change the Filebeat password with `--user` and `--password`.
```
[root@localhost passwords_good]# bash wazuh-passwords-tool2.sh --admin-user wazuh --admin-password 9qdiBXzBX?hpXACy3W1r2h8Jjq5keEMn --api  --user admin --password VpSUav82Y8x05AT*+*sqU406mAKIq8.g
28/05/2024 10:18:59 INFO: The new password for Filebeat is VpSUav82Y8x05AT*+*sqU406mAKIq8.g
```

### Wazuh dashboard

With the dashboard we had the problem that we couldn't change the password for `kibanaserver` and `wazuh-wui`. Like the server, we can now change the passwords of these with the `--changeall` option and also with `--user` and `--password`.

#### Tests

- Change dashboard passwords with `--changeall`.
```
root@debian9:/home/vagrant/passwords_good# bash wazuh-passwords-tool.sh --change-all -f wazuh-passwords_update.txt
29/05/2024 10:45:56 INFO: The password for the kibanaserver user in the dashboard has been updated to EKf49pm3QtqszKgWiz.HRfEc5adN7QFY
29/05/2024 10:46:07 INFO: Updated wazuh-wui user password in wazuh dashboard to 'r7jH.SQ4SMqbzVXcbJrkiyrwvWd+G*w8'. 
```
- Change dashboard passwords with `--user` and `--password`.
```
root@debian9:/home/vagrant/passwords_good# bash wazuh-passwords-tool.sh --user kibanaserver --password EKf49pm3QtqszKgWiz.HRfEc5adN7QFY
29/05/2024 10:50:55 INFO: The password for the kibanaserver user in the dashboard has been updated to EKf49pm3QtqszKgWiz.HRfEc5adN7QFY

root@debian9:/home/vagrant/passwords_good# bash wazuh-passwords-tool.sh --user wazuh-wui --password r7jH.SQ4SMqbzVXcbJrkiyrwvWd+G*w8
28/05/2024 12:22:52 INFO: Updated wazuh-wui user password in wazuh dashboard to 'r7jH.SQ4SMqbzVXcbJrkiyrwvWd+G*w8'.
```

When passwords are changed and the dashboard url is accessed, it works correctly.

### All-in-one deployment

Tests have also been done for when there is an AIO. 

#### Tests

- Everything has been tested for correctness when changing all passwords without specifying API users:
```console
$ bash wazuh-passwords-tool2.sh --change-all -f wazuh-passwords_update.txt
04/06/2024 11:52:15 INFO: Updating the internal users.
04/06/2024 11:52:25 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
04/06/2024 11:52:25 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
04/06/2024 11:53:46 INFO: The password for user admin is ?9zBL5vLxdiechfjoCFVL7rNAN+36.b9
04/06/2024 11:53:46 INFO: The password for user kibanaserver is 1e6bGRTx?8z5KWJnqra+Mzwnk6rCkyri
04/06/2024 11:53:46 INFO: The password for user kibanaro is kBuhapjyQ170ObEA3AmZjyISS*W.11d4
04/06/2024 11:53:46 INFO: The password for user logstash is *1pd0Ntv.YsankXLmuTYT4OqBRVX+YbD
04/06/2024 11:53:46 INFO: The password for user readall is mcdRtvPv9wz5hQyH+.QuiFVHfFoeAg?X
04/06/2024 11:53:46 INFO: The password for user snapshotrestore is 6pRcmPHVay3jZSp?*4UW?arKC+DpIBF6
04/06/2024 11:53:46 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
```
- Change of all passwords where API passwords are changed as well.  If we check the output of filebeat, we can see that it works correctly.
```console
$ bash wazuh-passwords-tool2.sh --change-all --admin-user wazuh --admin-password 7Ei?ypDsCK.49JCkamajmBYrP5RlJICu -f wazuh-passwords_update.txt
04/06/2024 12:04:57 INFO: Updating the internal users.
04/06/2024 12:05:05 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
04/06/2024 12:06:31 INFO: The password for user admin is ?9zBL5vLxdiechfjoCFVL7rNAN+36.b9
04/06/2024 12:06:31 INFO: The password for user kibanaserver is 1e6bGRTx?8z5KWJnqra+Mzwnk6rCkyri
04/06/2024 12:06:31 INFO: The password for user kibanaro is kBuhapjyQ170ObEA3AmZjyISS*W.11d4
04/06/2024 12:06:31 INFO: The password for user logstash is *1pd0Ntv.YsankXLmuTYT4OqBRVX+YbD
04/06/2024 12:06:31 INFO: The password for user readall is mcdRtvPv9wz5hQyH+.QuiFVHfFoeAg?X
04/06/2024 12:06:31 INFO: The password for user snapshotrestore is 6pRcmPHVay3jZSp?*4UW?arKC+DpIBF6
04/06/2024 12:06:31 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
04/06/2024 12:06:34 INFO: The password for Wazuh API user wazuh is 7Ei?ypDsCK.49JCkamajmBYrP5RlJICu
04/06/2024 12:06:35 INFO: The password for Wazuh API user wazuh-wui is HPAhx+gmunIeoyb8ImYga3v6858*baQd
04/06/2024 12:06:35 INFO: Updated wazuh-wui user password in wazuh dashboard.
$ filebeat test output
elasticsearch: https://127.0.0.1:9200...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.2
    dial up... OK
  talk to server... OK
  version: 7.10.2
```

- When the dashboard is installed in a distributed deployment, we can change the password of the user that communicates with the server without giving the admin credentials. In this case, as the manager is installed, we would have to specify them. If we try this, we get the following output:
```console
$ bash wazuh-passwords-tool2.sh --user wazuh-wui --password 59_pRcmPHVay3jZSp?*4UW?nMrKF+DpIFF3
04/06/2024 12:15:31 INFO: Updating the internal users.
04/06/2024 12:15:39 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
04/06/2024 12:15:39 ERROR: The given user does not exist
```
If we do it with the right credentials, we can see that it does change:

```console
$ bash wazuh-passwords-tool2.sh --user wazuh-wui --password
root@ip-172-31-44-59:/home/ubuntu# bash wazuh-passwords-tool2.sh --api --admin-user wazuh --admin-password 7Ei?ypDsCK.49JCkamajmBYrP5RlJICu --user wazuh-wui --password 59_pRcmPHVay3jZSp?*4UW?nMrKF+DpIFF3
04/06/2024 12:33:05 INFO: The password for Wazuh API user wazuh-wui is 59_pRcmPHVay3jZSp?*4UW?nMrKF+DpIFF3
04/06/2024 12:33:05 INFO: Updated wazuh-wui user password in wazuh dashboard.
```
Everything works correctly with the changes:
![Captura de pantalla 2024-06-04 a las 14 38 34](https://github.com/wazuh/wazuh-packages/assets/74021522/a0791ac1-0b29-4308-bcdc-435d8f2971fb)
