### PR TITLE
Added support for Rocky Linux 9.4 in Installation assistant

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -200,7 +200,8 @@ function check_curlVersion() {
 function check_dist() {
     common_logger -d "Checking system distribution."
     dist_detect
-    if [ "${DIST_NAME}" != "centos" ] && [ "${DIST_NAME}" != "rhel" ] && [ "${DIST_NAME}" != "amzn" ] && [ "${DIST_NAME}" != "ubuntu" ]; then
+    if  [ "${DIST_NAME}" != "centos" ] && [ "${DIST_NAME}" != "rhel" ] &&
+        [ "${DIST_NAME}" != "amzn" ]   && [ "${DIST_NAME}" != "ubuntu" ] && [ "${DIST_NAME}" != "rocky" ]; then
         notsupported=1
     fi
     if [ "${DIST_NAME}" == "centos" ] && { [ "${DIST_VER}" -ne "7" ] && [ "${DIST_VER}" -ne "8" ]; }; then
@@ -211,9 +212,9 @@ function check_dist() {
     fi
 
     if [ "${DIST_NAME}" == "amzn" ]; then
-        if [ "${DIST_VER}" != "2" ] &&
-           [ "${DIST_VER}" != "2023" ] &&
-           [ "${DIST_VER}" != "2018.03" ]; then
+        if  [ "${DIST_VER}" != "2" ] &&
+            [ "${DIST_VER}" != "2023" ] &&
+            [ "${DIST_VER}" != "2018.03" ]; then
             notsupported=1
         fi
         if [ "${DIST_VER}" -eq "2023" ]; then
@@ -232,6 +233,13 @@ function check_dist() {
             notsupported=1
         fi
     fi
+
+    if [ "${DIST_NAME}" == "rocky" ]; then
+        if [ "${DIST_VER}" != "9" ] || [ "${DIST_SUBVER}" != "4" ]; then
+            notsupported=1
+        fi
+    fi
+
     if [ -n "${notsupported}" ] && [ -z "${ignore}" ]; then
         common_logger -e "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check."
         exit 1


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-qa/issues/5435|

The OS was added to the supported systems of the Installation assistant.

<details><summary>:green_circle: Installation log</summary>

```console
[root@ip-172-31-92-255 rocky]# bash wazuh-install.sh -a -v
29/05/2024 14:01:13 DEBUG: Checking root permissions.
29/05/2024 14:01:13 DEBUG: Checking sudo package.
29/05/2024 14:01:13 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
29/05/2024 14:01:13 INFO: Verbose logging redirected to /var/log/wazuh-install.log
29/05/2024 14:01:13 DEBUG: YUM package manager will be used.
29/05/2024 14:01:13 DEBUG: Checking system distribution.
29/05/2024 14:01:13 DEBUG: Detected distribution name: rocky
29/05/2024 14:01:13 DEBUG: Detected distribution version: 9
29/05/2024 14:01:13 DEBUG: Installing check dependencies.
29/05/2024 14:01:13 DEBUG: Checking Wazuh installation.
29/05/2024 14:01:13 DEBUG: Checking system architecture.
29/05/2024 14:01:13 INFO: Verifying that your system meets the recommended minimum hardware requirements.
29/05/2024 14:01:13 DEBUG: CPU cores detected: 2
29/05/2024 14:01:13 DEBUG: Free RAM memory detected: 3848
29/05/2024 14:01:13 DEBUG: Installing check dependencies.
29/05/2024 14:01:13 INFO: Wazuh web interface port will be 443.
29/05/2024 14:01:13 INFO: --- Dependencies ---
29/05/2024 14:01:13 INFO: Installing lsof.
Last metadata expiration check: 0:36:00 ago on Wed 29 May 2024 01:25:14 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: lsof x86_64 4.94.0-3.el9 baseos 238 k Transaction Summary ================================================================================ Install 1 Package Total download size: 238 k Installed size: 624 k Downloading Packages: lsof-4.94.0-3.el9.x86_64.rpm 599 kB/s | 238 kB 00:00 -------------------------------------------------------------------------------- Total 476 kB/s | 238 kB 00:00 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Installing : lsof-4.94.0-3.el9.x86_64 1/1 Running scriptlet: lsof-4.94.0-3.el9.x86_64 1/1 Verifying : lsof-4.94.0-3.el9.x86_64 1/1 Installed: lsof-4.94.0-3.el9.x86_64 Complete!
Last metadata expiration check: 0:36:00 ago on Wed 29 May 2024 01:25:14 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: lsof x86_64 4.94.0-3.el9 baseos 238 k Transaction Summary ================================================================================ Install 1 Package Total download size: 238 k Installed size: 624 k Downloading Packages: lsof-4.94.0-3.el9.x86_64.rpm 599 kB/s | 238 kB 00:00 -------------------------------------------------------------------------------- Total 476 kB/s | 238 kB 00:00 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Installing : lsof-4.94.0-3.el9.x86_64 1/1 Running scriptlet: lsof-4.94.0-3.el9.x86_64 1/1 Verifying : lsof-4.94.0-3.el9.x86_64 1/1 Installed: lsof-4.94.0-3.el9.x86_64 Complete!
29/05/2024 14:01:16 DEBUG: Checking ports availability.
29/05/2024 14:01:16 DEBUG: Installing prerequisites dependencies.
29/05/2024 14:01:16 DEBUG: Checking curl tool version.
29/05/2024 14:01:16 DEBUG: Adding the Wazuh repository.
[wazuh]
gpgcheck=1
gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
enabled=1
name=EL-${releasever} - Wazuh
baseurl=https://packages-dev.wazuh.com/pre-release/yum/
protect=1
29/05/2024 14:01:17 INFO: Wazuh development repository added.
29/05/2024 14:01:17 INFO: --- Configuration files ---
29/05/2024 14:01:17 INFO: Generating configuration files.
29/05/2024 14:01:17 DEBUG: Creating Wazuh certificates.
29/05/2024 14:01:17 DEBUG: Reading configuration file.
29/05/2024 14:01:17 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:17 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:17 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:17 INFO: Generating the root certificate.
29/05/2024 14:01:18 INFO: Generating Admin certificates.
29/05/2024 14:01:18 DEBUG: Generating Admin private key.
29/05/2024 14:01:18 DEBUG: Converting Admin private key to PKCS8 format.
29/05/2024 14:01:18 DEBUG: Generating Admin CSR.
29/05/2024 14:01:18 DEBUG: Creating Admin certificate.
29/05/2024 14:01:18 INFO: Generating Wazuh indexer certificates.
29/05/2024 14:01:18 DEBUG: Creating the certificates for wazuh-indexer indexer node.
29/05/2024 14:01:18 DEBUG: Generating certificate configuration.
29/05/2024 14:01:18 DEBUG: Creating the Wazuh indexer tmp key pair.
29/05/2024 14:01:19 DEBUG: Creating the Wazuh indexer certificates.
29/05/2024 14:01:19 INFO: Generating Filebeat certificates.
29/05/2024 14:01:19 DEBUG: Generating the certificates for wazuh-server server node.
29/05/2024 14:01:19 DEBUG: Generating certificate configuration.
29/05/2024 14:01:19 DEBUG: Creating the Wazuh server tmp key pair.
29/05/2024 14:01:19 DEBUG: Creating the Wazuh server certificates.
29/05/2024 14:01:19 INFO: Generating Wazuh dashboard certificates.
29/05/2024 14:01:19 DEBUG: Generating certificate configuration.
29/05/2024 14:01:19 DEBUG: Creating the Wazuh dashboard tmp key pair.
29/05/2024 14:01:20 DEBUG: Creating the Wazuh dashboard certificates.
29/05/2024 14:01:20 DEBUG: Cleaning certificate files.
29/05/2024 14:01:20 DEBUG: Generating password file.
29/05/2024 14:01:20 DEBUG: Generating random passwords.
29/05/2024 14:01:20 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
29/05/2024 14:01:20 DEBUG: Extracting Wazuh configuration.
29/05/2024 14:01:20 DEBUG: Reading configuration file.
29/05/2024 14:01:21 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:21 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:21 DEBUG: Checking if 127.0.0.1 is private.
29/05/2024 14:01:21 INFO: --- Wazuh indexer ---
29/05/2024 14:01:21 INFO: Starting Wazuh indexer installation.
EL-9 - Wazuh 11 MB/s | 26 MB 00:02 Last metadata expiration check: 0:00:12 ago on Wed 29 May 2024 02:01:22 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: wazuh-indexer x86_64 4.8.0-1 wazuh 743 M Transaction Summary ================================================================================ Install 1 Package Total download size: 743 M Installed size: 1.0 G Downloading Packages: wazuh-indexer-4.8.0-1.x86_64.rpm 24 MB/s | 743 MB 00:30 -------------------------------------------------------------------------------- Total 24 MB/s | 743 MB 00:30 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Running scriptlet: wazuh-indexer-4.8.0-1.x86_64 1/1 Installing : wazuh-indexer-4.8.0-1.x86_64 1/1 Running scriptlet: wazuh-indexer-4.8.0-1.x86_64 1/1 Created opensearch keystore in /etc/wazuh-indexer/opensearch.keystore Verifying : wazuh-indexer-4.8.0-1.x86_64 1/1 Installed: wazuh-indexer-4.8.0-1.x86_64 Complete!
29/05/2024 14:03:27 DEBUG: Checking Wazuh installation.
29/05/2024 14:03:27 DEBUG: There are Wazuh indexer remaining files.
29/05/2024 14:03:27 INFO: Wazuh indexer installation finished.
29/05/2024 14:03:27 DEBUG: Configuring Wazuh indexer.
29/05/2024 14:03:27 DEBUG: Copying Wazuh indexer certificates.
29/05/2024 14:03:27 INFO: Wazuh indexer post-install configuration finished.
29/05/2024 14:03:27 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /usr/lib/systemd/system/wazuh-indexer.service.
29/05/2024 14:03:51 INFO: wazuh-indexer service started.
29/05/2024 14:03:51 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
29/05/2024 14:04:02 INFO: Wazuh indexer cluster security configuration initialized.
29/05/2024 14:04:02 INFO: Wazuh indexer cluster initialized.
29/05/2024 14:04:02 INFO: --- Wazuh server ---
29/05/2024 14:04:02 INFO: Starting the Wazuh manager installation.
Last metadata expiration check: 0:02:41 ago on Wed 29 May 2024 02:01:22 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: wazuh-manager x86_64 4.8.0-1 wazuh 298 M Transaction Summary ================================================================================ Install 1 Package Total download size: 298 M Installed size: 887 M Downloading Packages: wazuh-manager-4.8.0-1.x86_64.rpm 42 MB/s | 298 MB 00:07 -------------------------------------------------------------------------------- Total 42 MB/s | 298 MB 00:07 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Running scriptlet: wazuh-manager-4.8.0-1.x86_64 1/1 Installing : wazuh-manager-4.8.0-1.x86_64 1/1 Running scriptlet: wazuh-manager-4.8.0-1.x86_64 1/1 Verifying : wazuh-manager-4.8.0-1.x86_64 1/1 Installed: wazuh-manager-4.8.0-1.x86_64 Complete!
29/05/2024 14:05:27 DEBUG: Checking Wazuh installation.
29/05/2024 14:05:27 DEBUG: There are Wazuh remaining files.
29/05/2024 14:05:27 DEBUG: There are Wazuh indexer remaining files.
29/05/2024 14:05:27 INFO: Wazuh manager installation finished.
29/05/2024 14:05:27 DEBUG: Configuring Wazuh manager.
29/05/2024 14:05:27 DEBUG: Setting provisional Wazuh indexer password.
29/05/2024 14:05:27 INFO: Wazuh manager vulnerability detection configuration finished.
29/05/2024 14:05:27 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /usr/lib/systemd/system/wazuh-manager.service.
29/05/2024 14:05:40 INFO: wazuh-manager service started.
29/05/2024 14:05:40 INFO: Starting Filebeat installation.
Last metadata expiration check: 0:04:20 ago on Wed 29 May 2024 02:01:22 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: filebeat x86_64 7.10.2-1 wazuh 21 M Transaction Summary ================================================================================ Install 1 Package Total download size: 21 M Installed size: 70 M Downloading Packages: filebeat-oss-7.10.2-x86_64.rpm 16 MB/s | 21 MB 00:01 -------------------------------------------------------------------------------- Total 16 MB/s | 21 MB 00:01 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Installing : filebeat-7.10.2-1.x86_64 1/1 Running scriptlet: filebeat-7.10.2-1.x86_64 1/1 Verifying : filebeat-7.10.2-1.x86_64 1/1 Installed: filebeat-7.10.2-1.x86_64 Complete!
29/05/2024 14:06:49 DEBUG: Checking Wazuh installation.
29/05/2024 14:06:49 DEBUG: There are Wazuh remaining files.
29/05/2024 14:06:49 DEBUG: There are Wazuh indexer remaining files.
29/05/2024 14:06:49 DEBUG: There are Filebeat remaining files.
29/05/2024 14:06:49 INFO: Filebeat installation finished.
29/05/2024 14:06:49 DEBUG: Configuring Filebeat.
29/05/2024 14:06:49 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
29/05/2024 14:06:50 DEBUG: Filebeat module was downloaded successfully.
29/05/2024 14:06:50 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
29/05/2024 14:06:52 INFO: Filebeat post-install configuration finished.
29/05/2024 14:06:52 INFO: Starting service filebeat.
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /usr/lib/systemd/system/filebeat.service.
29/05/2024 14:06:53 INFO: filebeat service started.
29/05/2024 14:06:53 INFO: --- Wazuh dashboard ---
29/05/2024 14:06:53 INFO: Starting Wazuh dashboard installation.
Last metadata expiration check: 0:00:30 ago on Wed 29 May 2024 02:06:26 PM UTC. Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Installing: wazuh-dashboard x86_64 4.8.0-1 wazuh 275 M Transaction Summary ================================================================================ Install 1 Package Total download size: 275 M Installed size: 911 M Downloading Packages: wazuh-dashboard-4.8.0-1.x86_64.rpm 22 MB/s | 275 MB 00:12 -------------------------------------------------------------------------------- Total 22 MB/s | 275 MB 00:12 Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Running scriptlet: wazuh-dashboard-4.8.0-1.x86_64 1/1 Installing : wazuh-dashboard-4.8.0-1.x86_64 1/1 Running scriptlet: wazuh-dashboard-4.8.0-1.x86_64 1/1 Verifying : wazuh-dashboard-4.8.0-1.x86_64 1/1 Installed: wazuh-dashboard-4.8.0-1.x86_64 Complete!
29/05/2024 14:09:53 DEBUG: Checking Wazuh installation.
29/05/2024 14:09:53 DEBUG: There are Wazuh remaining files.
29/05/2024 14:09:53 DEBUG: There are Wazuh indexer remaining files.
29/05/2024 14:09:53 DEBUG: There are Filebeat remaining files.
29/05/2024 14:09:53 DEBUG: There are Wazuh dashboard remaining files.
29/05/2024 14:09:53 INFO: Wazuh dashboard installation finished.
29/05/2024 14:09:53 DEBUG: Configuring Wazuh dashboard.
29/05/2024 14:09:53 DEBUG: Copying Wazuh dashboard certificates.
29/05/2024 14:09:53 DEBUG: Wazuh dashboard certificate setup finished.
29/05/2024 14:09:53 INFO: Wazuh dashboard post-install configuration finished.
29/05/2024 14:09:53 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
29/05/2024 14:09:54 INFO: wazuh-dashboard service started.
29/05/2024 14:09:54 DEBUG: Setting Wazuh indexer cluster passwords.
29/05/2024 14:09:54 DEBUG: Checking Wazuh installation.
29/05/2024 14:09:54 DEBUG: There are Wazuh remaining files.
29/05/2024 14:09:55 DEBUG: There are Wazuh indexer remaining files.
29/05/2024 14:09:55 DEBUG: There are Filebeat remaining files.
29/05/2024 14:09:55 DEBUG: There are Wazuh dashboard remaining files.
29/05/2024 14:09:55 INFO: Updating the internal users.
29/05/2024 14:09:55 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
29/05/2024 14:10:09 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
29/05/2024 14:10:09 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
29/05/2024 14:10:09 DEBUG: The internal users have been updated before changing the passwords.
29/05/2024 14:10:11 DEBUG: Generating password hashes.
29/05/2024 14:10:26 DEBUG: Password hashes generated.
29/05/2024 14:10:26 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
29/05/2024 14:10:32 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
29/05/2024 14:10:32 DEBUG: Restarting filebeat service...
29/05/2024 14:10:33 DEBUG: filebeat started.
29/05/2024 14:10:33 DEBUG: Restarting wazuh-manager service...
29/05/2024 14:10:51 DEBUG: wazuh-manager started.
29/05/2024 14:10:55 DEBUG: Restarting wazuh-dashboard service...
29/05/2024 14:10:56 DEBUG: wazuh-dashboard started.
29/05/2024 14:10:56 DEBUG: Running security admin tool.
29/05/2024 14:10:56 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/rocky
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
29/05/2024 14:11:08 DEBUG: Passwords changed.
29/05/2024 14:11:08 DEBUG: Changing API passwords.
29/05/2024 14:11:18 INFO: Initializing Wazuh dashboard web application.
29/05/2024 14:11:19 INFO: Wazuh dashboard web application not yet initialized. Waiting...
29/05/2024 14:11:35 INFO: Wazuh dashboard web application not yet initialized. Waiting...
29/05/2024 14:11:50 INFO: Wazuh dashboard web application initialized.
29/05/2024 14:11:50 INFO: --- Summary ---
29/05/2024 14:11:50 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: Xv*9Mxwy9?rVQm9N7jyjl4v2IbxlQMkN
29/05/2024 14:11:50 INFO: --- Dependencies ---
29/05/2024 14:11:50 INFO: Removing lsof.
Dependencies resolved. ================================================================================ Package Architecture Version Repository Size ================================================================================ Removing: lsof x86_64 4.94.0-3.el9 @baseos 624 k Transaction Summary ================================================================================ Remove 1 Package Freed space: 624 k Running transaction check Transaction check succeeded. Running transaction test Transaction test succeeded. Running transaction Preparing : 1/1 Erasing : lsof-4.94.0-3.el9.x86_64 1/1 Running scriptlet: lsof-4.94.0-3.el9.x86_64 1/1 Verifying : lsof-4.94.0-3.el9.x86_64 1/1 Removed: lsof-4.94.0-3.el9.x86_64 Complete!
29/05/2024 14:11:52 DEBUG: Restoring Wazuh repository.
29/05/2024 14:11:52 INFO: Installation finished.
[root@ip-172-31-92-255 rocky]# 

```

</details>

:green_circle: Accessing web interface:

![image](https://github.com/wazuh/wazuh-qa/assets/72193239/255747e7-3ce3-4786-895b-906a495e13cb)
