### PR TITLE
Allow installation on any OS

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -240,9 +240,10 @@ function check_dist() {
         fi
     fi
 
-    if [ -n "${notsupported}" ] && [ -z "${ignore}" ]; then
-        common_logger -e "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04. The current system does not match this list. Use -i|--ignore-check to skip this check."
-        exit 1
+    if [ -n "${notsupported}" ]; then
+        
+        common_logger "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04."
+        common_logger -w "The current system does not match with the list of recommended systems. The installation may not work properly."
     fi
     common_logger -d "Detected distribution name: ${DIST_NAME}"
     common_logger -d "Detected distribution version: ${DIST_VER}"

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -241,7 +241,6 @@ function check_dist() {
     fi
 
     if [ -n "${notsupported}" ]; then
-        
         common_logger "The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04."
         common_logger -w "The current system does not match with the list of recommended systems. The installation may not work properly."
     fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -35,7 +35,7 @@ function getHelp() {
     echo -e "                Display this help and exit."
     echo -e ""
     echo -e "        -i,  --ignore-check"
-    echo -e "                Ignore the check for system compatibility and minimum hardware requirements."
+    echo -e "                Ignore the check for minimum hardware requirements."
     echo -e ""
     echo -e "        -o,  --overwrite"
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
@@ -243,7 +243,7 @@ function main() {
 
     checks_arch
     if [ -n "${ignore}" ]; then
-        common_logger -w "Hardware and system checks ignored."
+        common_logger -w "Hardware checks ignored."
     else
         common_logger "Verifying that your system meets the recommended minimum hardware requirements."
         checks_health


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2967|

## Description

The purpose of this PR is to allow the installation of wazuh components on any operating system even if it is not one of the recommended ones. In addition, the logs will always show if an operating system is not one of the recommended ones and will warn the user of possible failures during the installation.

### Tests

<details><summary>Try to install wazuh AIO with a not recommended OS</summary>

```
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
11/06/2024 09:16:03 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
11/06/2024 09:16:03 INFO: Verbose logging redirected to /var/log/wazuh-install.log
11/06/2024 09:16:03 INFO: The recommended systems are: Red Hat Enterprise Linux 7, 8, 9; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04, 22.04.
11/06/2024 09:16:03 WARNING: The current system does not match with the list of recommended systems. The installation may not work properly.
11/06/2024 09:16:28 INFO: Verifying that your system meets the recommended minimum hardware requirements.
11/06/2024 09:16:35 INFO: Wazuh web interface port will be 443.
11/06/2024 09:16:44 INFO: --- Dependencies ----
11/06/2024 09:16:44 INFO: Installing apt-transport-https.
11/06/2024 09:16:51 INFO: Installing debhelper.
11/06/2024 09:17:12 INFO: Wazuh repository added.
11/06/2024 09:17:12 INFO: --- Configuration files ---
11/06/2024 09:17:12 INFO: Generating configuration files.
11/06/2024 09:17:13 INFO: Generating the root certificate.
11/06/2024 09:17:13 INFO: Generating Admin certificates.
11/06/2024 09:17:13 INFO: Generating Wazuh indexer certificates.
11/06/2024 09:17:14 INFO: Generating Filebeat certificates.
11/06/2024 09:17:14 INFO: Generating Wazuh dashboard certificates.
11/06/2024 09:17:14 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
11/06/2024 09:17:15 INFO: --- Wazuh indexer ---
```

As shown, even though the OS is not one of the recommended ones, it continues with the installation.
</details>


## Additional Considerations

The related issue also asks that if the OS has neither YUM nor APT installed, it will show an error and exit the script. This feature was already implemented before, so it was not necessary to implement it.

### Tests

<details><summary>Try to use a OS without YUM or APT</summary>

```
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
11/06/2024 09:43:41 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
11/06/2024 09:43:41 INFO: Verbose logging redirected to /var/log/wazuh-install.log
11/06/2024 09:43:41 ERROR: Couldn't find YUM or APT package manager. Try installing the one corresponding to your operating system and then, launch the installation assistant again.
```

</details>