### PR TITLE
Change cert-tool to use only one wazuh-certificates folder

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -456,7 +456,22 @@ function cert_readConfig() {
 }
 
 function cert_setpermisions() {
-    eval "chmod -R 744 ${cert_tmp_path} ${debug}"
+    eval "chmod -R 744 ${1} ${debug}"
+}
+
+function set_certs_directory() {
+
+    if [ -d "${base_path}/wazuh-certificates" ]; then
+        eval "cp -f ${cert_tmp_path}/* ${base_path}/wazuh-certificates ${debug}"
+        eval "rm -R ${cert_tmp_path}"
+        cert_setpermisions "${base_path}/wazuh-certificates"
+        common_logger -d "Wazuh-certificates directory exists. Copied files from '${cert_tmp_path}' to '${base_path}/wazuh-certificates' and removed '${cert_tmp_path}'."
+    else
+        cert_setpermisions "${cert_tmp_path}"
+        eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+        common_logger -d "Moved '${cert_tmp_path}' to '${base_path}/wazuh-certificates'."
+    fi
+
 }
 
 function cert_convertCRLFtoLF() {

--- a/unattended_installer/cert_tool/certMain.sh
+++ b/unattended_installer/cert_tool/certMain.sh
@@ -159,13 +159,6 @@ function main() {
         done
 
         common_logger "Verbose logging redirected to ${logfile}"
-
-        if [[ -d "${base_path}"/wazuh-certificates ]]; then
-            if [ -n "$(ls -A "${base_path}"/wazuh-certificates)" ]; then
-                common_logger -e "Directory wazuh-certificates already exists in the same path as the script. Please, remove the certs directory to create new certificates."
-                exit 1
-            fi
-        fi
         
         if [[ ! -d "${cert_tmp_path}" ]]; then
             mkdir -p "${cert_tmp_path}"
@@ -183,8 +176,7 @@ function main() {
             cert_generateAdmincertificate
             common_logger "Admin certificates created."
             cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            set_certs_directory
         fi
 
         if [[ -n "${all}" ]]; then
@@ -201,15 +193,13 @@ function main() {
                 common_logger "Wazuh dashboard certificates created."
             fi
             cert_cleanFiles
-            cert_setpermisions
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            set_certs_directory
         fi
 
         if [[ -n "${ca}" ]]; then
             cert_generateRootCAcertificate
             common_logger "Authority certificates created."
-            cert_cleanFiles
-            eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+            set_certs_directory
         fi
 
         if [[ -n "${cindexer}" ]]; then
@@ -218,8 +208,7 @@ function main() {
                 cert_generateIndexercertificates
                 common_logger "Wazuh indexer certificates created."
                 cert_cleanFiles
-                cert_setpermisions
-                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+                set_certs_directory
             else
                 common_logger -e "Indexer node not present in config.yml."
                 exit 1
@@ -232,8 +221,7 @@ function main() {
                 cert_generateFilebeatcertificates
                 common_logger "Wazuh Filebeat certificates created."
                 cert_cleanFiles
-                cert_setpermisions
-                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+                set_certs_directory
             else
                 common_logger -e "Server node not present in config.yml."
                 exit 1
@@ -246,8 +234,7 @@ function main() {
                 cert_generateDashboardcertificates
                 common_logger "Wazuh dashboard certificates created."
                 cert_cleanFiles
-                cert_setpermisions
-                eval "mv ${cert_tmp_path} ${base_path}/wazuh-certificates ${debug}"
+                set_certs_directory
             else
                 common_logger -e "Dashboard node not present in config.yml."
                 exit 1


### PR DESCRIPTION
Before when we want to create different certificates we create one `wazuh-certificates` folder per wazuh component. Now only use one and improve the scalability.

|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/1801 |

## Context

Before, when the `certs-tool.sh` script was executed, a `wazuh-certificates` directory was created in the base directory for each execution. This meant that if you first created certificates for one component, and then wanted to create certificates for another component, it would not allow you to do so as there was already a `wazuh-certificates` directory.
This complicated the creation of certificates for distributions where there were two components installed on the same machine (for example, an indexer and a server).

## Description

With this PR, it is now possible to create certificates for any component by hosting them in the same `wazuh-certificates`. 

If the `wazuh-certificates` directory exists, the new certificates are added to it, overwriting the existing ones. For example, if I create a `root-ca.pem` certificate and try to add another `root-ca.pem` certificate, it will be overwritten, keeping the new changes.

This allows for scalability, being able to generate the necessary certificates without having to save several `wazuh-certificates` directories. 

### Tests

First I create the `CA` certificates:
<details><summary>Create CA certificates</summary>

``` console
root@ubuntu-focal:/home/vagrant# bash wazuh-certs-tool.sh -ca
12/06/2024 11:19:31 INFO: Verbose logging redirected to /home/vagrant/wazuh-certificates-tool.log
12/06/2024 11:19:31 INFO: Generating the root certificate.
12/06/2024 11:19:31 INFO: Authority certificates created.
root@ubuntu-focal:/home/vagrant# ls wazuh-certificates
root-ca.key  root-ca.pem
```

</details>

 If I try to create a new certificate for the dashboard, it is added to the existing directory:
<details><summary>Create Dashboard certificates</summary>

```console
 bash wazuh-certs-tool.sh -wd wazuh-certificates/root-ca.pem wazuh-certificates/root-ca.key -v
12/06/2024 11:20:29 INFO: Verbose logging redirected to /home/vagrant/wazuh-certificates-tool.log
12/06/2024 11:20:29 DEBUG: Reading configuration file.
12/06/2024 11:20:29 DEBUG: Checking if 192.168.56.12 is private.
12/06/2024 11:20:29 DEBUG: Checking if 192.168.56.11 is private.
12/06/2024 11:20:29 DEBUG: Checking if 192.168.56.13 is private.
12/06/2024 11:20:29 DEBUG: Checking if the root CA exists.
12/06/2024 11:20:29 INFO: Generating Wazuh dashboard certificates.
12/06/2024 11:20:29 DEBUG: Generating certificate configuration.
12/06/2024 11:20:29 DEBUG: Creating the Wazuh dashboard tmp key pair.
12/06/2024 11:20:29 DEBUG: Creating the Wazuh dashboard certificates.
12/06/2024 11:20:29 INFO: Wazuh dashboard certificates created.
12/06/2024 11:20:29 DEBUG: Cleaning certificate files.
12/06/2024 11:20:29 DEBUG: Wazuh-certificates directory exists. Copied files from '/tmp/wazuh-certificates' to '/home/vagrant/wazuh-certificates' and removed '/tmp/wazuh-certificates'.
root@ubuntu-focal:/home/vagrant# ls wazuh-certificates
dashboard-key.pem  dashboard.pem  root-ca.key  root-ca.pem
```
</details>
