### PR TITLE
Added `--install-dependencies` parameter to OVA generation

### DIFF
--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -14,7 +14,7 @@ CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ASSETS_PATH="${CURRENT_PATH}/assets"
 CUSTOM_PATH="${ASSETS_PATH}/custom"
 BUILDER_ARGS="-i"
-INSTALL_ARGS="-a"
+INSTALL_ARGS="-a --install-dependencies"
 
 if [[ "${PACKAGES_REPOSITORY}" == "dev" ]]; then
   BUILDER_ARGS+=" -d"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2879|

## Description

The aim of this PR is to add the new `-id|--install-dependencies` parameter to the OVA generation. This parameter will make the Installation assistant to install the necessary dependencies automatically. Related: https://github.com/wazuh/wazuh-packages/pull/3002

In the following log, it is checked that the OVA is using the new parameter to install Wazuh, and the installation is not stopped.

```console
./generate_ova.sh -r dev -g yes                                      
Version to build: 5.0.0 with development repository
==> default: VM not created. Moving on...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'amznlinux-2'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: vm_wazuh
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: wazuh-user
    default: SSH auth method: password
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Rsyncing folder: /home/davidcr01/Wazuh/wazuh-packages/ova/ => /tmp
==> default:   - Exclude: [".vagrant/", "output"]
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20240613-13308-cezy9o.sh
    default: Using dev packages
    default: + bash /tmp/unattended_installer/builder.sh -i -d
    default: ++ cut -d '"' -f 2
    default: ++ cat /tmp/unattended_installer/wazuh-install.sh
    default: ++ grep wazuh_version=
    default: + WAZUH_VERSION=5.0.0
    default: + systemConfig
    default: Upgrading the system. This may take a while ...
    default: + echo 'Upgrading the system. This may take a while ...'
    default: + yum upgrade -y
    default: + mv /tmp/assets/custom/grub/wazuh.png /boot/grub2/
    default: + mv /tmp/assets/custom/grub/grub /etc/default/
    default: + grub2-mkconfig -o /boot/grub2/grub.cfg
    default: + mv /tmp/assets/custom/enable_fips.sh /tmp/
    default: + chmod 755 /tmp/enable_fips.sh
    default: + bash /tmp/enable_fips.sh
    default: Loaded plugins: langpacks, priorities, update-motd
    default: No packages marked for update
    default: Loaded plugins: langpacks, priorities, update-motd
    default: Resolving Dependencies
    default: --> Running transaction check
    default: ---> Package dracut-fips.x86_64 0:033-535.amzn2.1.6 will be installed
    default: --> Processing Dependency: hmaccalc for package: dracut-fips-033-535.amzn2.1.6.x86_64
    default: --> Running transaction check
    default: ---> Package hmaccalc.x86_64 0:0.9.13-4.amzn2.0.1 will be installed
    default: --> Finished Dependency Resolution
    default: 
    default: Dependencies Resolved
    default: 
    default: ================================================================================
    default:  Package           Arch         Version                  Repository        Size
    default: ================================================================================
    default: Installing:
    default:  dracut-fips       x86_64       033-535.amzn2.1.6        amzn2-core        60 k
    default: Installing for dependencies:
    default:  hmaccalc          x86_64       0.9.13-4.amzn2.0.1       amzn2-core        26 k
    default: 
    default: Transaction Summary
    default: ================================================================================
    default: Install  1 Package (+1 Dependent package)
    default: 
    default: Total download size: 87 k
    default: Installed size: 107 k
    default: Downloading packages:
    default: --------------------------------------------------------------------------------
    default: Total                                               26 kB/s |  87 kB  00:03
    default: Running transaction check
    default: Running transaction test
    default: Transaction test succeeded
    default: Running transaction
    default:   Installing : hmaccalc-0.9.13-4.amzn2.0.1.x86_64                           1/2
    default:   Installing : dracut-fips-033-535.amzn2.1.6.x86_64                         2/2
    default:   Verifying  : dracut-fips-033-535.amzn2.1.6.x86_64                         1/2
    default:   Verifying  : hmaccalc-0.9.13-4.amzn2.0.1.x86_64                           2/2
    default: 
    default: Installed:
    default:   dracut-fips.x86_64 0:033-535.amzn2.1.6
    default: 
    default: Dependency Installed:
    default:   hmaccalc.x86_64 0:0.9.13-4.amzn2.0.1
    default: 
    default: Complete!
    default: + mv /tmp/assets/custom/automatic_set_ram.sh /etc/
    default: + chmod 755 /etc/automatic_set_ram.sh
    default: + mv /tmp/assets/custom/updateIndexerHeap.service /etc/systemd/system/
    default: + systemctl daemon-reload
    default: + systemctl enable updateIndexerHeap.service
    default: Created symlink from /etc/systemd/system/multi-user.target.wants/updateIndexerHeap.service to /etc/systemd/system/updateIndexerHeap.service.
    default: + sed -i 's/root:.*:/root:$1$pNjjEA7K$USjdNwjfh7A\.vHCf8suK41::0:99999:7:::/g' /etc/shadow
    default: + hostname wazuh-server
    default: + sed -i 's/PermitRootLogin yes/#PermitRootLogin yes/g' /etc/ssh/sshd_config
    default: + sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
    default: + echo 'PermitRootLogin no'
    default: + bash /tmp/assets/custom/messages.sh yes 5.0.0 wazuh-user
    default: + cat
    default: + cat
    default: + preInstall
    default: + sed -i 's/passwords+=\(.*\)/passwords+=\("${users[i]}"\)/g' /tmp/unattended_installer/wazuh-install.sh
    default: + sed -i 's/api_passwords+=\(.*\)//g' /tmp/unattended_installer/wazuh-install.sh
    default: + sed -i 's/passwords_checkPassword .*//g' /tmp/unattended_installer/wazuh-install.sh
    default: + sed -i 's/filecorrect=.*/filecorrect=1/g' /tmp/unattended_installer/wazuh-install.sh
    default: + sed -i 's/main "$@"//g' /tmp/unattended_installer/wazuh-install.sh
    default: + cat /tmp/assets/custom/functions.sh
    default: + echo ''
    default: + echo 'main "$@"'
    default: + bash /tmp/unattended_installer/wazuh-install.sh -a --install-dependencies -v
    default: 13/06/2024 09:32:07 DEBUG: Checking root permissions.
    default: 13/06/2024 09:32:07 DEBUG: Checking sudo package.
    default: 13/06/2024 09:32:07 INFO: Starting Wazuh installation assistant. Wazuh version: 5.0.0
    default: 13/06/2024 09:32:07 INFO: Verbose logging redirected to /var/log/wazuh-install.log
    default: 13/06/2024 09:32:07 DEBUG: YUM package manager will be used.
    default: 13/06/2024 09:32:07 DEBUG: Checking system distribution.
    default: 13/06/2024 09:32:07 DEBUG: Detected distribution name: amzn
    default: 13/06/2024 09:32:07 DEBUG: Detected distribution version: 2
    default: 13/06/2024 09:32:07 DEBUG: Checking Wazuh installation.
    default: 13/06/2024 09:32:07 DEBUG: Checking system architecture.
    default: 13/06/2024 09:32:07 INFO: Wazuh web interface port will be 443.
    default: 13/06/2024 09:32:08 INFO: Verifying that your system meets the recommended minimum hardware requirements.
    default: 13/06/2024 09:32:08 DEBUG: CPU cores detected: 2
    default: 13/06/2024 09:32:08 DEBUG: Free RAM memory detected: 3927
    default: 13/06/2024 09:32:08 DEBUG: Checking ports availability.
    default: 13/06/2024 09:32:08 DEBUG: Checking curl tool version.
    default: 13/06/2024 09:32:08 DEBUG: Adding the Wazuh repository.
    default: [wazuh]
    default: gpgcheck=1
    default: gpgkey=https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
    default: enabled=1
    default: name=EL-${releasever} - Wazuh
    default: baseurl=https://packages-dev.wazuh.com/pre-release/yum/
    default: protect=1
    default: 13/06/2024 09:32:09 INFO: Wazuh development repository added.
    default: 13/06/2024 09:32:09 INFO: --- Configuration files ---
    default: 13/06/2024 09:32:09 INFO: Generating configuration files.
    default: 13/06/2024 09:32:09 DEBUG: Creating Wazuh certificates.
    default: 13/06/2024 09:32:09 DEBUG: Reading configuration file.
    default: 13/06/2024 09:32:09 DEBUG: Checking if 127.0.0.1 is private.
    default: 13/06/2024 09:32:09 DEBUG: Checking if 127.0.0.1 is private.
    default: 13/06/2024 09:32:09 DEBUG: Checking if 127.0.0.1 is private.
    default: 13/06/2024 09:32:09 INFO: Generating the root certificate.
    default: 13/06/2024 09:32:09 INFO: Generating Admin certificates.
    default: 13/06/2024 09:32:09 DEBUG: Generating Admin private key.
    default: 13/06/2024 09:32:10 DEBUG: Converting Admin private key to PKCS8 format.
    default: 13/06/2024 09:32:10 DEBUG: Generating Admin CSR.
    default: 13/06/2024 09:32:10 DEBUG: Creating Admin certificate.
    default: 13/06/2024 09:32:10 INFO: Generating Wazuh indexer certificates.
    default: 13/06/2024 09:32:10 DEBUG: Creating the certificates for wazuh-indexer indexer node.
    default: 13/06/2024 09:32:10 DEBUG: Generating certificate configuration.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh indexer tmp key pair.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh indexer certificates.
    default: 13/06/2024 09:32:10 INFO: Generating Filebeat certificates.
    default: 13/06/2024 09:32:10 DEBUG: Generating the certificates for wazuh-server server node.
    default: 13/06/2024 09:32:10 DEBUG: Generating certificate configuration.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh server tmp key pair.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh server certificates.
    default: 13/06/2024 09:32:10 INFO: Generating Wazuh dashboard certificates.
    default: 13/06/2024 09:32:10 DEBUG: Generating certificate configuration.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh dashboard tmp key pair.
    default: 13/06/2024 09:32:10 DEBUG: Creating the Wazuh dashboard certificates.
    default: 13/06/2024 09:32:11 DEBUG: Cleaning certificate files.
    default: 13/06/2024 09:32:11 DEBUG: Generating password file.
    default: 13/06/2024 09:32:11 DEBUG: Generating random passwords.
    default: 13/06/2024 09:32:11 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
    default: 13/06/2024 09:32:11 DEBUG: Extracting Wazuh configuration.
    default: 13/06/2024 09:32:11 DEBUG: Reading configuration file.
```