### PR TITLE
Change apt to dpkg for better performance

### DIFF
--- a/unattended_installer/common_functions/common.sh
+++ b/unattended_installer/common_functions/common.sh
@@ -91,7 +91,9 @@ function common_checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         eval "rpm -q wazuh-manager --quiet && wazuh_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
-        wazuh_installed=$(apt list --installed  2>/dev/null | grep wazuh-manager)
+        if dpkg -l wazuh-manager 2>/dev/null | grep -q -E '^ii\s'; then
+            wazuh_installed=1
+        fi
     fi
 
     if [ -d "/var/ossec" ]; then
@@ -103,7 +105,9 @@ function common_checkInstalled() {
         eval "rpm -q wazuh-indexer --quiet && indexer_installed=1"
 
     elif [ "${sys_type}" == "apt-get" ]; then
-        indexer_installed=$(apt list --installed 2>/dev/null | grep wazuh-indexer)
+        if dpkg -l wazuh-indexer 2>/dev/null | grep -q -E '^ii\s'; then
+            indexer_installed=1
+        fi
     fi
 
     if [ -d "/var/lib/wazuh-indexer/" ] || [ -d "/usr/share/wazuh-indexer" ] || [ -d "/etc/wazuh-indexer" ] || [ -f "${base_path}/search-guard-tlstool*" ]; then
@@ -114,7 +118,9 @@ function common_checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         eval "rpm -q filebeat --quiet && filebeat_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
-        filebeat_installed=$(apt list --installed  2>/dev/null | grep filebeat)
+        if dpkg -l filebeat 2>/dev/null | grep -q -E '^ii\s'; then
+            filebeat_installed=1
+        fi
     fi
 
     if [ -d "/var/lib/filebeat/" ] || [ -d "/usr/share/filebeat" ] || [ -d "/etc/filebeat" ]; then
@@ -125,7 +131,9 @@ function common_checkInstalled() {
     if [ "${sys_type}" == "yum" ]; then
         eval "rpm -q wazuh-dashboard --quiet && dashboard_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
-        dashboard_installed=$(apt list --installed  2>/dev/null | grep wazuh-dashboard)
+        if dpkg -l wazuh-dashboard 2>/dev/null | grep -q -E '^ii\s'; then
+            dashboard_installed=1
+        fi
     fi
 
     if [ -d "/var/lib/wazuh-dashboard/" ] || [ -d "/usr/share/wazuh-dashboard" ] || [ -d "/etc/wazuh-dashboard" ] || [ -d "/run/wazuh-dashboard/" ]; then

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -470,10 +470,10 @@ function checks_firewall(){
         eval "rpm -q firewalld --quiet && firewalld_installed=1"
         eval "rpm -q ufw --quiet && ufw_installed=1"
     elif [ "${sys_type}" == "apt-get" ]; then
-        if apt list --installed 2>/dev/null | grep -q -E ^"firewalld"\/; then
+        if dpkg -l "firewalld" 2>/dev/null | grep -q -E '^ii\s'; then
             firewalld_installed=1
         fi
-        if apt list --installed 2>/dev/null | grep -q -E ^"ufw"\/; then
+        if dpkg -l "ufw" 2>/dev/null | grep -q -E '^ii\s'; then
             ufw_installed=1
         fi
     fi

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -121,7 +121,7 @@ function installCommon_aptInstallList(){
     not_installed=()
 
     for dep in "${dependencies[@]}"; do
-        if ! apt list --installed 2>/dev/null | grep -q -E ^"${dep}"\/; then
+        if ! dpkg -l "${dep}" 2>/dev/null | grep -q -E '^ii\s'; then
             not_installed+=("${dep}")
             for wia_dep in "${wia_apt_dependencies[@]}"; do
                 if [ "${wia_dep}" == "${dep}" ]; then
@@ -601,7 +601,7 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-manager -y ${debug}"
-            eval "apt list --installed 2>/dev/null | grep wazuh-manager"
+            eval "dpkg -l wazuh-manager 2>/dev/null | grep -E '^ii\s'"
         fi
 
         manager_installed=${PIPESTATUS[0]}
@@ -629,7 +629,7 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-indexer -y ${debug}"
-            eval "apt list --installed 2>/dev/null | grep wazuh-indexer"
+            eval "dpkg -l wazuh-indexer 2>/dev/null | grep -E '^ii\s'"
         fi
 
         indexer_installed=${PIPESTATUS[0]}
@@ -658,7 +658,7 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge filebeat -y ${debug}"
-            eval "apt list --installed 2>/dev/null | grep filebeat"
+            eval "dpkg -l filebeat 2>/dev/null | grep -E '^ii\s'"
         fi
 
         filebeat_installed=${PIPESTATUS[0]}
@@ -687,7 +687,7 @@ function installCommon_rollBack() {
         elif [ "${sys_type}" == "apt-get" ]; then
             common_checkAptLock
             eval "apt-get remove --purge wazuh-dashboard -y ${debug}"
-            eval "apt list --installed 2>/dev/null | grep wazuh-dashboard"
+            eval "dpkg -l wazuh-dashboard 2>/dev/null | grep -E '^ii\s'"
         fi
 
         dashboard_installed=${PIPESTATUS[0]}

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -18,7 +18,7 @@ function offline_checkDependencies() {
         if [ "${sys_type}" == "yum" ]; then
             eval "yum list installed 2>/dev/null | grep -q -E ^"${dep}"\\."
         elif [ "${sys_type}" == "apt-get" ]; then
-            eval "apt list --installed 2>/dev/null | grep -q -E ^"${dep}"\/"
+            eval "dpkg -l "${dep}" 2>/dev/null | grep -q -E '^ii\s'"
         fi
         
         if [ "${PIPESTATUS[0]}" != 0 ]; then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2983|

# Description

The purpose of this PR is to improve the speed of checking packages installed with `APT`. 
`APT` has been changed to `dpkg` due to better performance.

### Speed tests
If we compare the execution results when checking the installed wazuh components we get the following data:

<details><summary>Check with APT</summary>

```console
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
13/06/2024 09:34:46 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 09:34:46 INFO: Verbose logging redirected to /var/log/wazuh-install.log
Total time for apt: 1699 ms
```

</details>

<details><summary>Check with dpkg</summary>

```console
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
13/06/2024 09:30:00 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 09:30:00 INFO: Verbose logging redirected to /var/log/wazuh-install.log
Total time for dpkg: 115 ms
```
With this we check how the improvement when using dpkg is **93.23%**

</details>

### Install components tests

To check that the components are installed correctly when changing apt to dpkg, an AIO has been installed. 

<details><summary>AIO installation</summary>

```console
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
13/06/2024 09:47:22 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 09:47:22 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/06/2024 09:47:22 INFO: Verifying that your system meets the recommended minimum hardware requirements.
13/06/2024 09:47:31 INFO: Wazuh web interface port will be 443.
13/06/2024 09:47:43 INFO: Wazuh development repository added.
13/06/2024 09:47:43 INFO: --- Configuration files ---
13/06/2024 09:47:43 INFO: Generating configuration files.
13/06/2024 09:47:44 INFO: Generating the root certificate.
13/06/2024 09:47:44 INFO: Generating Admin certificates.
13/06/2024 09:47:44 INFO: Generating Wazuh indexer certificates.
13/06/2024 09:47:44 INFO: Generating Filebeat certificates.
13/06/2024 09:47:44 INFO: Generating Wazuh dashboard certificates.
13/06/2024 09:47:45 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
13/06/2024 09:47:45 INFO: --- Wazuh indexer ---
13/06/2024 09:47:45 INFO: Starting Wazuh indexer installation.
13/06/2024 09:51:13 INFO: Wazuh indexer installation finished.
13/06/2024 09:51:13 INFO: Wazuh indexer post-install configuration finished.
13/06/2024 09:51:13 INFO: Starting service wazuh-indexer.
13/06/2024 09:51:57 INFO: wazuh-indexer service started.
13/06/2024 09:51:57 INFO: Initializing Wazuh indexer cluster security settings.
13/06/2024 09:52:08 INFO: Wazuh indexer cluster security configuration initialized.
13/06/2024 09:52:08 INFO: Wazuh indexer cluster initialized.
13/06/2024 09:52:08 INFO: --- Wazuh server ---
13/06/2024 09:52:08 INFO: Starting the Wazuh manager installation.
13/06/2024 09:56:19 INFO: Wazuh manager installation finished.
13/06/2024 09:56:20 INFO: Wazuh manager vulnerability detection configuration finished.
13/06/2024 09:56:20 INFO: Starting service wazuh-manager.
13/06/2024 09:56:46 INFO: wazuh-manager service started.
13/06/2024 09:56:46 INFO: Starting Filebeat installation.
13/06/2024 09:59:32 INFO: Filebeat installation finished.
13/06/2024 10:00:10 INFO: Filebeat post-install configuration finished.
13/06/2024 10:00:10 INFO: Starting service filebeat.
13/06/2024 10:00:21 INFO: filebeat service started.
13/06/2024 10:00:21 INFO: --- Wazuh dashboard ---
13/06/2024 10:00:21 INFO: Starting Wazuh dashboard installation.
13/06/2024 10:09:49 INFO: Wazuh dashboard installation finished.
13/06/2024 10:09:50 INFO: Wazuh dashboard post-install configuration finished.
13/06/2024 10:09:50 INFO: Starting service wazuh-dashboard.
13/06/2024 10:09:56 INFO: wazuh-dashboard service started.
13/06/2024 10:09:57 INFO: Updating the internal users.
13/06/2024 10:10:33 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
13/06/2024 10:12:18 INFO: Initializing Wazuh dashboard web application.
13/06/2024 10:15:39 INFO: Wazuh dashboard web application initialized.
13/06/2024 10:15:39 INFO: --- Summary ---
```
</details>

If we try to reinstall it, we can see that the components are already installed.

<details><summary>Try to reinstall wazuh components</summary>

```console
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -a
13/06/2024 10:39:08 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 10:39:09 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/06/2024 10:39:44 ERROR: Wazuh manager already installed.
13/06/2024 10:39:44 ERROR: Wazuh indexer already installed.
13/06/2024 10:39:44 ERROR: Wazuh dashboard already installed.
13/06/2024 10:39:44 ERROR: Filebeat already installed.
13/06/2024 10:39:44 INFO: If you want to overwrite the current installation, run this script adding the option -o/--overwrite. This will erase all the existing configuration and data.
```

</details>

It has also been tested to try uninstalling the components. Both when they are installed and when they do not exist:

<details><summary>Uninstalling wazuh components when they are installed</summary>

```console
oot@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -u
13/06/2024 10:55:27 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 10:55:27 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/06/2024 10:55:27 INFO: Removing Wazuh manager.
13/06/2024 10:56:17 INFO: Wazuh manager removed.
13/06/2024 10:56:17 INFO: Removing Wazuh indexer.
13/06/2024 10:56:29 INFO: Wazuh indexer removed.
13/06/2024 10:56:29 INFO: Removing Filebeat.
13/06/2024 10:56:36 INFO: Filebeat removed.
13/06/2024 10:56:36 INFO: Removing Wazuh dashboard.
13/06/2024 10:57:27 INFO: Wazuh dashboard removed.

```

We see how to uninstall them correctly

</details>

<details><summary>Try to uninstall wazuh components when they are not installed </summary>

```console
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -u
13/06/2024 11:14:25 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 11:14:25 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/06/2024 11:14:25 INFO: Wazuh manager not found in the system so it was not uninstalled.
13/06/2024 11:14:25 INFO: Filebeat not found in the system so it was not uninstalled.
13/06/2024 11:14:25 INFO: Wazuh indexer not found in the system so it was not uninstalled.
13/06/2024 11:14:25 INFO: Wazuh dashboard not found in the system so it was not uninstalled.
13/06/2024 11:14:25 INFO: Wazuh GPG key not found in the system
```
We can see how the installed packages are detected correctly.
</details>

### Offline installation tests

In the offline installation section, check that the necessary packages are installed. 
<details><summary>Offline installation packages installed</summary>

```console 
root@ubuntu-focal:/home/vagrant# bash wazuh-install.sh -of -a -v
13/06/2024 11:02:09 DEBUG: Checking root permissions.
13/06/2024 11:02:09 DEBUG: Checking sudo package.
13/06/2024 11:02:09 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.0
13/06/2024 11:02:09 INFO: Verbose logging redirected to /var/log/wazuh-install.log
13/06/2024 11:02:09 DEBUG: APT package manager will be used.
13/06/2024 11:02:09 DEBUG: Checking system distribution.
13/06/2024 11:02:09 DEBUG: Detected distribution name: ubuntu
13/06/2024 11:02:09 DEBUG: Detected distribution version: 20
13/06/2024 11:02:09 INFO: Checking installed dependencies for Offline installation.
13/06/2024 11:02:09 DEBUG: Offline dependencies are installed.
```

</details>