### PR TITLE
Add condition when trying to change API user credentials

### DIFF
--- a/unattended_installer/passwords_tool/passwordsMain.sh
+++ b/unattended_installer/passwords_tool/passwordsMain.sh
@@ -26,9 +26,11 @@ function getHelp() {
     echo -e ""
     echo -e "        -au,  --admin-user <adminUser>"
     echo -e "                Admin user for Wazuh API, Required to change Wazuh API passwords."
+    echo -e "                Requires -A|--api."
     echo -e ""
     echo -e "        -ap,  --admin-password <adminPassword>"
     echo -e "                Password for Wazuh API admin user, Required to change Wazuh API passwords."
+    echo -e "                Requires -A|--api."
     echo -e ""
     echo -e "        -u,  --user <user>"
     echo -e "                Indicates the name of the user whose password will be changed."
@@ -214,6 +216,10 @@ function main() {
         fi
 
         if [ -z "${nuser}" ] && [ -z "${password}" ] && [ -z "${changeall}" ] && [ -z  "${p_file}" ]; then
+            getHelp
+        fi
+
+        if [ -n "${adminUser}" ] && [ -n "${adminPassword}" ] && [ -z "${api}" ]; then
             getHelp
         fi
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/external-devel-requests/issues/2301|

## Context 

When attempting to change an api user's password without specifying the `--api` option, the script does not indicate that this argument must be passed to make the change effective. This may result in the user thinking that the password has been changed correctly even though it has not.

<details><summary>Changing passwords fails without feedback from it</summary>

If I try to change the password of the wazuh user in an AIO environment, the message that appears is the one corresponding to the change of the wazuh indexer passwords. As there are no passwords to change, it does nothing, it just displays the message.

```console
$ bash wazuh-passwords-tool.sh -au wazuh -ap Cnsjz+1PZS7+Hu2kk0DauFm*z2GML6a+ -u wazuh -p xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm
17/06/2024 10:02:29 INFO: Generating password hash
17/06/2024 10:02:44 WARNING: Password changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
$ TOKEN=$(curl -u wazuh:xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    59  100    59    0     0    206      0 --:--:-- --:--:-- --:--:--   206
$ echo $TOKEN
{"title": "Unauthorized", "detail": "Invalid credentials"}
```

If I try to get the token with the "old" password, I can get it, showing that the password has not changed.
```console
$ TOKEN=$(curl -u wazuh:Cnsjz+1PZS7+Hu2kk0DauFm*z2GML6a+ -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   398  100   398    0     0    804      0 --:--:-- --:--:-- --:--:--   804
$ echo $TOKEN
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzE4NjE4OTY3LCJleHAiOjE3MTg2MTk4NjcsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ABl8NC8aK80LqPgSYAegH8aZ_iWkPpI7cO6ee1NPOLi_f3ShHcouiiVIAPET_OapWwarMxSvEWxp5gf01fQUiPI-AVWPW5YiCUjQbaD_3UAcsBJmm52jG8Y0Dx4A9w8lcRn_XLvLedDG66aT0NQY-hnV2rvy1J3xfIrQfhGAHSvpOaLC
```

</details>


## Description

The aim of this PR is to add a new validation in the options passed to the `wazuh-passwords-tool.sh` script where, if the user tries to change the passwords without specifying the `--api` option, the output will be the script help.

To make it clearer to the user that the `--api` option is required when changing API user passwords, a line has been added to the help of each option saying that the `-A|--api` option is required in order to change the password correctly.

### Tests

<details><summary>Try to change the user API password without the --api option</summary>

Now if I try to change the password without specifying the `--api` option, the help pops up where it now appears in both the `-au` and `-ap` options that `-A|--api` is required in order to change the password.

```console
$ bash wazuh-passwords-tool.sh -au wazuh -ap Cnsjz+1PZS7+Hu2kk0DauFm*z2GML6a+ -u wazuh -p xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm

NAME
        wazuh-passwords-tool.sh - Manage passwords for Wazuh indexer users.

SYNOPSIS
        wazuh-passwords-tool.sh [OPTIONS]

DESCRIPTION
        -a,  --change-all
                Changes all the Wazuh indexer and Wazuh API user passwords and prints them on screen.
                To change API passwords -au|--admin-user and -ap|--admin-password are required.

        -A,  --api
                Change the Wazuh API password.
                Requires -u|--user, and -p|--password, -au|--admin-user and -ap|--admin-password.

        -au,  --admin-user <adminUser>
                Admin user for Wazuh API, Required to change Wazuh API passwords.
                Requires -A|--api.

        -ap,  --admin-password <adminPassword>
                Password for Wazuh API admin user, Required to change Wazuh API passwords.
                Requires -A|--api.

        -u,  --user <user>
                Indicates the name of the user whose password will be changed.
                If no password specified it will generate a random one.

        -p,  --password <password>
                Indicates the new password, must be used with option -u.

        -c,  --cert <route-admin-certificate>
                Indicates route to the admin certificate.

        -k,  --certkey <route-admin-certificate-key>
                Indicates route to the admin certificate key.

        -v,  --verbose
                Shows the complete script execution output.

        -f,  --file <wazuh-passwords.txt>
                Changes the passwords for the ones given in the file.

                Wazuh indexer users must have this format:

                    # Description
                      indexer_username: <user>
                      indexer_password: <password>

                Wazuh API users must have this format:

                    # Description
                      api_username: <user>
                      api_password: <password>

        -gf, --generate-file <wazuh-passwords.txt>
                Generate password file with random passwords for standard users.

        -h,  --help
                Shows help.
```

</details>

<details><summary>Try to change the user API password with the --api option</summary>

Specifying the `--api` option now works normally.

```console
$ bash wazuh-passwords-tool.sh -au wazuh -ap Cnsjz+1PZS7+Hu2kk0DauFm*z2GML6a+ -u wazuh -p xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm --api
17/06/2024 10:26:03 INFO: The password for Wazuh API user wazuh is xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm
root@ip-172-31-38-236:/home/ubuntu# TOKEN=$(curl -u wazuh:xMzqfVE3x0K2Wc6Rzw64?0zhI0yiW+Pm -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   398  100   398    0     0    761      0 --:--:-- --:--:-- --:--:--   762
$ echo $TOKEN
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzE4NjE5OTgyLCJleHAiOjE3MTg2MjA4ODIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ATQx9dZsrRIoJvsBCYwBoTYv7MNdFE6pGFzN-HuQV_xvxbfmnLG59k4vKnvn9Y9vi7tl33t4yVLvXDIYypqV7DKYAeCoIemzz3qgQ23DwwOoA_BCO6Pthgu7tTilKugEODnRDlpCpOiNtkalJoAPHBMNVuFL69UGPUjfnt9k9LkLd07M
```

</details>
