### PR TITLE
Added check when generating certificates for multiple DNS

### DIFF
--- a/unattended_installer/cert_tool/certFunctions.sh
+++ b/unattended_installer/cert_tool/certFunctions.sh
@@ -368,11 +368,15 @@ function cert_readConfig() {
 
         for ip in "${all_ips[@]}"; do
             isIP=$(echo "${ip}" | grep -P "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$")
+            isDNS=$(echo "${ip}" | grep -P "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.([A-Za-z]{2,})$" )
             if [[ -n "${isIP}" ]]; then
                 if ! cert_checkPrivateIp "$ip"; then
                     common_logger -e "The IP ${ip} is public."
                     exit 1
                 fi
+            elif [[ -n "${isDNS}" ]]; then
+                common_logger -e "The DNS ${ip} is not valid."
+                exit 1
             fi
         done
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2371|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The aim of this PR is to add a check in the certificates generation. This check ensures that every DNS specified in the `config.yml` file was valid. This comprobation was already done by the certificates tool, but it was enhanced to cover the multiple DNS use case:

### Before

With the following YAML file, the certificates were created. Notice that the `localhost` DNS is invalid:
```YAML
nodes:
  server:
    - name: wazuh-server
      ip: www.google.es
      ip: facebook.es
      ip: wikipedia.org
```

### After

Now, with the check, the invalid DNS is fetched and the certificates generation is stopped.
```console
root@ubuntu22:/home/vagrant# bash wazuh-certs-tool.sh -A -v
17/06/2024 16:11:51 INFO: Verbose logging redirected to /home/vagrant/wazuh-certificates-tool.log
17/06/2024 16:11:51 DEBUG: Reading configuration file.
17/06/2024 16:11:52 ERROR: The DNS localhost is not valid.
root@ubuntu22:/home/vagrant# 
```


## Testing

The performed testing is in the following comment: https://github.com/wazuh/wazuh-packages/issues/2371#issuecomment-2173818359. Also, it has been checked that this change does not affect to the IP certificates generation.


