### PR TITLE
Fixed kibanaserver change password

### DIFF
--- a/unattended_installer/passwords_tool/passwordsFunctions.sh
+++ b/unattended_installer/passwords_tool/passwordsFunctions.sh
@@ -17,7 +17,7 @@ function passwords_changePassword() {
         for i in "${!passwords[@]}"
         do
             if [ -n "${indexer_installed}" ] && [ -f "/etc/wazuh-indexer/backup/internal_users.yml" ]; then
-                awk -v new=${hashes[i]} 'prev=="'${users[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
+                awk -v new='"'"${hashes[i]}"'"' 'prev=="'${users[i]}':"{sub(/\042.*/,""); $0=$0 new} {prev=$1} 1' /etc/wazuh-indexer/backup/internal_users.yml > internal_users.yml_tmp && mv -f internal_users.yml_tmp /etc/wazuh-indexer/backup/internal_users.yml
             fi
 
             if [ "${users[i]}" == "admin" ]; then
@@ -277,10 +277,11 @@ function passwords_generatePassword() {
 function passwords_generatePasswordFile() {
 
     common_logger -d "Generating password file."
-    users=( admin kibanaserver kibanaro logstash readall snapshotrestore )
+    users=( admin anomalyadmin kibanaserver kibanaro logstash readall snapshotrestore )
     api_users=( wazuh wazuh-wui )
     user_description=(
         "Admin user for the web user interface and Wazuh indexer. Use this user to log in to Wazuh dashboard"
+        "Anomaly detection user for the web user interface"
         "Wazuh dashboard user for establishing the connection with Wazuh indexer"
         "Regular Dashboard user, only has read permissions to all indices and all permissions on the .kibana index"
         "Filebeat user for CRUD operations on Wazuh indices"


### PR DESCRIPTION
Close https://github.com/wazuh/wazuh-packages/issues/3056

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
The user `anomalyadmin` is added to the indexer user list. This user is new for version 4.9.0, and its absence generated a problem in the configuration of the rest of the users with the security admin.

This is used to add double quotes to the hash of the internal-users file.


## Logs example

<!--
Paste here related logs
-->

### Wazuh indexer installation

```console
root@ubuntu-jammy:~# curl -sO https://packages-dev.wazuh.com/4.9/config.yml
root@ubuntu-jammy:~# vim config.yml 
root@ubuntu-jammy:~# cp /home/vagrant/wazuh-install.sh .
root@ubuntu-jammy:~# bash wazuh-install.sh --generate-config-files
30/07/2024 14:16:30 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
30/07/2024 14:16:30 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/07/2024 14:16:46 INFO: Verifying that your system meets the recommended minimum hardware requirements.
30/07/2024 14:16:49 INFO: --- Configuration files ---
30/07/2024 14:16:49 INFO: Generating configuration files.
30/07/2024 14:16:49 INFO: Generating the root certificate.
30/07/2024 14:16:50 INFO: Generating Admin certificates.
30/07/2024 14:16:50 INFO: Generating Wazuh indexer certificates.
30/07/2024 14:16:51 INFO: Generating Filebeat certificates.
30/07/2024 14:16:51 INFO: Generating Wazuh dashboard certificates.
30/07/2024 14:16:51 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
root@ubuntu-jammy:~# bash wazuh-install.sh --wazuh-indexer node-1
30/07/2024 14:16:54 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
30/07/2024 14:16:54 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/07/2024 14:16:58 INFO: Verifying that your system meets the recommended minimum hardware requirements.
30/07/2024 14:17:07 INFO: --- Dependencies ----
30/07/2024 14:17:07 INFO: Installing apt-transport-https.
30/07/2024 14:17:15 INFO: Wazuh development repository added.
30/07/2024 14:17:15 INFO: --- Wazuh indexer ---
30/07/2024 14:17:15 INFO: Starting Wazuh indexer installation.
30/07/2024 14:18:58 INFO: Wazuh indexer installation finished.
30/07/2024 14:18:58 INFO: Wazuh indexer post-install configuration finished.
30/07/2024 14:18:58 INFO: Starting service wazuh-indexer.
30/07/2024 14:19:08 INFO: wazuh-indexer service started.
30/07/2024 14:19:08 INFO: Initializing Wazuh indexer cluster security settings.
30/07/2024 14:19:09 INFO: Wazuh indexer cluster initialized.
30/07/2024 14:19:09 INFO: Installation finished.
root@ubuntu-jammy:~# bash wazuh-install.sh --start-cluster
30/07/2024 14:19:21 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
30/07/2024 14:19:21 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/07/2024 14:19:26 INFO: Verifying that your system meets the recommended minimum hardware requirements.
30/07/2024 14:19:32 INFO: Wazuh indexer cluster security configuration initialized.
30/07/2024 14:20:03 INFO: Updating the internal users.
30/07/2024 14:20:05 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
30/07/2024 14:20:11 INFO: Wazuh indexer cluster started.
root@ubuntu-jammy:~# tar -axf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt -O | grep -P "\'admin\'" -A 1
  indexer_username: 'admin'
  indexer_password: 'C3bY0Ur35.*ZYPTIKoMQA9X*8jQHzGuk'
root@ubuntu-jammy:~# curl -k -u admin:C3bY0Ur35.*ZYPTIKoMQA9X*8jQHzGuk https://localhost:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-indexer-cluster",
  "cluster_uuid" : "e98DoaqnTNyICnhC17blbA",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "deb",
    "build_hash" : "2c952aba7735bee5f4b0bb9cfc821d68ffbdd636",
    "build_date" : "2024-07-19T16:32:15.451255Z",
    "build_snapshot" : false,
    "lucene_version" : "9.10.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

### Wazuh server installation

```console
root@ubuntu-jammy:~# bash wazuh-install.sh --wazuh-server wazuh-1
30/07/2024 14:20:48 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
30/07/2024 14:20:48 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/07/2024 14:20:52 INFO: Verifying that your system meets the recommended minimum hardware requirements.
30/07/2024 14:21:04 INFO: Wazuh development repository added.
30/07/2024 14:21:04 INFO: --- Wazuh server ---
30/07/2024 14:21:04 INFO: Starting the Wazuh manager installation.
30/07/2024 14:22:21 INFO: Wazuh manager installation finished.
30/07/2024 14:22:21 INFO: Wazuh manager vulnerability detection configuration finished.
30/07/2024 14:22:21 INFO: Starting service wazuh-manager.
30/07/2024 14:22:36 INFO: wazuh-manager service started.
30/07/2024 14:22:36 INFO: Starting Filebeat installation.
30/07/2024 14:23:03 INFO: Filebeat installation finished.
30/07/2024 14:23:07 INFO: Filebeat post-install configuration finished.
30/07/2024 14:23:09 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
30/07/2024 14:23:30 INFO: Starting service filebeat.
30/07/2024 14:23:31 INFO: filebeat service started.
30/07/2024 14:23:31 INFO: Installation finished.
```

### Wazuh dashboard installation

```console
root@ubuntu-jammy:~# bash wazuh-install.sh --wazuh-dashboard dashboard
30/07/2024 14:24:04 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
30/07/2024 14:24:04 INFO: Verbose logging redirected to /var/log/wazuh-install.log
30/07/2024 14:24:13 INFO: Verifying that your system meets the recommended minimum hardware requirements.
30/07/2024 14:24:17 INFO: Wazuh web interface port will be 443.
30/07/2024 14:24:22 INFO: --- Dependencies ----
30/07/2024 14:24:22 INFO: Installing debhelper.
30/07/2024 14:24:54 INFO: Wazuh development repository added.
30/07/2024 14:24:54 INFO: --- Wazuh dashboard ----
30/07/2024 14:24:54 INFO: Starting Wazuh dashboard installation.
30/07/2024 14:25:55 INFO: Wazuh dashboard installation finished.
30/07/2024 14:25:55 INFO: Wazuh dashboard post-install configuration finished.
30/07/2024 14:25:55 INFO: Starting service wazuh-dashboard.
30/07/2024 14:25:55 INFO: wazuh-dashboard service started.
30/07/2024 14:25:56 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
30/07/2024 14:26:30 INFO: Initializing Wazuh dashboard web application.
30/07/2024 14:26:31 INFO: Wazuh dashboard web application initialized.
30/07/2024 14:26:31 INFO: --- Summary ---
30/07/2024 14:26:31 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: C3bY0Ur35.*ZYPTIKoMQA9X*8jQHzGuk
30/07/2024 14:26:31 INFO: Installation finished.
```

![Screenshot_20240730_112814](https://github.com/user-attachments/assets/a2a97148-d674-4d86-85c5-482484d210f2)
