### PR TITLE
Fix removal of svc wazuh install service solaris11

### DIFF
--- a/solaris/solaris11/generate_wazuh_packages.sh
+++ b/solaris/solaris11/generate_wazuh_packages.sh
@@ -180,6 +180,8 @@ create_package() {
 
 
     # Package generation process
+    # Added creation of wazuh-agent.xml service manifest file
+    svcbundle -o wazuh-agent.xml -s service-name=application/wazuh-agent -s start-method="${install_path}/bin/${control_binary} start" -s stop-method="${install_path}/bin/${control_binary} stop" -s refresh-method="${install_path}/bin/${control_binary} restart"
     pkgsend generate ${install_path} | pkgfmt > wazuh-agent.p5m.1
     sed "s|<INSTALL_PATH>|${install_path}|" ${current_path}/postinstall.sh > ${current_path}/postinstall.sh.new
     mv ${current_path}/postinstall.sh.new ${current_path}/postinstall.sh
@@ -192,12 +194,10 @@ create_package() {
         mv wazuh-agent.p5m.1.aux_sed wazuh-agent.p5m.1
     done
     # Add service files
-    echo "file smf_manifest.xml path=lib/svc/manifest/site/post-install.xml owner=root group=sys mode=0744 restart_fmri=svc:/system/manifest-import:default" >> wazuh-agent.p5m.1
+    echo "file smf_manifest.xml path=lib/svc/manifest/site/wazuh-postinstall.xml owner=root group=sys mode=0744 restart_fmri=svc:/system/manifest-import:default" >> wazuh-agent.p5m.1
     echo "dir  path=var/ossec/installation_scripts owner=root group=bin mode=0755" >> wazuh-agent.p5m.1
     echo "file postinstall.sh path=var/ossec/installation_scripts/postinstall.sh owner=root group=bin mode=0744" >> wazuh-agent.p5m.1
-    echo "file wazuh-agent path=etc/init.d/wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
-    echo "file S97wazuh-agent path=etc/rc2.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
-    echo "file S97wazuh-agent path=etc/rc3.d/S97wazuh-agent owner=root group=sys mode=0744" >> wazuh-agent.p5m.1
+    echo "file wazuh-agent.xml path=lib/svc/manifest/application/wazuh-agent.xml owner=root group=sys mode=0744 restart_fmri=svc:/system/manifest-import:default" >> wazuh-agent.p5m.1
 
     # Add user and group wazuh
     echo "group groupname=wazuh" >> wazuh-agent.p5m.1

--- a/solaris/solaris11/postinstall.sh
+++ b/solaris/solaris11/postinstall.sh
@@ -60,4 +60,9 @@ rm -rf ${SCA_TMP_DIR}
 
 # Remove upgrade files after install/upgrade
 rm -rf ${install_path}/installation_scripts/
-rm -rf /lib/svc/manifest/site/post-install.xml
+
+# Disable the wazuh-postinstall service
+svcadm disable site/wazuh-postinstall
+
+# Remove the wazuh-postinstall service manifest
+rm -rf /lib/svc/manifest/site/wazuh-postinstall.xml

--- a/solaris/solaris11/smf_manifest.xml
+++ b/solaris/solaris11/smf_manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <!DOCTYPE service_bundle
   SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
-<service_bundle type="manifest" name="site/wazuh-install">
-    <service version="1" type="service" name="site/wazuh-install">
+<service_bundle type="manifest" name="site/wazuh-postinstall">
+    <service version="1" type="service" name="site/wazuh-postinstall">
         <dependency restart_on="none" type="service"
             name="multi_user_dependency" grouping="require_all">
             <service_fmri value="svc:/milestone/multi-user"/>


### PR DESCRIPTION
|Related issue|
|---|
| #2238  #2313 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

### Problem Description:

After installing the Wazuh agent Solaris package and before rebooting, the service `svc:/site/wazuh-install:default` is in the `online` state. However, after rebooting the system, the following status is observed:

- Running `sudo svcs|grep wazuh` reveals that the Wazuh agent services `lrc:/etc/rc2_d/S97wazuh-agent` and `lrc:/etc/rc3_d/S97wazuh-agent` are in the `legacy_run` state.
- The `svc:/site/wazuh-install:default` service is in the `maintenance` state.

```
sudo svcs|grep wazuh
legacy_run      8:55:14 lrc:/etc/rc2_d/S97wazuh-agent
legacy_run      8:55:17 lrc:/etc/rc3_d/S97wazuh-agent
maintenance     8:55:15 svc:/site/wazuh-install:default
```

Upon further investigation using `svcs -xv svc:/site/wazuh-install:default`, it is found that the service has been in the `maintenance` state since the reboot, with the reason being that the start method failed repeatedly, exiting with status 127. The log file `/var/svc/log/site-wazuh-install:default.log` indicates that the start method is attempting to execute `var/ossec/installation_scripts/postinstall.sh`, but this script is not found, leading to the service failure.

Log File Excerpt:
```
[ 2024 Aug  2 08:54:44 Enabled. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
```

The Wazuh agent service fails to start after a system reboot because the post-installation script `var/ossec/installation_scripts/postinstall.sh` is missing, resulting in the service entering the maintenance state.

I fixed the problem by disabling the wazuh-install service before removing the service manifest file. Additional changes included renaming wazuh-install to wazuh-postinstall to better reflect its purpose. I also added the wazuh-agent service to the Service Management Facility (SMF) and removed the legacy run service to ensure a clean service management setup.

Now, after installation, the process will automatically uninstall the wazuh-postinstall service and enable the wazuh-agent service. The wazuh-agent service will initially be in a maintenance state until the ossec.conf file is updated. Once the configuration is updated, the service can be cleared from maintenance and restarted using the svcs command.

```
sudo svcadm clear wazuh-agent
sudo svcadm restart wazuh-agent
```

Now clean and online:
```
svcs|grep wazuh
online         13:33:14 svc:/application/wazuh-agent:default
```


## Logs example

Log File Excerpt:
```
sudo svcs|grep wazuh
legacy_run      8:55:14 lrc:/etc/rc2_d/S97wazuh-agent
legacy_run      8:55:17 lrc:/etc/rc3_d/S97wazuh-agent
maintenance     8:55:15 svc:/site/wazuh-install:default

svcs -xv svc:/site/wazuh-install:default
svc:/site/wazuh-install:default (?)
 State: maintenance since Fri Aug  2 08:55:15 2024
Reason: Start method failed repeatedly, last exited with status 127.
   See: http://support.oracle.com/msg/SMF-8000-KS
   See: /var/svc/log/site-wazuh-install:default.log
Impact: This service is not running.

[ 2024 Aug  2 08:54:44 Enabled. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
[ 2024 Aug  2 08:55:15 Executing start method ("var/ossec/installation_scripts/postinstall.sh"). ]
/usr/sbin/sh: var/ossec/installation_scripts/postinstall.sh: not found
[ 2024 Aug  2 08:55:15 Method "start" exited with status 127. ]
```

## Tests


<!-- Minimum checks required -->
- Build the package in any supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] macOS
  - [x ] Solaris
  - [ ] AIX
  - [ ] HP-UX
- [ x] Package installation
- [ x] Package upgrade
- [ ] Package downgrade
- [x ] Package remove
- [ ] Package install/remove/install
- [ ] Change added to CHANGELOG.md

<!-- Depending on the affected OS -->
- Tests for Linux RPM
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] `%files` section is correctly updated if necessary
- Tests for Linux deb
  - [ ] Build the package for x86_64
  - [ ] Build the package for i386
  - [ ] Build the package for armhf
  - [ ] Build the package for aarch64
  - [ ] Package install/remove/install
  - [ ] Package install/purge/install
  - [ ] Check file permissions after installing the package
- Tests for macOS
  - [ ] Test the package from macOS Sierra to Mojave
- Tests for Solaris
  - [ ] Test the package on Solaris 10
  - [ x] Test the package on Solaris 11

  - [ ] Check file permissions on Solaris 11 template
- Tests for IBM AIX
  - [ ] `%files` section is correctly updated if necessary
  - [ ] Check the changes from IBM AIX 5 to 7
