### PR TITLE
Fixed bugs for offline installation with the installation assistant

### DIFF
--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -31,8 +31,8 @@ function checks_arguments() {
     # -------------- Offline installation ---------------------
 
     if [ -n "${offline_install}" ]; then
-        if [ -z "${AIO}" ] && [ -z "${dashboard}" ] && [ -z "${indexer}" ] && [ -z "${wazuh}" ]; then
-            common_logger -e "The -of|--offline-installation option must be used with -a, -ws, -wi, or -wd."
+        if [ -z "${AIO}" ] && [ -z "${dashboard}" ] && [ -z "${indexer}" ] && [ -z "${wazuh}" ] && [ -z "${start_indexer_cluster}" ]; then
+            common_logger -e "The -of|--offline-installation option must be used with -a, -ws, -s, -wi, or -wd."
             exit 1
         fi
     fi

--- a/unattended_installer/install_functions/checks.sh
+++ b/unattended_installer/install_functions/checks.sh
@@ -378,15 +378,17 @@ function checks_specifications() {
 
 function checks_ports() {
 
-    dep="lsof"
-    if [ "${sys_type}" == "yum" ]; then
-        installCommon_yumInstallList "${dep}"
-    elif [ "${sys_type}" == "apt-get" ]; then
-        installCommon_aptInstallList "${dep}"
-    fi
+    if [ -z "${offline_install}" ]; then
+        dep="lsof"
+        if [ "${sys_type}" == "yum" ]; then
+            installCommon_yumInstallList "${dep}"
+        elif [ "${sys_type}" == "apt-get" ]; then
+            installCommon_aptInstallList "${dep}"
+        fi
 
-    if [ "${#not_installed[@]}" -gt 0 ]; then
-            wia_dependencies_installed+=("${dep}")
+        if [ "${#not_installed[@]}" -gt 0 ]; then
+                wia_dependencies_installed+=("${dep}")
+        fi
     fi
 
     common_logger -d "Checking ports availability."

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -186,12 +186,28 @@ function indexer_startCluster() {
         common_logger "Wazuh indexer cluster security configuration initialized."
     fi
 
+    # Validate Wazuh indexer security admin it is initialized
+    indexer_security_admin_comm="common_curl -XGET https://"${indexer_node_ips[pos]}":9200/ -uadmin:admin -k --max-time 120 --silent -w \"%{http_code}\" --output /dev/null"
+    http_status=$(eval "${indexer_security_admin_comm}")
+    retries=0
+    max_retries=5
+    while [ "${http_status}" -ne 200 ]; do
+        common_logger -d "Waiting for Wazuh indexer to be ready. wazuh-indexer status: ${http_status}"
+        sleep 5
+        retries=$((retries+1))
+        if [ "${retries}" -eq "${max_retries}" ]; then
+            common_logger -e "The Wazuh indexer cluster security configuration could not be initialized."
+            exit 1
+        fi
+        http_status=$(eval "${indexer_security_admin_comm}")
+    done
+
     # Wazuh alerts template injection
     if [ -n "${offline_install}" ]; then
-        filebeat_wazuh_template="${offline_files_path}/wazuh-template.json"
+        filebeat_wazuh_template="file://${offline_files_path}/wazuh-template.json"
     fi
-    eval "common_curl --silent ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent --max-time 300 --retry 5 --retry-delay 5 ${debug}"
-    if [  "${PIPESTATUS[0]}" != 0  ]; then
+    http_status=$(eval "common_curl --silent '${filebeat_wazuh_template}' --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H \'Content-Type: application/json\' -d @- -uadmin:admin -k --max-time 300 --retry 5 --retry-delay 5 -w "%{http_code}" -o /dev/null")
+    if [ "${http_status}" -ne 200 ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."
         exit 1
     else

--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -187,6 +187,9 @@ function indexer_startCluster() {
     fi
 
     # Wazuh alerts template injection
+    if [ -n "${offline_install}" ]; then
+        filebeat_wazuh_template="${offline_files_path}/wazuh-template.json"
+    fi
     eval "common_curl --silent ${filebeat_wazuh_template} --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H 'Content-Type: application/json' -d @- -uadmin:admin -k --silent --max-time 300 --retry 5 --retry-delay 5 ${debug}"
     if [  "${PIPESTATUS[0]}" != 0  ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."

--- a/unattended_installer/install_functions/installCommon.sh
+++ b/unattended_installer/install_functions/installCommon.sh
@@ -390,35 +390,65 @@ function installCommon_installPrerequisites() {
     if [ "${sys_type}" == "yum" ]; then
         if [ "${1}" == "AIO" ]; then
             deps=($(echo "${indexer_yum_dependencies[@]}" "${dashboard_yum_dependencies[@]}" | tr ' ' '\n' | sort -u))
-            common_logger -d "${message}"
-            installCommon_yumInstallList "${deps[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_yumInstallList "${deps[@]}"
+            else
+                offline_checkPrerequisites "${deps[@]}"
+            fi
         fi
         if [ "${1}" == "indexer" ]; then
-            common_logger -d "${message}"
-            installCommon_yumInstallList "${indexer_yum_dependencies[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_yumInstallList "${indexer_yum_dependencies[@]}"
+            else
+                offline_checkPrerequisites "${indexer_yum_dependencies[@]}"
+            fi
         fi
         if [ "${1}" == "dashboard" ]; then
-            common_logger -d "${message}"
-            installCommon_yumInstallList "${dashboard_yum_dependencies[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_yumInstallList "${dashboard_yum_dependencies[@]}"
+            else
+                offline_checkPrerequisites "${dashboard_yum_dependencies[@]}"
+            fi
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
-        eval "apt-get update -q ${debug}"
+        if [ -z "${offline_install}" ]; then 
+            eval "apt-get update -q ${debug}"
+        fi
         if [ "${1}" == "AIO" ]; then
             deps=($(echo "${wazuh_apt_dependencies[@]}" "${indexer_apt_dependencies[@]}" "${dashboard_apt_dependencies[@]}" | tr ' ' '\n' | sort -u))
-            common_logger -d "${message}"
-            installCommon_aptInstallList "${deps[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_aptInstallList "${deps[@]}"
+            else
+                offline_checkPrerequisites "${deps[@]}"
+            fi
         fi
         if [ "${1}" == "indexer" ]; then
-            common_logger -d "${message}"
-            installCommon_aptInstallList "${indexer_apt_dependencies[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_aptInstallList "${indexer_apt_dependencies[@]}"
+            else
+                offline_checkPrerequisites "${indexer_apt_dependencies[@]}"
+            fi
         fi
         if [ "${1}" == "dashboard" ]; then
-            common_logger -d "${message}"
-            installCommon_aptInstallList "${dashboard_apt_dependencies[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_aptInstallList "${dashboard_apt_dependencies[@]}"
+            else
+                offline_checkPrerequisites "${dashboard_apt_dependencies[@]}"
+            fi
         fi
         if [ "${1}" == "wazuh" ]; then
-            common_logger -d "${message}"
-            installCommon_aptInstallList "${wazuh_apt_dependencies[@]}"
+            if [ -z "${offline_install}" ]; then
+                common_logger -d "${message}"
+                installCommon_aptInstallList "${wazuh_apt_dependencies[@]}"
+            else
+                offline_checkPrerequisites "${wazuh_apt_dependencies[@]}"
+            fi
         fi
     fi
 

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -251,10 +251,6 @@ function main() {
 
 # -------------- Preliminary checks and Prerequisites --------------------------------
 
-    if [ -z "${uninstall}" ]; then
-        installCommon_installCheckDependencies
-    fi
-
     if [ -z "${configurations}" ] && [ -z "${AIO}" ] && [ -z "${download}" ]; then
         checks_previousCertificate
     fi

--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -41,7 +41,7 @@ function getHelp() {
     echo -e "                Overwrites previously installed components. This will erase all the existing configuration and data."
     echo -e ""
     echo -e "        -of,  --offline-installation"
-    echo -e "                Perform an offline installation. This option must be used with -a, -ws, -wi, or -wd."
+    echo -e "                Perform an offline installation. This option must be used with -a, -ws, -s, -wi, or -wd."
     echo -e ""
     echo -e "        -p,  --port"
     echo -e "                Specifies the Wazuh web user interface port. By default is the 443 TCP port. Recommended ports are: 8443, 8444, 8080, 8888, 9000."

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -22,7 +22,7 @@ config_file="${base_path}/config.yml"
 readonly tar_file_name="wazuh-install-files.tar"
 tar_file="${base_path}/${tar_file_name}"
 
-readonly filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
+filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
 
 readonly dashboard_cert_path="/etc/wazuh-dashboard/certs"
 readonly filebeat_cert_path="/etc/filebeat/certs"

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -11,7 +11,7 @@
 # Checks the necessary dependencies for the installation
 function offline_checkDependencies() {
 
-    dependencies=( curl tar gnupg openssl )
+    dependencies=( curl tar gnupg openssl lsof )
 
     common_logger "Checking installed dependencies for Offline installation."
     for dep in "${dependencies[@]}"; do
@@ -28,6 +28,26 @@ function offline_checkDependencies() {
     done
     common_logger -d "Offline dependencies are installed."
 
+}
+
+# Checks the necessary packages needed for a Wazuh component
+function offline_checkPrerequisites(){
+
+    dependencies=("$@")
+    common_logger "Checking prerequisites for Offline installation."
+    for dep in "${dependencies[@]}"; do
+        if [ "${sys_type}" == "yum" ]; then
+            eval "yum list installed 2>/dev/null | grep -q -E ^"${dep}"\\."
+        elif [ "${sys_type}" == "apt-get" ]; then
+            eval "apt list --installed 2>/dev/null | grep -q -E ^"${dep}"\/"
+        fi
+        
+        if [ "${PIPESTATUS[0]}" != 0 ]; then
+            common_logger -e "${dep} is necessary for the offline installation."
+            exit 1
+        fi
+    done
+    common_logger -d "Offline prerequisites are installed."
 }
 
 # Checks the necessary files for the installation


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-packages/issues/3072

After testing on a machine without internet access, a couple of errors were detected which were corrected with the changes in this PR:

## Tests

### Wazuh indexer:

```console
ubuntu@ip-172-31-46-83:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-indexer node-1
15/08/2024 15:15:55 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
15/08/2024 15:15:55 INFO: Verbose logging redirected to /var/log/wazuh-install.log
15/08/2024 15:15:55 INFO: Checking installed dependencies for Offline installation.
15/08/2024 15:16:01 INFO: Verifying that your system meets the recommended minimum hardware requirements.
15/08/2024 15:16:02 INFO: Checking prerequisites for Offline installation.
15/08/2024 15:16:05 INFO: Checking wazuh-offline.tar.gz file.
15/08/2024 15:16:06 INFO: --- Wazuh indexer ---
15/08/2024 15:16:06 INFO: Starting Wazuh indexer installation.
15/08/2024 15:16:34 INFO: Wazuh indexer installation finished.
15/08/2024 15:16:35 INFO: Wazuh indexer post-install configuration finished.
15/08/2024 15:16:35 INFO: Starting service wazuh-indexer.
15/08/2024 15:17:01 INFO: wazuh-indexer service started.
15/08/2024 15:17:01 INFO: Initializing Wazuh indexer cluster security settings.
15/08/2024 15:17:05 INFO: Wazuh indexer cluster initialized.
15/08/2024 15:17:05 INFO: Installation finished.
ubuntu@ip-172-31-46-83:~$ sudo bash wazuh-install.sh --start-cluster --offline-installation -v
15/08/2024 15:17:24 DEBUG: Checking root permissions.
15/08/2024 15:17:24 DEBUG: Checking sudo package.
15/08/2024 15:17:24 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
15/08/2024 15:17:24 INFO: Verbose logging redirected to /var/log/wazuh-install.log
15/08/2024 15:17:24 DEBUG: APT package manager will be used.
15/08/2024 15:17:24 DEBUG: Checking system distribution.
15/08/2024 15:17:24 DEBUG: Detected distribution name: ubuntu
15/08/2024 15:17:24 DEBUG: Detected distribution version: 22
15/08/2024 15:17:24 INFO: Checking installed dependencies for Offline installation.
15/08/2024 15:17:26 DEBUG: Offline dependencies are installed.
15/08/2024 15:17:26 DEBUG: Checking Wazuh installation.
15/08/2024 15:17:28 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:17:29 DEBUG: Checking system architecture.
15/08/2024 15:17:29 INFO: Verifying that your system meets the recommended minimum hardware requirements.
15/08/2024 15:17:29 DEBUG: CPU cores detected: 2
15/08/2024 15:17:29 DEBUG: Free RAM memory detected: 7833
15/08/2024 15:17:29 DEBUG: Checking previous certificate existence.
15/08/2024 15:17:29 INFO: Checking wazuh-offline.tar.gz file.
15/08/2024 15:17:29 DEBUG: wazuh-offline.tar.gz was found correctly.
15/08/2024 15:17:29 DEBUG: Extracting files from wazuh-offline.tar.gz
15/08/2024 15:17:29 DEBUG: Offline files extracted successfully.
15/08/2024 15:17:29 DEBUG: Extracting Wazuh configuration.
15/08/2024 15:17:29 DEBUG: Reading configuration file.
15/08/2024 15:17:29 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:17:29 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:17:29 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:17:29 DEBUG: Starting Wazuh indexer cluster.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.13.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
15/08/2024 15:17:35 INFO: Wazuh indexer cluster security configuration initialized.
15/08/2024 15:17:35 DEBUG: Waiting for Wazuh indexer to be ready. wazuh-indexer status: 503
15/08/2024 15:17:40 DEBUG: Waiting for Wazuh indexer to be ready. wazuh-indexer status: 503
15/08/2024 15:17:46 DEBUG: Inserted wazuh-alerts template into the Wazuh indexer cluster.
15/08/2024 15:17:46 DEBUG: Setting Wazuh indexer cluster passwords.
15/08/2024 15:17:46 DEBUG: Checking Wazuh installation.
15/08/2024 15:17:47 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:17:48 INFO: Updating the internal users.
15/08/2024 15:17:48 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.13.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
15/08/2024 15:17:53 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
15/08/2024 15:17:53 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
15/08/2024 15:17:53 DEBUG: The internal users have been updated before changing the passwords.
15/08/2024 15:17:53 DEBUG: Generating password hashes.
15/08/2024 15:18:03 DEBUG: Password hashes generated.
15/08/2024 15:18:03 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.13.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
15/08/2024 15:18:07 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
15/08/2024 15:18:07 DEBUG: Running security admin tool.
15/08/2024 15:18:08 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.13.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/ubuntu
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
15/08/2024 15:18:12 DEBUG: Passwords changed.
15/08/2024 15:18:12 INFO: Wazuh indexer cluster started.
ubuntu@ip-172-31-46-83:~$ sudo tar -axf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt -O | grep -P "\'admin\'" -A 1
  indexer_username: 'admin'
  indexer_password: 'nBbBGIVxUwarL?C6gaFwp4nxKghYEyLb'
ubuntu@ip-172-31-46-83:~$ curl -k -u admin:nBbBGIVxUwarL?C6gaFwp4nxKghYEyLb https://127.0.0.1:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-indexer-cluster",
  "cluster_uuid" : "2QpMf9ZaR2GPPjZDSNIKeQ",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "deb",
    "build_hash" : "521f27c3793bc1d0d250a81a237dce08b28d0ffc",
    "build_date" : "2024-08-09T09:32:04.236040Z",
    "build_snapshot" : false,
    "lucene_version" : "9.10.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
ubuntu@ip-172-31-46-83:~$ curl -k -u admin:nBbBGIVxUwarL?C6gaFwp4nxKghYEyLb https://127.0.0.1:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                               cluster_manager name
127.0.0.1           49          52  27    0.42    0.51     0.45 dimr      data,ingest,master,remote_cluster_client *               node-1
```

### Wazuh manager:

```console
ubuntu@ip-172-31-46-83:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-server wazuh-1 -v
15/08/2024 15:19:49 DEBUG: Checking root permissions.
15/08/2024 15:19:49 DEBUG: Checking sudo package.
15/08/2024 15:19:49 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
15/08/2024 15:19:49 INFO: Verbose logging redirected to /var/log/wazuh-install.log
15/08/2024 15:19:49 DEBUG: APT package manager will be used.
15/08/2024 15:19:49 DEBUG: Checking system distribution.
15/08/2024 15:19:49 DEBUG: Detected distribution name: ubuntu
15/08/2024 15:19:49 DEBUG: Detected distribution version: 22
15/08/2024 15:19:49 INFO: Checking installed dependencies for Offline installation.
15/08/2024 15:19:52 DEBUG: Offline dependencies are installed.
15/08/2024 15:19:52 DEBUG: Checking Wazuh installation.
15/08/2024 15:19:53 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:19:54 DEBUG: Checking system architecture.
15/08/2024 15:19:54 INFO: Verifying that your system meets the recommended minimum hardware requirements.
15/08/2024 15:19:54 DEBUG: CPU cores detected: 2
15/08/2024 15:19:54 DEBUG: Free RAM memory detected: 7833
15/08/2024 15:19:54 DEBUG: Checking previous certificate existence.
15/08/2024 15:19:54 DEBUG: Checking ports availability.
15/08/2024 15:19:56 INFO: Checking prerequisites for Offline installation.
15/08/2024 15:19:58 DEBUG: Offline prerequisites are installed.
15/08/2024 15:19:58 INFO: Checking wazuh-offline.tar.gz file.
15/08/2024 15:19:58 DEBUG: wazuh-offline.tar.gz was found correctly.
15/08/2024 15:19:58 DEBUG: Extracting files from wazuh-offline.tar.gz
15/08/2024 15:19:58 DEBUG: Offline files extracted successfully.
15/08/2024 15:19:58 DEBUG: Checking curl tool version.
15/08/2024 15:19:58 DEBUG: Extracting Wazuh configuration.
15/08/2024 15:19:58 DEBUG: Reading configuration file.
15/08/2024 15:19:59 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:19:59 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:19:59 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:19:59 DEBUG: Checking node names in the configuration file.
15/08/2024 15:19:59 INFO: --- Wazuh server ---
15/08/2024 15:19:59 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 32 not upgraded. Need to get 0 B/322 MB of archives. After this operation, 891 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-manager_4.9.0-1_amd64.deb wazuh-manager amd64 4.9.0-1 [322 MB] Selecting previous NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1
15/08/2024 15:22:04 DEBUG: Checking Wazuh installation.
15/08/2024 15:22:04 DEBUG: There are Wazuh remaining files.
15/08/2024 15:22:05 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:22:06 INFO: Wazuh manager installation finished.
15/08/2024 15:22:06 DEBUG: Configuring Wazuh manager.
15/08/2024 15:22:06 DEBUG: Setting provisional Wazuh indexer password.
15/08/2024 15:22:06 INFO: Wazuh manager vulnerability detection configuration finished.
15/08/2024 15:22:06 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
15/08/2024 15:22:31 INFO: wazuh-manager service started.
15/08/2024 15:22:31 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 32 not upgraded. Need to get 0 B/22.1 MB of archives NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: wazuh-manager.serviceeb filebeat amd64 7.10.2 [22.1 MB] Selecting previously unselected package filebeat.
15/08/2024 15:22:43 DEBUG: Checking Wazuh installation.
15/08/2024 15:22:43 DEBUG: There are Wazuh remaining files.
15/08/2024 15:22:44 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:22:45 DEBUG: There are Filebeat remaining files.
15/08/2024 15:22:45 INFO: Filebeat installation finished.
15/08/2024 15:22:45 DEBUG: Configuring Filebeat.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
15/08/2024 15:22:46 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
15/08/2024 15:22:46 INFO: Filebeat post-install configuration finished.
15/08/2024 15:22:46 DEBUG: Setting Wazuh indexer cluster passwords.
15/08/2024 15:22:46 DEBUG: Checking Wazuh installation.
15/08/2024 15:22:47 DEBUG: There are Wazuh remaining files.
15/08/2024 15:22:48 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:22:49 DEBUG: There are Filebeat remaining files.
Successfully updated the keystore
Successfully updated the keystore
15/08/2024 15:22:51 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
15/08/2024 15:22:51 DEBUG: Restarting filebeat service...
15/08/2024 15:22:52 DEBUG: filebeat started.
15/08/2024 15:22:52 DEBUG: Restarting wazuh-manager service...
15/08/2024 15:23:17 DEBUG: wazuh-manager started.
15/08/2024 15:23:17 DEBUG: Changing API passwords.
15/08/2024 15:23:19 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
15/08/2024 15:23:22 INFO: filebeat service started.
15/08/2024 15:23:22 INFO: Installation finished.
ubuntu@ip-172-31-46-83:~$ sudo systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2024-08-15 15:23:17 UTC; 1min 31s ago
      Tasks: 146 (limit: 9381)
     Memory: 5.1G
        CPU: 1min 34.258s
     CGroup: /system.slice/wazuh-manager.service
             ├─111354 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─111355 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─111358 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─111361 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─111403 /var/ossec/bin/wazuh-authd
             ├─111420 /var/ossec/bin/wazuh-db
             ├─111445 /var/ossec/bin/wazuh-execd
             ├─111459 /var/ossec/bin/wazuh-analysisd
             ├─111471 /var/ossec/bin/wazuh-syscheckd
             ├─111518 /var/ossec/bin/wazuh-remoted
             ├─111552 /var/ossec/bin/wazuh-logcollector
             ├─111572 /var/ossec/bin/wazuh-monitord
             └─111594 /var/ossec/bin/wazuh-modulesd

Aug 15 15:23:09 ip-172-31-46-83 env[111290]: Started wazuh-analysisd...
Aug 15 15:23:10 ip-172-31-46-83 env[111290]: Started wazuh-syscheckd...
Aug 15 15:23:11 ip-172-31-46-83 env[111290]: Started wazuh-remoted...
Aug 15 15:23:12 ip-172-31-46-83 env[111290]: Started wazuh-logcollector...
Aug 15 15:23:13 ip-172-31-46-83 env[111290]: Started wazuh-monitord...
Aug 15 15:23:13 ip-172-31-46-83 env[111590]: 2024/08/15 15:23:13 wazuh-modulesd:router: INFO: Loaded router module.
Aug 15 15:23:13 ip-172-31-46-83 env[111590]: 2024/08/15 15:23:13 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Aug 15 15:23:14 ip-172-31-46-83 env[111290]: Started wazuh-modulesd...
Aug 15 15:23:16 ip-172-31-46-83 env[111290]: Completed.
Aug 15 15:23:17 ip-172-31-46-83 systemd[1]: Started Wazuh manager.
ubuntu@ip-172-31-46-83:~$ sudo systemctl status filebeat
● filebeat.service - Filebeat sends log files to Logstash or directly to Elasticsearch.
     Loaded: loaded (/lib/systemd/system/filebeat.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2024-08-15 15:22:52 UTC; 2min 2s ago
       Docs: https://www.elastic.co/products/beats/filebeat
   Main PID: 111033 (filebeat)
      Tasks: 8 (limit: 9381)
     Memory: 11.7M
        CPU: 165ms
     CGroup: /system.slice/filebeat.service
             └─111033 /usr/share/filebeat/bin/filebeat --environment systemd -c /etc/filebeat/filebeat.yml --path.home /usr/share/filebeat --path.config /etc/filebeat --path.data /var/lib/filebeat --path.logs /var/log/filebeat

Aug 15 15:22:52 ip-172-31-46-83 systemd[1]: Started Filebeat sends log files to Logstash or directly to Elasticsearch..
```

### Wazuh dashboard:

```console
ubuntu@ip-172-31-46-83:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard -v
15/08/2024 15:45:34 DEBUG: Checking root permissions.
15/08/2024 15:45:34 DEBUG: Checking sudo package.
15/08/2024 15:45:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
15/08/2024 15:45:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
15/08/2024 15:45:34 DEBUG: APT package manager will be used.
15/08/2024 15:45:34 DEBUG: Checking system distribution.
15/08/2024 15:45:34 DEBUG: Detected distribution name: ubuntu
15/08/2024 15:45:34 DEBUG: Detected distribution version: 22
15/08/2024 15:45:34 INFO: Checking installed dependencies for Offline installation.
15/08/2024 15:45:37 DEBUG: Offline dependencies are installed.
15/08/2024 15:45:37 DEBUG: Checking Wazuh installation.
15/08/2024 15:45:38 DEBUG: There are Wazuh remaining files.
15/08/2024 15:45:39 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:45:39 DEBUG: There are Filebeat remaining files.
15/08/2024 15:45:40 DEBUG: Checking system architecture.
15/08/2024 15:45:40 INFO: Verifying that your system meets the recommended minimum hardware requirements.
15/08/2024 15:45:40 DEBUG: CPU cores detected: 2
15/08/2024 15:45:40 DEBUG: Free RAM memory detected: 7833
15/08/2024 15:45:40 DEBUG: Checking previous certificate existence.
15/08/2024 15:45:40 INFO: Wazuh web interface port will be 443.
15/08/2024 15:45:40 DEBUG: Checking ports availability.
15/08/2024 15:45:41 INFO: Checking prerequisites for Offline installation.
15/08/2024 15:45:45 DEBUG: Offline prerequisites are installed.
15/08/2024 15:45:45 INFO: Checking wazuh-offline.tar.gz file.
15/08/2024 15:45:45 DEBUG: wazuh-offline.tar.gz was found correctly.
15/08/2024 15:45:45 DEBUG: Extracting files from wazuh-offline.tar.gz
15/08/2024 15:45:45 DEBUG: Offline files extracted successfully.
15/08/2024 15:45:45 DEBUG: Checking curl tool version.
15/08/2024 15:45:45 DEBUG: Extracting Wazuh configuration.
15/08/2024 15:45:45 DEBUG: Reading configuration file.
15/08/2024 15:45:45 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:45:45 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:45:45 DEBUG: Checking if 127.0.0.1 is private.
15/08/2024 15:45:45 DEBUG: Checking node names in the configuration file.
15/08/2024 15:45:45 INFO: --- Wazuh dashboard ----
15/08/2024 15:45:45 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 32 not upgraded. Need to get 0 B/166 MB of archives. After this operation, 935 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-dashboard_4.9.0-1_amd64.deb wazuh-dashboard amd64 4.9.0-1 [166 MB] Selecting previously unselected package NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1
15/08/2024 15:46:51 DEBUG: Checking Wazuh installation.
15/08/2024 15:46:52 DEBUG: There are Wazuh remaining files.
15/08/2024 15:46:53 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:46:53 DEBUG: There are Filebeat remaining files.
15/08/2024 15:46:54 DEBUG: There are Wazuh dashboard remaining files.
15/08/2024 15:46:54 INFO: Wazuh dashboard installation finished.
15/08/2024 15:46:54 DEBUG: Configuring Wazuh dashboard.
15/08/2024 15:46:54 DEBUG: Copying Wazuh dashboard certificates.
15/08/2024 15:46:54 DEBUG: Wazuh dashboard certificate setup finished.
15/08/2024 15:46:54 INFO: Wazuh dashboard post-install configuration finished.
15/08/2024 15:46:54 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
15/08/2024 15:46:55 INFO: wazuh-dashboard service started.
15/08/2024 15:46:55 DEBUG: Setting Wazuh indexer cluster passwords.
15/08/2024 15:46:55 DEBUG: Checking Wazuh installation.
15/08/2024 15:46:55 DEBUG: There are Wazuh remaining files.
15/08/2024 15:46:56 DEBUG: There are Wazuh indexer remaining files.
15/08/2024 15:46:57 DEBUG: There are Filebeat remaining files.
15/08/2024 15:46:57 DEBUG: There are Wazuh dashboard remaining files.
Successfully updated the keystore
Successfully updated the keystore
15/08/2024 15:46:58 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
15/08/2024 15:46:58 DEBUG: Restarting filebeat service...
15/08/2024 15:46:59 DEBUG: filebeat started.
15/08/2024 15:46:59 DEBUG: Restarting wazuh-manager service...
15/08/2024 15:47:22 DEBUG: wazuh-manager started.
15/08/2024 15:47:24 DEBUG: Restarting wazuh-dashboard service...
15/08/2024 15:47:25 DEBUG: wazuh-dashboard started.
15/08/2024 15:47:25 DEBUG: Changing API passwords.
15/08/2024 15:47:45 INFO: Initializing Wazuh dashboard web application.
15/08/2024 15:47:46 DEBUG: Wazuh dashboard connection was successful.
15/08/2024 15:47:46 INFO: Wazuh dashboard web application initialized.
15/08/2024 15:47:46 INFO: --- Summary ---
15/08/2024 15:47:46 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: nBbBGIVxUwarL?C6gaFwp4nxKghYEyLb
15/08/2024 15:47:46 INFO: Installation finished.
```

![Screenshot_20240815_124900](https://github.com/user-attachments/assets/e27364d9-c166-44e8-81e2-e4894d226632)
![Screenshot_20240815_124847](https://github.com/user-attachments/assets/79528d1d-5c85-4bc9-aa51-b1caf0377aea)
![Screenshot_20240815_124919](https://github.com/user-attachments/assets/7fc2a93f-28c1-4c18-b67e-cba81fd3508c)

