### PR TITLE
Fix 4.8.2 version bump

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -29,7 +29,7 @@ date=datetime.datetime.strptime(args.date, FORMAT_STRING)
 version=Version(args.version)
 
 ## Find files to bump .spec, changelog, pkginfo, .pkgproj, test-*.sh,
-## installVariables.sh, CHANGELOG.md
+## installVariables.sh, unattended_installer/builder.sh, CHANGELOG.md
 spec_files=glob.glob('**/*.spec', recursive=True)
 changelog_files=glob.glob('**/changelog', recursive=True)
 copyright_files=glob.glob('**/copyright', recursive=True)
@@ -37,6 +37,7 @@ pkginfo_files=glob.glob('**/pkginfo', recursive=True)
 pkgproj_files=glob.glob('**/*.pkgproj', recursive=True)
 test_files=glob.glob('**/test-*.sh', recursive=True)
 install_variables_files=glob.glob('**/installVariables.sh', recursive=True)
+unattended_builder_files=glob.glob('**/unattended_installer/builder.sh', recursive=True)
 changelog_md_files=glob.glob('**/CHANGELOG.md', recursive=True)
 VERSION_files=glob.glob('**/VERSION', recursive=True)
 
@@ -169,6 +170,19 @@ for install_variables_file in install_variables_files:
         filedata=re.sub(REGEX, f'wazuh_version=\"{version}\"', filedata)
 
     with open(install_variables_file, 'w', encoding="utf-8") as file:
+        file.write(filedata)
+
+## Bump version in unattended installer build file
+
+for builder_file in unattended_builder_files:
+    with open(builder_file, 'r', encoding="utf-8") as file:
+        print('Bumping version in ' + builder_file)
+        filedata=file.read()
+        # Replace version and revision
+        REGEX=r'source_branch="(\d+\.\d+\.\d+)"'
+        filedata=re.sub(REGEX, f'source_branch="{version}"', filedata)
+
+    with open(builder_file, 'w', encoding="utf-8") as file:
         file.write(filedata)
 
 ## Bump version in CHANGELOG.md files

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 """
 This script is used to bump the version of the Wazuh packages repository.
     Copyright (C) 2015-2020, Wazuh Inc.

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="4.8.1"
+source_branch="4.8.2"
 
 function getHelp() {
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #3075|

This PR continues https://github.com/wazuh/wazuh-packages/pull/3076, and adds:

1. Fix the version bump tool to modify _unattended_installer/builder.sh_.
2. Make the version bump tool executable.
3. Delete file _hello_, added by mistake.