### PR TITLE
Fixed bug when inserting Filebeat template

### DIFF
--- a/unattended_installer/install_functions/indexer.sh
+++ b/unattended_installer/install_functions/indexer.sh
@@ -206,7 +206,7 @@ function indexer_startCluster() {
     if [ -n "${offline_install}" ]; then
         filebeat_wazuh_template="file://${offline_files_path}/wazuh-template.json"
     fi
-    http_status=$(eval "common_curl --silent '${filebeat_wazuh_template}' --max-time 300 --retry 5 --retry-delay 5 ${debug}" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H \'Content-Type: application/json\' -d @- -uadmin:admin -k --max-time 300 --retry 5 --retry-delay 5 -w "%{http_code}" -o /dev/null")
+    http_status=$(eval "common_curl --silent '${filebeat_wazuh_template}' --max-time 300 --retry 5 --retry-delay 5" | eval "common_curl -X PUT 'https://${indexer_node_ips[pos]}:9200/_template/wazuh' -H \'Content-Type: application/json\' -d @- -uadmin:admin -k --max-time 300 --silent --retry 5 --retry-delay 5 -w "%{http_code}" -o /dev/null")
     if [ "${http_status}" -ne 200 ]; then
         common_logger -e "The wazuh-alerts template could not be inserted into the Wazuh indexer cluster."
         exit 1


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-packages/issues/3081

The bug when trying to insert the Filebeat template has been fixed, with this the Offline installation works both in debug mode and without debug mode


## Test

### Offline installation without debug

<details>
<summary>Indexer</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-indexer node-1
20/08/2024 19:43:55 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:43:55 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:43:55 INFO: Checking installed dependencies for Offline installation.
20/08/2024 19:44:00 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:44:02 INFO: Checking prerequisites for Offline installation.
20/08/2024 19:44:04 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 19:44:05 INFO: --- Wazuh indexer ---
20/08/2024 19:44:05 INFO: Starting Wazuh indexer installation.
20/08/2024 19:45:37 INFO: Wazuh indexer installation finished.
20/08/2024 19:45:37 INFO: Wazuh indexer post-install configuration finished.
20/08/2024 19:45:37 INFO: Starting service wazuh-indexer.
20/08/2024 19:46:01 INFO: wazuh-indexer service started.
20/08/2024 19:46:01 INFO: Initializing Wazuh indexer cluster security settings.
20/08/2024 19:46:04 INFO: Wazuh indexer cluster initialized.
20/08/2024 19:46:04 INFO: Installation finished.
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --start-cluster --offline-installation
20/08/2024 19:46:08 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:46:08 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:46:08 INFO: Checking installed dependencies for Offline installation.
20/08/2024 19:46:14 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:46:14 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 19:46:25 INFO: Wazuh indexer cluster security configuration initialized.
20/08/2024 19:46:29 INFO: Updating the internal users.
20/08/2024 19:46:33 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
20/08/2024 19:46:49 INFO: Wazuh indexer cluster started.
```
</details>

<details>

<summary>Manager</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-server wazuh-1
20/08/2024 19:46:58 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:46:58 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:46:58 INFO: Checking installed dependencies for Offline installation.
20/08/2024 19:47:03 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:47:04 INFO: Checking prerequisites for Offline installation.
20/08/2024 19:47:06 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 19:47:07 INFO: --- Wazuh server ---
20/08/2024 19:47:07 INFO: Starting the Wazuh manager installation.
20/08/2024 19:49:05 INFO: Wazuh manager installation finished.
20/08/2024 19:49:05 INFO: Wazuh manager vulnerability detection configuration finished.
20/08/2024 19:49:05 INFO: Starting service wazuh-manager.
20/08/2024 19:49:29 INFO: wazuh-manager service started.
20/08/2024 19:49:29 INFO: Starting Filebeat installation.
20/08/2024 19:49:44 INFO: Filebeat installation finished.
20/08/2024 19:49:45 INFO: Filebeat post-install configuration finished.
20/08/2024 19:49:51 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 19:50:20 INFO: Starting service filebeat.
20/08/2024 19:50:22 INFO: filebeat service started.
20/08/2024 19:50:22 INFO: Installation finished.
```
</details>

<details>
<summary>Dashboard</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard
20/08/2024 19:52:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:52:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:52:57 INFO: Checking installed dependencies for Offline installation.
20/08/2024 19:53:03 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:53:03 INFO: Wazuh web interface port will be 443.
20/08/2024 19:53:05 INFO: Checking prerequisites for Offline installation.
20/08/2024 19:53:09 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 19:53:09 INFO: --- Wazuh dashboard ----
20/08/2024 19:53:09 INFO: Starting Wazuh dashboard installation.
20/08/2024 19:54:19 INFO: Wazuh dashboard installation finished.
20/08/2024 19:54:19 INFO: Wazuh dashboard post-install configuration finished.
20/08/2024 19:54:19 INFO: Starting service wazuh-dashboard.
20/08/2024 19:54:20 INFO: wazuh-dashboard service started.
20/08/2024 19:54:23 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 19:55:10 INFO: Initializing Wazuh dashboard web application.
20/08/2024 19:55:11 INFO: Wazuh dashboard web application initialized.
20/08/2024 19:55:11 INFO: --- Summary ---
20/08/2024 19:55:11 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: TAqAxuU4PVEec.oq7ddMXxc+r.*fj.c6
20/08/2024 19:55:11 INFO: Installation finished.
```
</details>

![Screenshot_20240820_165854](https://github.com/user-attachments/assets/ef0ea65b-ea60-4ff6-ba86-5afd3ba4bd3d)


### Offline installation with debug

<details>
<summary>Indexer</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-indexer node-1 -v
20/08/2024 20:05:39 DEBUG: Checking root permissions.
20/08/2024 20:05:39 DEBUG: Checking sudo package.
20/08/2024 20:05:39 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 20:05:39 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 20:05:39 DEBUG: APT package manager will be used.
20/08/2024 20:05:39 DEBUG: Checking system distribution.
20/08/2024 20:05:39 DEBUG: Detected distribution name: ubuntu
20/08/2024 20:05:39 DEBUG: Detected distribution version: 22
20/08/2024 20:05:39 INFO: Checking installed dependencies for Offline installation.
20/08/2024 20:05:42 DEBUG: Offline dependencies are installed.
20/08/2024 20:05:42 DEBUG: Checking Wazuh installation.
20/08/2024 20:05:44 DEBUG: Checking system architecture.
20/08/2024 20:05:45 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 20:05:45 DEBUG: CPU cores detected: 2
20/08/2024 20:05:45 DEBUG: Free RAM memory detected: 3839
20/08/2024 20:05:45 DEBUG: Checking previous certificate existence.
20/08/2024 20:05:45 DEBUG: Checking ports availability.
20/08/2024 20:05:46 INFO: Checking prerequisites for Offline installation.
20/08/2024 20:05:49 DEBUG: Offline prerequisites are installed.
20/08/2024 20:05:49 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 20:05:49 DEBUG: wazuh-offline.tar.gz was found correctly.
20/08/2024 20:05:49 DEBUG: Extracting files from wazuh-offline.tar.gz
20/08/2024 20:05:49 DEBUG: Offline files extracted successfully.
20/08/2024 20:05:49 DEBUG: Checking curl tool version.
20/08/2024 20:05:49 DEBUG: Extracting Wazuh configuration.
20/08/2024 20:05:49 DEBUG: Reading configuration file.
20/08/2024 20:05:49 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:05:49 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:05:49 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:05:49 DEBUG: Checking node names in the configuration file.
20/08/2024 20:05:49 INFO: --- Wazuh indexer ---
20/08/2024 20:05:49 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 35 not upgraded. Need to get 0 B/753 MB of archives. After this operation, 1050 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-indexer_4.8.2-1_amd64.deb wazuh-indexer amd64 4.8.2-1 [753 MB] Selecting previously unselected package wazu NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
20/08/2024 20:07:21 DEBUG: Checking Wazuh installation.
20/08/2024 20:07:22 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:07:23 INFO: Wazuh indexer installation finished.
20/08/2024 20:07:23 DEBUG: Configuring Wazuh indexer.
20/08/2024 20:07:23 DEBUG: Copying Wazuh indexer certificates.
20/08/2024 20:07:23 INFO: Wazuh indexer post-install configuration finished.
20/08/2024 20:07:23 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
20/08/2024 20:07:46 INFO: wazuh-indexer service started.
20/08/2024 20:07:46 INFO: Initializing Wazuh indexer cluster security settings.
20/08/2024 20:07:47 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 20:07:47 DEBUG: Checking Wazuh installation.
20/08/2024 20:07:49 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:07:50 INFO: Wazuh indexer cluster initialized.
20/08/2024 20:07:50 INFO: Installation finished.
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --start-cluster --offline-installation -v
20/08/2024 20:07:56 DEBUG: Checking root permissions.
20/08/2024 20:07:56 DEBUG: Checking sudo package.
20/08/2024 20:07:56 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 20:07:56 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 20:07:56 DEBUG: APT package manager will be used.
20/08/2024 20:07:56 DEBUG: Checking system distribution.
20/08/2024 20:07:56 DEBUG: Detected distribution name: ubuntu
20/08/2024 20:07:56 DEBUG: Detected distribution version: 22
20/08/2024 20:07:56 INFO: Checking installed dependencies for Offline installation.
20/08/2024 20:07:59 DEBUG: Offline dependencies are installed.
20/08/2024 20:07:59 DEBUG: Checking Wazuh installation.
20/08/2024 20:08:00 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:08:01 DEBUG: Checking system architecture.
20/08/2024 20:08:01 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 20:08:01 DEBUG: CPU cores detected: 2
20/08/2024 20:08:01 DEBUG: Free RAM memory detected: 3839
20/08/2024 20:08:01 DEBUG: Checking previous certificate existence.
20/08/2024 20:08:01 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 20:08:01 DEBUG: wazuh-offline.tar.gz was found correctly.
20/08/2024 20:08:01 DEBUG: Extracting files from wazuh-offline.tar.gz
20/08/2024 20:08:01 DEBUG: Offline files extracted successfully.
20/08/2024 20:08:01 DEBUG: Extracting Wazuh configuration.
20/08/2024 20:08:01 DEBUG: Reading configuration file.
20/08/2024 20:08:02 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:08:02 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:08:02 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:08:02 DEBUG: Starting Wazuh indexer cluster.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
20/08/2024 20:08:11 INFO: Wazuh indexer cluster security configuration initialized.
20/08/2024 20:08:12 DEBUG: Inserted wazuh-alerts template into the Wazuh indexer cluster.
20/08/2024 20:08:12 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 20:08:12 DEBUG: Checking Wazuh installation.
20/08/2024 20:08:13 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:08:14 INFO: Updating the internal users.
20/08/2024 20:08:14 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 20:08:19 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
20/08/2024 20:08:19 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
20/08/2024 20:08:19 DEBUG: The internal users have been updated before changing the passwords.
20/08/2024 20:08:19 DEBUG: The given user anomalyadmin does not exist
20/08/2024 20:08:19 DEBUG: Generating password hashes.
20/08/2024 20:08:26 DEBUG: Password hashes generated.
20/08/2024 20:08:26 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 20:08:30 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
20/08/2024 20:08:30 DEBUG: Running security admin tool.
20/08/2024 20:08:30 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-indexer-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/ubuntu
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
20/08/2024 20:08:34 DEBUG: Passwords changed.
20/08/2024 20:08:34 INFO: Wazuh indexer cluster started.
```
</details>

<details>

<summary>Manager</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-server wazuh-1 -v
20/08/2024 20:10:03 DEBUG: Checking root permissions.
20/08/2024 20:10:03 DEBUG: Checking sudo package.
20/08/2024 20:10:03 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 20:10:03 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 20:10:03 DEBUG: APT package manager will be used.
20/08/2024 20:10:03 DEBUG: Checking system distribution.
20/08/2024 20:10:03 DEBUG: Detected distribution name: ubuntu
20/08/2024 20:10:03 DEBUG: Detected distribution version: 22
20/08/2024 20:10:03 INFO: Checking installed dependencies for Offline installation.
20/08/2024 20:10:07 DEBUG: Offline dependencies are installed.
20/08/2024 20:10:07 DEBUG: Checking Wazuh installation.
20/08/2024 20:10:08 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:10:09 DEBUG: Checking system architecture.
20/08/2024 20:10:09 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 20:10:09 DEBUG: CPU cores detected: 2
20/08/2024 20:10:09 DEBUG: Free RAM memory detected: 3839
20/08/2024 20:10:09 DEBUG: Checking previous certificate existence.
20/08/2024 20:10:09 DEBUG: Checking ports availability.
20/08/2024 20:10:11 INFO: Checking prerequisites for Offline installation.
20/08/2024 20:10:13 DEBUG: Offline prerequisites are installed.
20/08/2024 20:10:13 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 20:10:13 DEBUG: wazuh-offline.tar.gz was found correctly.
20/08/2024 20:10:13 DEBUG: Extracting files from wazuh-offline.tar.gz
20/08/2024 20:10:13 DEBUG: Offline files extracted successfully.
20/08/2024 20:10:13 DEBUG: Checking curl tool version.
20/08/2024 20:10:13 DEBUG: Extracting Wazuh configuration.
20/08/2024 20:10:13 DEBUG: Reading configuration file.
20/08/2024 20:10:14 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:10:14 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:10:14 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:10:14 DEBUG: Checking node names in the configuration file.
20/08/2024 20:10:14 INFO: --- Wazuh server ---
20/08/2024 20:10:14 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 35 not upgraded. Need to get 0 B/314 MB of archives. After this operation, 915 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-manager_4.8.2-1_amd64.deb wazuh-manager amd64 4.8.2-1 [314 MB] Selecting previous NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
20/08/2024 20:12:10 DEBUG: Checking Wazuh installation.
20/08/2024 20:12:11 DEBUG: There are Wazuh remaining files.
20/08/2024 20:12:12 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:12:13 INFO: Wazuh manager installation finished.
20/08/2024 20:12:13 DEBUG: Configuring Wazuh manager.
20/08/2024 20:12:13 DEBUG: Setting provisional Wazuh indexer password.
20/08/2024 20:12:13 INFO: Wazuh manager vulnerability detection configuration finished.
20/08/2024 20:12:13 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
20/08/2024 20:12:39 INFO: wazuh-manager service started.
20/08/2024 20:12:39 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 35 not upgraded. Need to get 0 B/22.1 MB of archives NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.serviced64.deb filebeat amd64 7.10.2 [22.1 MB] Selecting previously unselected package filebeat.
20/08/2024 20:12:51 DEBUG: Checking Wazuh installation.
20/08/2024 20:12:51 DEBUG: There are Wazuh remaining files.
20/08/2024 20:12:52 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:12:53 DEBUG: There are Filebeat remaining files.
20/08/2024 20:12:54 INFO: Filebeat installation finished.
20/08/2024 20:12:54 DEBUG: Configuring Filebeat.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
20/08/2024 20:12:54 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 20:12:57 INFO: Filebeat post-install configuration finished.
20/08/2024 20:12:57 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 20:12:57 DEBUG: Checking Wazuh installation.
20/08/2024 20:12:58 DEBUG: There are Wazuh remaining files.
20/08/2024 20:12:59 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:13:00 DEBUG: There are Filebeat remaining files.
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 20:13:03 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 20:13:03 DEBUG: Restarting filebeat service...
20/08/2024 20:13:04 DEBUG: filebeat started.
20/08/2024 20:13:04 DEBUG: Restarting wazuh-manager service...
20/08/2024 20:13:28 DEBUG: wazuh-manager started.
20/08/2024 20:13:28 DEBUG: Changing API passwords.
20/08/2024 20:13:32 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
20/08/2024 20:13:34 INFO: filebeat service started.
20/08/2024 20:13:34 INFO: Installation finished.
```
</details>

<details>
<summary>Dashboard</summary>

```console
ubuntu@ip-172-31-42-166:~$ sudo bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard -v
20/08/2024 20:13:45 DEBUG: Checking root permissions.
20/08/2024 20:13:45 DEBUG: Checking sudo package.
20/08/2024 20:13:45 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 20:13:45 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 20:13:45 DEBUG: APT package manager will be used.
20/08/2024 20:13:45 DEBUG: Checking system distribution.
20/08/2024 20:13:45 DEBUG: Detected distribution name: ubuntu
20/08/2024 20:13:45 DEBUG: Detected distribution version: 22
20/08/2024 20:13:45 INFO: Checking installed dependencies for Offline installation.
20/08/2024 20:13:49 DEBUG: Offline dependencies are installed.
20/08/2024 20:13:49 DEBUG: Checking Wazuh installation.
20/08/2024 20:13:50 DEBUG: There are Wazuh remaining files.
20/08/2024 20:13:51 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:13:51 DEBUG: There are Filebeat remaining files.
20/08/2024 20:13:52 DEBUG: Checking system architecture.
20/08/2024 20:13:52 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 20:13:52 DEBUG: CPU cores detected: 2
20/08/2024 20:13:52 DEBUG: Free RAM memory detected: 3839
20/08/2024 20:13:52 DEBUG: Checking previous certificate existence.
20/08/2024 20:13:52 INFO: Wazuh web interface port will be 443.
20/08/2024 20:13:52 DEBUG: Checking ports availability.
20/08/2024 20:13:54 INFO: Checking prerequisites for Offline installation.
20/08/2024 20:13:59 DEBUG: Offline prerequisites are installed.
20/08/2024 20:13:59 INFO: Checking wazuh-offline.tar.gz file.
20/08/2024 20:13:59 DEBUG: wazuh-offline.tar.gz was found correctly.
20/08/2024 20:13:59 DEBUG: Extracting files from wazuh-offline.tar.gz
20/08/2024 20:13:59 DEBUG: Offline files extracted successfully.
20/08/2024 20:13:59 DEBUG: Checking curl tool version.
20/08/2024 20:13:59 DEBUG: Extracting Wazuh configuration.
20/08/2024 20:13:59 DEBUG: Reading configuration file.
20/08/2024 20:13:59 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:13:59 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:13:59 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 20:13:59 DEBUG: Checking node names in the configuration file.
20/08/2024 20:13:59 INFO: --- Wazuh dashboard ----
20/08/2024 20:13:59 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 35 not upgraded. Need to get 0 B/186 MB of archives. After this operation, 999 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-dashboard_4.8.2-1_amd64.deb wazuh-dashboard amd64 4.8.2-1 [186 MB] Selecting previously unselected package NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1
20/08/2024 20:16:08 DEBUG: Checking Wazuh installation.
20/08/2024 20:16:09 DEBUG: There are Wazuh remaining files.
20/08/2024 20:16:10 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:16:11 DEBUG: There are Filebeat remaining files.
20/08/2024 20:16:11 DEBUG: There are Wazuh dashboard remaining files.
20/08/2024 20:16:11 INFO: Wazuh dashboard installation finished.
20/08/2024 20:16:11 DEBUG: Configuring Wazuh dashboard.
20/08/2024 20:16:11 DEBUG: Copying Wazuh dashboard certificates.
20/08/2024 20:16:11 DEBUG: Wazuh dashboard certificate setup finished.
20/08/2024 20:16:11 INFO: Wazuh dashboard post-install configuration finished.
20/08/2024 20:16:11 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
20/08/2024 20:16:12 INFO: wazuh-dashboard service started.
20/08/2024 20:16:12 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 20:16:12 DEBUG: Checking Wazuh installation.
20/08/2024 20:16:13 DEBUG: There are Wazuh remaining files.
20/08/2024 20:16:14 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 20:16:14 DEBUG: There are Filebeat remaining files.
20/08/2024 20:16:15 DEBUG: There are Wazuh dashboard remaining files.
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 20:16:15 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 20:16:15 DEBUG: Restarting filebeat service...
20/08/2024 20:16:16 DEBUG: filebeat started.
20/08/2024 20:16:16 DEBUG: Restarting wazuh-manager service...
20/08/2024 20:17:43 DEBUG: wazuh-manager started.
20/08/2024 20:17:45 DEBUG: Restarting wazuh-dashboard service...
20/08/2024 20:17:46 DEBUG: wazuh-dashboard started.
20/08/2024 20:17:46 DEBUG: Changing API passwords.
20/08/2024 20:18:06 INFO: Initializing Wazuh dashboard web application.
20/08/2024 20:18:07 DEBUG: Wazuh dashboard connection was successful.
20/08/2024 20:18:07 INFO: Wazuh dashboard web application initialized.
20/08/2024 20:18:07 INFO: --- Summary ---
20/08/2024 20:18:07 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: TAqAxuU4PVEec.oq7ddMXxc+r.*fj.c6
20/08/2024 20:18:07 INFO: Installation finished.
```
</details>

![Screenshot_20240820_171839](https://github.com/user-attachments/assets/7e34d59c-7a39-4537-ad85-4cb3e2b4d356)



### Online installation without debug

<details>
<summary>AIO</summary>

```console
ubuntu@ip-172-31-43-249:~$ sudo bash wazuh-install.sh -a
20/08/2024 19:07:45 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:07:45 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:07:54 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:07:54 INFO: Wazuh web interface port will be 443.
20/08/2024 19:08:10 INFO: Wazuh development repository added.
20/08/2024 19:08:10 INFO: --- Configuration files ---
20/08/2024 19:08:10 INFO: Generating configuration files.
20/08/2024 19:08:11 INFO: Generating the root certificate.
20/08/2024 19:08:11 INFO: Generating Admin certificates.
20/08/2024 19:08:11 INFO: Generating Wazuh indexer certificates.
20/08/2024 19:08:11 INFO: Generating Filebeat certificates.
20/08/2024 19:08:12 INFO: Generating Wazuh dashboard certificates.
20/08/2024 19:08:13 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
20/08/2024 19:08:13 INFO: --- Wazuh indexer ---
20/08/2024 19:08:13 INFO: Starting Wazuh indexer installation.
20/08/2024 19:09:50 INFO: Wazuh indexer installation finished.
20/08/2024 19:09:50 INFO: Wazuh indexer post-install configuration finished.
20/08/2024 19:09:50 INFO: Starting service wazuh-indexer.
20/08/2024 19:10:14 INFO: wazuh-indexer service started.
20/08/2024 19:10:14 INFO: Initializing Wazuh indexer cluster security settings.
20/08/2024 19:10:25 INFO: Wazuh indexer cluster security configuration initialized.
20/08/2024 19:10:25 INFO: Wazuh indexer cluster initialized.
20/08/2024 19:10:25 INFO: --- Wazuh server ---
20/08/2024 19:10:25 INFO: Starting the Wazuh manager installation.
20/08/2024 19:12:22 INFO: Wazuh manager installation finished.
20/08/2024 19:12:22 INFO: Wazuh manager vulnerability detection configuration finished.
20/08/2024 19:12:22 INFO: Starting service wazuh-manager.
20/08/2024 19:12:45 INFO: wazuh-manager service started.
20/08/2024 19:12:45 INFO: Starting Filebeat installation.
20/08/2024 19:13:01 INFO: Filebeat installation finished.
20/08/2024 19:13:03 INFO: Filebeat post-install configuration finished.
20/08/2024 19:13:03 INFO: Starting service filebeat.
20/08/2024 19:13:05 INFO: filebeat service started.
20/08/2024 19:13:05 INFO: --- Wazuh dashboard ---
20/08/2024 19:13:05 INFO: Starting Wazuh dashboard installation.
20/08/2024 19:15:28 INFO: Wazuh dashboard installation finished.
20/08/2024 19:15:28 INFO: Wazuh dashboard post-install configuration finished.
20/08/2024 19:15:28 INFO: Starting service wazuh-dashboard.
20/08/2024 19:15:28 INFO: wazuh-dashboard service started.
20/08/2024 19:15:31 INFO: Updating the internal users.
20/08/2024 19:15:40 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
20/08/2024 19:15:58 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 19:16:40 INFO: Initializing Wazuh dashboard web application.
20/08/2024 19:16:40 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 19:16:56 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 19:17:11 INFO: Wazuh dashboard web application initialized.
20/08/2024 19:17:11 INFO: --- Summary ---
20/08/2024 19:17:11 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: R*JdzqVi8NCj1SU2Zr0BPz2?5.0Mbi3S
20/08/2024 19:17:11 INFO: Installation finished.
```
</details>

### Online installation with debug

<details>
<summary>AIO</summary>

```console
ubuntu@ip-172-31-43-249:~$ sudo bash wazuh-install.sh -a -v
20/08/2024 19:27:19 DEBUG: Checking root permissions.
20/08/2024 19:27:19 DEBUG: Checking sudo package.
20/08/2024 19:27:19 INFO: Starting Wazuh installation assistant. Wazuh version: 4.8.2
20/08/2024 19:27:19 INFO: Verbose logging redirected to /var/log/wazuh-install.log
20/08/2024 19:27:19 DEBUG: APT package manager will be used.
20/08/2024 19:27:19 DEBUG: Checking system distribution.
20/08/2024 19:27:19 DEBUG: Detected distribution name: ubuntu
20/08/2024 19:27:19 DEBUG: Detected distribution version: 22
20/08/2024 19:27:19 DEBUG: Installing check dependencies.
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Get:4 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Fetched 129 kB in 1s (131 kB/s)
Reading package lists...
20/08/2024 19:27:26 DEBUG: Checking Wazuh installation.
20/08/2024 19:27:28 DEBUG: Checking system architecture.
20/08/2024 19:27:28 INFO: Verifying that your system meets the recommended minimum hardware requirements.
20/08/2024 19:27:28 DEBUG: CPU cores detected: 2
20/08/2024 19:27:28 DEBUG: Free RAM memory detected: 3839
20/08/2024 19:27:29 INFO: Wazuh web interface port will be 443.
20/08/2024 19:27:29 DEBUG: Checking ports availability.
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
20/08/2024 19:27:34 DEBUG: Installing prerequisites dependencies.
20/08/2024 19:27:39 DEBUG: Checking curl tool version.
20/08/2024 19:27:39 DEBUG: Adding the Wazuh repository.
gpg: keyring '/usr/share/keyrings/wazuh.gpg' created
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Get:5 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [40.3 kB]
Fetched 57.6 kB in 1s (53.6 kB/s)
Reading package lists...
20/08/2024 19:27:42 INFO: Wazuh development repository added.
20/08/2024 19:27:42 INFO: --- Configuration files ---
20/08/2024 19:27:42 INFO: Generating configuration files.
20/08/2024 19:27:43 DEBUG: Creating Wazuh certificates.
20/08/2024 19:27:43 DEBUG: Reading configuration file.
20/08/2024 19:27:43 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:43 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:43 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:43 INFO: Generating the root certificate.
20/08/2024 19:27:44 INFO: Generating Admin certificates.
20/08/2024 19:27:44 DEBUG: Generating Admin private key.
20/08/2024 19:27:44 DEBUG: Converting Admin private key to PKCS8 format.
20/08/2024 19:27:44 DEBUG: Generating Admin CSR.
20/08/2024 19:27:44 DEBUG: Creating Admin certificate.
20/08/2024 19:27:44 INFO: Generating Wazuh indexer certificates.
20/08/2024 19:27:44 DEBUG: Creating the certificates for wazuh-indexer indexer node.
20/08/2024 19:27:44 DEBUG: Generating certificate configuration.
20/08/2024 19:27:44 DEBUG: Creating the Wazuh indexer tmp key pair.
20/08/2024 19:27:44 DEBUG: Creating the Wazuh indexer certificates.
20/08/2024 19:27:44 INFO: Generating Filebeat certificates.
20/08/2024 19:27:44 DEBUG: Generating the certificates for wazuh-server server node.
20/08/2024 19:27:44 DEBUG: Generating certificate configuration.
20/08/2024 19:27:44 DEBUG: Creating the Wazuh server tmp key pair.
20/08/2024 19:27:45 DEBUG: Creating the Wazuh server certificates.
20/08/2024 19:27:45 INFO: Generating Wazuh dashboard certificates.
20/08/2024 19:27:45 DEBUG: Generating certificate configuration.
20/08/2024 19:27:45 DEBUG: Creating the Wazuh dashboard tmp key pair.
20/08/2024 19:27:45 DEBUG: Creating the Wazuh dashboard certificates.
20/08/2024 19:27:45 DEBUG: Cleaning certificate files.
20/08/2024 19:27:45 DEBUG: Generating password file.
20/08/2024 19:27:45 DEBUG: Generating random passwords.
20/08/2024 19:27:46 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
20/08/2024 19:27:46 DEBUG: Extracting Wazuh configuration.
20/08/2024 19:27:46 DEBUG: Reading configuration file.
20/08/2024 19:27:46 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:46 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:46 DEBUG: Checking if 127.0.0.1 is private.
20/08/2024 19:27:46 INFO: --- Wazuh indexer ---
20/08/2024 19:27:46 INFO: Starting Wazuh indexer installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-indexer 0 upgraded, 1 newly installed, 0 to remove and 35 not upgraded. Need to get 0 B/753 MB of arch NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
20/08/2024 19:29:06 DEBUG: Checking Wazuh installation.
20/08/2024 19:29:07 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 19:29:08 INFO: Wazuh indexer installation finished.
20/08/2024 19:29:08 DEBUG: Configuring Wazuh indexer.
20/08/2024 19:29:08 DEBUG: Copying Wazuh indexer certificates.
20/08/2024 19:29:08 INFO: Wazuh indexer post-install configuration finished.
20/08/2024 19:29:08 INFO: Starting service wazuh-indexer.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-indexer.service → /lib/systemd/system/wazuh-indexer.service.
20/08/2024 19:29:33 INFO: wazuh-indexer service started.
20/08/2024 19:29:33 INFO: Initializing Wazuh indexer cluster security settings.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index does not exists, attempt to create it ... done (0-all replicas)
Populate config from /etc/wazuh-indexer/opensearch-security/
Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml 
   SUCC: Configuration for 'config' created or updated
Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml 
   SUCC: Configuration for 'roles' created or updated
Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' created or updated
Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml 
   SUCC: Configuration for 'actiongroups' created or updated
Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml 
   SUCC: Configuration for 'tenants' created or updated
Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' created or updated
Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml 
   SUCC: Configuration for 'whitelist' created or updated
Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml 
   SUCC: Configuration for 'audit' created or updated
Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml 
   SUCC: Configuration for 'allowlist' created or updated
SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","internalusers","actiongroups","config"]) due to: null
Done with success
20/08/2024 19:29:45 INFO: Wazuh indexer cluster security configuration initialized.
20/08/2024 19:29:45 INFO: Wazuh indexer cluster initialized.
20/08/2024 19:29:45 INFO: --- Wazuh server ---
20/08/2024 19:29:45 INFO: Starting the Wazuh manager installation.
Reading package lists... Building dependency tree... Reading state information... Suggested packages: expect The following NEW packages will be installed: wazuh-manager 0 upgraded, 1 newly installed, 0 to remove and 36 not upgraded. Nee NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.servicewazuh-manager.
20/08/2024 19:31:30 DEBUG: Checking Wazuh installation.
20/08/2024 19:31:31 DEBUG: There are Wazuh remaining files.
20/08/2024 19:31:31 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 19:31:32 INFO: Wazuh manager installation finished.
20/08/2024 19:31:32 DEBUG: Configuring Wazuh manager.
20/08/2024 19:31:32 DEBUG: Setting provisional Wazuh indexer password.
20/08/2024 19:31:33 INFO: Wazuh manager vulnerability detection configuration finished.
20/08/2024 19:31:33 INFO: Starting service wazuh-manager.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-manager.service → /lib/systemd/system/wazuh-manager.service.
20/08/2024 19:31:55 INFO: wazuh-manager service started.
20/08/2024 19:31:55 INFO: Starting Filebeat installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: filebeat 0 upgraded, 1 newly installed, 0 to remove and 37 not upgraded. Need to get 0 B/22.1 MB of archives NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
20/08/2024 19:32:06 DEBUG: Checking Wazuh installation.
20/08/2024 19:32:06 DEBUG: There are Wazuh remaining files.
20/08/2024 19:32:07 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 19:32:08 DEBUG: There are Filebeat remaining files.
20/08/2024 19:32:08 INFO: Filebeat installation finished.
20/08/2024 19:32:08 DEBUG: Configuring Filebeat.
20/08/2024 19:32:09 DEBUG: Filebeat template was download successfully.
wazuh/
wazuh/_meta/
wazuh/_meta/docs.asciidoc
wazuh/_meta/fields.yml
wazuh/_meta/config.yml
wazuh/alerts/
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/module.yml
wazuh/archives/
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
20/08/2024 19:32:09 DEBUG: Filebeat module was downloaded successfully.
20/08/2024 19:32:09 DEBUG: Copying Filebeat certificates.
Created filebeat keystore
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 19:32:10 INFO: Filebeat post-install configuration finished.
20/08/2024 19:32:10 INFO: Starting service filebeat.
Synchronizing state of filebeat.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable filebeat
Created symlink /etc/systemd/system/multi-user.target.wants/filebeat.service → /lib/systemd/system/filebeat.service.
20/08/2024 19:32:13 INFO: filebeat service started.
20/08/2024 19:32:13 INFO: --- Wazuh dashboard ---
20/08/2024 19:32:13 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 37 not upgraded. Need to get 0 B/186 MB of ar NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 6.5.0-1022-aws NEEDRESTART-KEXP: 6.5.0-1022-aws NEEDRESTART-KSTA: 1 NEEDRESTART-SVC: filebeat.service
20/08/2024 19:34:31 DEBUG: Checking Wazuh installation.
20/08/2024 19:34:32 DEBUG: There are Wazuh remaining files.
20/08/2024 19:34:32 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 19:34:33 DEBUG: There are Filebeat remaining files.
20/08/2024 19:34:33 DEBUG: There are Wazuh dashboard remaining files.
20/08/2024 19:34:33 INFO: Wazuh dashboard installation finished.
20/08/2024 19:34:33 DEBUG: Configuring Wazuh dashboard.
20/08/2024 19:34:33 DEBUG: Copying Wazuh dashboard certificates.
20/08/2024 19:34:33 DEBUG: Wazuh dashboard certificate setup finished.
20/08/2024 19:34:33 INFO: Wazuh dashboard post-install configuration finished.
20/08/2024 19:34:33 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
20/08/2024 19:34:34 INFO: wazuh-dashboard service started.
20/08/2024 19:34:34 DEBUG: Setting Wazuh indexer cluster passwords.
20/08/2024 19:34:34 DEBUG: Checking Wazuh installation.
20/08/2024 19:34:35 DEBUG: There are Wazuh remaining files.
20/08/2024 19:34:35 DEBUG: There are Wazuh indexer remaining files.
20/08/2024 19:34:36 DEBUG: There are Filebeat remaining files.
20/08/2024 19:34:37 DEBUG: There are Wazuh dashboard remaining files.
20/08/2024 19:34:37 INFO: Updating the internal users.
20/08/2024 19:34:37 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 19:34:46 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
20/08/2024 19:34:46 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
20/08/2024 19:34:46 DEBUG: The internal users have been updated before changing the passwords.
20/08/2024 19:34:48 DEBUG: The given user anomalyadmin does not exist
20/08/2024 19:34:48 DEBUG: Generating password hashes.
20/08/2024 19:34:59 DEBUG: Password hashes generated.
20/08/2024 19:34:59 DEBUG: Creating password backup.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Will retrieve '/config' into /etc/wazuh-indexer/backup/config.yml 
   SUCC: Configuration for 'config' stored in /etc/wazuh-indexer/backup/config.yml
Will retrieve '/roles' into /etc/wazuh-indexer/backup/roles.yml 
   SUCC: Configuration for 'roles' stored in /etc/wazuh-indexer/backup/roles.yml
Will retrieve '/rolesmapping' into /etc/wazuh-indexer/backup/roles_mapping.yml 
   SUCC: Configuration for 'rolesmapping' stored in /etc/wazuh-indexer/backup/roles_mapping.yml
Will retrieve '/internalusers' into /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' stored in /etc/wazuh-indexer/backup/internal_users.yml
Will retrieve '/actiongroups' into /etc/wazuh-indexer/backup/action_groups.yml 
   SUCC: Configuration for 'actiongroups' stored in /etc/wazuh-indexer/backup/action_groups.yml
Will retrieve '/tenants' into /etc/wazuh-indexer/backup/tenants.yml 
   SUCC: Configuration for 'tenants' stored in /etc/wazuh-indexer/backup/tenants.yml
Will retrieve '/nodesdn' into /etc/wazuh-indexer/backup/nodes_dn.yml 
   SUCC: Configuration for 'nodesdn' stored in /etc/wazuh-indexer/backup/nodes_dn.yml
Will retrieve '/whitelist' into /etc/wazuh-indexer/backup/whitelist.yml 
   SUCC: Configuration for 'whitelist' stored in /etc/wazuh-indexer/backup/whitelist.yml
Will retrieve '/allowlist' into /etc/wazuh-indexer/backup/allowlist.yml 
   SUCC: Configuration for 'allowlist' stored in /etc/wazuh-indexer/backup/allowlist.yml
Will retrieve '/audit' into /etc/wazuh-indexer/backup/audit.yml 
   SUCC: Configuration for 'audit' stored in /etc/wazuh-indexer/backup/audit.yml
20/08/2024 19:35:03 DEBUG: Password backup created in /etc/wazuh-indexer/backup.
Successfully updated the keystore
Successfully updated the keystore
20/08/2024 19:35:04 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
20/08/2024 19:35:04 DEBUG: Restarting filebeat service...
20/08/2024 19:35:04 DEBUG: filebeat started.
20/08/2024 19:35:04 DEBUG: Restarting wazuh-manager service...
20/08/2024 19:35:26 DEBUG: wazuh-manager started.
20/08/2024 19:35:28 DEBUG: Restarting wazuh-dashboard service...
20/08/2024 19:35:29 DEBUG: wazuh-dashboard started.
20/08/2024 19:35:29 DEBUG: Running security admin tool.
20/08/2024 19:35:29 DEBUG: Loading new passwords changes.
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
Security Admin v7
Will connect to 127.0.0.1:9200 ... done
Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
OpenSearch Version: 2.10.0
Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
Clustername: wazuh-cluster
Clusterstate: GREEN
Number of nodes: 1
Number of data nodes: 1
.opendistro_security index already exists, so we do not need to create one.
Populate config from /home/ubuntu
Force type: internalusers
Will update '/internalusers' with /etc/wazuh-indexer/backup/internal_users.yml 
   SUCC: Configuration for 'internalusers' created or updated
SUCC: Expected 1 config types for node {"updated_config_types":["internalusers"],"updated_config_size":1,"message":null} is 1 (["internalusers"]) due to: null
Done with success
20/08/2024 19:35:36 DEBUG: Passwords changed.
20/08/2024 19:35:36 DEBUG: Changing API passwords.
20/08/2024 19:35:45 INFO: Initializing Wazuh dashboard web application.
20/08/2024 19:35:45 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 19:36:01 INFO: Wazuh dashboard web application not yet initialized. Waiting...
20/08/2024 19:36:16 INFO: Wazuh dashboard web application initialized.
20/08/2024 19:36:16 INFO: --- Summary ---
20/08/2024 19:36:16 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: xLsnzVT.2RjB9sgkyu9XEa?10uL*nMee
20/08/2024 19:36:16 DEBUG: Restoring Wazuh repository.
20/08/2024 19:36:16 INFO: Installation finished.
```
</details>