### PR TITLE
Change version to tag ref in the Filebeat template

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="4.9.0"
+source_branch="v4.9.0"
 
 function getHelp() {
 
@@ -76,7 +76,9 @@ function buildInstaller() {
         echo 'readonly filebeat_wazuh_module="${repobaseurl}/filebeat/wazuh-filebeat-0.4.tar.gz"' >> "${output_script_path}"
         echo 'readonly bucket="packages-dev.wazuh.com"' >> "${output_script_path}"
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
-        sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
+        if [[ ! $source_branch =~ "-" ]]; then
+            sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
+        fi
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -309,7 +311,6 @@ function checkDistDetectURL() {
 function checkFilebeatURL() {
 
     # Import variables
-    eval "$(grep -E "wazuh_version_tag=" "${resources_installer}/installVariables.sh")"
     eval "$(grep -E "filebeat_wazuh_template=" "${resources_installer}/installVariables.sh")"
     new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -309,6 +309,7 @@ function checkDistDetectURL() {
 function checkFilebeatURL() {
 
     # Import variables
+    eval "$(grep -E "wazuh_version_tag=" "${resources_installer}/installVariables.sh")"
     eval "$(grep -E "filebeat_wazuh_template=" "${resources_installer}/installVariables.sh")"
     new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -9,6 +9,7 @@
 ## Package vars
 readonly wazuh_major="4.9"
 readonly wazuh_version="4.9.0"
+readonly wazuh_version_tag="v4.9.0-rc2"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 readonly source_branch="v${wazuh_version}"
@@ -22,7 +23,7 @@ config_file="${base_path}/config.yml"
 readonly tar_file_name="wazuh-install-files.tar"
 tar_file="${base_path}/${tar_file_name}"
 
-filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
+filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_version_tag}/extensions/elasticsearch/7.x/wazuh-template.json"
 
 readonly dashboard_cert_path="/etc/wazuh-dashboard/certs"
 readonly filebeat_cert_path="/etc/filebeat/certs"

--- a/unattended_installer/install_functions/installVariables.sh
+++ b/unattended_installer/install_functions/installVariables.sh
@@ -9,7 +9,6 @@
 ## Package vars
 readonly wazuh_major="4.9"
 readonly wazuh_version="4.9.0"
-readonly wazuh_version_tag="v4.9.0-rc2"
 readonly filebeat_version="7.10.2"
 readonly wazuh_install_vesion="0.1"
 readonly source_branch="v${wazuh_version}"
@@ -23,7 +22,7 @@ config_file="${base_path}/config.yml"
 readonly tar_file_name="wazuh-install-files.tar"
 tar_file="${base_path}/${tar_file_name}"
 
-filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_version_tag}/extensions/elasticsearch/7.x/wazuh-template.json"
+filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
 
 readonly dashboard_cert_path="/etc/wazuh-dashboard/certs"
 readonly filebeat_cert_path="/etc/filebeat/certs"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/3092|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

# Description

The Installation Assistant, when it has to download the Filebeat template, uses the branch as a reference in the URL. This can cause problems when testing the correct functioning of the components because, if this file is updated in the branch, it would be using a version that does not belong to the current stage.

To solve this problem, a variable has been added in `installVariables.sh` file that refers to the stage of the current version.

>[!IMPORTANT]
>With this, whenever we have to bump a version we will need to change the new tag reference.

## Logs example

Every test doing in this process can be seen here: 
- https://github.com/wazuh/wazuh-packages/issues/3092#issuecomment-2328589181
