### PR TITLE
Change version to tag reference in source_branch references

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -16,7 +16,7 @@ readonly resources_certs="${base_path_builder}/cert_tool"
 readonly resources_passwords="${base_path_builder}/passwords_tool"
 readonly resources_common="${base_path_builder}/common_functions"
 readonly resources_download="${base_path_builder}/downloader"
-source_branch="4.9.1"
+source_branch="v4.9.1"
 
 function getHelp() {
 
@@ -48,8 +48,6 @@ function getHelp() {
 
 function buildInstaller() {
 
-    checkDistDetectURL
-
     output_script_path="${base_path_builder}/wazuh-install.sh"
 
     ## Create installer script
@@ -78,10 +76,6 @@ function buildInstaller() {
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
         if [[ ! $(grep -E "source_branch=" "${resources_installer}/installVariables.sh" | sed -E 's/.*source_branch="([^"]+)"/\1/') =~ "-" ]]; then
             sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
-        else
-            eval "$(grep -E "wazuh_version=" "${resources_installer}/installVariables.sh")"
-            eval "$(grep -E "source_branch=" "${resources_installer}/installVariables.sh")"
-        fi
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -121,6 +115,7 @@ function buildInstaller() {
     done
 
     ## dist-detect.sh
+    checkDistDetectURL
     echo "function dist_detect() {" >> "${output_script_path}"
     curl -s "https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh" | sed '/^#/d' >> "${output_script_path}"
     echo "}" >> "${output_script_path}"
@@ -287,8 +282,7 @@ function builder_main() {
 
 function checkDistDetectURL() {
 
-    urls=("https://raw.githubusercontent.com/wazuh/wazuh/v${source_branch}/src/init/dist-detect.sh"
-          "https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh"
+    urls=("https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/src/init/dist-detect.sh"
           "https://raw.githubusercontent.com/wazuh/wazuh/master/src/init/dist-detect.sh")
 
     for url in "${urls[@]}"; do

--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -76,6 +76,8 @@ function buildInstaller() {
         echo 'readonly repository="'"${devrepo}"'"' >> "${output_script_path}"
         if [[ ! $(grep -E "source_branch=" "${resources_installer}/installVariables.sh" | sed -E 's/.*source_branch="([^"]+)"/\1/') =~ "-" ]]; then
             sed -i 's|v${wazuh_version}|${wazuh_version}|g' "${resources_installer}/installVariables.sh"
+            pre_release_tag=1
+        fi
     else
         echo 'readonly repogpg="https://packages.wazuh.com/key/GPG-KEY-WAZUH"' >> "${output_script_path}"
         echo 'readonly repobaseurl="https://packages.wazuh.com/4.x"' >> "${output_script_path}"
@@ -266,6 +268,9 @@ function builder_main() {
         chmod 500 ${output_script_path}
         if [ -n "${change_filebeat_url}" ]; then
             sed -i -E "s|(https.+)master(.+wazuh-template.json)|\1\\$\\{source_branch\\}\2|"  "${resources_installer}/installVariables.sh"
+        fi
+        if [[ -n "${development}" && -n "${pre_release_tag}" ]]; then
+            sed -i 's|${wazuh_version}|v${wazuh_version}|g' "${resources_installer}/installVariables.sh"
         fi
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/3092|

## Description

The Installation Assistant, when it has to download the Filebeat template, uses the branch as a reference in the URL. This can cause problems when testing the correct functioning of the components because, if this file is updated in the branch, it would be using a version that does not belong to the current stage.
To solve this problem, the logic of the code has been changed.

>[!IMPORTANT]
 >Now when testing a stage, the `source_branch` variables in `installVariables.sh` and `builder.sh` will need to take the value of the current tag being used for the stage. For example `source_branch="v{wazuh_version}-rc2"`

More information here:

- https://github.com/wazuh/wazuh-packages/issues/3092#issuecomment-2331307571

## Logs example

Every test doing in this process can be seen here:

## Tests

- https://github.com/wazuh/wazuh-packages/issues/3092#issuecomment-2328589181
- https://github.com/wazuh/wazuh-packages/issues/3092#issuecomment-2331307571

