### PR TITLE
Fix bug when changing the Filebeat URL in the Installation Assistant

### DIFF
--- a/unattended_installer/builder.sh
+++ b/unattended_installer/builder.sh
@@ -86,6 +86,7 @@ function buildInstaller() {
         echo 'readonly repository="4.x"' >> "${output_script_path}"
     fi
     echo >> "${output_script_path}"
+    checkFilebeatURL
     grep -Ev '^#|^\s*$' ${resources_common}/commonVariables.sh >> "${output_script_path}"
     grep -Ev '^#|^\s*$' ${resources_installer}/installVariables.sh >> "${output_script_path}"
     echo >> "${output_script_path}"
@@ -132,9 +133,6 @@ function buildInstaller() {
     ## Main function and call to it
     echo >> "${output_script_path}"
     echo "main \"\$@\"" >> "${output_script_path}"
-
-    checkFilebeatURL
-
 }
 
 function buildPasswordsTool() {
@@ -309,7 +307,10 @@ function checkDistDetectURL() {
 function checkFilebeatURL() {
 
     # Import variables
-    eval "$(grep -E "filebeat_wazuh_template=" "${resources_installer}/installVariables.sh")"
+    eval "$(grep -E "wazuh_version=" "${resources_installer}/installVariables.sh")"
+    eval "$(grep -E "source_branch=" "${resources_installer}/installVariables.sh" | sed 's/source_branch=/install_variables_source_branch=/')"
+    eval "$(grep -E "filebeat_wazuh_template=" "${resources_installer}/installVariables.sh" | sed "s/\${source_branch}/$install_variables_source_branch/")"
+
     new_filebeat_url="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
 
     # Get the response of the URL and check it


### PR DESCRIPTION
|Related issue|
|---|
| #3099  |

## Description

When checking if the Filebeat URL was valid, if it wasn't, it was replaced with a valid URL. However, this change was never included in the `wazuh-install.sh` because the function was called after the content had already been written to the `wazuh-install.sh`. Additionally, when evaluating the URL, it was being evaluated using the `source_branch` variable from the file where it was being evaluated, in this case, from `builder.sh`, when it should have used the one from the `installVariables.sh` file.

To solve the first issue, it was simply necessary to change the position of the function since it was executed at the end, after adding the content to the `wazuh-install.sh`, and therefore it didn't capture any possible changes that might have been made.

The second issue was resolved by evaluating the necessary variables from installVariables.sh. In this case, `wazuh_version`and source_branch. To avoid overwriting the `source_branch` value from `builder.sh`, it was renamed with a different name. This way, when the Filebeat URL is evaluated, it will use the correct source_branch value.

## Tests

- When the URL needs to be changed

```console
root@ip-172-31-46-84:/home/ubuntu/unattended_installer# bash builder.sh -i -d
Inside checkFilebeatURL
source_branch from builder.sh: 4.9.1
source_branch from installVariables.sh: SOURCE_FROM_INSTALL_VARIABLES
Filebeat URL=https://raw.githubusercontent.com/wazuh/wazuh/SOURCE_FROM_INSTALL_VARIABLES/extensions/elasticsearch/7.x/wazuh-template.json
Changing Filebeat URL...
Outside of checkFilebeatURL
root@ip-172-31-46-84:/home/ubuntu/unattended_installer# cat wazuh-install.sh | grep filebeat_wazuh_template=\"https
filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/master/extensions/elasticsearch/7.x/wazuh-template.json"
```

- When the URL does not need to be changed

```console
root@ip-172-31-46-84:/home/ubuntu/unattended_installer# bash builder.sh -i -d
Inside checkFilebeatURL
source_branch from builder.sh: v4.9.0
source_branch from installVariables.sh: v4.9.0
Filebeat URL=https://raw.githubusercontent.com/wazuh/wazuh/v4.9.0/extensions/elasticsearch/7.x/wazuh-template.json
Outside of checkFilebeatURL
root@ip-172-31-46-84:/home/ubuntu/unattended_installer# cat wazuh-install.sh | grep filebeat_wazuh_template=\"https
filebeat_wazuh_template="https://raw.githubusercontent.com/wazuh/wazuh/${source_branch}/extensions/elasticsearch/7.x/wazuh-template.json"
```