### PR TITLE
Offline Installation Assistant import the downloaded GPG Wazuh key.

### DIFF
--- a/unattended_installer/install_functions/installMain.sh
+++ b/unattended_installer/install_functions/installMain.sh
@@ -290,6 +290,7 @@ function main() {
     if [ -n "${offline_install}" ]; then
         offline_checkPreinstallation
         offline_extractFiles
+        offline_importGPGKey
     fi
 
     if [ -n "${AIO}" ] || [ -n "${indexer}" ] || [ -n "${dashboard}" ] || [ -n "${wazuh}" ]; then

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -101,3 +101,21 @@ function offline_extractFiles() {
 
     common_logger -d "Offline files extracted successfully."
 }
+
+# Imports the GPG key from the extracted tar file
+function offline_importGPGKey() {
+    if [ "${sys_type}" == "yum" ]; then
+        eval "rpm --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
+        if [ "${PIPESTATUS[0]}" != 0 ]; then
+            common_logger -e "Cannot import Wazuh GPG key"
+            exit 1
+        fi
+    elif [ "${sys_type}" == "apt-get" ]; then
+        eval "gpg --no-default-keyring --keyring gnupg-ring:${offline_files_path}/GPG-KEY-WAZUH --import - ${debug}"
+        if [ "${PIPESTATUS[0]}" != 0 ]; then
+            common_logger -e "Cannot import Wazuh GPG key"
+            exit 1
+        fi
+        eval "chmod 644 ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
+    fi
+}

--- a/unattended_installer/install_functions/wazuh-offline-installation.sh
+++ b/unattended_installer/install_functions/wazuh-offline-installation.sh
@@ -104,6 +104,8 @@ function offline_extractFiles() {
 
 # Imports the GPG key from the extracted tar file
 function offline_importGPGKey() {
+
+    common_logger -d "Importing Wazuh GPG key."
     if [ "${sys_type}" == "yum" ]; then
         eval "rpm --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
         if [ "${PIPESTATUS[0]}" != 0 ]; then
@@ -111,11 +113,12 @@ function offline_importGPGKey() {
             exit 1
         fi
     elif [ "${sys_type}" == "apt-get" ]; then
-        eval "gpg --no-default-keyring --keyring gnupg-ring:${offline_files_path}/GPG-KEY-WAZUH --import - ${debug}"
+        eval "gpg --import ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
         if [ "${PIPESTATUS[0]}" != 0 ]; then
             common_logger -e "Cannot import Wazuh GPG key"
             exit 1
         fi
         eval "chmod 644 ${offline_files_path}/GPG-KEY-WAZUH ${debug}"
     fi
+    
 }


### PR DESCRIPTION
|Closes|
|---|
|https://github.com/wazuh/wazuh-packages/issues/3093|

## Description

The aim of this PR is to fix the warning that was displayed when installing the Wazuh components in an offline environment. To achieve that it's needed to import the key from a local file. The key is inside the `wazuh-offline.tar.gz` previously downloaded in other instance and then unzipped in the corresponding directory.

## Logs

<details><summary>Installation logs in deb package manager:</summary>

```shellsession
root@ip-172-31-43-250:/home/ubuntu# ls
wazuh-install-files.tar  wazuh-install.sh  wazuh-offline.tar.gz
root@ip-172-31-43-250:/home/ubuntu# bash wazuh-install.sh --offline-installation --wazuh-indexer node-1
10/09/2024 10:13:06 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:13:06 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:13:06 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:13:10 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:13:11 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:13:14 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:13:25 INFO: --- Wazuh indexer ---
10/09/2024 10:13:25 INFO: Starting Wazuh indexer installation.
10/09/2024 10:13:57 INFO: Wazuh indexer installation finished.
10/09/2024 10:13:57 INFO: Wazuh indexer post-install configuration finished.
10/09/2024 10:13:57 INFO: Starting service wazuh-indexer.
10/09/2024 10:14:22 INFO: wazuh-indexer service started.
10/09/2024 10:14:22 INFO: Initializing Wazuh indexer cluster security settings.
10/09/2024 10:14:25 INFO: Wazuh indexer cluster initialized.
10/09/2024 10:14:25 INFO: Installation finished.
root@ip-172-31-43-250:/home/ubuntu# bash wazuh-install.sh --offline-installation --start-cluster
10/09/2024 10:21:31 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:21:31 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:21:31 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:21:37 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:21:37 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:21:43 INFO: Wazuh indexer cluster security configuration initialized.
10/09/2024 10:21:51 INFO: Updating the internal users.
10/09/2024 10:21:55 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
10/09/2024 10:22:12 INFO: Wazuh indexer cluster started.
root@ip-172-31-43-250:/home/ubuntu# tar -axf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt -O | grep -P "\'admin\'" -A 1
  indexer_username: 'admin'
  indexer_password: 'L8i?wYbz1SJ1wMd?cZrc4RzS*Gz8Sw6+'
root@ip-172-31-43-250:/home/ubuntu# curl -k -u admin:L8i?wYbz1SJ1wMd?cZrc4RzS*Gz8Sw6+ https://127.0.0.1:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-indexer-cluster",
  "cluster_uuid" : "X-00EzVbQSW5gHqWbsCh2A",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "deb",
    "build_hash" : "9fd1835bba77ae04d48550eb4dc9be4787070806",
    "build_date" : "2024-08-30T10:06:03.028357Z",
    "build_snapshot" : false,
    "lucene_version" : "9.10.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
root@ip-172-31-43-250:/home/ubuntu# curl -k -u admin:L8i?wYbz1SJ1wMd?cZrc4RzS*Gz8Sw6+ https://127.0.0.1:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                               cluster_manager name
127.0.0.1           65          81   5    0.01    0.13     0.16 dimr      data,ingest,master,remote_cluster_client *               node-1
root@ip-172-31-43-250:/home/ubuntu# bash wazuh-install.sh --offline-installation --wazuh-server wazuh-1
10/09/2024 10:36:37 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:36:37 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:36:37 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:36:43 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:36:44 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:36:46 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:36:47 INFO: --- Wazuh server ---
10/09/2024 10:36:47 INFO: Starting the Wazuh manager installation.
10/09/2024 10:38:21 INFO: Wazuh manager installation finished.
10/09/2024 10:38:21 INFO: Wazuh manager vulnerability detection configuration finished.
10/09/2024 10:38:21 INFO: Starting service wazuh-manager.
10/09/2024 10:38:44 INFO: wazuh-manager service started.
10/09/2024 10:38:44 INFO: Starting Filebeat installation.
10/09/2024 10:39:03 INFO: Filebeat installation finished.
10/09/2024 10:39:04 INFO: Filebeat post-install configuration finished.
10/09/2024 10:39:09 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:39:37 INFO: Starting service filebeat.
10/09/2024 10:39:39 INFO: filebeat service started.
10/09/2024 10:39:39 INFO: Installation finished.
root@ip-172-31-43-250:/home/ubuntu# bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard
10/09/2024 10:41:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:41:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:41:34 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:41:40 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:41:40 INFO: Wazuh web interface port will be 443.
10/09/2024 10:41:41 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:41:46 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:41:46 INFO: --- Wazuh dashboard ----
10/09/2024 10:41:46 INFO: Starting Wazuh dashboard installation.
10/09/2024 10:42:51 INFO: Wazuh dashboard installation finished.
10/09/2024 10:42:51 INFO: Wazuh dashboard post-install configuration finished.
10/09/2024 10:42:51 INFO: Starting service wazuh-dashboard.
10/09/2024 10:42:52 INFO: wazuh-dashboard service started.
10/09/2024 10:42:55 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:44:38 INFO: Initializing Wazuh dashboard web application.
10/09/2024 10:44:39 INFO: Wazuh dashboard web application initialized.
10/09/2024 10:44:39 INFO: --- Summary ---
10/09/2024 10:44:39 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: L8i?wYbz1SJ1wMd?cZrc4RzS*Gz8Sw6+
10/09/2024 10:44:39 INFO: Installation finished.
root@ip-172-31-43-250:/home/ubuntu# cat /var/log/wazuh-install.log
10/09/2024 10:41:34 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:41:34 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:41:34 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:41:40 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:41:40 INFO: Wazuh web interface port will be 443.
10/09/2024 10:41:41 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:41:46 INFO: Checking wazuh-offline.tar.gz file.
gpg: key 96B3EE5F29111145: "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
10/09/2024 10:41:46 INFO: --- Wazuh dashboard ----
10/09/2024 10:41:46 INFO: Starting Wazuh dashboard installation.
Reading package lists... Building dependency tree... Reading state information... The following NEW packages will be installed: wazuh-dashboard 0 upgraded, 1 newly installed, 0 to remove and 212 not upgraded. Need to get 0 B/166 MB of archives. After this operation, 934 MB of additional disk space will be used. Get:1 /home/ubuntu/wazuh-offline/wazuh-packages/wazuh-dashboard_4 NEEDRESTART-VER: 3.5 NEEDRESTART-KCUR: 5.19.0-1025-aws NEEDRESTART-KEXP: 5.19.0-1025-aws NEEDRESTART-KSTA: 1rd.
10/09/2024 10:42:51 INFO: Wazuh dashboard installation finished.
10/09/2024 10:42:51 INFO: Wazuh dashboard post-install configuration finished.
10/09/2024 10:42:51 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
10/09/2024 10:42:52 INFO: wazuh-dashboard service started.
Successfully updated the keystore
Successfully updated the keystore
10/09/2024 10:42:55 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:44:38 INFO: Initializing Wazuh dashboard web application.
10/09/2024 10:44:39 INFO: Wazuh dashboard web application initialized.
10/09/2024 10:44:39 INFO: Installation finished.
```

</details>

<details><summary>Installation logs in rpm package manager:</summary>

```shellsession
[root@ip-172-31-39-64 ec2-user]# ls
wazuh-install-files.tar  wazuh-install.sh  wazuh-offline.tar.gz
[root@ip-172-31-39-64 ec2-user]# bash wazuh-install.sh --offline-installation --wazuh-indexer node-1
10/09/2024 09:31:14 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 09:31:14 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 09:31:14 INFO: Checking installed dependencies for Offline installation.
10/09/2024 09:31:17 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 09:31:17 INFO: Checking prerequisites for Offline installation.
10/09/2024 09:31:18 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 09:31:31 INFO: --- Wazuh indexer ---
10/09/2024 09:31:31 INFO: Starting Wazuh indexer installation.
10/09/2024 09:31:51 INFO: Wazuh indexer installation finished.
10/09/2024 09:31:51 INFO: Wazuh indexer post-install configuration finished.
10/09/2024 09:31:51 INFO: Starting service wazuh-indexer.
10/09/2024 09:32:18 INFO: wazuh-indexer service started.
10/09/2024 09:32:18 INFO: Initializing Wazuh indexer cluster security settings.
10/09/2024 09:32:19 INFO: Wazuh indexer cluster initialized.
10/09/2024 09:32:19 INFO: Installation finished.
[root@ip-172-31-39-64 ec2-user]# bash wazuh-install.sh --offline-installation --start-cluster
10/09/2024 09:32:58 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 09:32:58 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 09:32:58 INFO: Checking installed dependencies for Offline installation.
10/09/2024 09:33:01 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 09:33:01 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 09:33:08 INFO: Wazuh indexer cluster security configuration initialized.
10/09/2024 09:33:14 INFO: Updating the internal users.
10/09/2024 09:33:19 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
10/09/2024 09:33:38 INFO: Wazuh indexer cluster started.
[root@ip-172-31-39-64 ec2-user]# tar -axf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt -O | grep -P "\'admin\'" -A 1
  indexer_username: 'admin'
  indexer_password: 'I2D6wunS06?.0ywzd89uSK+jTEbZRHuu'
[root@ip-172-31-39-64 ec2-user]# curl -k -u admin:I2D6wunS06?.0ywzd89uSK+jTEbZRHuu https://127.0.0.1:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-indexer-cluster",
  "cluster_uuid" : "YjyZU5dRSdWzjGYFzuh0_A",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "9fd1835bba77ae04d48550eb4dc9be4787070806",
    "build_date" : "2024-08-30T10:04:33.447803Z",
    "build_snapshot" : false,
    "lucene_version" : "9.10.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
[root@ip-172-31-39-64 ec2-user]# curl -k -u admin:I2D6wunS06?.0ywzd89uSK+jTEbZRHuu https://127.0.0.1:9200/_cat/nodes?v
ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                               cluster_manager name
127.0.0.1           45          75   2    0.09    0.03     0.01 dimr      data,ingest,master,remote_cluster_client *               node-1
[root@ip-172-31-39-64 ec2-user]# bash wazuh-install.sh --offline-installation --wazuh-server wazuh-1
10/09/2024 10:36:42 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:36:42 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:36:42 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:36:44 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:36:45 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:36:45 INFO: --- Wazuh server ---
10/09/2024 10:36:45 INFO: Starting the Wazuh manager installation.
10/09/2024 10:37:57 INFO: Wazuh manager installation finished.
10/09/2024 10:37:57 INFO: Wazuh manager vulnerability detection configuration finished.
10/09/2024 10:37:57 INFO: Starting service wazuh-manager.
10/09/2024 10:38:17 INFO: wazuh-manager service started.
10/09/2024 10:38:17 INFO: Starting Filebeat installation.
10/09/2024 10:38:54 INFO: Filebeat installation finished.
10/09/2024 10:38:55 INFO: Filebeat post-install configuration finished.
10/09/2024 10:38:56 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:39:25 INFO: Starting service filebeat.
10/09/2024 10:39:26 INFO: filebeat service started.
10/09/2024 10:39:26 INFO: Installation finished.
[root@ip-172-31-39-64 ec2-user]# bash wazuh-install.sh --offline-installation --wazuh-dashboard dashboard
10/09/2024 10:41:29 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:41:29 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:41:29 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:41:32 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:41:32 INFO: Wazuh web interface port will be 443.
10/09/2024 10:41:33 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:41:33 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:41:34 INFO: --- Wazuh dashboard ----
10/09/2024 10:41:34 INFO: Starting Wazuh dashboard installation.
10/09/2024 10:43:34 INFO: Wazuh dashboard installation finished.
10/09/2024 10:43:34 INFO: Wazuh dashboard post-install configuration finished.
10/09/2024 10:43:34 INFO: Starting service wazuh-dashboard.
10/09/2024 10:43:35 INFO: wazuh-dashboard service started.
10/09/2024 10:43:36 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:45:20 INFO: Initializing Wazuh dashboard web application.
10/09/2024 10:45:21 INFO: Wazuh dashboard web application initialized.
10/09/2024 10:45:21 INFO: --- Summary ---
10/09/2024 10:45:21 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    User: admin
    Password: I2D6wunS06?.0ywzd89uSK+jTEbZRHuu
10/09/2024 10:45:21 INFO: Installation finished.
[root@ip-172-31-39-64 ec2-user]# cat /var/log/wazuh-install.log
10/09/2024 10:41:29 INFO: Starting Wazuh installation assistant. Wazuh version: 4.9.0
10/09/2024 10:41:29 INFO: Verbose logging redirected to /var/log/wazuh-install.log
10/09/2024 10:41:29 INFO: Checking installed dependencies for Offline installation.
10/09/2024 10:41:32 INFO: Verifying that your system meets the recommended minimum hardware requirements.
10/09/2024 10:41:32 INFO: Wazuh web interface port will be 443.
10/09/2024 10:41:33 INFO: Checking prerequisites for Offline installation.
10/09/2024 10:41:33 INFO: Checking wazuh-offline.tar.gz file.
10/09/2024 10:41:34 INFO: --- Wazuh dashboard ----
10/09/2024 10:41:34 INFO: Starting Wazuh dashboard installation.
Verifying... ######################################## Preparing... ######################################## Updating / installing... wazuh-dashboard-4.9.0-2 ########################################
10/09/2024 10:43:34 INFO: Wazuh dashboard installation finished.
10/09/2024 10:43:34 INFO: Wazuh dashboard post-install configuration finished.
10/09/2024 10:43:34 INFO: Starting service wazuh-dashboard.
Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service → /etc/systemd/system/wazuh-dashboard.service.
10/09/2024 10:43:35 INFO: wazuh-dashboard service started.
Successfully updated the keystore
Successfully updated the keystore
10/09/2024 10:43:36 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
10/09/2024 10:45:20 INFO: Initializing Wazuh dashboard web application.
10/09/2024 10:45:21 INFO: Wazuh dashboard web application initialized.
10/09/2024 10:45:21 INFO: Installation finished.
```

</details>

## Tests

<details><summary>Dashboard web interface Ubuntu:</summary>

Landing page:
![landing-ubuntu](https://github.com/user-attachments/assets/e7785e32-0332-4e33-8ed3-3a2b2d056b53)

About:
![about-ubuntu](https://github.com/user-attachments/assets/195f8c31-cbff-40d4-9553-0ba813db0589)

</details>

<details><summary>Dashboard web interface Amazon Linux:</summary>

Landing page:
![landing-amazonlinux](https://github.com/user-attachments/assets/fe6cde96-3663-41d6-9ad3-919e2dd5886b)

About:
![about-amazonlinux](https://github.com/user-attachments/assets/3fa3e08f-b1bb-4358-8c1c-9fe83ab23c91)

</details>

