### PR TITLE
Add stage parameter in bump_version script

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -22,6 +22,9 @@ arg_parser.add_argument('-v', '--version', action='store', dest='version',
                         help='Version to bump to', required=True)
 arg_parser.add_argument('-r', '--revision', action='store', dest='revision',
                         help='Revision to bump to. Default: 1', default=1)
+arg_parser.add_argument('-s', '--stage', action='store', dest='stage',
+                        help='Stage to bump to. Default: none',
+                        default='')
 arg_parser.add_argument('-d', '--date', action='store', dest='date',
                         help='Date to bump to. Format: m-d-Y. Default: today',
                         default=datetime.date.today().strftime(FORMAT_STRING))
@@ -42,7 +45,7 @@ install_variables_files=glob.glob('**/installVariables.sh', recursive=True)
 unattended_builder_files=glob.glob('**/unattended_installer/builder.sh', recursive=True)
 changelog_md_files=glob.glob('**/CHANGELOG.md', recursive=True)
 VERSION_files=glob.glob('**/VERSION', recursive=True)
-builder_files=glob.glob('**/unattended_installer/builder.sh', recursive=True)
+
 
 #Format variables
 SPEC_FORMAT_STRING="%a %b %d %Y"
@@ -85,11 +88,15 @@ test_files_dict = {
 install_variables_files_dict = {
     r'wazuh_major=\"(\d+\.\d+)\"':
     f'wazuh_major=\"{version.major}.{version.minor}\"',
-    r'wazuh_version=\"(\d+\.\d+\.\d+)\"':f'wazuh_version=\"{version}\"'}
+    r'wazuh_version=\"(\d+\.\d+\.\d+)\"': f'wazuh_version=\"{version}\"',
+    r'source_branch="v\$\{wazuh_version\}(-[a-zA-Z0-9]+)?"': f'source_branch=\"v${{wazuh_version}}-{args.stage}\"' if args.stage else
+    'source_branch="v${wazuh_version}"'}
 
 unattended_builder_files_dict = {
-    r'source_branch="(\d+\.\d+\.\d+)"':f'source_branch="{version}"'}
+    r'source_branch="v(\d+\.\d+\.\d+)(-[a-zA-Z0-9]+)?"': f'source_branch=\"v{version}-{args.stage}\"' if args.stage else
+    f'source_branch="v{version}"'}
 
+# if there is no line with version
 changelog_md_files_dict = {
     (r'All notable changes to this project '
     r'will be documented in this file.'):
@@ -98,8 +105,6 @@ changelog_md_files_dict = {
     + (f"## [{version}]\n\n- https://github.com/wazuh/"
     f"wazuh-packages/releases/tag/v{version}\n")}
 
-builder_files_dict = {
-    r'source_branch=\"(\d+\.\d+\.\d+)\"': f'source_branch=\"{version}\"'}
 
 VERSION_files_dict = {
     r'(\d+\.\d+\.\d+)': f'{version}'}
@@ -126,6 +131,24 @@ def bump_file_list(file_list, regex_replacement):
             file.write(filedata)
 
 
+def check_version_in_changelog_md():
+    for changelog_md_file in changelog_md_files:
+        with open(changelog_md_file, 'r', encoding="utf-8") as file:
+            filedata = file.read()
+            if re.search(rf'## \[{version}\]', filedata):
+                return True
+    return False
+
+
+def check_version_in_spec_files():
+    for spec_file in spec_files:
+        with open(spec_file, 'r', encoding="utf-8") as file:
+            filedata = file.read()
+            if re.search(rf'support <info@wazuh.com> - {version}', filedata):
+                return True
+    return False
+
+
 ## Bump version in deb changelog files
 for changelog_file in changelog_files:
     with open(changelog_file, 'r', encoding="utf-8") as file:
@@ -145,13 +168,12 @@ for changelog_file in changelog_files:
         file.write(filedata)
 
 
-bump_file_list(spec_files,spec_files_dict)
+None if check_version_in_spec_files() else bump_file_list(spec_files,spec_files_dict)
 bump_file_list(copyright_files,copyright_files_dict)
 bump_file_list(pkginfo_files,pkginfo_files_dict)
 bump_file_list(pkgproj_files,pkgproj_files_dict)
 bump_file_list(test_files,test_files_dict)
 bump_file_list(install_variables_files,install_variables_files_dict)
 bump_file_list(unattended_builder_files,unattended_builder_files_dict)
-bump_file_list(changelog_md_files,changelog_md_files_dict)
+None if check_version_in_changelog_md() else bump_file_list(changelog_md_files,changelog_md_files_dict)
 bump_file_list(VERSION_files,VERSION_files_dict)
-bump_file_list(builder_files,builder_files_dict)


### PR DESCRIPTION
|Related issue|
|---|
| #3120 |

## Description

Due to the new change made in #3098, it was necessary to modify the `bump_version.py` script. A new stage parameter (-s) has been added, where, when used, the given stage will be appended to both `source_branch` variables in the `unattended_installer/install_functions/installVariables.sh` and `unattended_installer/builder.sh` files.

The purpose of this is that every time a support new stage is created and a tag is generated, these variables will retain the version value along with the stage (e.g., `source_branch=v4.9.1-rc1`).

Once the tag with the correct value is created, these variables should retain the value without the stage in the branch, only with the version (e.g., `source_branch=v4.9.1`).

>[!NOTE]
> If the `-s` option is not used, no stage will be added, and if there was one previously, it will be removed.

To achieve this, the script will need to be run twice: once with the `-s` option to add the stage, and then again without the `-s` option to remove the stage after the tag is created.

Each time the file was executed, both the `CHANGELOG` and `aix/SPECS/wazuh-agent-aix.spec` files would add an entry mentioning the current version. To fix this and allow the script to be called multiple times without creating duplicate entries, two functions have been created to validate that an entry with the current version doesn't already exist.

## Tests

Below is the process for adding a stage to the source_branch variables, as well as its removal, which simply involves running the script again without the -s option.

```
$ cat unattended_installer/builder.sh | grep source_branch=\"v4
source_branch="v4.9.1"

$ cat unattended_installer/install_functions/installVariables.sh | grep source_branch=
readonly source_branch="v${wazuh_version}"

$ python3 bump_version.py -v 4.10.0 -s rc3
Bumping version in aix/SPECS/wazuh-agent-aix.spec
Bumping version in solaris/solaris10/pkginfo
Bumping version in tests/unattended/unit/suites/test-certFunctions.sh
Bumping version in tests/unattended/unit/suites/test-indexer.sh
Bumping version in tests/unattended/unit/suites/test-passwordsFunctions.sh
Bumping version in tests/unattended/unit/suites/test-installCommon.sh
Bumping version in tests/unattended/unit/suites/test-manager.sh
Bumping version in tests/unattended/unit/suites/test-checks.sh
Bumping version in tests/unattended/unit/suites/test-dashboard.sh
Bumping version in tests/unattended/unit/suites/test-common.sh
Bumping version in tests/unattended/unit/suites/test-filebeat.sh
Bumping version in unattended_installer/install_functions/installVariables.sh
Bumping version in unattended_installer/builder.sh
Bumping version in CHANGELOG.md
Bumping version in VERSION

$ cat unattended_installer/builder.sh | grep source_branch=\"v4
source_branch="v4.10.0-rc3"

$ cat unattended_installer/install_functions/installVariables.sh | grep source_branch=
readonly source_branch="v${wazuh_version}-rc3"

$ python3 bump_version.py -v 4.10.0

Bumping version in aix/SPECS/wazuh-agent-aix.spec
Bumping version in solaris/solaris10/pkginfo
Bumping version in tests/unattended/unit/suites/test-certFunctions.sh
Bumping version in tests/unattended/unit/suites/test-indexer.sh
Bumping version in tests/unattended/unit/suites/test-passwordsFunctions.sh
Bumping version in tests/unattended/unit/suites/test-installCommon.sh
Bumping version in tests/unattended/unit/suites/test-manager.sh
Bumping version in tests/unattended/unit/suites/test-checks.sh
Bumping version in tests/unattended/unit/suites/test-dashboard.sh
Bumping version in tests/unattended/unit/suites/test-common.sh
Bumping version in tests/unattended/unit/suites/test-filebeat.sh
Bumping version in unattended_installer/install_functions/installVariables.sh
Bumping version in unattended_installer/builder.sh
Bumping version in CHANGELOG.md
Bumping version in VERSION

$ cat unattended_installer/builder.sh | grep source_branch=\"v4
source_branch="v4.10.0"

$ cat unattended_installer/install_functions/installVariables.sh | grep source_branch=
readonly source_branch="v${wazuh_version}"
```
